### PR TITLE
feat(mcps): align entity IDs on UUIDs and shared MuggleEntityIdSchema

### DIFF
--- a/packages/mcps/src/mcp/contracts/muggle-entity-id-schema.ts
+++ b/packages/mcps/src/mcp/contracts/muggle-entity-id-schema.ts
@@ -1,0 +1,13 @@
+/**
+ * Shared Zod schema for Muggle entity identifiers stored as UUIDs.
+ *
+ * Used for cloud resource IDs (projects, use cases, test cases, scripts, secrets, workflows)
+ * and for local run-result / test-script record filenames (randomUUID).
+ */
+
+import { z } from "zod";
+
+/**
+ * UUID string schema — single source of truth for Muggle ID validation across MCP contracts.
+ */
+export const MuggleEntityIdSchema = z.string().uuid();

--- a/packages/mcps/src/mcp/e2e/contracts/index.ts
+++ b/packages/mcps/src/mcp/e2e/contracts/index.ts
@@ -3,6 +3,10 @@
  */
 
 import { z } from "zod";
+
+import { MuggleEntityIdSchema } from "../../contracts/muggle-entity-id-schema.js";
+
+export { MuggleEntityIdSchema };
 export * from "./local-run-schemas.js";
 
 // =============================================================================
@@ -19,12 +23,12 @@ export const PaginationInputSchema = z.object({
  * UUID string schema for Muggle Test cloud resource IDs
  * (projects, PRD files, secrets, use cases, test cases, scripts, workflow runtimes, etc.).
  */
-export const IdSchema = z.string().uuid();
+export const IdSchema = MuggleEntityIdSchema;
 
 /**
  * Bulk test-script replay batch id (server assigns via randomUUID per TestScriptReplayBulkWorkflowRun).
  */
-export const RunBatchIdSchema = z.string().uuid().describe("Bulk replay run batch ID (UUID)");
+export const RunBatchIdSchema = MuggleEntityIdSchema.describe("Bulk replay run batch ID (UUID)");
 
 /** Token package id from wallet catalog (Stripe metadata SKU; not a UUID). */
 export const TokenPackageIdSchema = z.string().min(1).describe("Token package ID from wallet catalog");

--- a/packages/mcps/src/mcp/e2e/contracts/index.ts
+++ b/packages/mcps/src/mcp/e2e/contracts/index.ts
@@ -15,8 +15,34 @@ export const PaginationInputSchema = z.object({
   pageSize: z.number().int().positive().max(100).optional().describe("Number of items per page"),
 });
 
-/** ID string schema. */
-export const IdSchema = z.string().min(1).describe("Unique identifier");
+/**
+ * UUID string schema for Muggle Test cloud resource IDs
+ * (projects, PRD files, secrets, use cases, test cases, scripts, workflow runtimes, etc.).
+ */
+export const IdSchema = z.string().uuid();
+
+/**
+ * Bulk test-script replay batch id (server assigns via randomUUID per TestScriptReplayBulkWorkflowRun).
+ */
+export const RunBatchIdSchema = z.string().uuid().describe("Bulk replay run batch ID (UUID)");
+
+/** Token package id from wallet catalog (Stripe metadata SKU; not a UUID). */
+export const TokenPackageIdSchema = z.string().min(1).describe("Token package ID from wallet catalog");
+
+/** Stripe payment method id (pm_…). */
+export const StripePaymentMethodIdSchema = z
+  .string()
+  .regex(/^pm_[a-zA-Z0-9]+$/)
+  .describe("Stripe payment method ID (pm_…)");
+
+/**
+ * API key record id from the server (24 hex chars from randomBytes(12); not a UUID).
+ */
+export const ApiKeyRecordIdSchema = z
+  .string()
+  .length(24)
+  .regex(/^[0-9a-f]+$/i)
+  .describe("API key record ID (24-character hex)");
 
 /** Optional memory configuration overrides in workflow params. */
 export const WorkflowMemoryParamsSchema = z.object({
@@ -29,6 +55,17 @@ export const WorkflowParamsSchema = z.object({
   memory: WorkflowMemoryParamsSchema.optional().describe("Per-run memory override settings"),
 }).passthrough().optional().describe("Optional workflow parameters for workflow-level overrides");
 
+/**
+ * Token usage cost breakdown dimension (matches server TokenUsageFilterType).
+ */
+export const TokenUsageFilterTypeSchema = z.enum([
+  "project",
+  "useCase",
+  "testCase",
+  "testScript",
+  "actionScript",
+]).describe("Token cost aggregation dimension");
+
 // =============================================================================
 // Project Schemas
 // =============================================================================
@@ -40,15 +77,15 @@ export const ProjectCreateInputSchema = z.object({
 });
 
 export const ProjectGetInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID to retrieve"),
+  projectId: IdSchema.describe("Project ID (UUID) to retrieve"),
 });
 
 export const ProjectDeleteInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID to delete"),
+  projectId: IdSchema.describe("Project ID (UUID) to delete"),
 });
 
 export const ProjectUpdateInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID to update"),
+  projectId: IdSchema.describe("Project ID (UUID) to update"),
   projectName: z.string().min(1).max(255).optional().describe("New project name"),
   description: z.string().optional().describe("Updated description"),
   url: z.string().url().optional().describe("Updated target URL"),
@@ -61,23 +98,23 @@ export const ProjectListInputSchema = PaginationInputSchema.extend({});
 // =============================================================================
 
 export const PrdFileUploadInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID to associate the PRD file with"),
+  projectId: IdSchema.describe("Project ID (UUID) to associate the PRD file with"),
   fileName: z.string().min(1).describe("Name of the file"),
   contentBase64: z.string().min(1).describe("Base64-encoded file content"),
   contentType: z.string().optional().describe("MIME type of the file"),
 });
 
 export const PrdFileListInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID to list PRD files for"),
+  projectId: IdSchema.describe("Project ID (UUID) to list PRD files for"),
 });
 
 export const PrdFileDeleteInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID"),
-  prdFileId: IdSchema.describe("PRD file ID to delete"),
+  projectId: IdSchema.describe("Project ID (UUID)"),
+  prdFileId: IdSchema.describe("PRD file ID (UUID) to delete"),
 });
 
 export const PrdFileProcessStartInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID to process PRD files for"),
+  projectId: IdSchema.describe("Project ID (UUID) to process PRD files for"),
   name: z.string().min(1).describe("Workflow name"),
   description: z.string().min(1).describe("Description of the PRD processing workflow"),
   prdFilePath: z.string().min(1).describe("Storage path of the uploaded PRD file (from upload response)"),
@@ -88,7 +125,7 @@ export const PrdFileProcessStartInputSchema = z.object({
 });
 
 export const PrdFileProcessLatestRunInputSchema = z.object({
-  workflowRuntimeId: IdSchema.describe("PRD processing workflow runtime ID"),
+  workflowRuntimeId: IdSchema.describe("PRD processing workflow runtime ID (UUID)"),
 });
 
 // =============================================================================
