### PR TITLE
chore: plugin publish readiness

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,14 +1,15 @@
 {
   "name": "muggle-plugins",
   "owner": {
-    "name": "Muggle AI"
+    "name": "Muggle AI",
+    "email": "support@muggle-ai.com"
   },
   "plugins": [
     {
       "name": "muggle",
       "source": "./plugin",
-      "description": "Muggle AI QA and autonomous dev workflow plugin.",
-      "version": "2.0.2"
+      "description": "AI-powered QA testing and autonomous dev pipeline. Test your web app with a real browser, generate test cases from English, and run a full code-to-PR cycle.",
+      "version": "3.0.0"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@muggleai/works",
-    "version": "2.0.2",
+    "version": "3.0.0",
     "description": "Deliver quality web products with an AI agent team. Autonomous pipeline that codes, tests, and QA-validates your app — from Claude Code and Cursor to PR.",
     "type": "module",
     "main": "dist/index.js",
@@ -18,6 +18,7 @@
         "build": "tsup && node scripts/build-plugin.mjs",
         "build:plugin": "node scripts/build-plugin.mjs",
         "build:release": "npm run build",
+        "verify:plugin": "node scripts/verify-plugin-marketplace.mjs",
         "build:workspace": "turbo run build",
         "typecheck:workspace": "turbo run typecheck",
         "lint:workspace": "turbo run lint",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,8 +1,20 @@
 {
   "name": "muggle",
-  "description": "Muggle AI QA and autonomous dev workflow plugin.",
-  "version": "2.0.2",
+  "description": "AI-powered QA testing and autonomous dev pipeline. Test your web app with a real browser, generate test cases from English, and run a full code-to-PR cycle.",
+  "version": "3.0.0",
   "author": {
-    "name": "Muggle AI"
-  }
+    "name": "Muggle AI",
+    "email": "support@muggle-ai.com"
+  },
+  "homepage": "https://www.muggletest.com",
+  "repository": "https://github.com/multiplex-ai/muggle-ai-works",
+  "license": "MIT",
+  "keywords": [
+    "qa",
+    "testing",
+    "mcp",
+    "browser-automation",
+    "ai-coding",
+    "muggle-ai"
+  ]
 }

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,0 +1,53 @@
+# Muggle AI Plugin for Claude Code
+
+AI-powered QA testing and autonomous dev pipeline for Claude Code. Test your web app with a real browser, generate test cases from plain English, and run a full code-to-PR cycle.
+
+## Install
+
+```
+/plugin marketplace add https://github.com/multiplex-ai/muggle-ai-works
+/plugin install muggle@muggle-plugins
+```
+
+## Skills
+
+| Skill | What it does |
+|:---|:---|
+| `/muggle:muggle-do` | Autonomous dev pipeline: requirements, code, unit tests, QA, PR |
+| `/muggle:test-feature-local` | Test a feature on localhost with AI-driven browser automation |
+| `/muggle:publish-test-to-cloud` | Publish local test runs to Muggle AI cloud |
+
+## MCP Tools
+
+The plugin ships an MCP server with 70+ tools for project management, test case generation, browser automation, and reporting. The server starts automatically when the plugin is enabled.
+
+## Hooks
+
+A `SessionStart` hook ensures the Electron QA engine is downloaded and up to date.
+
+## Requirements
+
+- Claude Code 1.0.33 or later
+- Node.js 22+
+
+## Upgrade
+
+```
+/plugin update muggle@muggle-plugins
+```
+
+## Uninstall
+
+```
+/plugin uninstall muggle@muggle-plugins
+```
+
+## Links
+
+- [MuggleTest](https://www.muggletest.com)
+- [GitHub](https://github.com/multiplex-ai/muggle-ai-works)
+- [Migration guide](https://github.com/multiplex-ai/muggle-ai-works/blob/master/MIGRATION.md)
+
+## License
+
+MIT

--- a/scripts/verify-plugin-marketplace.mjs
+++ b/scripts/verify-plugin-marketplace.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "fs";
+import { dirname, join, resolve } from "path";
+import { fileURLToPath } from "url";
+
+const currentFilePath = fileURLToPath(import.meta.url);
+const scriptsDirectoryPath = dirname(currentFilePath);
+const repositoryRootPath = join(scriptsDirectoryPath, "..");
+
+const packageJsonPath = join(repositoryRootPath, "package.json");
+const marketplaceJsonPath = join(repositoryRootPath, ".claude-plugin", "marketplace.json");
+const pluginManifestPath = join(repositoryRootPath, "plugin", ".claude-plugin", "plugin.json");
+const builtPluginManifestPath = join(repositoryRootPath, "dist", "plugin", ".claude-plugin", "plugin.json");
+
+verifyPluginMarketplace();
+
+/**
+ * Verify plugin metadata and marketplace catalog consistency.
+ * @returns {void}
+ */
+function verifyPluginMarketplace() {
+    const packageJson = readJsonFile(packageJsonPath);
+    const marketplaceJson = readJsonFile(marketplaceJsonPath);
+    const pluginManifest = readJsonFile(pluginManifestPath);
+    const builtPluginManifest = readJsonFile(builtPluginManifestPath);
+
+    assertValue({
+        condition: marketplaceJson.name === "muggle-plugins",
+        message: "Marketplace name must be muggle-plugins.",
+    });
+
+    assertValue({
+        condition: Array.isArray(marketplaceJson.plugins) && marketplaceJson.plugins.length === 1,
+        message: "Marketplace must declare exactly one plugin entry.",
+    });
+
+    const [marketplacePlugin] = marketplaceJson.plugins;
+
+    assertValue({
+        condition: marketplacePlugin.name === pluginManifest.name,
+        message: "Marketplace plugin name must match plugin manifest name.",
+    });
+
+    assertValue({
+        condition: marketplacePlugin.version === packageJson.version,
+        message: "Marketplace plugin version must match package.json version.",
+    });
+
+    assertValue({
+        condition: pluginManifest.version === packageJson.version,
+        message: "Plugin manifest version must match package.json version.",
+    });
+
+    assertValue({
+        condition: builtPluginManifest.version === packageJson.version,
+        message: "Built plugin manifest version must match package.json version.",
+    });
+
+    assertValue({
+        condition: typeof marketplacePlugin.source === "string" && marketplacePlugin.source.length > 0,
+        message: "Marketplace plugin source must be a non-empty string.",
+    });
+
+    const marketplacePluginSourcePath = resolve(repositoryRootPath, marketplacePlugin.source);
+
+    assertValue({
+        condition: existsSync(marketplacePluginSourcePath),
+        message: `Marketplace plugin source path does not exist: ${marketplacePluginSourcePath}`,
+    });
+
+    console.log("Plugin marketplace verification passed.");
+}
+
+/**
+ * Read a JSON file from disk.
+ * @param {string} pathToFile
+ * @returns {Record<string, unknown>}
+ */
+function readJsonFile(pathToFile) {
+    const fileContent = readFileSync(pathToFile, "utf-8");
+    return JSON.parse(fileContent);
+}
+
+/**
+ * Assert a verification condition.
+ * @param {{ condition: boolean, message: string }} params
+ * @returns {void}
+ */
+function assertValue({ condition, message }) {
+    if (!condition) {
+        throw new Error(message);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `plugin/README.md` with installation, usage, upgrade, and uninstall instructions
- Enrich `plugin/.claude-plugin/plugin.json` with homepage, repository, license, keywords for official marketplace submission
- Fix version to 3.0.0 across package.json, plugin manifest, and marketplace catalog
- Restore `scripts/verify-plugin-marketplace.mjs` and `verify:plugin` script lost in squash merge

## Test plan

- [x] `pnpm run build` passes
- [x] `pnpm run verify:plugin` passes
- [x] `claude plugin validate ./plugin` passes
- [x] `claude plugin validate ./dist/plugin` passes


Made with [Cursor](https://cursor.com)