### PR TITLE
Restore npm upgrade before publish; document OIDC requirement

### DIFF
--- a/.github/workflows/publish-works-to-npm.yml
+++ b/.github/workflows/publish-works-to-npm.yml
@@ -234,6 +234,9 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Upgrade npm
+        run: npm install -g npm@latest
+
       - name: Download package artifact
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/publish-works-to-npm.yml
+++ b/.github/workflows/publish-works-to-npm.yml
@@ -9,6 +9,10 @@ name: Publish Works to npm
 # - GitHub → Settings → Environments → `npm-publish`: confirm `NPM_TOKEN` (or
 #   OIDC-only setup) still applies; environment rules are per-repo, but any
 #   external docs or runbooks that reference the old workflow path need updating.
+# - Do not remove the publish job step that upgrades npm (see that job below).
+#   Node 22 images ship npm 10.x; trusted publishing / OIDC needs npm >= 11.5.1.
+#   Without it, publish often fails with ENEEDAUTH when OIDC is required or tokens
+#   are disallowed. See: https://docs.npmjs.com/trusted-publishers
 # -----------------------------------------------------------------------------
 
 run-name: >-
@@ -234,6 +238,12 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
+      # REQUIRED: keep this step. npm on the runner is often 10.x; trusted
+      # publishing (OIDC) requires npm CLI >= 11.5.1 per npm docs. The CLI prefers
+      # OIDC over NODE_AUTH_TOKEN when both apply; a too-old npm breaks OIDC and
+      # you get ENEEDAUTH / publish failures—especially if the package disallows
+      # classic tokens. Do not delete to "simplify" or fix unrelated npm warnings;
+      # see reverted commit e9460c5 and npm trusted-publishers troubleshooting.
       - name: Upgrade npm
         run: npm install -g npm@latest
 


### PR DESCRIPTION
Reverts the removal of the publish job step that runs `npm install -g npm@latest` (see #39 / e9460c5). Node 22 runners ship npm 10.x; trusted publishing and OIDC need npm CLI >= 11.5.1 per npm docs, so dropping the step led to ENEEDAUTH-style publish failures.

Adds comments at the workflow header and above the upgrade step so the step is not removed again without understanding the auth impact.

Made with [Cursor](https://cursor.com)