@@ -96,11 +133,11 @@ export const PrdFileProcessLatestRunInputSchema = z.object({
 // =============================================================================
 
 export const SecretListInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID to list secrets for"),
+  projectId: IdSchema.describe("Project ID (UUID) to list secrets for"),
 });
 
 export const SecretCreateInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID to create the secret for"),
+  projectId: IdSchema.describe("Project ID (UUID) to create the secret for"),
   name: z.string().min(1).describe("Secret name/key"),
   value: z.string().min(1).describe("Secret value"),
   description: z.string().min(1).describe("Human-readable description for selection guidance"),
@@ -108,18 +145,18 @@ export const SecretCreateInputSchema = z.object({
 });
 
 export const SecretGetInputSchema = z.object({
-  secretId: IdSchema.describe("Secret ID to retrieve"),
+  secretId: IdSchema.describe("Secret ID (UUID) to retrieve"),
 });
 
 export const SecretUpdateInputSchema = z.object({
-  secretId: IdSchema.describe("Secret ID to update"),
+  secretId: IdSchema.describe("Secret ID (UUID) to update"),
   name: z.string().min(1).optional().describe("Updated secret name"),
   value: z.string().min(1).optional().describe("Updated secret value"),
   description: z.string().optional().describe("Updated description"),
 });
 
 export const SecretDeleteInputSchema = z.object({
-  secretId: IdSchema.describe("Secret ID to delete"),
+  secretId: IdSchema.describe("Secret ID (UUID) to delete"),
 });
 
 // =============================================================================
@@ -127,37 +164,37 @@ export const SecretDeleteInputSchema = z.object({
 // =============================================================================
 
 export const UseCaseDiscoveryMemoryGetInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID to get use case discovery memory for"),
+  projectId: IdSchema.describe("Project ID (UUID) to get use case discovery memory for"),
 });
 
 export const UseCaseCandidatesApproveInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID"),
+  projectId: IdSchema.describe("Project ID (UUID)"),
   approvedCandidateIds: z.array(IdSchema).min(1).describe("IDs of candidates to approve/graduate"),
 });
 
 export const UseCaseListInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID to list use cases for"),
+  projectId: IdSchema.describe("Project ID (UUID) to list use cases for"),
 }).merge(PaginationInputSchema);
 
 export const UseCaseGetInputSchema = z.object({
-  useCaseId: IdSchema.describe("Use case ID to retrieve"),
+  useCaseId: IdSchema.describe("Use case ID (UUID) to retrieve"),
 });
 
 export const UseCasePromptPreviewInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID to generate use case for"),
+  projectId: IdSchema.describe("Project ID (UUID) to generate use case for"),
   instruction: z.string().min(1).describe("Natural language instruction describing the use case (e.g., 'As a logged-in user, I can add items to cart')"),
 });
 
 export const UseCaseCreateFromPromptsInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID to create use cases for"),
+  projectId: IdSchema.describe("Project ID (UUID) to create use cases for"),
   prompts: z.array(z.object({
     instruction: z.string().min(1).describe("Natural language instruction describing the use case"),
   })).min(1).describe("Array of prompts to generate use cases from"),
 });
 
 export const UseCaseUpdateFromPromptInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID"),
-  useCaseId: IdSchema.describe("Use case ID to update"),
+  projectId: IdSchema.describe("Project ID (UUID)"),
+  useCaseId: IdSchema.describe("Use case ID (UUID) to update"),
   instruction: z.string().min(1).describe("Natural language instruction to regenerate the use case from"),
 });
 
@@ -166,26 +203,26 @@ export const UseCaseUpdateFromPromptInputSchema = z.object({
 // =============================================================================
 
 export const TestCaseListInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID to list test cases for"),
+  projectId: IdSchema.describe("Project ID (UUID) to list test cases for"),
 }).merge(PaginationInputSchema);
 
 export const TestCaseGetInputSchema = z.object({
-  testCaseId: IdSchema.describe("Test case ID to retrieve"),
+  testCaseId: IdSchema.describe("Test case ID (UUID) to retrieve"),
 });
 
 export const TestCaseListByUseCaseInputSchema = z.object({
-  useCaseId: IdSchema.describe("Use case ID to list test cases for"),
+  useCaseId: IdSchema.describe("Use case ID (UUID) to list test cases for"),
 });
 
 export const TestCaseGenerateFromPromptInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID"),
-  useCaseId: IdSchema.describe("Use case ID to generate test cases for"),
+  projectId: IdSchema.describe("Project ID (UUID)"),
+  useCaseId: IdSchema.describe("Use case ID (UUID) to generate test cases for"),
   instruction: z.string().min(1).describe("Natural language instruction describing the test cases to generate"),
 });
 
 export const TestCaseCreateInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID"),
-  useCaseId: IdSchema.describe("Use case ID to associate the test case with"),
+  projectId: IdSchema.describe("Project ID (UUID)"),
+  useCaseId: IdSchema.describe("Use case ID (UUID) to associate the test case with"),
   title: z.string().min(1).describe("Test case title"),
   description: z.string().min(1).describe("Detailed description of what the test case validates"),
   goal: z.string().min(1).describe("Concise, measurable goal of the test"),
@@ -204,16 +241,16 @@ export const TestCaseCreateInputSchema = z.object({
 // =============================================================================
 
 export const TestScriptListInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID to list test scripts for"),
-  testCaseId: IdSchema.optional().describe("Optional test case ID to filter scripts by"),
+  projectId: IdSchema.describe("Project ID (UUID) to list test scripts for"),
+  testCaseId: IdSchema.optional().describe("Optional test case ID (UUID) to filter scripts by"),
 }).merge(PaginationInputSchema);
 
 export const TestScriptGetInputSchema = z.object({
-  testScriptId: IdSchema.describe("Test script ID to retrieve"),
+  testScriptId: IdSchema.describe("Test script ID (UUID) to retrieve"),
 });
 
 export const TestScriptListPaginatedInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID to list test scripts for"),
+  projectId: IdSchema.describe("Project ID (UUID) to list test scripts for"),
 }).merge(PaginationInputSchema);
 
 // =============================================================================
