### PR TITLE
chore(release): @muggleai/works 4.4.0, Electron 1.0.36

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.3.0"
+      "version": "4.4.0"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.3.0"
+      "version": "4.4.0"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@muggleai/works",
     "mcpName": "io.github.multiplex-ai/muggle",
-    "version": "4.3.0",
+    "version": "4.4.0",
     "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
     "type": "module",
     "main": "dist/index.js",
@@ -42,14 +42,14 @@
         "test:watch": "vitest"
     },
     "muggleConfig": {
-        "electronAppVersion": "1.0.32",
+        "electronAppVersion": "1.0.36",
         "downloadBaseUrl": "https://github.com/multiplex-ai/muggle-ai-works/releases/download",
         "runtimeTargetDefault": "dev",
         "checksums": {
-            "darwin-arm64": "8a0c66138a7d7cf8225c749304a2624a0b950a907f35893259d3a7c98758eb23",
-            "darwin-x64": "9efc098ced8fe7ee724560ff66f902a9663f2601389bf71cb1016cca86d03468",
-            "win32-x64": "60eb2f6e0179423920e4553c1b25d6051cedf1fdc5f568a96976b85625cb32be",
-            "linux-x64": "36212f0ec3da6325d7c22cfd5226dede2645b2a86a190a168f3747dc5b1b7b97"
+            "darwin-arm64": "0466282dbccab499a42a1da13e4ff1883b58044de8c66858e77bad0cbee6979e",
+            "darwin-x64": "405730a320b8eb6ced6e250840b75758de32355705eedeeb81297aa3e211805a",
+            "win32-x64": "962fd484f8409b662ba71f24fdafb0a665f28e52b7066696f5c5d16ebc7ba1ed",
+            "linux-x64": "f3cd45b893fa7f90e0af1e5b911ce13bf9a7a25d038298cb1ff2465145f08abc"
         }
     },
     "dependencies": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "4.3.0",
+  "version": "4.4.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "4.3.0",
+      "version": "4.4.0",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
Release **@muggleai/works** `4.4.0` (minor from 4.3.0).

- Updates `muggleConfig.electronAppVersion` to **1.0.36** and checksums from `electron-app-v1.0.36` release asset.
- Syncs plugin and marketplace manifests via build.

Local verification: `pnpm run build` and `pnpm run verify:electron-release-checksums` passed.

Made with [Cursor](https://cursor.com)