### PR TITLE
Release @muggleai/works 4.2.4 (Electron 1.0.32)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.2.3"
+      "version": "4.2.4"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.2.3"
+      "version": "4.2.4"
     }
   ]
 }

--- a/.cursor/skills/muggle-works-npm-release/SKILL.md
+++ b/.cursor/skills/muggle-works-npm-release/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: muggle-works-npm-release
+description: >-
+  Internal workflow to ship a new @muggleai/works npm version: align bundled
+  Electron app (GitHub release), refresh checksums, bump package version, build,
+  verify, and publish. Use when releasing muggle-ai-works or refreshing
+  electronAppVersion.
+---
+
+# Muggle AI Works — npm release (internal)
+
+## When to use
+
+- Publishing `@muggleai/works` to npm after product or packaging changes.
+- Pointing the npm package at the **latest** published Electron desktop build (`electron-app-v*` on GitHub).
+
+## Source of truth
+
+| What | Where |
+| :--- | :---- |
+| npm package version | Root `package.json` → `version` |
+| Bundled desktop build | Root `package.json` → `muggleConfig.electronAppVersion` |
+| Download URL base | `muggleConfig.downloadBaseUrl` (usually `https://github.com/multiplex-ai/muggle-ai-works/releases/download`) |
+| Per-platform SHA256 | `muggleConfig.checksums` keys: `darwin-arm64`, `darwin-x64`, `win32-x64`, `linux-x64` |
+| Release artifacts | GitHub repo `multiplex-ai/muggle-ai-works`, tags `electron-app-vX.Y.Z` |
+
+The teaching-service `packages/electron-app/package.json` **version** field is not the same as `electronAppVersion`; the latter must match an existing **`electron-app-v*`** GitHub release with `checksums.txt` and the four `MuggleAI-*.zip` assets.
+
+## Steps
+
+1. **Resolve latest Electron release**  
+   List tags (example): `https://api.github.com/repos/multiplex-ai/muggle-ai-works/releases?per_page=20` and take the newest `electron-app-v*` (e.g. `electron-app-v1.0.32` → version `1.0.32`).
+
+2. **Fetch checksums**  
+   Download `checksums.txt` from  
+   `{downloadBaseUrl}/electron-app-v{version}/checksums.txt`  
+   Map lines to `muggleConfig.checksums`:
+   - `MuggleAI-darwin-arm64.zip` → `darwin-arm64`
+   - `MuggleAI-darwin-x64.zip` → `darwin-x64`
+   - `MuggleAI-win32-x64.zip` → `win32-x64`
+   - `MuggleAI-linux-x64.zip` → `linux-x64`
+
+3. **Edit root `package.json`**  
+   - Bump `version` (semver for the npm package).  
+   - Set `muggleConfig.electronAppVersion` to the chosen `X.Y.Z`.  
+   - Fill all four `muggleConfig.checksums` entries (do not leave empty strings if you want install-time verification).
+
+4. **Build and sync manifests**  
+   From repo root: `npm run build`  
+   (runs `tsup`, `scripts/sync-versions.mjs`, and `scripts/build-plugin.mjs` so plugin/marketplace versions match `package.json`.)
+
+5. **Verify Electron release**  
+   `npm run verify:electron-release-checksums`  
+   Confirms `checksums.txt` exists for `electron-app-v{muggleConfig.electronAppVersion}` and lists all required zips.
+
+6. **Quality gates (as needed)**  
+   `npm run typecheck`, `npm test`, `npm run lint:check`, `npm run verify:upgrade-experience`, etc.
+
+7. **Publish to npm**  
+   - Ensure `npm whoami` succeeds and the account has **publish** rights to the `@muggleai` scope.  
+   - `npm publish --access public`  
+   If `PUT` returns **404**, the logged-in user typically lacks permission to publish under `@muggleai/works`; fix org/token access, then retry.
+
+8. **Git**  
+   Commit the updated `package.json`, synced manifests (`.claude-plugin/`, `.cursor-plugin/`, `plugin/`, `server.json`), and any regenerated `dist/` if your process requires it. Tag or open PR per team practice.
+
+## Quick checksums fetch (manual)
+
+```bash
+curl -sL "https://github.com/multiplex-ai/muggle-ai-works/releases/download/electron-app-vVERSION/checksums.txt"
+```
+
+Replace `VERSION` with the semver (no `v` prefix in the path segment after `electron-app-v`).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@muggleai/works",
     "mcpName": "io.github.multiplex-ai/muggle",
-    "version": "4.2.3",
+    "version": "4.2.4",
     "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
     "type": "module",
     "main": "dist/index.js",
@@ -42,14 +42,14 @@
         "test:watch": "vitest"
     },
     "muggleConfig": {
-        "electronAppVersion": "1.0.29",
+        "electronAppVersion": "1.0.32",
         "downloadBaseUrl": "https://github.com/multiplex-ai/muggle-ai-works/releases/download",
         "runtimeTargetDefault": "dev",
         "checksums": {
-            "darwin-arm64": "",
-            "darwin-x64": "",
-            "win32-x64": "",
-            "linux-x64": ""
+            "darwin-arm64": "8a0c66138a7d7cf8225c749304a2624a0b950a907f35893259d3a7c98758eb23",
+            "darwin-x64": "9efc098ced8fe7ee724560ff66f902a9663f2601389bf71cb1016cca86d03468",
+            "win32-x64": "60eb2f6e0179423920e4553c1b25d6051cedf1fdc5f568a96976b85625cb32be",
+            "linux-x64": "36212f0ec3da6325d7c22cfd5226dede2645b2a86a190a168f3747dc5b1b7b97"
         }
     },
     "dependencies": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "4.3.0",
+  "version": "4.2.4",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "4.2.3",
+  "version": "4.2.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "4.2.3",
+      "version": "4.2.4",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
## Summary
- Bump `@muggleai/works` to **4.2.4** and sync plugin/marketplace manifests.
- Point `muggleConfig.electronAppVersion` at **1.0.32** (latest `electron-app-v*` GitHub release) and fill platform SHA256 checksums from `checksums.txt`.
- Add internal Cursor skill `.cursor/skills/muggle-works-npm-release/SKILL.md` documenting the npm + Electron release workflow.

## Verification
- `npm run build`
- `npm run verify:electron-release-checksums`

## Follow-up
Publish to npm from a machine with `@muggleai` publish access: `npm publish --access public`.

Made with [Cursor](https://cursor.com)