@@ -221,7 +258,7 @@ export const TestScriptListPaginatedInputSchema = z.object({
 // =============================================================================
 
 export const ActionScriptGetInputSchema = z.object({
-  actionScriptId: IdSchema.describe("Action script ID to retrieve"),
+  actionScriptId: IdSchema.describe("Action script ID (UUID) to retrieve"),
 });
 
 // =============================================================================
@@ -229,7 +266,7 @@ export const ActionScriptGetInputSchema = z.object({
 // =============================================================================
 
 export const WorkflowStartWebsiteScanInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID to scan"),
+  projectId: IdSchema.describe("Project ID (UUID) to scan"),
   url: z.string().url().describe("Website URL to scan"),
   description: z.string().min(1).describe("Description of what to scan/discover"),
   archiveUnapproved: z.boolean().optional().describe("Whether to archive unapproved candidates before scanning"),
@@ -237,16 +274,16 @@ export const WorkflowStartWebsiteScanInputSchema = z.object({
 });
 
 export const WorkflowListRuntimesInputSchema = z.object({
-  projectId: IdSchema.optional().describe("Filter by project ID"),
+  projectId: IdSchema.optional().describe("Filter by project ID (UUID)"),
 });
 
 export const WorkflowGetLatestRunInputSchema = z.object({
-  workflowRuntimeId: IdSchema.describe("Workflow runtime ID"),
+  workflowRuntimeId: IdSchema.describe("Workflow runtime ID (UUID)"),
 });
 
 export const WorkflowStartTestCaseDetectionInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID"),
-  useCaseId: IdSchema.describe("Use case ID to detect test cases for"),
+  projectId: IdSchema.describe("Project ID (UUID)"),
+  useCaseId: IdSchema.describe("Use case ID (UUID) to detect test cases for"),
   name: z.string().min(1).describe("Workflow name"),
   description: z.string().min(1).describe("Workflow description"),
   url: z.string().url().describe("Target website URL"),
@@ -254,9 +291,9 @@ export const WorkflowStartTestCaseDetectionInputSchema = z.object({
 });
 
 export const WorkflowStartTestScriptGenerationInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID"),
-  useCaseId: IdSchema.describe("Use case ID"),
-  testCaseId: IdSchema.describe("Test case ID"),
+  projectId: IdSchema.describe("Project ID (UUID)"),
+  useCaseId: IdSchema.describe("Use case ID (UUID)"),
+  testCaseId: IdSchema.describe("Test case ID (UUID)"),
   name: z.string().min(1).describe("Workflow name"),
   url: z.string().url().describe("Target website URL"),
   goal: z.string().min(1).describe("Test goal"),
@@ -267,40 +304,40 @@ export const WorkflowStartTestScriptGenerationInputSchema = z.object({
 });
 
 export const WorkflowGetLatestScriptGenByTestCaseInputSchema = z.object({
-  testCaseId: IdSchema.describe("Test case ID"),
+  testCaseId: IdSchema.describe("Test case ID (UUID)"),
 });
 
 export const WorkflowStartTestScriptReplayInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID"),
-  useCaseId: IdSchema.describe("Use case ID"),
-  testCaseId: IdSchema.describe("Test case ID"),
-  testScriptId: IdSchema.describe("Test script ID to replay"),
+  projectId: IdSchema.describe("Project ID (UUID)"),
+  useCaseId: IdSchema.describe("Use case ID (UUID)"),
+  testCaseId: IdSchema.describe("Test case ID (UUID)"),
+  testScriptId: IdSchema.describe("Test script ID (UUID) to replay"),
   name: z.string().min(1).describe("Workflow name"),
   workflowParams: WorkflowParamsSchema,
 });
 
 export const WorkflowStartTestScriptReplayBulkInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID"),
+  projectId: IdSchema.describe("Project ID (UUID)"),
   name: z.string().min(1).describe("Workflow name"),
   intervalSec: z.number().int().describe("Interval in seconds (-1 for one-time / on-demand)"),
-  useCaseId: IdSchema.optional().describe("Optional: only replay test cases under this use case"),
+  useCaseId: IdSchema.optional().describe("Optional: only replay test cases under this use case (UUID)"),
   namePrefix: z.string().optional().describe("Optional: prefix for generated workflow names"),
   limit: z.number().int().optional().describe("Optional: limit number of test cases to replay"),
-  testCaseIds: z.array(IdSchema).optional().describe("Optional: targeted test cases to replay"),
+  testCaseIds: z.array(IdSchema).optional().describe("Optional: targeted test case UUIDs to replay"),
   repeatPerTestCase: z.number().int().optional().describe("Optional: repeat count per test case"),
   workflowParams: WorkflowParamsSchema,
 });
 
 export const WorkflowGetReplayBulkBatchSummaryInputSchema = z.object({
-  runBatchId: IdSchema.describe("Run batch ID"),
+  runBatchId: RunBatchIdSchema.describe("Run batch ID (UUID) from bulk replay workflow"),
 });
 
 export const WorkflowCancelRunInputSchema = z.object({
-  workflowRunId: IdSchema.describe("Workflow run ID to cancel"),
+  workflowRunId: IdSchema.describe("Workflow run ID (UUID) to cancel"),
 });
 
 export const WorkflowCancelRuntimeInputSchema = z.object({
-  workflowRuntimeId: IdSchema.describe("Workflow runtime ID to cancel"),
+  workflowRuntimeId: IdSchema.describe("Workflow runtime ID (UUID) to cancel"),
 });
 
 // =============================================================================
@@ -308,31 +345,31 @@ export const WorkflowCancelRuntimeInputSchema = z.object({
 // =============================================================================
 
 export const ProjectTestResultsSummaryInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID to get test results summary for"),
+  projectId: IdSchema.describe("Project ID (UUID) to get test results summary for"),
 });
 
 export const ProjectTestScriptsSummaryInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID to get test scripts summary for"),
+  projectId: IdSchema.describe("Project ID (UUID) to get test scripts summary for"),
 });
 
 export const ProjectTestRunsSummaryInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID to get test runs summary for"),
+  projectId: IdSchema.describe("Project ID (UUID) to get test runs summary for"),
 });
 
 export const ReportStatsSummaryInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID to get report stats for"),
+  projectId: IdSchema.describe("Project ID (UUID) to get report stats for"),
 });
 
 export const ReportCostQueryInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID"),
+  projectId: IdSchema.describe("Project ID (UUID)"),
   startDateKey: z.string().optional().describe("Start date key (YYYYMMDD)"),
   endDateKey: z.string().optional().describe("End date key (YYYYMMDD)"),
-  filterType: z.string().optional().describe("Filter type for cost breakdown"),
-  filterIds: z.array(z.unknown()).optional().describe("Filter IDs"),
+  filterType: TokenUsageFilterTypeSchema.optional().describe("Aggregation dimension for cost breakdown"),
+  filterIds: z.array(IdSchema).optional().describe("Entity UUIDs matching filterType (project / use case / test case / test script / action script)"),
 });
 
 export const ReportPreferencesUpsertInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID"),
+  projectId: IdSchema.describe("Project ID (UUID)"),
   channels: z.array(z.unknown()).describe("Delivery channels to enable"),
   emails: z.array(z.unknown()).optional().describe("Email addresses for delivery"),
   phones: z.array(z.unknown()).optional().describe("Phone numbers for SMS delivery"),
@@ -341,7 +378,7 @@ export const ReportPreferencesUpsertInputSchema = z.object({
 });
 
 export const ReportFinalGenerateInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID to generate report for"),
