### PR TITLE
fix(ci): remove broken npm global upgrade in publish job

### DIFF
--- a/.github/workflows/publish-works-to-npm.yml
+++ b/.github/workflows/publish-works-to-npm.yml
@@ -215,10 +215,7 @@ jobs:
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
-      
-      - name: Upgrade npm
-        run: npm install -g npm@latest
-        
+
       - name: Download package artifact
         uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
The **Publish Works to npm** job failed on `npm install -g npm@latest` (missing `promise-retry` in the runner npm tree). Node 22\u2019s bundled npm is enough for `npm publish` with provenance.

Made with [Cursor](https://cursor.com)