### PR TITLE
feat(works): compatibility contracts and electron release verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,8 +114,8 @@ jobs:
       - name: Build
         run: pnpm run build
 
-  # Verify all plugin manifests are consistent
-  verify-manifests:
+  # Verify plugin manifests and compatibility contracts
+  verify-compatibility:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -137,3 +137,6 @@ jobs:
 
       - name: Verify plugin manifests
         run: pnpm run verify:plugin
+
+      - name: Verify compatibility contracts
+        run: pnpm run verify:contracts

--- a/.github/workflows/publish-works.yml
+++ b/.github/workflows/publish-works.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Build
         run: pnpm run build
 
+      - name: Verify electron release checksums
+        run: pnpm run verify:electron-release-checksums
+
   package-audit:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/upgrade-experience.yml
+++ b/.github/workflows/upgrade-experience.yml
@@ -1,0 +1,34 @@
+name: Upgrade Experience
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 9 * * 1"
+
+jobs:
+  verify-upgrade-experience:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Verify compatibility contracts
+        run: pnpm run verify:contracts
+
+      - name: Verify existing-user upgrade experience
+        run: pnpm run verify:upgrade-experience

--- a/README.md
+++ b/README.md
@@ -498,8 +498,11 @@ muggle-ai-works/
 ├── scripts/                 # Build and release
 │   ├── build-plugin.mjs     #   Assembles dist/plugin/ from plugin/ source
 │   ├── verify-plugin-marketplace.mjs  # Validates plugin/marketplace consistency
+│   ├── verify-compatibility-contracts.mjs # Validates long-term surface contracts
+│   ├── verify-upgrade-experience.mjs  # Validates in-place upgrade behavior
 │   └── postinstall.mjs      #   npm postinstall (Electron app download)
 │
+├── config/compatibility/     # Contract baselines (CLI/MCP/plugin/skills)
 ├── bin/                     # CLI entrypoint (muggle.js → dist/cli.js)
 ├── dist/                    # Build output (gitignored)
 ├── .claude-plugin/          # Marketplace catalog (marketplace.json)
@@ -513,6 +516,9 @@ pnpm install              # Install dependencies
 pnpm run build            # Build (tsup + plugin artifact)
 pnpm run build:plugin     # Rebuild plugin artifact only
 pnpm run verify:plugin    # Validate plugin/marketplace metadata consistency
+pnpm run verify:contracts # Validate compatibility contracts (CLI/MCP/plugin/skills)
+pnpm run verify:electron-release-checksums # Ensure checksums.txt exists for bundled electron release
+pnpm run verify:upgrade-experience # Validate existing-user cleanup + re-download flow
 pnpm run dev              # Dev mode (watch)
 pnpm test                 # Run tests
 pnpm run lint             # Lint (auto-fix)
@@ -525,8 +531,9 @@ CI/CD and publishing
 
 | Workflow            | Trigger             | Description                                                  |
 | ------------------- | ------------------- | ------------------------------------------------------------ |