+  projectId: IdSchema.describe("Project ID (UUID) to generate report for"),
   exportFormat: z.enum(["pdf", "html", "markdown"]).describe("Export format for the report"),
 });
 
@@ -350,7 +387,7 @@ export const ReportFinalGenerateInputSchema = z.object({
 // =============================================================================
 
 export const WalletTopUpInputSchema = z.object({
-  packageId: IdSchema.describe("Token package ID to purchase"),
+  packageId: TokenPackageIdSchema.describe("Token package ID to purchase"),
   checkoutSuccessCallback: z.string().url().describe("URL to redirect to when checkout succeeds"),
   checkoutCancelCallback: z.string().url().describe("URL to redirect to when checkout is canceled"),
 });
@@ -361,7 +398,7 @@ export const WalletPaymentMethodCreateSetupSessionInputSchema = z.object({
 });
 
 export const WalletAutoTopUpSetPaymentMethodInputSchema = z.object({
-  paymentMethodId: IdSchema.describe("Saved Stripe payment method ID (e.g., pm_xxx)"),
+  paymentMethodId: StripePaymentMethodIdSchema.describe("Saved Stripe payment method ID"),
 });
 
 export const WalletPaymentMethodListInputSchema = z.object({});
@@ -369,7 +406,7 @@ export const WalletPaymentMethodListInputSchema = z.object({});
 export const WalletAutoTopUpUpdateInputSchema = z.object({
   enabled: z.boolean().describe("Whether auto top-up is enabled"),
   topUpTriggerTokenThreshold: z.number().int().min(0).describe("Token balance threshold to trigger auto top-up"),
-  packageId: IdSchema.describe("Token package ID to purchase when auto top-up triggers"),
+  packageId: TokenPackageIdSchema.describe("Token package ID to purchase when auto top-up triggers"),
 });
 
 // =============================================================================
@@ -377,13 +414,13 @@ export const WalletAutoTopUpUpdateInputSchema = z.object({
 // =============================================================================
 
 export const RecommendScheduleInputSchema = z.object({
-  projectId: IdSchema.optional().describe("Project ID for context"),
+  projectId: IdSchema.optional().describe("Project ID (UUID) for context"),
   testFrequency: z.enum(["daily", "weekly", "onDemand"]).optional().describe("Desired test frequency"),
   timezone: z.string().optional().describe("Timezone for scheduling"),
 });
 
 export const RecommendCicdSetupInputSchema = z.object({
-  projectId: IdSchema.optional().describe("Project ID for context"),
+  projectId: IdSchema.optional().describe("Project ID (UUID) for context"),
   repositoryProvider: z.enum(["github", "azureDevOps", "gitlab", "other"]).optional().describe("Git repository provider"),
   cadence: z.enum(["onPullRequest", "nightly", "onDemand"]).optional().describe("CI/CD trigger cadence"),
 });
@@ -400,11 +437,11 @@ export const ApiKeyCreateInputSchema = z.object({
 export const ApiKeyListInputSchema = z.object({});
 
 export const ApiKeyGetInputSchema = z.object({
-  apiKeyId: IdSchema.describe("ID of the API key to retrieve"),
+  apiKeyId: ApiKeyRecordIdSchema.describe("ID of the API key record to retrieve"),
 });
 
 export const ApiKeyRevokeInputSchema = z.object({
-  apiKeyId: IdSchema.describe("ID of the API key to revoke"),
+  apiKeyId: ApiKeyRecordIdSchema.describe("ID of the API key record to revoke"),
 });
 
 // =============================================================================

--- a/packages/mcps/src/mcp/e2e/contracts/local-run-schemas.ts
+++ b/packages/mcps/src/mcp/e2e/contracts/local-run-schemas.ts
@@ -19,9 +19,9 @@ export const LocalExecutionContextInputSchema = z.object({
  * Input schema for remote local-run upload tool.
  */
 export const LocalRunUploadInputSchema = z.object({
-  projectId: z.string().min(1).describe("Project ID for the local run"),
-  useCaseId: z.string().min(1).describe("Use case ID for the local run"),
-  testCaseId: z.string().min(1).describe("Test case ID for the local run"),
+  projectId: z.string().uuid().describe("Project ID (UUID) for the local run"),
+  useCaseId: z.string().uuid().describe("Use case ID (UUID) for the local run"),
+  testCaseId: z.string().uuid().describe("Test case ID (UUID) for the local run"),
   runType: z.enum(["generation", "replay"]).describe("Type of local run to upload"),
   productionUrl: z.string().url().describe("Cloud production URL associated with the run"),
   localExecutionContext: LocalExecutionContextInputSchema.describe("Local execution metadata"),

--- a/packages/mcps/src/mcp/e2e/contracts/local-run-schemas.ts
+++ b/packages/mcps/src/mcp/e2e/contracts/local-run-schemas.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { MuggleEntityIdSchema } from "../../contracts/muggle-entity-id-schema.js";
+
 /**
  * Local execution context schema for local-run upload.
  */
@@ -19,9 +21,9 @@ export const LocalExecutionContextInputSchema = z.object({
  * Input schema for remote local-run upload tool.
  */
 export const LocalRunUploadInputSchema = z.object({
-  projectId: z.string().uuid().describe("Project ID (UUID) for the local run"),
-  useCaseId: z.string().uuid().describe("Use case ID (UUID) for the local run"),
-  testCaseId: z.string().uuid().describe("Test case ID (UUID) for the local run"),
+  projectId: MuggleEntityIdSchema.describe("Project ID (UUID) for the local run"),
+  useCaseId: MuggleEntityIdSchema.describe("Use case ID (UUID) for the local run"),
+  testCaseId: MuggleEntityIdSchema.describe("Test case ID (UUID) for the local run"),
   runType: z.enum(["generation", "replay"]).describe("Type of local run to upload"),
   productionUrl: z.string().url().describe("Cloud production URL associated with the run"),
   localExecutionContext: LocalExecutionContextInputSchema.describe("Local execution metadata"),

--- a/packages/mcps/src/mcp/local/contracts/index.ts
+++ b/packages/mcps/src/mcp/local/contracts/index.ts
@@ -2,6 +2,7 @@
  * Re-export all contract schemas.
  */
 
+export { MuggleEntityIdSchema } from "../../contracts/muggle-entity-id-schema.js";
 export * from "./auth-schemas.js";
 export * from "./project-schemas.js";
 export * from "./session-schemas.js";

--- a/packages/mcps/src/mcp/local/contracts/project-schemas.ts
+++ b/packages/mcps/src/mcp/local/contracts/project-schemas.ts
@@ -14,11 +14,7 @@
 
 import { z } from "zod";
 
-/**
- * UUID string schema for Muggle cloud resource IDs and local run-result / test-script record IDs
- * (aligned with e2e `IdSchema` and `randomUUID()` storage filenames).
- */
-const MuggleUuidSchema = z.string().uuid();
+import { MuggleEntityIdSchema } from "../../contracts/muggle-entity-id-schema.js";
 
 // ========================================
 // Test Case Schema (from muggle-remote-test-case-get)
@@ -30,7 +26,7 @@ const MuggleUuidSchema = z.string().uuid();
  */
 export const TestCaseDetailsSchema = z.object({
   /** Cloud test case ID. */
-  id: MuggleUuidSchema.describe("Cloud test case ID (UUID)"),
+  id: MuggleEntityIdSchema.describe("Cloud test case ID (UUID)"),
   /** Test case title. */
   title: z.string().min(1).describe("Test case title"),
   /** Test goal. */
@@ -44,9 +40,9 @@ export const TestCaseDetailsSchema = z.object({
   /** Original cloud URL (for reference, replaced by localUrl). */
   url: z.string().url().optional().describe("Original cloud URL (replaced by localUrl during execution)"),
   /** Cloud project ID (required for electron workflow context). */
-  projectId: MuggleUuidSchema.describe("Cloud project ID (UUID)"),
+  projectId: MuggleEntityIdSchema.describe("Cloud project ID (UUID)"),
   /** Cloud use case ID (required for electron workflow context). */
-  useCaseId: MuggleUuidSchema.describe("Cloud use case ID (UUID)"),
+  useCaseId: MuggleEntityIdSchema.describe("Cloud use case ID (UUID)"),
 });
 
 export type TestCaseDetails = z.infer<typeof TestCaseDetailsSchema>;
@@ -62,21 +58,21 @@ export type TestCaseDetails = z.infer<typeof TestCaseDetailsSchema>;
  */
 export const TestScriptDetailsSchema = z.object({
   /** Cloud test script ID. */
-  id: MuggleUuidSchema.describe("Cloud test script ID (UUID)"),
+  id: MuggleEntityIdSchema.describe("Cloud test script ID (UUID)"),
   /** Script name. */
   name: z.string().min(1).describe("Test script name"),
   /** Cloud test case ID this script belongs to. */
-  testCaseId: MuggleUuidSchema.describe("Cloud test case ID (UUID) this script was generated from"),
+  testCaseId: MuggleEntityIdSchema.describe("Cloud test case ID (UUID) this script was generated from"),
   /** Action script ID reference (use muggle-remote-action-script-get to fetch content). */
-  actionScriptId: MuggleUuidSchema.describe(
+  actionScriptId: MuggleEntityIdSchema.describe(
     "Action script ID (UUID) — use muggle-remote-action-script-get to fetch the full script",
   ),
   /** Original cloud URL (for reference, replaced by localUrl). */
   url: z.string().url().optional().describe("Original cloud URL (replaced by localUrl during execution)"),
   /** Cloud project ID (required for electron workflow context). */
-  projectId: MuggleUuidSchema.describe("Cloud project ID (UUID)"),
+  projectId: MuggleEntityIdSchema.describe("Cloud project ID (UUID)"),
   /** Cloud use case ID (required for electron workflow context). */
-  useCaseId: MuggleUuidSchema.describe("Cloud use case ID (UUID)"),
+  useCaseId: MuggleEntityIdSchema.describe("Cloud use case ID (UUID)"),
 });
 
 export type TestScriptDetails = z.infer<typeof TestScriptDetailsSchema>;
@@ -129,7 +125,7 @@ export type ExecuteReplayInput = z.infer<typeof ExecuteReplayInputSchema>;
  * Cancel execution input schema.
  */
 export const CancelExecutionInputSchema = z.object({
-  runId: MuggleUuidSchema.describe("Run ID (UUID) to cancel"),
+  runId: MuggleEntityIdSchema.describe("Run ID (UUID) to cancel"),
 });
 
 export type CancelExecutionInput = z.infer<typeof CancelExecutionInputSchema>;
@@ -142,7 +138,7 @@ export type CancelExecutionInput = z.infer<typeof CancelExecutionInputSchema>;
  * Run result list input schema.
  */
 export const RunResultListInputSchema = z.object({
-  cloudTestCaseId: MuggleUuidSchema.optional().describe("Optional cloud test case ID (UUID) to filter by"),
+  cloudTestCaseId: MuggleEntityIdSchema.optional().describe("Optional cloud test case ID (UUID) to filter by"),
   limit: z.number().int().positive().optional().describe("Maximum results to return (default: 20)"),
 });
 
@@ -152,7 +148,7 @@ export type RunResultListInput = z.infer<typeof RunResultListInputSchema>;
  * Run result get input schema.
  */
 export const RunResultGetInputSchema = z.object({
-  runId: MuggleUuidSchema.describe("Run result ID (UUID) to retrieve"),
+  runId: MuggleEntityIdSchema.describe("Run result ID (UUID) to retrieve"),
 });
 
 export type RunResultGetInput = z.infer<typeof RunResultGetInputSchema>;
@@ -165,7 +161,7 @@ export type RunResultGetInput = z.infer<typeof RunResultGetInputSchema>;
  * Test script list input schema.
  */
 export const TestScriptListInputSchema = z.object({
-  cloudTestCaseId: MuggleUuidSchema.optional().describe("Optional cloud test case ID (UUID) to filter by"),
+  cloudTestCaseId: MuggleEntityIdSchema.optional().describe("Optional cloud test case ID (UUID) to filter by"),
 });
 
 export type TestScriptListInput = z.infer<typeof TestScriptListInputSchema>;
@@ -174,7 +170,7 @@ export type TestScriptListInput = z.infer<typeof TestScriptListInputSchema>;
  * Test script get input schema.
  */
 export const TestScriptGetInputSchema = z.object({
-  testScriptId: MuggleUuidSchema.describe("Local stored test script ID (UUID) to retrieve"),
+  testScriptId: MuggleEntityIdSchema.describe("Local stored test script ID (UUID) to retrieve"),
 });
 
 export type TestScriptGetInput = z.infer<typeof TestScriptGetInputSchema>;
@@ -188,8 +184,8 @@ export type TestScriptGetInput = z.infer<typeof TestScriptGetInputSchema>;
  * Uses local run ID to find the generated script and cloud IDs for where to publish.
  */
 export const PublishTestScriptInputSchema = z.object({
-  runId: MuggleUuidSchema.describe("Local run result ID (UUID) from muggle_execute_test_generation"),
-  cloudTestCaseId: MuggleUuidSchema.describe("Cloud test case ID (UUID) to publish the script under"),
+  runId: MuggleEntityIdSchema.describe("Local run result ID (UUID) from muggle_execute_test_generation"),
+  cloudTestCaseId: MuggleEntityIdSchema.describe("Cloud test case ID (UUID) to publish the script under"),
 });
 
 export type PublishTestScriptInput = z.infer<typeof PublishTestScriptInputSchema>;

--- a/packages/mcps/src/mcp/local/contracts/project-schemas.ts
+++ b/packages/mcps/src/mcp/local/contracts/project-schemas.ts
@@ -14,6 +14,12 @@
 
 import { z } from "zod";
 
+/**
+ * UUID string schema for Muggle cloud resource IDs and local run-result / test-script record IDs
+ * (aligned with e2e `IdSchema` and `randomUUID()` storage filenames).
+ */
+const MuggleUuidSchema = z.string().uuid();
+
 // ========================================
 // Test Case Schema (from muggle-remote-test-case-get)
 // ========================================
@@ -24,7 +30,7 @@ import { z } from "zod";
  */
 export const TestCaseDetailsSchema = z.object({
   /** Cloud test case ID. */
-  id: z.string().min(1).describe("Cloud test case ID"),
+  id: MuggleUuidSchema.describe("Cloud test case ID (UUID)"),
   /** Test case title. */
   title: z.string().min(1).describe("Test case title"),
   /** Test goal. */
@@ -38,9 +44,9 @@ export const TestCaseDetailsSchema = z.object({
   /** Original cloud URL (for reference, replaced by localUrl). */
   url: z.string().url().optional().describe("Original cloud URL (replaced by localUrl during execution)"),
   /** Cloud project ID (required for electron workflow context). */
-  projectId: z.string().min(1).describe("Cloud project ID"),
+  projectId: MuggleUuidSchema.describe("Cloud project ID (UUID)"),
   /** Cloud use case ID (required for electron workflow context). */
-  useCaseId: z.string().min(1).describe("Cloud use case ID"),
+  useCaseId: MuggleUuidSchema.describe("Cloud use case ID (UUID)"),
 });
 
 export type TestCaseDetails = z.infer<typeof TestCaseDetailsSchema>;
@@ -56,22 +62,21 @@ export type TestCaseDetails = z.infer<typeof TestCaseDetailsSchema>;
  */
 export const TestScriptDetailsSchema = z.object({
   /** Cloud test script ID. */
-  id: z.string().min(1).describe("Cloud test script ID"),
+  id: MuggleUuidSchema.describe("Cloud test script ID (UUID)"),
   /** Script name. */
   name: z.string().min(1).describe("Test script name"),
   /** Cloud test case ID this script belongs to. */
-  testCaseId: z.string().min(1).describe("Cloud test case ID this script was generated from"),
+  testCaseId: MuggleUuidSchema.describe("Cloud test case ID (UUID) this script was generated from"),
   /** Action script ID reference (use muggle-remote-action-script-get to fetch content). */
-  actionScriptId: z
-    .string()
-    .uuid()
-    .describe("Action script ID (UUID) — use muggle-remote-action-script-get to fetch the full script"),
+  actionScriptId: MuggleUuidSchema.describe(
+    "Action script ID (UUID) — use muggle-remote-action-script-get to fetch the full script",
+  ),
   /** Original cloud URL (for reference, replaced by localUrl). */
   url: z.string().url().optional().describe("Original cloud URL (replaced by localUrl during execution)"),
   /** Cloud project ID (required for electron workflow context). */
-  projectId: z.string().min(1).describe("Cloud project ID"),
+  projectId: MuggleUuidSchema.describe("Cloud project ID (UUID)"),
   /** Cloud use case ID (required for electron workflow context). */
-  useCaseId: z.string().min(1).describe("Cloud use case ID"),
+  useCaseId: MuggleUuidSchema.describe("Cloud use case ID (UUID)"),
 });
 
 export type TestScriptDetails = z.infer<typeof TestScriptDetailsSchema>;
@@ -124,7 +129,7 @@ export type ExecuteReplayInput = z.infer<typeof ExecuteReplayInputSchema>;
  * Cancel execution input schema.
  */
 export const CancelExecutionInputSchema = z.object({
-  runId: z.string().min(1).describe("Run ID to cancel"),
+  runId: MuggleUuidSchema.describe("Run ID (UUID) to cancel"),
 });
 
 export type CancelExecutionInput = z.infer<typeof CancelExecutionInputSchema>;
@@ -137,7 +142,7 @@ export type CancelExecutionInput = z.infer<typeof CancelExecutionInputSchema>;
  * Run result list input schema.
  */
 export const RunResultListInputSchema = z.object({
-  cloudTestCaseId: z.string().optional().describe("Optional cloud test case ID to filter by"),
+  cloudTestCaseId: MuggleUuidSchema.optional().describe("Optional cloud test case ID (UUID) to filter by"),
   limit: z.number().int().positive().optional().describe("Maximum results to return (default: 20)"),
 });
 
@@ -147,7 +152,7 @@ export type RunResultListInput = z.infer<typeof RunResultListInputSchema>;
  * Run result get input schema.
  */
 export const RunResultGetInputSchema = z.object({
-  runId: z.string().min(1).describe("Run result ID to retrieve"),
+  runId: MuggleUuidSchema.describe("Run result ID (UUID) to retrieve"),
 });
 
 export type RunResultGetInput = z.infer<typeof RunResultGetInputSchema>;
@@ -160,7 +165,7 @@ export type RunResultGetInput = z.infer<typeof RunResultGetInputSchema>;
  * Test script list input schema.
  */
 export const TestScriptListInputSchema = z.object({
-  cloudTestCaseId: z.string().optional().describe("Optional cloud test case ID to filter by"),
+  cloudTestCaseId: MuggleUuidSchema.optional().describe("Optional cloud test case ID (UUID) to filter by"),
 });
 
 export type TestScriptListInput = z.infer<typeof TestScriptListInputSchema>;
@@ -169,7 +174,7 @@ export type TestScriptListInput = z.infer<typeof TestScriptListInputSchema>;
  * Test script get input schema.
  */
 export const TestScriptGetInputSchema = z.object({
-  testScriptId: z.string().min(1).describe("Test script ID to retrieve"),
+  testScriptId: MuggleUuidSchema.describe("Local stored test script ID (UUID) to retrieve"),
 });
 
 export type TestScriptGetInput = z.infer<typeof TestScriptGetInputSchema>;
@@ -183,8 +188,8 @@ export type TestScriptGetInput = z.infer<typeof TestScriptGetInputSchema>;
  * Uses local run ID to find the generated script and cloud IDs for where to publish.
  */
 export const PublishTestScriptInputSchema = z.object({
-  runId: z.string().min(1).describe("Local run result ID from muggle_execute_test_generation"),
-  cloudTestCaseId: z.string().min(1).describe("Cloud test case ID to publish the script under"),
+  runId: MuggleUuidSchema.describe("Local run result ID (UUID) from muggle_execute_test_generation"),
+  cloudTestCaseId: MuggleUuidSchema.describe("Cloud test case ID (UUID) to publish the script under"),
 });
 
 export type PublishTestScriptInput = z.infer<typeof PublishTestScriptInputSchema>;

--- a/packages/mcps/src/mcp/local/contracts/project-schemas.ts
+++ b/packages/mcps/src/mcp/local/contracts/project-schemas.ts
@@ -62,7 +62,10 @@ export const TestScriptDetailsSchema = z.object({
   /** Cloud test case ID this script belongs to. */
   testCaseId: z.string().min(1).describe("Cloud test case ID this script was generated from"),
   /** Action script ID reference (use muggle-remote-action-script-get to fetch content). */
-  actionScriptId: z.string().min(1).describe("Action script ID - use muggle-remote-action-script-get to fetch the full script"),
+  actionScriptId: z
+    .string()
+    .uuid()
+    .describe("Action script ID (UUID) — use muggle-remote-action-script-get to fetch the full script"),
   /** Original cloud URL (for reference, replaced by localUrl). */
   url: z.string().url().optional().describe("Original cloud URL (replaced by localUrl during execution)"),
   /** Cloud project ID (required for electron workflow context). */

--- a/packages/mcps/src/mcp/local/services/execution-service.ts
+++ b/packages/mcps/src/mcp/local/services/execution-service.ts
@@ -390,6 +390,7 @@ function buildGenerationActionScript(params: {
     url: params.localUrl,
     description: params.testCase.title,
     precondition: params.testCase.precondition ?? "",
+    instructions: params.testCase.instructions ?? "",
     expectedResult: params.testCase.expectedResult,
     steps: [],
     ownerId: params.ownerUserId,

--- a/packages/mcps/src/mcp/local/services/run-result-storage-service.ts
+++ b/packages/mcps/src/mcp/local/services/run-result-storage-service.ts
@@ -9,123 +9,31 @@
  * All entity management (projects, use cases, test cases) happens in the cloud.
  */
 
+import { randomUUID } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
 import { getLogger } from "../../../shared/logger.js";
 
+import type {
+  ILocalExecutionContext,
+  IRunResult,
+  IRunResultStorageTestScript,
+  RunResultType,
+} from "../types/run-result-storage-types.js";
+
 import { getStorageService } from "./storage-service.js";
 
 const logger = getLogger();
 
-// ========================================
-// Types
-// ========================================
-
-/**
- * Run result status.
- */
-export type RunResultStatus = "pending" | "running" | "passed" | "failed" | "cancelled";
-
-/**
- * Run result type.
- */
-export type RunResultType = "generation" | "replay";
-
-/**
- * Local execution context captured during local run execution.
- */
-export interface ILocalExecutionContext {
-  /** URL executed locally (typically localhost). */
-  originalUrl: string;
-  /** Cloud production URL associated with the test case/script. */
-  productionUrl: string;
-  /** User ID who ran the local execution. */
-  runByUserId: string;
-  /** Machine hostname for the local execution environment. */
-  machineHostname?: string;
-  /** OS information for local execution environment. */
-  osInfo?: string;
-  /** Electron app version used for local execution. */
-  electronAppVersion?: string;
-  /** MCP server version used for local execution. */
-  mcpServerVersion?: string;
-  /** Local execution completion timestamp (epoch ms). */
-  localExecutionCompletedAt?: number;
-}
-
-/**
- * Run result record.
- */
-export interface IRunResult {
-  /** Unique run ID. */
-  id: string;
-  /** Run type. */
-  runType: RunResultType;
-  /** Run status. */
-  status: RunResultStatus;
-  /** Cloud test case ID. */
-  cloudTestCaseId: string;
-  /** Cloud project ID. */
-  projectId: string;
-  /** Cloud use case ID. */
-  useCaseId: string;
-  /** Local URL used for testing. */
-  localUrl: string;
-  /** Cloud production URL for the same test. */
-  productionUrl: string;
-  /** Local execution context details. */
-  localExecutionContext: ILocalExecutionContext;
-  /** Associated test script ID (if generated). */
-  testScriptId?: string;
-  /** Path to run artifacts directory (action script, screenshots, results). */
-  artifactsDir?: string;
-  /** Execution time in ms. */
-  executionTimeMs?: number;
-  /** Error message if failed. */
-  errorMessage?: string;
-  /** Created timestamp. */
-  createdAt: string;
-  /** Updated timestamp. */
-  updatedAt: string;
-  /** Studio returned result (populated by electron-app after execution). */
-  studioReturnedResult?: unknown;
-}
-
-/**
- * Test script status.
- */
-export type TestScriptStatus = "pending" | "generated" | "published" | "failed";
-
-/**
- * Locally generated test script.
- */
-export interface ILocalTestScript {
-  /** Unique script ID. */
-  id: string;
-  /** Script name. */
-  name: string;
-  /** Target URL. */
-  url: string;
-  /** Script status. */
-  status: TestScriptStatus;
-  /** Cloud test case ID. */
-  cloudTestCaseId: string;
-  /** Test goal. */
-  goal?: string;
-  /** Action script steps. */
-  actionScript?: unknown[];
-  /** Cloud action script ID (if published). */
-  cloudActionScriptId?: string;
-  /** Created timestamp. */
-  createdAt: string;
-  /** Updated timestamp. */
-  updatedAt: string;
-}
-
-// ========================================
-// Service Implementation
-// ========================================
+export type {
+  ILocalExecutionContext,
+  IRunResult,
+  IRunResultStorageTestScript,
+  RunResultStatus,
+  RunResultType,
+  TestScriptStatus,
+} from "../types/run-result-storage-types.js";
 
 /**
  * Run Result Storage Service class.
@@ -225,7 +133,7 @@ export class RunResultStorageService {
     localExecutionContext: ILocalExecutionContext;
   }): IRunResult {
     const now = new Date().toISOString();
-    const id = `run_${Date.now()}_${Math.random().toString(36).substring(2, 8)}`;
+    const id = randomUUID();
 
     const result: IRunResult = {
       id: id,
@@ -271,15 +179,15 @@ export class RunResultStorageService {
   /**
    * List all test scripts.
    */
-  listTestScripts(): ILocalTestScript[] {
+  listTestScripts(): IRunResultStorageTestScript[] {
     try {
       const files = fs.readdirSync(this.testScriptsDir).filter((f) => f.endsWith(".json"));
-      const scripts: ILocalTestScript[] = [];
+      const scripts: IRunResultStorageTestScript[] = [];
 
       for (const file of files) {
         try {
           const content = fs.readFileSync(path.join(this.testScriptsDir, file), "utf-8");
-          scripts.push(JSON.parse(content) as ILocalTestScript);
+          scripts.push(JSON.parse(content) as IRunResultStorageTestScript);
         } catch {
           logger.warn("Failed to read test script file", { file: file });
         }
@@ -295,7 +203,7 @@ export class RunResultStorageService {
   /**
    * Get a test script by ID.
    */
-  getTestScript(testScriptId: string): ILocalTestScript | undefined {
+  getTestScript(testScriptId: string): IRunResultStorageTestScript | undefined {
     const filePath = path.join(this.testScriptsDir, `${testScriptId}.json`);
     if (!fs.existsSync(filePath)) {
       return undefined;
@@ -303,7 +211,7 @@ export class RunResultStorageService {
 
     try {
       const content = fs.readFileSync(filePath, "utf-8");
-      return JSON.parse(content) as ILocalTestScript;
+      return JSON.parse(content) as IRunResultStorageTestScript;
     } catch {
       return undefined;
     }
@@ -312,7 +220,7 @@ export class RunResultStorageService {
   /**
    * Save a test script.
    */
-  saveTestScript(script: ILocalTestScript): void {
+  saveTestScript(script: IRunResultStorageTestScript): void {
     const filePath = path.join(this.testScriptsDir, `${script.id}.json`);
     fs.writeFileSync(filePath, JSON.stringify(script, null, 2));
   }
@@ -325,11 +233,11 @@ export class RunResultStorageService {
     url: string;
     cloudTestCaseId: string;
     goal?: string;
-  }): ILocalTestScript {
+  }): IRunResultStorageTestScript {
     const now = new Date().toISOString();
-    const id = `ts_${Date.now()}_${Math.random().toString(36).substring(2, 8)}`;
+    const id = randomUUID();
 
-    const script: ILocalTestScript = {
+    const script: IRunResultStorageTestScript = {
       id: id,
       name: params.name,
       url: params.url,
@@ -347,13 +255,16 @@ export class RunResultStorageService {
   /**
    * Update a test script.
    */
-  updateTestScript(testScriptId: string, updates: Partial<ILocalTestScript>): ILocalTestScript | undefined {
+  updateTestScript(
+    testScriptId: string,
+    updates: Partial<IRunResultStorageTestScript>,
+  ): IRunResultStorageTestScript | undefined {
     const script = this.getTestScript(testScriptId);
     if (!script) {
       return undefined;
     }
 
-    const updated: ILocalTestScript = {
+    const updated: IRunResultStorageTestScript = {
       ...script,
       ...updates,
       updatedAt: new Date().toISOString(),

--- a/packages/mcps/src/mcp/local/types/index.ts
+++ b/packages/mcps/src/mcp/local/types/index.ts
@@ -6,6 +6,7 @@ export * from "./enums.js";
 export * from "./auth-types.js";
 export * from "./config-types.js";
 export * from "./execution-types.js";
+export * from "./run-result-storage-types.js";
 export * from "./project-types.js";
 export * from "./storage-params.js";
 export * from "./tool-types.js";

--- a/packages/mcps/src/mcp/local/types/run-result-storage-types.ts
+++ b/packages/mcps/src/mcp/local/types/run-result-storage-types.ts
@@ -1,0 +1,108 @@
+/**
+ * Types for run-result file storage (run-results/ and test-scripts/ JSON artifacts).
+ * Distinct from project-types ILocalTestScript (full project entity model).
+ */
+
+/**
+ * Run result status.
+ */
+export type RunResultStatus = "pending" | "running" | "passed" | "failed" | "cancelled";
+
+/**
+ * Run result type.
+ */
+export type RunResultType = "generation" | "replay";
+
+/**
+ * Local execution context captured during local run execution.
+ */
+export interface ILocalExecutionContext {
+  /** URL executed locally (typically localhost). */
+  originalUrl: string;
+  /** Cloud production URL associated with the test case/script. */
+  productionUrl: string;
+  /** User ID who ran the local execution. */
+  runByUserId: string;
+  /** Machine hostname for the local execution environment. */
+  machineHostname?: string;
+  /** OS information for local execution environment. */
+  osInfo?: string;
+  /** Electron app version used for local execution. */
+  electronAppVersion?: string;
+  /** MCP server version used for local execution. */
+  mcpServerVersion?: string;
+  /** Local execution completion timestamp (epoch ms). */
+  localExecutionCompletedAt?: number;
+}
+
+/**
+ * Run result record persisted under run-results/.
+ */
+export interface IRunResult {
+  /** Unique run ID (UUID, aligned with cloud IWorkflowRunData.id). */
+  id: string;
+  /** Run type. */
+  runType: RunResultType;
+  /** Run status. */
+  status: RunResultStatus;
+  /** Cloud test case ID. */
+  cloudTestCaseId: string;
+  /** Cloud project ID. */
+  projectId: string;
+  /** Cloud use case ID. */
+  useCaseId: string;
+  /** Local URL used for testing. */
+  localUrl: string;
+  /** Cloud production URL for the same test. */
+  productionUrl: string;
+  /** Local execution context details. */
+  localExecutionContext: ILocalExecutionContext;
+  /** Associated test script ID (if generated). */
+  testScriptId?: string;
+  /** Path to run artifacts directory (action script, screenshots, results). */
+  artifactsDir?: string;
+  /** Execution time in ms. */
+  executionTimeMs?: number;
+  /** Error message if failed. */
+  errorMessage?: string;
+  /** Created timestamp. */
+  createdAt: string;
+  /** Updated timestamp. */
+  updatedAt: string;
+  /** Studio returned result (populated by electron-app after execution). */
+  studioReturnedResult?: unknown;
+}
+
+/**
+ * Test script status for persisted test-scripts/*.json records.
+ */
+export type TestScriptStatus = "pending" | "generated" | "published" | "failed";
+
+/**
+ * Test script record persisted under test-scripts/ (run-result storage).
+ */
+export interface IRunResultStorageTestScript {
+  /**
+   * Unique local test script ID (UUID).
+   * Used as actionScriptId / testScriptId in local generation payloads; aligns with cloud action script IDs.
+   */
+  id: string;
+  /** Script name. */
+  name: string;
+  /** Target URL. */
+  url: string;
+  /** Script status. */
+  status: TestScriptStatus;
+  /** Cloud test case ID. */
+  cloudTestCaseId: string;
+  /** Test goal. */
+  goal?: string;
+  /** Action script steps. */
+  actionScript?: unknown[];
+  /** Cloud action script ID (if published). */
+  cloudActionScriptId?: string;
+  /** Created timestamp. */
+  createdAt: string;
+  /** Updated timestamp. */
+  updatedAt: string;
+}


### PR DESCRIPTION
## Summary

This PR moves MCP contract and local storage work off `master` into a dedicated branch.

### Changes
- **Run results / test scripts:** Local IDs use `randomUUID()`; storage types live in `run-result-storage-types.ts`.
- **E2E contracts (`e2e/contracts/index.ts`):** `IdSchema` is UUID-only; `RunBatchIdSchema`; separate schemas for non-UUID IDs (token package, Stripe `pm_`, API key hex); cost report `filterType` / `filterIds`; workflow and report `.describe` strings note UUIDs where relevant.
- **Local contracts (`local/contracts/project-schemas.ts`):** Cloud and local record IDs validated with the same UUID rules as E2E.
- **Shared schema:** `mcp/contracts/muggle-entity-id-schema.ts` exports `MuggleEntityIdSchema`; `IdSchema`, local-run upload, and local project schemas all use it to avoid drift.

### Verification
- `npm run typecheck` in `packages/mcps` passes.

### Note
Legacy local files using non-UUID run/script IDs will fail validation until recreated or migrated.

Made with [Cursor](https://cursor.com)