### PR TITLE
chore(release): @muggleai/works 4.2.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.2.4"
+      "version": "4.2.5"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.2.4"
+      "version": "4.2.5"
     }
   ]
 }

--- a/.github/workflows/publish-works-to-npm.yml
+++ b/.github/workflows/publish-works-to-npm.yml
@@ -113,7 +113,12 @@ jobs:
           INPUT_BUMP: ${{ inputs.bump }}
         run: |
           if [ -n "$INPUT_VERSION" ]; then
-            npm version "$INPUT_VERSION" --no-git-tag-version
+            CURRENT=$(node -p "require('./package.json').version")
+            if [ "$CURRENT" != "$INPUT_VERSION" ]; then
+              npm version "$INPUT_VERSION" --no-git-tag-version
+            else
+              echo "package.json already at $INPUT_VERSION, skipping npm version"
+            fi
           else
             npm version "$INPUT_BUMP" --no-git-tag-version
           fi

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@muggleai/works",
     "mcpName": "io.github.multiplex-ai/muggle",
-    "version": "4.2.4",
+    "version": "4.2.5",
     "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
     "type": "module",
     "main": "dist/index.js",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "4.2.4",
+  "version": "4.2.5",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "4.2.4",
+      "version": "4.2.5",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
## Why
- **4.2.4** never reached npm: tag push failed on removed `npm install -g npm@latest` step (fixed on main).
- Manual dispatch with `version=4.2.4` failed because `npm version` errors when the version is unchanged.

## Changes
- Patch bump to **4.2.5** (manifests synced).
- Manual publish step: if `inputs.version` equals current `package.json` version, skip `npm version`.

After merge, push tag `v4.2.5` to run **Publish Works to npm**.

Made with [Cursor](https://cursor.com)