### PR TITLE
fix(ci): npm publish via OIDC (remove empty token auth)

### DIFF
--- a/.github/workflows/publish-works-to-npm.yml
+++ b/.github/workflows/publish-works-to-npm.yml
@@ -6,9 +6,9 @@ name: Publish Works to npm
 # - npmjs.com → package → Access → Trusted Publishing / automation: the allowed
 #   GitHub workflow is often tied to the workflow *filename* (and sometimes
 #   display name). Update it to match after a rename.
-# - GitHub → Settings → Environments → `npm-publish`: confirm `NPM_TOKEN` (or
-#   OIDC-only setup) still applies; environment rules are per-repo, but any
-#   external docs or runbooks that reference the old workflow path need updating.
+# - GitHub → Settings → Environments → `npm-publish`: confirm the environment
+#   exists and OIDC trusted publishing is configured on npmjs.com.
+#   Auth is handled via OIDC (id-token: write), not via NPM_TOKEN.
 # - Do not remove the publish job step that activates npm 11.x (see that job below).
 #   Node 22 images ship npm 10.x; trusted publishing / OIDC needs npm >= 11.5.1.
 #   Do not switch back to `npm install -g npm`—it can fail on ubuntu-latest + Node 22
@@ -220,8 +220,8 @@ jobs:
           muggle --version
           muggle doctor
 
-  # Publishes with secrets from Environment `npm-publish` — see top-of-file note
-  # when renaming this workflow or the workflow display name.
+  # Publishes via OIDC trusted publishing — see top-of-file note when renaming
+  # this workflow or the workflow display name.
   publish:
     runs-on: ubuntu-latest
     needs:
@@ -253,9 +253,10 @@ jobs:
         with:
           name: npm-package
 
-      - name: Publish to npm (with provenance)
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Remove token auth line so npm uses OIDC
+        run: sed -i '/_authToken/d' "$NPM_CONFIG_USERCONFIG"
+
+      - name: Publish to npm (with provenance via OIDC)
         run: npm publish "${{ needs.package-audit.outputs.package_tarball }}" --access public --provenance
 
   # TODO: Add publish-mcp-registry job when mcp-publisher CLI is publicly available.


### PR DESCRIPTION
When `NPM_TOKEN` is not set, `setup-node` still writes an empty `_authToken` into `.npmrc`, so `npm publish` fails with `ENEEDAUTH` before OIDC trusted publishing runs.

This removes `NODE_AUTH_TOKEN` from the publish step and strips the `_authToken` line from the temp npmrc so npm uses OIDC (already configured on npmjs.com for this workflow and `npm-publish` environment).

Made with [Cursor](https://cursor.com)