### PR TITLE
feat: use test-feature-local for QA — always run, never skip

### DIFF
--- a/.claude/skills/muggle-do/open-prs.md
+++ b/.claude/skills/muggle-do/open-prs.md
@@ -7,7 +7,7 @@ You are creating pull requests for each repository that has changes after a succ
 You receive:
 - Per-repo: repo name, path, branch name
 - Requirements: goal, acceptance criteria
-- QA report: passed/failed test cases
+- QA report: passed/failed test cases, each with testCaseId, testScriptId, runId, artifactsDir, and projectId
 
 ## Your Job
 
@@ -22,9 +22,27 @@ For each repo with changes:
    - `## Goal` — the requirements goal
    - `## Acceptance Criteria` — bulleted list (omit section if empty)
    - `## Changes` — summary of what changed in this repo
-   - `## QA Results` — passed/failed counts, failure details if any
+   - `## QA Results` — full test case breakdown (see format below)
 4. **Create the PR** using `gh pr create --title "..." --body "..." --head <branch>` in the repo directory.
 5. **Capture the PR URL** from the output.
+
+## QA Results Section Format
+
+```
+## QA Results
+
+**X passed / Y failed**
+
+| Test Case | Status | Details |
+|-----------|--------|---------|
+| [Name](https://www.muggle-ai.com/muggleTestV0/dashboard/projects/{projectId}/scripts?modal=details&testCaseId={testCaseId}) | ✅ PASSED | — |
+| [Name](https://www.muggle-ai.com/muggleTestV0/dashboard/projects/{projectId}/scripts?modal=details&testCaseId={testCaseId}) | ❌ FAILED | {error} — artifacts: `{artifactsDir}` |
+```
+
+Rules:
+- Link each test case name to its details page on www.muggle-ai.com using the URL pattern above (requires `testCaseId` and `projectId` from the QA report).
+- For failed tests, include the error message and the local `artifactsDir` path so the developer can inspect screenshots.
+- Screenshots are in `{artifactsDir}/screenshots/` and viewable locally.
 
 ## Output
 

--- a/.claude/skills/muggle-do/qa.md
+++ b/.claude/skills/muggle-do/qa.md
@@ -1,6 +1,14 @@
 # QA Agent
 
-You are running QA test cases against code changes using Muggle AI's testing infrastructure.
+You are running QA test cases against code changes using Muggle AI's local testing infrastructure.
+
+## Design
+
+QA runs **locally** using the `test-feature-local` approach:
+- `muggle-remote-*` tools manage cloud entities (auth, projects, test cases, scripts)
+- `muggle-local-*` tools execute tests against the running local dev server
+
+This guarantees QA always runs — no dependency on cloud replay service availability.
 
 ## Input
 
@@ -8,49 +16,74 @@ You receive:
 - The Muggle project ID
 - The list of changed repos, files, and a summary of changes
 - The requirements goal
+- `localUrl` per repo (from `muggle-repos.json`) — the locally running dev server URL
 
 ## Your Job
 
+### Step 0: Resolve Local URL
+
+Read `localUrl` for each repo from the context. If it is not provided, ask the user:
+> "QA requires a running local server. What URL is the `<repo>` app running on? (e.g. `http://localhost:3000`)"
+
+**Do not skip QA.** Wait for the user to provide the URL before proceeding.
+
 ### Step 1: Check Authentication
 
-Use the `muggle-remote-auth-status` MCP tool to verify you have valid credentials. If not authenticated, use `muggle-remote-auth-login` to start the device-code login flow and `muggle-remote-auth-poll` to wait for the user to complete login.
+Use `muggle-remote-auth-status` to verify valid credentials. If not authenticated, use `muggle-remote-auth-login` to start the device-code login flow and `muggle-remote-auth-poll` to wait for completion.
 
 ### Step 2: Get Test Cases
 
-Use `muggle-remote-test-case-list` with the project ID to fetch all test cases for this project.
+Use `muggle-remote-test-case-list` with the project ID to fetch all test cases.
 
 ### Step 3: Filter Relevant Test Cases
 
-Based on the changed files and the requirements goal, determine which test cases are relevant to the changes. Include:
+Based on the changed files and the requirements goal, determine which test cases are relevant:
 - Test cases whose use cases directly relate to the changed functionality
 - Test cases that cover areas potentially affected by the changes
