### PR TITLE
Improve showUi approval flow and add Zod v4 JSON schema support

### DIFF
--- a/packages/mcps/src/mcp/local/contracts/project-schemas.ts
+++ b/packages/mcps/src/mcp/local/contracts/project-schemas.ts
@@ -90,8 +90,8 @@ export const ExecuteTestGenerationInputSchema = z.object({
   approveElectronAppLaunch: z.boolean().describe("Set to true after the user explicitly approves launching electron-app"),
   /** Optional timeout. */
   timeoutMs: z.number().int().positive().optional().describe("Timeout in milliseconds (default: 300000 = 5 min)"),
-  /** Show the electron-app UI during execution. */
-  showUi: z.boolean().optional().describe("Show the electron-app UI during execution (default: false, runs headless)"),
+  /** Show the electron-app UI during execution. Ask the user before approving; true = visible window, false or omit = headless. */
+  showUi: z.boolean().optional().describe("Show the electron-app UI during generation. Ask the user: true to watch the window, false or omit for headless."),
 });
 
 export type ExecuteTestGenerationInput = z.infer<typeof ExecuteTestGenerationInputSchema>;
@@ -111,8 +111,8 @@ export const ExecuteReplayInputSchema = z.object({
   approveElectronAppLaunch: z.boolean().describe("Set to true after the user explicitly approves launching electron-app"),
   /** Optional timeout. */
   timeoutMs: z.number().int().positive().optional().describe("Timeout in milliseconds (default: 180000 = 3 min)"),
-  /** Show the electron-app UI during execution. */
-  showUi: z.boolean().optional().describe("Show the electron-app UI during execution (default: false, runs headless)"),
+  /** Show the electron-app UI during execution. Ask the user before approving; true = visible window, false or omit = headless. */
+  showUi: z.boolean().optional().describe("Show the electron-app UI during replay. Ask the user: true to watch the window, false or omit for headless."),
 });
 
 export type ExecuteReplayInput = z.infer<typeof ExecuteReplayInputSchema>;

