### PR TITLE
fix: exclude .worktrees from vitest test discovery

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     passWithNoTests: true,
-    exclude: ['packages/**', 'apps/**', 'node_modules/**'],
+    exclude: ['packages/**', 'apps/**', 'node_modules/**', '.worktrees/**'],
   },
 });


### PR DESCRIPTION
## Summary
- Add `.worktrees/**` to vitest exclude list to prevent picking up third-party test files from git worktree checkouts
- Fixes 54 spurious test failures caused by test files in `.worktrees/autonomous-dev-cycle/node_modules/`

## Test plan
- [x] `npx vitest run` exits clean with no failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)