-| `ci.yml`            | Push/PR to `master` | Lint, test, build, plugin verification on multiple platforms |
-| `publish-works.yml` | Tag `v*` or manual  | Verify, audit, smoke-install, publish to npm                 |
+| `ci.yml`            | Push/PR to `master` | Lint, test, build, plugin + compatibility contract verification on multiple platforms |
+| `upgrade-experience.yml` | Weekly + manual | Existing-user upgrade validation (cleanup + re-download + health checks) |
+| `publish-works.yml` | Tag `v*` or manual  | Verify (including release checksums), audit, smoke-install, publish to npm |
 
 
 ```bash

--- a/config/compatibility/contracts.json
+++ b/config/compatibility/contracts.json
@@ -1,0 +1,54 @@
+{
+  "cli": {
+    "packageName": "@muggleai/works",
+    "binaryName": "muggle",
+    "mcpName": "io.github.multiplex-ai/muggle",
+    "requiredCommands": [
+      "serve",
+      "setup",
+      "upgrade",
+      "cleanup",
+      "doctor",
+      "status"
+    ]
+  },
+  "server": {
+    "name": "io.github.multiplex-ai/muggle",
+    "packageIdentifier": "@muggleai/works"
+  },
+  "plugins": {
+    "requiredName": "muggle",
+    "requiredHookCommandContains": "ensure-electron-app.sh"
+  },
+  "skills": {
+    "requiredDirectories": [
+      "muggle",
+      "muggle-do",
+      "muggle-repair",
+      "muggle-status",
+      "muggle-test",
+      "muggle-test-feature-local",
+      "muggle-test-import",
+      "muggle-upgrade"
+    ]
+  },
+  "compatibilityPolicy": {
+    "allowedLegacyStatuses": [
+      "supported",
+      "aliased",
+      "removed-with-guidance"
+    ],
+    "legacyIdentifiers": [
+      {
+        "surface": "marketplace",
+        "identifier": "muggle-works",
+        "status": "supported"
+      },
+      {
+        "surface": "cli",
+        "identifier": "muggle",
+        "status": "supported"
+      }
+    ]
+  }
+}

--- a/docs/compatibility-strategy.md
+++ b/docs/compatibility-strategy.md
@@ -1,0 +1,58 @@
+# Compatibility Strategy
+
+This document defines the long-term verification strategy used by `muggle-ai-works` to keep user-facing behavior stable across rebrands and other high-impact changes.
+
+## Objectives
+
+- Keep critical public surfaces stable by default.
+- Detect contract drift in CI before release.
+- Validate both fresh install and existing-user upgrade paths.
+
+## Contract Baselines
+
+The baseline contract file is:
+
+- `config/compatibility/contracts.json`
+
+It captures required values for:
+
+- CLI identity and required commands
+- MCP server naming and package identifier
+- plugin name and session-start hook behavior
+- required skill directories
+- legacy identifier policy (`supported`, `aliased`, `removed-with-guidance`)
+
+## Verification Commands
+
+- `pnpm run verify:plugin` checks manifest and marketplace alignment.
+- `pnpm run verify:contracts` checks CLI/MCP/plugin/skill contracts.
+- `pnpm run verify:electron-release-checksums` checks that the bundled electron release publishes `checksums.txt` with valid SHA256 entries for all platform artifacts.
+- `pnpm run verify:upgrade-experience` validates in-place existing-user upgrade behavior:
+  - setup download,
+  - cleanup of stale versions,
+  - force upgrade redownload,
+  - post-upgrade doctor/status health.
+
+## Change Risk Tiers
+
+Use this model to decide which checks are mandatory.
+
+1. **Low risk (internal-only)**  
+   Required: lint, tests, build, `verify:plugin`, `verify:contracts`.
+
+2. **Medium risk (runtime behavior)**  
+   Required: low-risk checks plus upgrade experience validation.
+
+3. **High risk (public contract changes)**  
+   Required: medium-risk checks plus targeted manual client smoke checks on Claude and Cursor.
+
+## Automation
+
+- `ci.yml` runs build-time verification on every push/PR to `master`.
+- `upgrade-experience.yml` runs weekly and on manual dispatch to validate existing-user upgrade behavior over time.
+
+## Operational Rules
+
+- If a public identifier changes, update `contracts.json` in the same PR.
+- Any intentionally removed identifier should include migration guidance.
+- A release should not proceed if medium/high-risk checks fail.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
         "sync:versions": "node scripts/sync-versions.mjs",
         "build:release": "npm run build",
         "verify:plugin": "node scripts/verify-plugin-marketplace.mjs",
+        "verify:contracts": "node scripts/verify-compatibility-contracts.mjs",
+        "verify:electron-release-checksums": "node scripts/verify-electron-release-checksums.mjs",
+        "verify:upgrade-experience": "node scripts/verify-upgrade-experience.mjs",
         "build:workspace": "turbo run build",
         "typecheck:workspace": "turbo run typecheck",
         "lint:workspace": "turbo run lint",
@@ -39,7 +42,7 @@
         "test:watch": "vitest"
     },
     "muggleConfig": {
-        "electronAppVersion": "1.0.23",
+        "electronAppVersion": "1.0.29",
         "downloadBaseUrl": "https://github.com/multiplex-ai/muggle-ai-works/releases/download",
         "runtimeTargetDefault": "dev",
         "checksums": {

--- a/packages/mcps/src/shared/config.ts
+++ b/packages/mcps/src/shared/config.ts
@@ -30,6 +30,9 @@ const DEFAULT_WEB_SERVICE_URL = "http://localhost:3001";
 /** Subdirectory for downloaded electron-app binaries. */
 const ELECTRON_APP_DIR = "electron-app";
 
+/** Prefix for electron-app release tags. */
+const ELECTRON_APP_RELEASE_TAG_PREFIX = "electron-app-v";
+
 /** API key storage file name. */
 const API_KEY_FILE = "api-key.json";
 
@@ -559,6 +562,38 @@ export function getBundledElectronAppVersion(): string {
  */
 export function getDownloadBaseUrl(): string {
   return getMuggleConfig().downloadBaseUrl;
+}
+
+/**
+ * Build electron-app release tag from a version string.
+ * @param version - Version string (for example, "1.0.28").
+ * @returns Release tag (for example, "electron-app-v1.0.28").
+ */
+export function buildElectronAppReleaseTag(version: string): string {
+  return `${ELECTRON_APP_RELEASE_TAG_PREFIX}${version}`;
+}
+
+/**
+ * Build a release asset URL for a specific electron-app version.
+ * @param params - Build parameters.
+ * @param params.version - Electron app version.
+ * @param params.assetFileName - Release asset file name.
+ * @returns Fully-qualified download URL.
+ */
+export function buildElectronAppReleaseAssetUrl(params: {
+  version: string;
+  assetFileName: string;
+}): string {
+  return `${getDownloadBaseUrl()}/${buildElectronAppReleaseTag(params.version)}/${params.assetFileName}`;
+}
+
+/**
+ * Build checksums.txt URL for a specific electron-app release version.
+ * @param version - Electron app version.
+ * @returns Fully-qualified checksums URL.
+ */
+export function buildElectronAppChecksumsUrl(version: string): string {
+  return `${getDownloadBaseUrl()}/${buildElectronAppReleaseTag(version)}/checksums.txt`;
 }
 
 /**

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "4.3.0",
+  "version": "4.2.3",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/scripts/verify-compatibility-contracts.mjs
+++ b/scripts/verify-compatibility-contracts.mjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+
+import { existsSync, readdirSync, readFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const currentFilePath = fileURLToPath(import.meta.url);
+const scriptsDirectoryPath = dirname(currentFilePath);
+const repositoryRootPath = join(scriptsDirectoryPath, "..");
+
+const contractsPath = join(repositoryRootPath, "config", "compatibility", "contracts.json");
+const packageJsonPath = join(repositoryRootPath, "package.json");
+const serverJsonPath = join(repositoryRootPath, "server.json");
+const claudePluginManifestPath = join(repositoryRootPath, "plugin", ".claude-plugin", "plugin.json");
+const cursorPluginManifestPath = join(repositoryRootPath, "plugin", ".cursor-plugin", "plugin.json");
+const hooksJsonPath = join(repositoryRootPath, "plugin", "hooks", "hooks.json");
+const skillDirectoryPath = join(repositoryRootPath, "plugin", "skills");
+const runCliPath = join(repositoryRootPath, "packages", "commands", "src", "cli", "run-cli.ts");
+
+verifyCompatibilityContracts();
+
+/**
+ * Verify compatibility contracts for CLI, MCP, plugin, and skills.
+ * @returns {void}
+ */
+function verifyCompatibilityContracts() {
+    const contracts = readJsonFile(contractsPath);
+    const packageJson = readJsonFile(packageJsonPath);
+    const serverJson = readJsonFile(serverJsonPath);
+    const claudePluginManifest = readJsonFile(claudePluginManifestPath);
+    const cursorPluginManifest = readJsonFile(cursorPluginManifestPath);
+    const hooksJson = readJsonFile(hooksJsonPath);
+    const runCliSourceCode = readTextFile(runCliPath);
+
+    verifyCliContract({
+        cliContract: contracts.cli,
+        packageJson: packageJson,
+        runCliSourceCode: runCliSourceCode,
+    });
+    verifyServerContract({
+        serverContract: contracts.server,
+        serverJson: serverJson,
+    });
+    verifyPluginContract({
+        pluginContract: contracts.plugins,
+        claudePluginManifest: claudePluginManifest,
+        cursorPluginManifest: cursorPluginManifest,
+        hooksJson: hooksJson,
+    });
+    verifySkillsContract({
+        skillsContract: contracts.skills,
+    });
+    verifyLegacyCompatibilityPolicy({
+        policyContract: contracts.compatibilityPolicy,
+    });
+
+    console.log("Compatibility contract verification passed.");
+}
+
+/**
+ * Verify CLI-level contract.
+ * @param {{ cliContract: Record<string, unknown>, packageJson: Record<string, unknown>, runCliSourceCode: string }} params
+ * @returns {void}
+ */
+function verifyCliContract({ cliContract, packageJson, runCliSourceCode }) {
+    assertValue({
+        condition: packageJson.name === cliContract.packageName,
+        message: `package.json name (${packageJson.name}) must equal cli.packageName (${cliContract.packageName}).`,
+    });
+    assertValue({
+        condition: packageJson.mcpName === cliContract.mcpName,
+        message: `package.json mcpName (${packageJson.mcpName}) must equal cli.mcpName (${cliContract.mcpName}).`,
+    });
+
+    const binaryName = cliContract.binaryName;
+    assertValue({
+        condition: Boolean(packageJson.bin) && packageJson.bin[binaryName],
+        message: `package.json bin must include key '${binaryName}'.`,
+    });
+
+    for (const requiredCommandName of cliContract.requiredCommands) {
+        assertValue({
+            condition: runCliSourceCode.includes(`.command("${requiredCommandName}")`),
+            message: `CLI command '${requiredCommandName}' is required but not found in run-cli.ts.`,
+        });
+    }
+}
+
+/**
+ * Verify MCP server contract.
+ * @param {{ serverContract: Record<string, unknown>, serverJson: Record<string, unknown> }} params
+ * @returns {void}
+ */
+function verifyServerContract({ serverContract, serverJson }) {
+    assertValue({
+        condition: serverJson.name === serverContract.name,
+        message: `server.json name (${serverJson.name}) must equal server.name (${serverContract.name}).`,
+    });
+    assertValue({
+        condition: Array.isArray(serverJson.packages) && serverJson.packages.length > 0,
+        message: "server.json packages must be a non-empty array.",
+    });
+    assertValue({
+        condition: serverJson.packages[0].identifier === serverContract.packageIdentifier,
+        message: `server.json packages[0].identifier (${serverJson.packages[0].identifier}) must equal server.packageIdentifier (${serverContract.packageIdentifier}).`,
+    });
+}
+
+/**
+ * Verify plugin manifests and hooks contract.
+ * @param {{ pluginContract: Record<string, unknown>, claudePluginManifest: Record<string, unknown>, cursorPluginManifest: Record<string, unknown>, hooksJson: Record<string, unknown> }} params
+ * @returns {void}
+ */
+function verifyPluginContract({ pluginContract, claudePluginManifest, cursorPluginManifest, hooksJson }) {
+    assertValue({
+        condition: claudePluginManifest.name === pluginContract.requiredName,
+        message: `plugin/.claude-plugin/plugin.json name (${claudePluginManifest.name}) must equal plugins.requiredName (${pluginContract.requiredName}).`,
+    });
+    assertValue({
+        condition: cursorPluginManifest.name === pluginContract.requiredName,
+        message: `plugin/.cursor-plugin/plugin.json name (${cursorPluginManifest.name}) must equal plugins.requiredName (${pluginContract.requiredName}).`,
+    });
+
+    const sessionStartHooks = hooksJson?.hooks?.SessionStart;
+    assertValue({
+        condition: Array.isArray(sessionStartHooks) && sessionStartHooks.length > 0,
+        message: "plugin/hooks/hooks.json must contain hooks.SessionStart entries.",
+    });
+
+    const firstHookCommand = sessionStartHooks?.[0]?.hooks?.[0]?.command;
+    assertValue({
+        condition: typeof firstHookCommand === "string" && firstHookCommand.includes(pluginContract.requiredHookCommandContains),
+        message: `plugin hook command must include '${pluginContract.requiredHookCommandContains}'.`,
+    });
+}
+
+/**
+ * Verify required skill directories exist.
+ * @param {{ skillsContract: Record<string, unknown> }} params
+ * @returns {void}
+ */
+function verifySkillsContract({ skillsContract }) {
+    assertValue({
+        condition: existsSync(skillDirectoryPath),
+        message: `Skill directory does not exist: ${skillDirectoryPath}`,
+    });
+
+    const skillDirectoryNames = readdirSync(skillDirectoryPath, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name);
+
+    for (const requiredDirectoryName of skillsContract.requiredDirectories) {
+        assertValue({
+            condition: skillDirectoryNames.includes(requiredDirectoryName),
+            message: `Required skill directory missing: plugin/skills/${requiredDirectoryName}`,
+        });
+    }
+}
+
+/**
+ * Verify legacy compatibility policy values.
+ * @param {{ policyContract: Record<string, unknown> }} params
+ * @returns {void}
+ */
+function verifyLegacyCompatibilityPolicy({ policyContract }) {
+    const allowedStatusValues = new Set(policyContract.allowedLegacyStatuses);
+    const legacyIdentifiers = policyContract.legacyIdentifiers;
+
+    assertValue({
+        condition: Array.isArray(legacyIdentifiers),
+        message: "compatibilityPolicy.legacyIdentifiers must be an array.",
+    });
+
+    for (const legacyIdentifierRecord of legacyIdentifiers) {
+        assertValue({
+            condition: allowedStatusValues.has(legacyIdentifierRecord.status),
+            message: `Invalid legacy status '${legacyIdentifierRecord.status}' for identifier '${legacyIdentifierRecord.identifier}'.`,
+        });
+    }
+}
+
+/**
+ * Read a JSON file from disk.
+ * @param {string} filePath
+ * @returns {Record<string, unknown>}
+ */
+function readJsonFile(filePath) {
+    assertValue({
+        condition: existsSync(filePath),
+        message: `Required file does not exist: ${filePath}`,
+    });
+
+    return JSON.parse(readFileSync(filePath, "utf-8"));
+}
+
+/**
+ * Read text file from disk.
+ * @param {string} filePath
+ * @returns {string}
+ */
+function readTextFile(filePath) {
+    assertValue({
+        condition: existsSync(filePath),
+        message: `Required file does not exist: ${filePath}`,
+    });
+
+    return readFileSync(filePath, "utf-8");
+}
+
+/**
+ * Assert a condition and throw with message on failure.
+ * @param {{ condition: boolean, message: string }} params
+ * @returns {void}
+ */
+function assertValue({ condition, message }) {
+    if (!condition) {
+        throw new Error(message);
+    }
+}

--- a/scripts/verify-electron-release-checksums.mjs
+++ b/scripts/verify-electron-release-checksums.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const currentFilePath = fileURLToPath(import.meta.url);
+const scriptsDirectoryPath = dirname(currentFilePath);
+const repositoryRootPath = join(scriptsDirectoryPath, "..");
+const packageJsonPath = join(repositoryRootPath, "package.json");
+
+verifyElectronReleaseChecksums().catch((error) => {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    console.error(`Electron release checksum verification failed: ${errorMessage}`);
+    process.exit(1);
+});
+
+/**
+ * Verify checksums.txt exists and includes all required platform artifacts.
+ * @returns {Promise<void>}
+ */
+async function verifyElectronReleaseChecksums() {
+    const packageJson = readJsonFile(packageJsonPath);
+    const bundledVersion = packageJson?.muggleConfig?.electronAppVersion;
+    const downloadBaseUrl = packageJson?.muggleConfig?.downloadBaseUrl;
+
+    assertValue({
+        condition: typeof bundledVersion === "string" && bundledVersion.length > 0,
+        message: "package.json muggleConfig.electronAppVersion must be defined.",
+    });
+    assertValue({
+        condition: typeof downloadBaseUrl === "string" && downloadBaseUrl.length > 0,
+        message: "package.json muggleConfig.downloadBaseUrl must be defined.",
+    });
+
+    const releaseTag = `electron-app-v${bundledVersion}`;
+    const checksumsUrl = `${downloadBaseUrl}/${releaseTag}/checksums.txt`;
+    const requiredAssetFileNames = [
+        "MuggleAI-darwin-arm64.zip",
+        "MuggleAI-darwin-x64.zip",
+        "MuggleAI-linux-x64.zip",
+        "MuggleAI-win32-x64.zip",
+    ];
+
+    console.log(`Verifying checksums asset: ${checksumsUrl}`);
+    const response = await fetch(checksumsUrl);
+    assertValue({
+        condition: response.ok,
+        message: `checksums.txt not available for ${releaseTag} (${response.status} ${response.statusText}).`,
+    });
+
+    const checksumsContent = await response.text();
+    for (const requiredAssetFileName of requiredAssetFileNames) {
+        assertValue({
+            condition: hasValidChecksumEntry({
+                checksumsContent: checksumsContent,
+                assetFileName: requiredAssetFileName,
+            }),
+            message: `checksums.txt missing valid SHA256 entry for ${requiredAssetFileName}.`,
+        });
+    }
+
+    console.log(`checksums.txt verified for ${releaseTag}.`);
+}
+
+/**
+ * Check whether checksums content has a valid sha256 line for an asset.
+ * @param {{ checksumsContent: string, assetFileName: string }} params
+ * @returns {boolean}
+ */
+function hasValidChecksumEntry({ checksumsContent, assetFileName }) {
+    const outputLines = checksumsContent.split("\n");
+    const checksumPattern = /^[a-fA-F0-9]{64}$/;
+
+    for (const outputLine of outputLines) {
+        const trimmedLine = outputLine.trim();
+        if (!trimmedLine) {
+            continue;
+        }
+
+        const parts = trimmedLine.split(/\s+/);
+        if (parts.length < 2) {
+            continue;
+        }
+
+        const checksumValue = parts[0];
+        const fileNameValue = parts.slice(1).join(" ").replace(/^\*?/, "");
+
+        if (fileNameValue === assetFileName && checksumPattern.test(checksumValue)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Read JSON file from disk.
+ * @param {string} filePath
+ * @returns {Record<string, unknown>}
+ */
+function readJsonFile(filePath) {
+    assertValue({
+        condition: existsSync(filePath),
+        message: `Required file does not exist: ${filePath}`,
+    });
+    return JSON.parse(readFileSync(filePath, "utf-8"));
+}
+
+/**
+ * Assert condition or throw.
+ * @param {{ condition: boolean, message: string }} params
+ * @returns {void}
+ */
+function assertValue({ condition, message }) {
+    if (!condition) {
+        throw new Error(message);
+    }
+}

--- a/scripts/verify-upgrade-experience.mjs
+++ b/scripts/verify-upgrade-experience.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from "fs";
+import { spawnSync } from "child_process";
+import { tmpdir } from "os";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const currentFilePath = fileURLToPath(import.meta.url);
+const scriptsDirectoryPath = dirname(currentFilePath);
+const repositoryRootPath = join(scriptsDirectoryPath, "..");
+
+const muggleCliPath = join(repositoryRootPath, "bin", "muggle.js");
+const ANSI_ESCAPE_CHARACTER = String.fromCharCode(27);
+const ANSI_ESCAPE_PATTERN = new RegExp(`${ANSI_ESCAPE_CHARACTER}\\[[0-9;]*m`, "g");
+const ALLOWED_DOCTOR_FAILURE_CHECK_NAMES = new Set([
+    "Authentication",
+    "API Key",
+    "Credentials File",
+    "Cursor MCP Config",
+]);
+
+verifyUpgradeExperience();
+
+/**
+ * Validate existing-user upgrade behavior:
+ * 1) setup download
+ * 2) cleanup old artifact
+ * 3) forced upgrade redownload
+ * 4) post-upgrade health checks
+ * @returns {void}
+ */
+function verifyUpgradeExperience() {
+    assertValue({
+        condition: existsSync(muggleCliPath),
+        message: `CLI entrypoint not found: ${muggleCliPath}`,
+    });
+
+    const isolatedHomeDirectoryPath = mkdtempSync(join(tmpdir(), "muggle-upgrade-smoke-"));
+    const isolatedEnvironmentVariables = createIsolatedEnvironmentVariables({
+        isolatedHomeDirectoryPath: isolatedHomeDirectoryPath,
+    });
+
+    try {
+        console.log(`Using isolated HOME for upgrade smoke: ${isolatedHomeDirectoryPath}`);
+
+        const setupResult = runMuggleCommand({
+            args: ["setup", "--force"],
+            environmentVariables: isolatedEnvironmentVariables,
+        });
+        assertValue({
+            condition: setupResult.success,
+            message: "setup --force failed; existing-user upgrade flow is broken.",
+        });
+
+        const dataDirectoryPath = join(isolatedHomeDirectoryPath, ".muggle-ai");
+        const electronAppRootDirectoryPath = join(dataDirectoryPath, "electron-app");
+        const initialVersionDirectoryPath = resolveInstalledVersionDirectoryPath({
+            electronAppRootDirectoryPath: electronAppRootDirectoryPath,
+        });
+        const initialInstallMetadataPath = join(initialVersionDirectoryPath, ".install-metadata.json");
+
+        assertValue({
+            condition: existsSync(initialInstallMetadataPath),
+            message: `Install metadata missing after setup/upgrade bootstrap: ${initialInstallMetadataPath}`,
+        });
+
+        const syntheticOldVersionDirectoryPath = join(electronAppRootDirectoryPath, "0.0.1");
+        mkdirSync(syntheticOldVersionDirectoryPath, { recursive: true });
+        writeFileSync(join(syntheticOldVersionDirectoryPath, "obsolete-marker.txt"), "obsolete\n", "utf-8");
+
+        runMuggleCommand({
+            args: ["cleanup", "--all"],
+            environmentVariables: isolatedEnvironmentVariables,
+        });
+
+        assertValue({
+            condition: !existsSync(syntheticOldVersionDirectoryPath),
+            message: "cleanup --all did not remove synthetic old version directory.",
+        });
+
+        const upgradeResult = runMuggleCommand({
+            args: ["upgrade", "--force"],
+            environmentVariables: isolatedEnvironmentVariables,
+        });
+        const upgradeCombinedOutput = upgradeResult.combinedOutput;
+        assertValue({
+            condition: !upgradeCombinedOutput.includes("Checksums file not found"),
+            message: "upgrade --force reported missing checksums.txt; checksum verification coverage is incomplete.",
+        });
+        assertValue({
+            condition: !upgradeCombinedOutput.includes("Checksum verification skipped"),
+            message: "upgrade --force skipped checksum verification; release artifacts must provide checksums.",
+        });
+
+        const versionDirectoryPaths = listVersionDirectoryPaths({
+            electronAppRootDirectoryPath: electronAppRootDirectoryPath,
+        });
+        assertValue({
+            condition: versionDirectoryPaths.length > 0,
+            message: "No electron-app version directories found after upgrade --force.",
+        });
+
+        const newestVersionDirectoryPath = getNewestDirectoryPath({
+            directoryPaths: versionDirectoryPaths,
+        });
+        const newestInstallMetadataPath = join(newestVersionDirectoryPath, ".install-metadata.json");
+
+        assertValue({
+            condition: existsSync(newestInstallMetadataPath),
+            message: `Install metadata missing in upgraded directory: ${newestInstallMetadataPath}`,
+        });
+
+        const doctorResult = runMuggleCommand({
+            args: ["doctor"],
+            environmentVariables: isolatedEnvironmentVariables,
+        });
+        assertValue({
+            condition: doctorResult.success,
+            message: "doctor command failed to run.",
+        });
+
+        const nonAllowlistedDoctorFailures = parseDoctorFailureCheckNames({
+            doctorOutput: doctorResult.combinedOutput,
+        }).filter((checkName) => !ALLOWED_DOCTOR_FAILURE_CHECK_NAMES.has(checkName));
+        assertValue({
+            condition: nonAllowlistedDoctorFailures.length === 0,
+            message: `doctor reported non-allowlisted failures: ${nonAllowlistedDoctorFailures.join(", ")}`,
+        });
+        runMuggleCommand({
+            args: ["status"],
+            environmentVariables: isolatedEnvironmentVariables,
+        });
+
+        console.log("Upgrade experience verification passed.");
+    } finally {
+        rmSync(isolatedHomeDirectoryPath, { recursive: true, force: true });
+    }
+}
+
+/**
+ * Execute the CLI with isolated environment variables.
+ * @param {{ args: string[], environmentVariables: NodeJS.ProcessEnv }} params
+ * @returns {void}
+ */
+function runMuggleCommand({ args, environmentVariables }) {
+    const commandArguments = [muggleCliPath, ...args];
+    console.log(`Running command: node ${commandArguments.join(" ")}`);
+    const commandResult = spawnSync(process.execPath, commandArguments, {
+        cwd: repositoryRootPath,
+        env: environmentVariables,
+        encoding: "utf-8",
+    });
+
+    const standardOutputText = commandResult.stdout ?? "";
+    const standardErrorText = commandResult.stderr ?? "";
+    const combinedOutput = `${standardOutputText}${standardErrorText}`;
+    process.stdout.write(standardOutputText);
+    process.stderr.write(standardErrorText);
+
+    return {
+        success: commandResult.status === 0,
+        statusCode: commandResult.status ?? -1,
+        combinedOutput: combinedOutput,
+    };
+}
+
+/**
+ * Parse failed doctor check names from doctor command output.
+ * @param {{ doctorOutput: string }} params
+ * @returns {string[]}
+ */
+function parseDoctorFailureCheckNames({ doctorOutput }) {
+    const failureCheckNames = [];
+    const cleanedOutput = doctorOutput.replaceAll(ANSI_ESCAPE_PATTERN, "");
+    const outputLines = cleanedOutput.split("\n");
+
+    for (const outputLine of outputLines) {
+        const trimmedLine = outputLine.trim();
+        const failedCheckMatch = trimmedLine.match(/^✗\s+([^:]+):/);
+        if (failedCheckMatch) {
+            failureCheckNames.push(failedCheckMatch[1]);
+        }
+    }
+
+    return failureCheckNames;
+}
+
+/**
+ * Create isolated HOME/HOMEPATH environment for smoke runs.
+ * @param {{ isolatedHomeDirectoryPath: string }} params
+ * @returns {NodeJS.ProcessEnv}
+ */
+function createIsolatedEnvironmentVariables({ isolatedHomeDirectoryPath }) {
+    return {
+        ...process.env,
+        HOME: isolatedHomeDirectoryPath,
+        USERPROFILE: isolatedHomeDirectoryPath,
+    };
+}
+
+/**
+ * List version-like subdirectories under electron-app root.
+ * @param {{ electronAppRootDirectoryPath: string }} params
+ * @returns {string[]}
+ */
+function listVersionDirectoryPaths({ electronAppRootDirectoryPath }) {
+    assertValue({
+        condition: existsSync(electronAppRootDirectoryPath),
+        message: `Electron app root directory not found: ${electronAppRootDirectoryPath}`,
+    });
+
+    const entries = readdirSync(electronAppRootDirectoryPath, { withFileTypes: true });
+    const versionDirectoryNamePattern = /^\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.-]+)?$/;
+
+    return entries
+        .filter((entry) => entry.isDirectory())
+        .filter((entry) => versionDirectoryNamePattern.test(entry.name))
+        .map((entry) => join(electronAppRootDirectoryPath, entry.name));
+}
+
+/**
+ * Resolve an installed version directory from electron-app root.
+ * @param {{ electronAppRootDirectoryPath: string }} params
+ * @returns {string}
+ */
+function resolveInstalledVersionDirectoryPath({ electronAppRootDirectoryPath }) {
+    const versionDirectoryPaths = listVersionDirectoryPaths({
+        electronAppRootDirectoryPath: electronAppRootDirectoryPath,
+    });
+
+    assertValue({
+        condition: versionDirectoryPaths.length > 0,
+        message: `No installed version directories found in: ${electronAppRootDirectoryPath}`,
+    });
+
+    return getNewestDirectoryPath({
+        directoryPaths: versionDirectoryPaths,
+    });
+}
+
+/**
+ * Get newest directory by mtime.
+ * @param {{ directoryPaths: string[] }} params
+ * @returns {string}
+ */
+function getNewestDirectoryPath({ directoryPaths }) {
+    assertValue({
+        condition: directoryPaths.length > 0,
+        message: "Cannot choose newest directory from an empty list.",
+    });
+
+    const sortedDirectoryPaths = [...directoryPaths].sort((leftDirectoryPath, rightDirectoryPath) => {
+        const leftMtimeMilliseconds = statSync(leftDirectoryPath).mtimeMs;
+        const rightMtimeMilliseconds = statSync(rightDirectoryPath).mtimeMs;
+        return rightMtimeMilliseconds - leftMtimeMilliseconds;
+    });
+
+    return sortedDirectoryPaths[0];
+}
+
+/**
+ * Assert condition.
+ * @param {{ condition: boolean, message: string }} params
+ * @returns {void}
+ */
+function assertValue({ condition, message }) {
+    if (!condition) {
+        throw new Error(message);
+    }
+}

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -10,9 +10,9 @@ import { arch, platform } from "os";
 import { pipeline } from "stream/promises";
 
 import {
+  buildElectronAppReleaseAssetUrl,
   calculateFileChecksum,
   getChecksumForPlatform,
-  getDownloadBaseUrl,
   getElectronAppChecksums,
   getElectronAppDir,
   getElectronAppVersion,
@@ -249,7 +249,6 @@ function cleanupFailedInstall(versionDir: string): void {
  */
 export async function setupCommand(options: ISetupOptions): Promise<void> {
   const version = getElectronAppVersion();
-  const baseUrl = getDownloadBaseUrl();
   const versionDir = getElectronAppDir(version);
   const platformKey = getPlatformKey();
 
@@ -261,7 +260,10 @@ export async function setupCommand(options: ISetupOptions): Promise<void> {
   }
 
   const binaryName = getBinaryName();
-  const downloadUrl = `${baseUrl}/v${version}/${binaryName}`;
+  const downloadUrl = buildElectronAppReleaseAssetUrl({
+    version: version,
+    assetFileName: binaryName,
+  });
 
   console.log(`Downloading Muggle Test Electron app v${version}...`);
   console.log(`URL: ${downloadUrl}`);

--- a/src/cli/upgrade.ts
+++ b/src/cli/upgrade.ts
@@ -10,9 +10,10 @@ import * as path from "path";
 import { pipeline } from "stream/promises";
 
 import {
+  buildElectronAppChecksumsUrl,
+  buildElectronAppReleaseAssetUrl,
   calculateFileChecksum,
   getDataDir,
-  getDownloadBaseUrl,
   getElectronAppDir,
   getElectronAppVersion,
   getLogger,
@@ -189,14 +190,16 @@ async function checkForUpdates (): Promise<IUpdateCheckResult> {
       const version = extractVersionFromTag(release.tag_name);
       if (version) {
         const updateAvailable = compareVersions(version, currentVersion) > 0;
-        const baseUrl = getDownloadBaseUrl();
         const binaryName = getBinaryName();
 
         return {
           currentVersion: currentVersion,
           latestVersion: version,
           updateAvailable: updateAvailable,
-          downloadUrl: `${baseUrl}/electron-app-v${version}/${binaryName}`,
+          downloadUrl: buildElectronAppReleaseAssetUrl({
+            version: version,
+            assetFileName: binaryName,
+          }),
         };
       }
     }
@@ -338,8 +341,7 @@ async function extractTarGz(tarPath: string, destDir: string): Promise<void> {
  * @returns The checksum or empty string if not available.
  */
 async function fetchChecksumFromRelease (version: string): Promise<string> {
-  const baseUrl = getDownloadBaseUrl();
-  const checksumUrl = `${baseUrl}/electron-app-v${version}/checksums.txt`;
+  const checksumUrl = buildElectronAppChecksumsUrl(version);
 
   try {
     const response = await fetch(checksumUrl);
@@ -511,9 +513,11 @@ export async function upgradeCommand (options: IUpgradeOptions): Promise<void> {
   try {
     // If specific version requested
     if (options.version) {
-      const baseUrl = getDownloadBaseUrl();
       const binaryName = getBinaryName();
-      const downloadUrl = `${baseUrl}/electron-app-v${options.version}/${binaryName}`;
+      const downloadUrl = buildElectronAppReleaseAssetUrl({
+        version: options.version,
+        assetFileName: binaryName,
+      });
 
       await downloadAndInstall(options.version, downloadUrl);
 


### PR DESCRIPTION
## Summary
- Add `config/compatibility/contracts.json` plus verify scripts for contracts, GitHub `checksums.txt` on Electron releases, and an upgrade smoke (isolated HOME).
- Extend CI (`verify:contracts`), add weekly/manual `upgrade-experience.yml`, and gate publish on `verify:electron-release-checksums`.
- Centralize electron release URL/tag helpers in `packages/mcps` shared config; align `setup` / `upgrade` CLI with `electron-app-v*` assets.
- Document in `docs/compatibility-strategy.md`; bump bundled `muggleConfig.electronAppVersion` to **1.0.29** (release includes `checksums.txt`).

## Test plan
- [x] `npm run typecheck`
- [x] `npm run verify:contracts`
- [x] `npm run verify:electron-release-checksums`
- [x] `npm run verify:upgrade-experience`
- [x] `npm run verify:plugin`

Made with [Cursor](https://cursor.com)