--- a/packages/mcps/src/mcp/tools/local/tool-registry.ts
+++ b/packages/mcps/src/mcp/tools/local/tool-registry.ts
@@ -304,7 +304,7 @@ const testScriptGetTool: ILocalMcpTool = {
 
 const executeTestGenerationTool: ILocalMcpTool = {
   name: "muggle-local-execute-test-generation",
-  description: "Generate a QA test script by launching a real browser against your web app. The browser navigates your app, executes the test case steps (like signing up, filling forms, clicking through flows), and produces a replayable test script with screenshots. Use this to create new browser tests for any user flow. Requires a test case (from muggle-remote-test-case-get) and a localhost URL. Launches an Electron browser — requires explicit approval via approveElectronAppLaunch. Runs headless by default; set showUi: true to watch.",
+  description: "Generate a QA test script by launching a real browser against your web app. The browser navigates your app, executes the test case steps (like signing up, filling forms, clicking through flows), and produces a replayable test script with screenshots. Use this to create new browser tests for any user flow. Requires a test case (from muggle-remote-test-case-get) and a localhost URL. Launches an Electron browser — requires explicit approval via approveElectronAppLaunch. Before approving, ask the user whether they want a visible GUI; pass showUi: true to watch the window or showUi: false for headless (default when omitted).",
   inputSchema: ExecuteTestGenerationInputSchema,
   execute: async (ctx) => {
     const logger = createChildLogger(ctx.correlationId);
@@ -313,7 +313,8 @@ const executeTestGenerationTool: ILocalMcpTool = {
     const input = ExecuteTestGenerationInputSchema.parse(ctx.input);
 
     if (!input.approveElectronAppLaunch) {
-      const uiMode = input.showUi ? "with visible UI" : "headless (no UI)";
+      const showUiExplicit = input.showUi !== undefined;
+      const uiMode = input.showUi === true ? "visible GUI (showUi: true)" : "headless (showUi: false or omitted)";
       return {
         content: [
           "## Electron App Launch Required",
@@ -321,23 +322,32 @@ const executeTestGenerationTool: ILocalMcpTool = {
           "This tool will launch the electron-app to generate a test script.",
           "Please set `approveElectronAppLaunch: true` to proceed.",
           "",
+          "**Visible GUI:** Ask the user whether they want to watch the Electron window during generation.",
+          "- If **yes** → when approving, pass `showUi: true`.",
+          "- If **no** → when approving, pass `showUi: false` (or omit `showUi`; generation runs headless).",
+          "",
+          showUiExplicit
+            ? `**Current choice:** ${uiMode}`
+            : "**Current choice:** not set — default on approval is headless unless you pass `showUi: true`.",
+          "",
           `**Test Case:** ${input.testCase.title}`,
           `**Local URL:** ${input.localUrl}`,
-          `**UI Mode:** ${uiMode}`,
           "",
-          "**Note:** The electron-app will open a browser window and navigate to your test URL.",
+          "**Note:** The electron-app will navigate your test URL and record steps.",
         ].join("\n"),
         isError: false,
         data: { requiresApproval: true },
       };
     }
 
+    const showUi = input.showUi === true;
+
     try {
       const result = await executeTestGeneration({
         testCase: input.testCase,
         localUrl: input.localUrl,
         timeoutMs: input.timeoutMs,
-        showUi: input.showUi,
+        showUi: showUi,
       });
 
       const content = [
@@ -347,6 +357,7 @@ const executeTestGenerationTool: ILocalMcpTool = {
         `**Test Script ID:** ${result.testScriptId}`,
         `**Status:** ${result.status}`,
         `**Duration:** ${result.executionTimeMs}ms`,
+        `**UI:** ${showUi ? "visible GUI" : "headless"}`,
         result.errorMessage ? `**Error:** ${result.errorMessage}` : "",
       ].filter(Boolean).join("\n");
 
@@ -365,7 +376,7 @@ const executeTestGenerationTool: ILocalMcpTool = {
 
 const executeReplayTool: ILocalMcpTool = {
   name: "muggle-local-execute-replay",
-  description: "Replay an existing QA test script in a real browser to verify your app still works correctly — use this for regression testing after code changes. The browser executes each saved step and captures screenshots so you can see what happened. Requires: (1) test script metadata from muggle-remote-test-script-get, (2) actionScript content from muggle-remote-action-script-get using the testScript.actionScriptId, and (3) a localhost URL. Launches an Electron browser — requires explicit approval via approveElectronAppLaunch. Runs headless by default; set showUi: true to watch.",
+  description: "Replay an existing QA test script in a real browser to verify your app still works correctly — use this for regression testing after code changes. The browser executes each saved step and captures screenshots so you can see what happened. Requires: (1) test script metadata from muggle-remote-test-script-get, (2) actionScript content from muggle-remote-action-script-get using the testScript.actionScriptId, and (3) a localhost URL. Launches an Electron browser — requires explicit approval via approveElectronAppLaunch. Before approving, ask the user whether they want a visible GUI; pass showUi: true to watch the window or showUi: false for headless (default when omitted).",
   inputSchema: ExecuteReplayInputSchema,
   execute: async (ctx) => {
     const logger = createChildLogger(ctx.correlationId);
@@ -374,7 +385,8 @@ const executeReplayTool: ILocalMcpTool = {
     const input = ExecuteReplayInputSchema.parse(ctx.input);
 
     if (!input.approveElectronAppLaunch) {
-      const uiMode = input.showUi ? "with visible UI" : "headless (no UI)";
+      const showUiExplicit = input.showUi !== undefined;
+      const uiMode = input.showUi === true ? "visible GUI (showUi: true)" : "headless (showUi: false or omitted)";
       return {
         content: [
           "## Electron App Launch Required",
@@ -382,17 +394,26 @@ const executeReplayTool: ILocalMcpTool = {
           "This tool will launch the electron-app to replay a test script.",
           "Please set `approveElectronAppLaunch: true` to proceed.",
           "",
+          "**Visible GUI:** Ask the user whether they want to watch the Electron window during replay.",
+          "- If **yes** → when approving, pass `showUi: true`.",
+          "- If **no** → when approving, pass `showUi: false` (or omit `showUi`; replay runs headless).",
+          "",
+          showUiExplicit
+            ? `**Current choice:** ${uiMode}`
+            : "**Current choice:** not set — default on approval is headless unless you pass `showUi: true`.",
+          "",
           `**Test Script:** ${input.testScript.name}`,
           `**Local URL:** ${input.localUrl}`,
           `**Steps:** ${input.actionScript.length}`,
-          `**UI Mode:** ${uiMode}`,
           "",
-          "**Note:** The electron-app will open a browser window and execute the test steps.",
+          "**Note:** The electron-app will execute the test steps against your local URL.",
         ].join("\n"),
         isError: false,
         data: { requiresApproval: true },
       };
     }
+
+    const showUi = input.showUi === true;
 
     try {
       const result = await executeReplay({
@@ -400,7 +421,7 @@ const executeReplayTool: ILocalMcpTool = {
         actionScript: input.actionScript,
         localUrl: input.localUrl,
         timeoutMs: input.timeoutMs,
-        showUi: input.showUi,
+        showUi: showUi,
       });
 
       const content = [
@@ -410,6 +431,7 @@ const executeReplayTool: ILocalMcpTool = {
         `**Test Script ID:** ${result.testScriptId}`,
         `**Status:** ${result.status}`,
         `**Duration:** ${result.executionTimeMs}ms`,
+        `**UI:** ${showUi ? "visible GUI" : "headless"}`,
         result.errorMessage ? `**Error:** ${result.errorMessage}` : "",
       ].filter(Boolean).join("\n");
 

--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -11,7 +11,7 @@ import {
   ReadResourceRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { v4 as uuidv4 } from "uuid";
-import { ZodError } from "zod";
+import { ZodError, z } from "zod";
 
 import {
   createChildLogger,
@@ -62,8 +62,17 @@ export function clearTools (): void {
  * @returns JSON Schema object.
  */
 function zodToJsonSchema (schema: unknown): object {
+  // Prefer native Zod v4 JSON schema conversion when available.
   try {
-    const zodSchema = schema as { _def?: { typeName?: string; }; };
+    if (schema && typeof schema === "object" && "safeParse" in (schema as Record<string, unknown>)) {
+      return z.toJSONSchema(schema as z.ZodType);
+    }
+  } catch {
+    // Fall through to legacy converter for compatibility.
+  }
+
+  try {
+    const zodSchema = schema as { _def?: { typeName?: string; type?: string; }; };
     if (zodSchema._def) {
       return convertZodDef(zodSchema);
     }
@@ -87,11 +96,13 @@ function convertZodDef (schema: unknown): object {
   const zodSchema = schema as {
     _def?: {
       typeName?: string;
-      shape?: () => Record<string, unknown>;
+      type?: string;
+      shape?: (() => Record<string, unknown>) | Record<string, unknown>;
       innerType?: unknown;
+      element?: unknown;
       checks?: Array<{ kind: string; value?: unknown; }>;
       description?: string;
-      values?: string[];
+      values?: string[] | Record<string, string>;
       options?: unknown[];
     };
     shape?: Record<string, unknown>;
@@ -103,11 +114,13 @@ function convertZodDef (schema: unknown): object {
   }
 
   const def = zodSchema._def;
-  const typeName = def.typeName;
+  const typeName = def.typeName ?? def.type;
 
   switch (typeName) {
-    case "ZodObject": {
-      const shape = def.shape ? def.shape() : zodSchema.shape || {};
+    case "ZodObject":
+    case "object": {
+      const shapeFromDef = typeof def.shape === "function" ? def.shape() : def.shape;
+      const shape = shapeFromDef || zodSchema.shape || {};
       const properties: Record<string, object> = {};
       const required: string[] = [];
 
@@ -129,7 +142,8 @@ function convertZodDef (schema: unknown): object {
       return result;
     }
 
-    case "ZodString": {
+    case "ZodString":
+    case "string": {
       const result: Record<string, unknown> = { type: "string" };
       if (def.description) result.description = def.description;
       if (def.checks) {
@@ -143,7 +157,8 @@ function convertZodDef (schema: unknown): object {
       return result;
     }
 
-    case "ZodNumber": {
+    case "ZodNumber":
+    case "number": {
       const result: Record<string, unknown> = { type: "number" };
       if (def.description) result.description = def.description;
       if (def.checks) {
@@ -156,31 +171,36 @@ function convertZodDef (schema: unknown): object {
       return result;
     }
 
-    case "ZodBoolean": {
+    case "ZodBoolean":
+    case "boolean": {
       const result: Record<string, unknown> = { type: "boolean" };
       if (def.description) result.description = def.description;
       return result;
     }
 
-    case "ZodArray": {
+    case "ZodArray":
+    case "array": {
       const result: Record<string, unknown> = {
         type: "array",
-        items: def.innerType ? convertZodDef(def.innerType) : {},
+        items: def.innerType ? convertZodDef(def.innerType) : def.element ? convertZodDef(def.element) : {},
       };
       if (def.description) result.description = def.description;
       return result;
     }
 
-    case "ZodEnum": {
+    case "ZodEnum":
+    case "enum": {
+      const enumValues = Array.isArray(def.values) ? def.values : def.values ? Object.values(def.values) : [];
       const result: Record<string, unknown> = {
         type: "string",
-        enum: def.values || [],
+        enum: enumValues,
       };
       if (def.description) result.description = def.description;
       return result;
     }
 
-    case "ZodOptional": {
+    case "ZodOptional":
+    case "optional": {
       const inner = def.innerType ? convertZodDef(def.innerType) : {};
       if (def.description) (inner as Record<string, unknown>).description = def.description;
       return inner;


### PR DESCRIPTION
## Summary
- **showUi prompt flow:** Updated test generation and replay tools to explicitly ask the user whether they want a visible GUI before approving the Electron launch, instead of silently defaulting to headless. Clearer descriptions and approval messages guide the agent to prompt the user.
- **Zod v4 JSON schema conversion:** `zodToJsonSchema` now tries native `z.toJSONSchema()` first (Zod v4), falling back to the legacy `_def`-walking converter. The legacy converter gained support for Zod v4 internal type names (`"object"`, `"string"`, `"number"`, `"boolean"`, `"array"`, `"enum"`, `"optional"`), function-or-object `shape`, `element` for arrays, and `Record`-style enum values.

## Test plan
- [ ] Verify MCP tool descriptions render correctly in Claude Code (`muggle-local-execute-test-generation`, `muggle-local-execute-replay`)
- [ ] Run test generation with `showUi: true` and `showUi: false` — confirm approval message reflects the choice
- [ ] Confirm Zod v4 schemas convert to valid JSON Schema via the MCP server
- [ ] Confirm legacy Zod v3-style schemas still convert correctly (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)