### PR TITLE
Make uploadedAt required in LocalExecutionContextInputSchema

### DIFF
--- a/packages/mcps/src/mcp/e2e/contracts/local-run-schemas.ts
+++ b/packages/mcps/src/mcp/e2e/contracts/local-run-schemas.ts
@@ -14,7 +14,7 @@ export const LocalExecutionContextInputSchema = z.object({
   electronAppVersion: z.string().optional().describe("Electron app version used for local run"),
   mcpServerVersion: z.string().optional().describe("MCP server version used for local run"),
   localExecutionCompletedAt: z.number().int().positive().describe("Epoch milliseconds when local run completed"),
-  uploadedAt: z.number().int().positive().optional().describe("Epoch milliseconds when uploaded to cloud"),
+  uploadedAt: z.number().int().positive().describe("Epoch milliseconds when uploaded to cloud"),
 });
 
 /**


### PR DESCRIPTION
## Summary

Tighten the `muggle-remote-local-run-upload` MCP tool's zod schema to match the prompt-service `ILocalExecutionContext` interface — `uploadedAt` is required by the backend but was marked optional in the zod schema, allowing silently-broken requests through.

## Background

While investigating a UI bug where locally-executed test script generation runs were showing as "Cloud" in the dashboard (root cause + fix in [muggle-ai-prompt-service#337](https://github.com/multiplex-ai/muggle-ai-prompt-service/pull/337)), I traced the full upload contract from electron-app → MCP tool → prompt-service and found this latent contract drift:

| Field | MCP zod schema | Backend interface |
|---|---|---|
| `uploadedAt` | `optional` | **required** |

The prompt-service controller (`mcp_workflow_controller.uploadMcpWorkflow`) does only shallow null-checks on top-level fields and never validates nested `localExecutionContext` fields. So an MCP caller invoking `muggle-remote-local-run-upload` without `uploadedAt` would have:
1. The zod schema accept the request
2. The backend pass it through unvalidated
3. Firestore store `localExecutionContext.uploadedAt = undefined`
4. The dashboard modal render `new Date(undefined).toLocaleString()` → "Invalid Date"

## Fix

Make `uploadedAt` required in the zod schema. Existing callers are unaffected because the local `publishTestScriptTool` always generates `uploadedAt: Date.now()` at upload time inside its `mapToUpstream` body builder.

## Test plan

- [x] `pnpm typecheck` passes
- [ ] After deploy, verify the local publish flow still works end-to-end (the local tool already always sends `uploadedAt`)
- [ ] Verify any direct callers of `muggle-remote-local-run-upload` (if any exist outside the local tool) now get a clear validation error instead of silent data loss

## Notes

- This is paired with [muggle-ai-prompt-service#337](https://github.com/multiplex-ai/muggle-ai-prompt-service/pull/337) which fixes the actual UI bug. This PR is the contract-tightening companion to prevent the same class of issue from recurring.
- A broader fix would be adding zod/JSON-schema validation to the prompt-service controller itself so the backend never silently accepts malformed payloads — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)