### PR TITLE
docs(ci): remind to update npm auth when renaming publish workflow

### DIFF
--- a/.github/workflows/publish-works-to-npm.yml
+++ b/.github/workflows/publish-works-to-npm.yml
@@ -1,5 +1,16 @@
 name: Publish Works to npm
 
+# -----------------------------------------------------------------------------
+# If you rename this file or change the workflow `name:` above, publishing may
+# silently fail (e.g. ENEEDAUTH) until auth is updated elsewhere:
+# - npmjs.com → package → Access → Trusted Publishing / automation: the allowed
+#   GitHub workflow is often tied to the workflow *filename* (and sometimes
+#   display name). Update it to match after a rename.
+# - GitHub → Settings → Environments → `npm-publish`: confirm `NPM_TOKEN` (or
+#   OIDC-only setup) still applies; environment rules are per-repo, but any
+#   external docs or runbooks that reference the old workflow path need updating.
+# -----------------------------------------------------------------------------
+
 run-name: >-
   Publish Works to npm (
   ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name
@@ -204,6 +215,8 @@ jobs:
           muggle --version
           muggle doctor
 
+  # Publishes with secrets from Environment `npm-publish` — see top-of-file note
+  # when renaming this workflow or the workflow display name.
   publish:
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
## Summary
Adds YAML comments to [`publish-works-to-npm.yml`](.github/workflows/publish-works-to-npm.yml):
- After the workflow `name:` — npm Trusted Publishing often keys off the workflow **filename**; GitHub Environment `npm-publish` / `NPM_TOKEN` must stay aligned.
- Above the `publish` job — pointer to that note.

No behavior change.

Made with [Cursor](https://cursor.com)