### PR TITLE
feat: include test case screenshots and script links in PR descriptions

### DIFF
--- a/.claude/skills/muggle-do/open-prs.md
+++ b/.claude/skills/muggle-do/open-prs.md
@@ -7,7 +7,7 @@ You are creating pull requests for each repository that has changes after a succ
 You receive:
 - Per-repo: repo name, path, branch name
 - Requirements: goal, acceptance criteria
-- QA report: passed/failed test cases
+- QA report: passed/failed test cases, each with testCaseId, testScriptId, and projectId
 
 ## Your Job
 
@@ -22,9 +22,32 @@ For each repo with changes:
    - `## Goal` — the requirements goal
    - `## Acceptance Criteria` — bulleted list (omit section if empty)
    - `## Changes` — summary of what changed in this repo
-   - `## QA Results` — passed/failed counts, failure details if any
+   - `## QA Results` — full test case breakdown (see format below)
 4. **Create the PR** using `gh pr create --title "..." --body "..." --head <branch>` in the repo directory.
 5. **Capture the PR URL** from the output.
+
+## QA Results Section Format
+
+Use this format for the `## QA Results` section:
+
+```
+## QA Results
+
+**X passed / Y failed / Z skipped**
+
+| Test Case | Status | Details |
+|-----------|--------|---------|
+| [Test case name](https://www.muggle-ai.com/muggleTestV0/dashboard/projects/{projectId}/scripts?modal=details&testCaseId={testCaseId}) | ✅ PASSED | — |
+| [Test case name](https://www.muggle-ai.com/muggleTestV0/dashboard/projects/{projectId}/scripts?modal=details&testCaseId={testCaseId}) | ❌ FAILED | {failure reason} |
+| Test case name | ⏭️ SKIPPED | no test script available |
+```
+
+Rules:
+- Link each test case name (that has a testCaseId) to its test script details page on www.muggle-ai.com using the URL pattern above.
+- The Details column shows the failure reason for failed tests, `—` for passed tests, and "no test script available" for skipped tests.
+- If a screenshot URL was captured for a test case, add it below the table row as an embedded image:
+  `![{test case name} — ending screenshot]({screenshotUrl})`
+  If the screenshotUrl is a `gs://` URI (Google Cloud Storage), skip embedding and instead note "(screenshot available on muggle-ai.com)" in the Details column.
 
 ## Output
 

--- a/.claude/skills/muggle-do/qa.md
+++ b/.claude/skills/muggle-do/qa.md
@@ -29,9 +29,12 @@ Based on the changed files and the requirements goal, determine which test cases
 ### Step 4: Run Test Scripts
 
 For each relevant test case that has test scripts:
-1. Use `muggle-remote-test-script-list` to find test scripts for the test case
-2. Use `muggle-remote-workflow-start-test-script-replay` to trigger a replay of the test script
-3. Use `muggle-remote-wf-get-ts-replay-latest-run` to poll for results (check every 10 seconds, timeout after 5 minutes per test)
+1. Use `muggle-remote-test-script-list` to find test scripts for the test case. Note the `testScriptId`.
+2. Use `muggle-remote-workflow-start-test-script-replay` to trigger a replay. Note the returned `workflowRuntimeId`.
+3. Use `muggle-remote-wf-get-ts-replay-latest-run` to poll for results (check every 10 seconds, timeout after 5 minutes per test).
+4. From the final run result, capture any screenshot URL if present in the result payload (look for a `screenshotUrl`, `summaryScreenshotUrl`, or similar field on the run result or its nested objects).
+
+**Retain per test case:** `testCaseId`, `testScriptId`, `workflowRuntimeId`, and any `screenshotUrl` found.
 
 ### Step 5: Collect Results
 
@@ -39,18 +42,22 @@ For each test case:
 - Record whether it passed or failed
 - If failed, capture the failure reason and any reproduction steps
 - If a test script doesn't exist for a test case, note it as "no script available" (not a failure)
+- Record the `testCaseId` and `testScriptId` so they can be used to build links in the PR description
 
 ## Output
 
 **QA Report:**
 
 **Passed:** (count)
-- (test case name): passed
+- (test case name) [testCaseId: `<id>`, testScriptId: `<id>`]: passed
 
 **Failed:** (count)
-- (test case name): (failure reason)
+- (test case name) [testCaseId: `<id>`, testScriptId: `<id>`]: (failure reason)
 
 **Skipped:** (count, if any had no test scripts)
 - (test case name): no test script available
+
+**Metadata:**
+- projectId: `<projectId>`
 
 **Overall:** ALL PASSED | FAILURES DETECTED | PARTIAL (some skipped)


### PR DESCRIPTION
## Goal
Enhance the muggle-do skill's PR descriptions to include QA test case results with ending screenshots and clickable links to test script details on www.muggle-ai.com.

## Acceptance Criteria
- PR descriptions include a QA section listing every test case that ran, with pass/fail status
- Each test case entry includes a clickable link to its test script details page on muggle-ai.com
- Each test case entry shows the ending screenshot if available (embedded image or link)
- The QA agent output captures testCaseId, testScriptId, and projectId for each test run

## Changes
- `.claude/skills/muggle-do/qa.md`: Step 4 now instructs the QA agent to capture `testCaseId`, `testScriptId`, `workflowRuntimeId`, and any screenshot URL from each replay run. Output format updated to include these IDs per test case plus `projectId` metadata.
- `.claude/skills/muggle-do/open-prs.md`: QA Results section now renders a markdown table with each test case linked to `https://www.muggle-ai.com/muggleTestV0/dashboard/projects/{projectId}/scripts?modal=details&testCaseId={testCaseId}`. Ending screenshots are embedded when a public (non-GCS) URL is available; GCS URIs are noted as "available on muggle-ai.com".

## QA Results

**Skipped — no applicable test cases**

| Test Case | Status | Details |
|-----------|--------|---------|
| (skill file changes only) | ⏭️ SKIPPED | No QA test cases cover prompt/instruction file changes |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)