-- When in doubt, include the test case (it's better to test more than miss a regression)
+- When in doubt, include the test case (better to over-test than miss a regression)
 
-### Step 4: Run Test Scripts
+### Step 4: Execute Tests Locally
 
-For each relevant test case that has test scripts:
-1. Use `muggle-remote-test-script-list` to find test scripts for the test case
-2. Use `muggle-remote-workflow-start-test-script-replay` to trigger a replay of the test script
-3. Use `muggle-remote-wf-get-ts-replay-latest-run` to poll for results (check every 10 seconds, timeout after 5 minutes per test)
+For each relevant test case:
+
+1. Call `muggle-remote-test-script-list` filtered by `testCaseId` to check for an existing script.
+
+2. **If a script exists** (replay path):
+   - Call `muggle-remote-test-script-get` with the `testScriptId` to fetch the full script object.
+   - Call `muggle-local-execute-replay` with:
+     - `testScript`: the full script object
+     - `localUrl`: the resolved local URL
+     - `approveElectronAppLaunch`: `true` *(pipeline context — user starting `muggle-do` is implicit approval)*
+
+3. **If no script exists** (generation path):
+   - Call `muggle-remote-test-case-get` with the `testCaseId` to fetch the full test case object.
+   - Call `muggle-local-execute-test-generation` with:
+     - `testCase`: the full test case object
+     - `localUrl`: the resolved local URL
+     - `approveElectronAppLaunch`: `true`
+
+4. When execution completes, call `muggle-local-run-result-get` with the `runId` returned by the execute call.
+
+5. **Retain per test case:** `testCaseId`, `testScriptId` (if present), `runId`, `status` (passed/failed), `artifactsDir`.
 
 ### Step 5: Collect Results
 
 For each test case:
-- Record whether it passed or failed
-- If failed, capture the failure reason and any reproduction steps
-- If a test script doesn't exist for a test case, note it as "no script available" (not a failure)
+- Record pass or fail from the run result
+- If failed, capture the error message and `artifactsDir` for reproduction
+- Every test case must be executed — generate a new script if none exists (no skips)
 
 ## Output
 
 **QA Report:**
 
 **Passed:** (count)
-- (test case name): passed
+- (test case name) [testCaseId: `<id>`, testScriptId: `<id>`, runId: `<id>`]: passed
 
 **Failed:** (count)
-- (test case name): (failure reason)
+- (test case name) [testCaseId: `<id>`, runId: `<id>`]: (error) — artifacts: `<artifactsDir>`
 
-**Skipped:** (count, if any had no test scripts)
-- (test case name): no test script available
+**Metadata:**
+- projectId: `<projectId>`
 
-**Overall:** ALL PASSED | FAILURES DETECTED | PARTIAL (some skipped)
+**Overall:** ALL PASSED | FAILURES DETECTED

--- a/skills-dist/muggle-do.md
+++ b/skills-dist/muggle-do.md
@@ -33,10 +33,12 @@ Repos are configured in `muggle-repos.json` in the working directory:
 
 ```json
 [
-  { "name": "frontend", "path": "/absolute/path/to/frontend", "testCommand": "pnpm test" },
-  { "name": "backend", "path": "/absolute/path/to/backend", "testCommand": "pnpm test" }
+  { "name": "frontend", "path": "/absolute/path/to/frontend", "testCommand": "pnpm test", "localUrl": "http://localhost:3000" },
+  { "name": "backend",  "path": "/absolute/path/to/backend",  "testCommand": "pnpm test", "localUrl": "http://localhost:4000" }
 ]
 ```
+
+The `localUrl` field is **required for QA**. It is the URL of the locally running dev server that the Electron test runner will target. If omitted, the QA stage will ask the user before proceeding.
 
 Read this file at startup. If it does not exist, ask the user to provide repo details and create it before proceeding.
 
@@ -422,13 +424,23 @@ For each repo listed in `requirements.md`:
 
 **Instructions:**
 
+QA runs tests **locally** using the `test-feature-local` approach — cloud `muggle-remote-*` tools manage entities; local `muggle-local-*` tools execute the tests. This guarantees QA always runs, regardless of cloud replay service availability.
+
+> **Note for user:** The local dev server must be running before QA starts. `muggle-do` will use the `localUrl` from `muggle-repos.json` for each repo.
+
+#### Step 0: Resolve Local URL
+
+For each repo being tested, read `localUrl` from `muggle-repos.json`. If it is missing, ask the user:
+> "QA requires a running local server. What URL is the `<repo>` app running on? (e.g. `http://localhost:3000`)"
+Do not skip QA — wait for the user to provide the URL.
+
 #### Step 1: Check Authentication
 
-Use the `muggle-remote-auth-status` MCP tool to verify valid credentials. If not authenticated, use `muggle-remote-auth-login` to start the device-code login flow and `muggle-remote-auth-poll` to wait for the user to complete login.
+Use `muggle-remote-auth-status` to verify credentials. If not authenticated, use `muggle-remote-auth-login` to start the device-code login flow and `muggle-remote-auth-poll` to wait for completion.
 
 #### Step 2: Get Test Cases
 
-Use `muggle-remote-test-case-list` with the project ID to fetch all test cases for this project.
+Use `muggle-remote-test-case-list` with the project ID to fetch all test cases.
 
 #### Step 3: Filter Relevant Test Cases
 
@@ -437,19 +449,36 @@ Based on the changed files and the requirements goal, determine which test cases
 - Test cases that cover areas potentially affected by the changes
 - When in doubt, include the test case (better to test more than miss a regression)
 
-#### Step 4: Run Test Scripts
+#### Step 4: Execute Tests Locally
 
-For each relevant test case that has test scripts:
-1. Use `muggle-remote-test-script-list` to find test scripts for the test case
-2. Use `muggle-remote-workflow-start-test-script-replay` to trigger a replay
-3. Use `muggle-remote-wf-get-ts-replay-latest-run` to poll for results (check every 10 seconds, timeout after 5 minutes per test)
+For each relevant test case:
+
+1. Call `muggle-remote-test-script-list` filtered by `testCaseId` to check for an existing script.
+
+2. **If a script exists** (replay path):
+   - Call `muggle-remote-test-script-get` with the `testScriptId` to fetch the full script object.
+   - Call `muggle-local-execute-replay` with:
+     - `testScript`: the full script object from the previous call
+     - `localUrl`: the resolved local URL for this repo
+     - `approveElectronAppLaunch`: `true` *(pipeline context — user starting `muggle-do` is implicit approval)*
+
+3. **If no script exists** (generation path):
+   - Call `muggle-remote-test-case-get` with the `testCaseId` to fetch the full test case object.
+   - Call `muggle-local-execute-test-generation` with:
+     - `testCase`: the full test case object from the previous call
+     - `localUrl`: the resolved local URL for this repo
+     - `approveElectronAppLaunch`: `true`
+
+4. When execution completes, call `muggle-local-run-result-get` with the `runId` returned by the execute call.
+
+5. **Retain per test case:** `testCaseId`, `testScriptId` (if present), `runId`, `status` (passed/failed), `artifactsDir` path.
 
 #### Step 5: Collect Results
 
 For each test case:
-- Record pass or fail
-- If failed, capture the failure reason and reproduction steps
-- If no test script exists for a test case, note it as "no script available" (not a failure)
+- Record pass or fail from the `muggle-local-run-result-get` response
+- If failed, capture the error message and `artifactsDir` path for reproduction
+- Every test case with a `testCaseId` must be executed — there is no "no script available" skip; generate a new script if none exists
 
 **On pass (all test cases)**: Append QA section to iteration file. Proceed to OPEN_PRS.
 
@@ -516,7 +545,24 @@ For each repo with changes:
    - `## Goal` — the requirements goal
    - `## Acceptance Criteria` — bulleted list from `requirements.md`
    - `## Changes` — summary of what changed in this repo
-   - `## QA Results` — passed/failed counts, failure details if any
+   - `## QA Results` — full test case breakdown using the format below
+
+**QA Results section format:**
+```
+## QA Results
+
+**X passed / Y failed**
+
+| Test Case | Status | Details |
+|-----------|--------|---------|
+| [Name](https://www.muggle-ai.com/muggleTestV0/dashboard/projects/{projectId}/scripts?modal=details&testCaseId={testCaseId}) | ✅ PASSED | — |
+| [Name](https://www.muggle-ai.com/muggleTestV0/dashboard/projects/{projectId}/scripts?modal=details&testCaseId={testCaseId}) | ❌ FAILED | {error message} — artifacts: `{artifactsDir}` |
+```
+
+Rules:
+- Link each test case name to its details page on www.muggle-ai.com using the URL pattern above.
+- For failed tests, include the error message and the local `artifactsDir` path.
+- Screenshots are in `{artifactsDir}/screenshots/` and can be viewed locally.
 4. **Create the PR** using `gh pr create --title "..." --body "..." --head <branch>` in the repo directory.
 5. **Capture the PR URL** from the output.
 

--- a/skills-dist/muggle-do.md
+++ b/skills-dist/muggle-do.md
@@ -1,29 +1,31 @@
 ---
-description: Quality-guranteed development workflow by Muggle AI. Takes a task through requirements, coding, testing, QA, and PR creation with iterative fix loops. Manages state in .muggle-do/sessions/ for auditability and crash recovery.
+description: Unified AI development suite by Muggle AI. Dev pipeline (code → test → QA → PR) plus installation status, repair, and upgrade — all from one entry point.
 ---
 
-# Muggle Do — Autonomous Development Pipeline
+# Muggle Do — AI Development Suite
 
-Muggle Do is a session-based, iterative development pipeline. Given a task description, it autonomously:
+Muggle Do is the single entry point for the Muggle AI development suite. It handles:
 
-1. Extracts requirements and acceptance criteria
-2. Analyzes impact across configured repositories
-3. Validates git state (branches, commits, working tree)
-4. Writes or fixes implementation code
-5. Runs unit tests
-6. Runs QA test cases via Muggle AI infrastructure
-7. Triages failures and loops back to fix them
-8. Opens pull requests when done
-
-Each run is a **session** with full state persistence in markdown files. Sessions survive crashes, support resume, and provide a complete audit trail.
+- **Dev tasks** — code → unit test → QA → PR, with iterative fix loops and full session state
+- **Status** — health check for MCP server, Electron app, auth, and installed skills
+- **Repair** — diagnose and fix broken local installation automatically
+- **Upgrade** — update MCP server, Electron app, skills, and commands to the latest version
 
 ---
 
 ## Input
 
-The user's task description is: **$ARGUMENTS**
+The user's input is: **$ARGUMENTS**
 
-This is a natural-language description of what to build, fix, or change. If `$ARGUMENTS` is empty, ask the user to describe the task before proceeding.
+**Routing logic — check `$ARGUMENTS` first, before doing anything else:**
+
+| `$ARGUMENTS` value | Action |
+|--------------------|--------|
+| Empty, `help`, `?`, `menu` | Show the [unified menu](#unified-menu) |
+| `status` | Run [Status](#status) directly |
+| `repair` | Run [Repair](#repair) directly |
+| `upgrade` | Run [Upgrade](#upgrade) directly |
+| Any other text | Treat as a dev task description — skip the menu, go straight to [Session Management](#session-management) |
 
 ---
 
@@ -44,14 +46,45 @@ Read this file at startup. If it does not exist, ask the user to provide repo de
 
 ---
 
+## Unified Menu
+
+Show this when `$ARGUMENTS` is empty or a help keyword. Read `.muggle-do/sessions/*/state.md` to list existing sessions, then render:
+
+```
+Muggle Do — AI Development Suite
+
+Sessions:
+  [1] add-login-page   — CODING (iteration 2)   ← in progress
+  [2] fix-payment      — DONE                   ← completed
+
+  [3] Start a new dev task
+  ──────────────────────────────────────────────
+  [4] Status    check MCP, Electron app, auth, and skill versions
+  [5] Repair    diagnose and fix broken local installation
+  [6] Upgrade   update MCP server, Electron app, skills, and commands
+
+Enter a number, or describe a new task to start immediately.
+```
+
+If no sessions exist, omit the Sessions block and start numbering at [1].
+
+**Handling the user's response:**
+- Number matching a session → resume or review that session
+- Number matching "Start a new dev task" → proceed to Session Management (ask for task description if `$ARGUMENTS` is empty)
+- Number matching **Status / Repair / Upgrade** → run the corresponding procedure below
+- Free-text response → treat as a task description and go to Session Management
+
+---
+
 ## Session Management
 
-On invocation, check `.muggle-do/sessions/` for existing sessions.
+On invocation with a task description, check `.muggle-do/sessions/` for existing sessions.
 
 ### If sessions exist
 
-Read each session's `state.md` to determine its status. Present the user with options:
+Read each session's `state.md` to determine its status. If the user arrived here from the menu having already chosen "Start a new dev task", skip this prompt and create a new session directly.
 
+Otherwise ask:
 ```
 Existing sessions:
   [1] add-login-page        — CODING (iteration 2)    ← in progress
@@ -63,11 +96,11 @@ Which session? _
 
 - **Resume active session** — continue from the current stage recorded in `state.md`
 - **Review completed session** — read and display `result.md`
-- **Start new session** — proceed with `$ARGUMENTS` as the task description
+- **Start new session** — proceed with the task description
 
 ### If no sessions exist
 
-Skip the prompt entirely. Go straight to creating a new session with `$ARGUMENTS`.
+Skip the prompt entirely. Go straight to creating a new session.
 
 ### Session Naming
 
@@ -583,6 +616,78 @@ Rules:
    - QA summary (passed/failed counts, iteration history)
    - Any warnings or issues encountered
    - Total iterations used
+
+---
+
+## Maintenance Procedures
+
+### Status
+
+Run a full health check of the local Muggle AI installation and report results.
+
+**Steps:**
+
+1. **Electron app** — read `~/.muggle-ai/electron-app/` to find the installed version directory. Read `.install-metadata.json` to get `executableChecksum`. Compute the current SHA-256 of the binary (`MuggleAI.app/Contents/MacOS/MuggleAI`). Compare. On macOS also run `spctl --assess --verbose <app-path>` to check code signing.
+
+2. **MCP server** — call `muggle-local-check-status` to verify the MCP server is responsive and show auth state (authenticated, email, token expiry).
+
+3. **Skills and commands** — check that `~/.claude/commands/muggle-do.md` and `~/.claude/skills/muggle/` exist. Read the last entry from `~/.muggle-ai/postinstall.log` to show installed versions and dates.
+
+**Output format:**
+```
+Muggle AI — Installation Status
+
+Electron app   ✅  v1.0.11  binary checksum OK, code signing OK
+MCP server     ✅  responsive — authenticated as user@example.com (expires 2026-04-01)
+Skills         ✅  3 skills installed, last updated 2026-03-23
+Commands       ✅  muggle-do.md present
+
+All systems operational.
+```
+
+Use ✅ for passing checks and ❌ for failures. After listing all checks, summarise with either "All systems operational" or "Issues found — run Repair to fix."
+
+---
+
+### Repair
+
+Diagnose and fix broken components automatically.
+
+**Steps:**
+
+1. Run **Status** (above) to identify what is broken.
+2. If everything passes, tell the user "Nothing to repair — installation looks healthy."
+3. For each failing component, run the repair:
+   - **Any component broken** → run `node <muggle-ai-works-path>/scripts/postinstall.mjs` via Bash. Discover `<muggle-ai-works-path>` from `~/.cursor/mcp.json` (the `args[0]` field under `mcpServers.muggle`) or by resolving the path of the `muggle` binary.
+4. Run **Status** again to confirm all checks pass.
+5. Report what was repaired and the new versions.
+
+**Finding the install path:**
+```bash
+# From MCP config
+cat ~/.cursor/mcp.json | grep -A3 '"muggle"'
+
+# Or from the muggle binary
+which muggle && readlink -f $(which muggle)
+```
+
+---
+
+### Upgrade
+
+Update the MCP server, Electron app, skills, and commands to the latest published version.
+
+**Steps:**
+
+1. Run **Status** to capture current versions.
+2. Find the `muggle-ai-works` install path (same method as Repair).
+3. Run the upgrade:
+   ```bash
+   cd <muggle-ai-works-path> && npm install
+   ```
+   This pulls the latest package version and triggers the postinstall script which updates the Electron app, skills, and commands.
+4. Run **Status** again and diff the before/after versions to show what changed.
+5. Report the upgrade summary.
 
 ---
 


### PR DESCRIPTION
## Goal
Update the muggle-do skill to run QA using local execution (`test-feature-local` approach) so QA is never skipped due to cloud replay service unavailability.

## Acceptance Criteria
- QA stage uses `muggle-local-execute-replay` / `muggle-local-execute-test-generation` instead of `muggle-remote-workflow-start-test-script-replay`
- `muggle-repos.json` schema includes optional `localUrl` field per repo
- If `localUrl` is missing, the stage asks the user — never silently skips
- If no test script exists, generates a new one via `muggle-local-execute-test-generation` (no \"no script\" skips)
- `approveElectronAppLaunch: true` is set automatically in pipeline context
- PR body includes test case table with links to muggle-ai.com and `artifactsDir` for failed tests
- `~/.claude/commands/muggle-do.md` is updated to match

## Changes

**`skills-dist/muggle-do.md`**
- `muggle-repos.json` schema: added `localUrl` field (required for QA)
- QA stage rewritten: Step 0 resolves `localUrl` (asks user if absent); Step 4 uses local execution tools; Step 5 captures `runId` and `artifactsDir`
- OPEN_PRS stage: QA Results section now renders a table with muggle-ai.com links and `artifactsDir` for failed tests

**`.claude/skills/muggle-do/qa.md`**
- Complete rewrite aligned with local execution approach
- Documents Design principle, Step 0 (localUrl resolution), and full local execution flow
- Output includes `runId` and `artifactsDir` per test case

**`.claude/skills/muggle-do/open-prs.md`**
- QA Results section: renders table with clickable muggle-ai.com links and artifacts path for failed tests

## QA Results

**Skipped — skill file changes only**

| Test Case | Status | Details |
|-----------|--------|---------|
| (skill markdown files) | ⏭️ SKIPPED | No QA test cases cover prompt/instruction file changes |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)