### PR TITLE
feat(skill): add muggle-test-regenerate-missing for bulk script catch-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This installs:
 - `/muggle:muggle-do` — autonomous dev pipeline (requirements to PR)
 - `/muggle:muggle-test` — change-driven E2E acceptance testing (local or remote, with PR posting)
 - `/muggle:muggle-test-feature-local` — local quick E2E acceptance testing
+- `/muggle:muggle-test-regenerate-missing` — bulk-regenerate test scripts for every test case that has no active script
 - `/muggle:muggle-status` — health check for muggle-works plugins (Electron app, MCP server, and auth)
 - `/muggle:muggle-repair` — diagnose and fix broken installation
 - `/muggle:muggle-upgrade` — update to the latest version
@@ -479,6 +480,7 @@ muggle-ai-works/
 │   │   ├── muggle/                        # /muggle:muggle — command router and menu
 │   │   ├── muggle-do/                     # /muggle:muggle-do — autonomous dev pipeline
 │   │   ├── muggle-test-feature-local/     # /muggle:muggle-test-feature-local
+│   │   ├── muggle-test-regenerate-missing/# /muggle:muggle-test-regenerate-missing
 │   │   ├── muggle-status/                 # /muggle:muggle-status
 │   │   ├── muggle-repair/                 # /muggle:muggle-repair
 │   │   └── muggle-upgrade/                # /muggle:muggle-upgrade

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -28,6 +28,7 @@ Type `muggle` to discover the full command family.
 | `/muggle:muggle-test` | Change-driven E2E acceptance router: detects code changes, maps to use cases, runs test generation locally or remotely, publishes to dashboard, opens in browser, posts E2E acceptance results to PR. |
 | `/muggle:muggle-test-feature-local` | Test a feature on localhost with AI-driven browser automation. Offers publish to cloud after each run. |
 | `/muggle:muggle-test-import` | Import existing tests into Muggle Test — from Playwright/Cypress specs, PRDs, Gherkin feature files, test plan docs, or any test artifact. |
+| `/muggle:muggle-test-regenerate-missing` | Bulk-regenerate test scripts for every test case in a project that doesn't currently have an active script. Scans DRAFT + GENERATION_PENDING, confirms the list with the user, and dispatches remote generation workflows for each. |
 | `/muggle:muggle-status` | Health check for Electron browser test runner, MCP server, and authentication. |
 | `/muggle:muggle-repair` | Diagnose and fix broken installation automatically. |
 | `/muggle:muggle-upgrade` | Update Electron browser test runner and MCP server to latest version. |

--- a/plugin/skills/muggle-test-regenerate-missing/SKILL.md
+++ b/plugin/skills/muggle-test-regenerate-missing/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: muggle-test-regenerate-missing
+description: "Bulk-regenerate test scripts for every test case in a Muggle AI project that doesn't currently have an active script. Scans the project, finds test cases stuck in DRAFT or GENERATION_PENDING (no usable script attached), shows the user the list, and on approval kicks off remote test script generation for each one in parallel via the Muggle cloud. Use this skill whenever the user asks to 'regenerate missing scripts', 'fill in missing test scripts', 'generate scripts for test cases without one', 'regen all the test cases that don't have scripts', 'rebuild scripts for stale test cases', 'fix test cases with no script', 'bulk regenerate', or any phrasing that means 'kick off script generation across a project for the cases that need it'. Triggers on: 'regenerate missing test scripts', 'generate scripts for all empty test cases', 'fill the gaps in my test scripts', 'bulk test script regen', 'all my test cases without active scripts'. This is the go-to skill for project-wide script catch-up — it handles discovery, filtering, confirmation, and remote workflow dispatch end-to-end."
+---
+
+# Muggle Test — Regenerate Missing Test Scripts
+
+A bulk maintenance skill for Muggle AI projects. It finds every test case in a project that does **not** currently have an active (ready-to-run) test script, shows the list to the user, and on approval triggers a remote test script generation workflow for each one. Useful after creating a batch of new test cases or when cleaning up a project that has drifted.
+
+Execution is **remote only** — Muggle's cloud generates the scripts in parallel against the project URL. The user's machine is not involved beyond making API calls.
+
+## Concept: what counts as "no active script"
+
+In the Muggle data model, a test case carries a status that reflects whether it has a usable script attached:
+
+| Status | Meaning | Regenerate? |
+|:-------|:--------|:-----------:|
+| `ACTIVE` | Has a generated, ready-to-run script | No — already good |
+| `DRAFT` | Created but never generated | **Yes** |
+| `GENERATION_PENDING` | Queued but generation never started | **Yes** |
+| `GENERATING` | Currently generating | No — generation is in flight; don't double-dispatch |
+| `REPLAY_PENDING` / `REPLAYING` | A replay is in flight; script exists | No — busy with replay |
+| `DEPRECATED` | Marked stale on purpose | No — user decision |
+| `ARCHIVED` | Hidden from normal flows | No — user decision |
+
+The skill targets exactly **DRAFT** and **GENERATION_PENDING** by default. These are the two states that mean "no usable script attached and nothing running to produce one." `GENERATING` is deliberately excluded — a workflow is already in progress, and firing a second one races against the first and wastes budget.
+
+Treat this filter as a default, not a law. If the user explicitly says "include generating ones too, they're stuck" or "include deprecated", respect the override — but don't widen the filter on your own.
+
+## UX Guidelines — Minimize Typing
+
+**Every selection-based question MUST use the `AskQuestion` tool** (or the platform's equivalent structured selection tool). Never ask the user to "reply with a number" — always present clickable options.
+
+- **Selections** (project, which test cases to include): Use `AskQuestion`, with `allow_multiple: true` for the test case picker.
+- **Free-text inputs** (project URL when creating, override filters): Only ask as plain text when the option set isn't finite.
+- **Batch related questions** when independent. Don't ask sequentially what could be one screen.
+
+## Workflow
+
+### Step 1 — Authenticate
+
+1. Call `muggle-remote-auth-status`.
+2. If not authenticated or expired → call `muggle-remote-auth-login`, then poll with `muggle-remote-auth-poll`.
+3. Do not skip auth and do not assume a stale token still works.
+
+If auth keeps failing, suggest the user run `muggle logout && muggle login` from a terminal.
+
+### Step 2 — Select Project (user must choose)
+
+A **project** is the unit on the Muggle AI dashboard that groups test cases, scripts, and runs. The user must pick the one to scan — never auto-select from repo name, branch, or URL heuristics.
+
+1. Call `muggle-remote-project-list`.
+2. Use `AskQuestion` to present projects as clickable options. Include the project URL in each label so the user can disambiguate. Always include "Create new project" as the last option.
+3. Wait for explicit selection.
+4. If the user picks "Create new project": collect `projectName`, `description`, and `url`, then call `muggle-remote-project-create`.
+
+Store `projectId` and `projectUrl` only after the user confirms — both are needed downstream.
+
+### Step 3 — Scan Test Cases
+
+Pull the full set of test cases for the project. The list endpoint is paginated.
+
+1. Call `muggle-remote-test-case-list` with `projectId`. Start at page 1; continue requesting pages until the response indicates no more items. Use a generous `pageSize` (e.g. 100) to keep the call count low.
+2. Accumulate everything into a single in-memory array.
+3. Tell the user the totals as you go if the project is large (e.g., "Found 247 test cases across the project").
+
+If the call returns zero test cases, stop and tell the user — there is nothing to regenerate. Suggest they create test cases first (point them at `muggle-test` or `muggle-test-feature-local`).
+
+### Step 4 — Filter to Missing Scripts
+
+Apply the default filter: keep only test cases where `status` ∈ `{DRAFT, GENERATION_PENDING}`.
+
+Then show a one-line summary. Also surface how many cases are currently `GENERATING` so the user knows about in-flight work (but don't include them in the candidate list unless they override the filter):
+
+```
+Project: <name> (<projectId>)
+Total test cases: 247
+With active script (skipped): 198
+Currently generating (skipped, in-flight): 32
+Needs regeneration: 17
+  • DRAFT: 12
+  • GENERATION_PENDING: 5
+```
+
+If after filtering the list is empty, congratulate the user — every test case already has an active script — and stop. Do not invent work.
+
+### Step 5 — Present and Confirm Selection
+
+Use `AskQuestion` with `allow_multiple: true` to present every candidate test case as a clickable option. The user must explicitly approve which ones to regenerate.
+
+For each option label, show enough context for the user to make a real decision:
+
+```
+[<status>] <title> — use case: <use case title>
+```
+
+For example:
+- `[DRAFT] Sign up with valid email — use case: User Registration`
+- `[GENERATION_PENDING] Add item to cart — use case: Checkout Flow`
+
+Default behavior:
+- If there are **≤ 25** candidates, present all of them in a single `AskQuestion` with everything pre-checked and let the user deselect anything they want to skip.
+- If there are **> 25** candidates, show the first 25 ranked by status priority (`DRAFT` → `GENERATION_PENDING`), plus a tail option **"Include all N — don't make me click each one"**. The user can also pick "Show next batch" to see more.
+
+After selection, call `AskQuestion` once more for a final confirmation:
+
+> "About to start remote test script generation for **N** test cases against `<projectUrl>`. This will consume Muggle workflow budget. Proceed?"
+>
+> - "Yes, start all N"
+> - "No, cancel"
+
+Only proceed after the user picks "Yes".
+
+### Step 6 — Dispatch Remote Generations
+
+For each selected test case, in order:
+
+1. Call `muggle-remote-test-case-get` with `testCaseId` to fetch the full record (the list endpoint returns a slim shape; generation needs `goal`, `precondition`, `instructions`, `expectedResult`, `url`).
+2. Call `muggle-remote-workflow-start-test-script-generation` with:
+   - `projectId` — from Step 2
+   - `useCaseId` — from the test case
+   - `testCaseId` — the test case being regenerated
+   - `name` — `"muggle-test-regenerate-missing: {test case title}"` (so it's easy to find this batch later in the dashboard)
+   - `url` — prefer the test case's own `url` if set, else the project URL from Step 2
+   - `goal`, `precondition`, `instructions`, `expectedResult` — straight from the test case. If `precondition` is empty, pass `"None"` (the schema requires a non-empty string).
+3. Capture the returned workflow runtime ID and store it alongside the test case.
+
+**Failure handling:** if a single dispatch fails (validation error, server error, missing field), log it inline, mark the test case as `dispatch_failed`, and continue to the next one. Do not abort the whole batch — partial progress is more useful than nothing.
+
+**Pacing:** Muggle's cloud handles parallelism on its side, so you don't need to throttle. Just dispatch sequentially as fast as the API will accept them.
+
+### Step 7 — Report
+
+After all dispatches are done, print a summary table:
+
+```
+Test Case                          Use Case             Prev Status       Dispatch       Runtime
+───────────────────────────────────────────────────────────────────────────────────────────────────
+Sign up with valid email           User Registration    DRAFT             ✅ started      rt-abc123
+Sign up with disposable email      User Registration    DRAFT             ✅ started      rt-def456
+Add item to cart                   Checkout Flow        GENERATION_PEND.  ✅ started      rt-ghi789
+Apply expired coupon               Checkout Flow        GENERATION_PEND.  ❌ failed       —
+───────────────────────────────────────────────────────────────────────────────────────────────────
+Total: 17 dispatched | 16 started | 1 failed
+```
+
+For failures: include a one-line error excerpt and (where possible) a hint at the cause (e.g., "missing instructions field — edit the test case in the dashboard, then re-run this skill").
+
+### Step 8 — Open the Dashboard
+
+Open the Muggle AI dashboard so the user can watch progress visually:
+
+```bash
+open "https://www.muggle-ai.com/muggleTestV0/dashboard/projects/{projectId}/runs"
+```
+
+Tell them:
+
+> "I've opened the project's runs page. Generation jobs typically take a few minutes each — they'll appear here as they progress. Your test cases will move into `ACTIVE` status as scripts complete."
+
+### Step 9 (optional) — Poll Status
+
+Only if the user explicitly asks for a status check, call `muggle-remote-wf-get-ts-gen-latest-run` for each runtime ID and report progress. **Do not poll on a tight loop by default** — the dispatch step is the actual goal of this skill, and the dashboard already shows live status better than a CLI loop ever can. Polling exists as a courtesy for users who don't want to leave the terminal.
+
+If the user wants a one-shot snapshot, present a small table:
+
+```
+Test Case                Runtime     Status      Steps so far
+────────────────────────────────────────────────────────────
+Sign up with valid email rt-abc123   RUNNING     6
+Add item to cart         rt-ghi789   COMPLETED   12
+```
+
+## Tool Reference
+
+| Phase | Tool |
+|:------|:-----|
+| Auth | `muggle-remote-auth-status`, `muggle-remote-auth-login`, `muggle-remote-auth-poll` |
+| Project | `muggle-remote-project-list`, `muggle-remote-project-create` |
+| Scan | `muggle-remote-test-case-list` (paginated) |
+| Detail | `muggle-remote-test-case-get` |
+| Dispatch | `muggle-remote-workflow-start-test-script-generation` |
+| Status (optional) | `muggle-remote-wf-get-ts-gen-latest-run`, `muggle-remote-wf-get-latest-ts-gen-by-tc` |
+| Browser | `open` (shell command) |
+
+## Non-negotiables
+
+- **The user MUST select the project** — present projects via `AskQuestion`, never infer from cwd, repo name, or URL guesses.
+- **The user MUST approve which test cases to regenerate** — show the candidates via `AskQuestion`, let them deselect, then confirm again before any dispatch. Bulk-regenerating without approval can waste meaningful workflow budget.
+- **Default filter is `DRAFT` + `GENERATION_PENDING`** — never include `GENERATING`, `ACTIVE`, `DEPRECATED`, `ARCHIVED`, `REPLAYING`, or `REPLAY_PENDING` unless the user explicitly says so. `GENERATING` already has a workflow in flight and dispatching another races against it. `ACTIVE` test cases already have working scripts. The rest reflect deliberate user decisions or in-flight replays the skill should not interfere with.
+- **Use `muggle-remote-test-case-get` before each dispatch** — the list endpoint returns a slim shape and generation needs the full payload.
+- **Failures don't abort the batch** — log and continue, then surface them at the end. Partial progress beats no progress.
+- **Never throttle artificially** — dispatch sequentially as fast as the API accepts. Muggle's cloud handles parallelism.
+- **Open the dashboard, don't poll by default** — the runs page is the canonical view of progress. Only poll if the user explicitly asks.
+- **Use `AskQuestion` for every selection** — never ask the user to type a number.
+- **Can be invoked at any state** — if the user already has a project chosen in conversation context, skip Step 2 and go straight to scanning.

--- a/plugin/skills/muggle-test-regenerate-missing/evals/evals.json
+++ b/plugin/skills/muggle-test-regenerate-missing/evals/evals.json
@@ -1,0 +1,58 @@
+{
+  "skill_name": "muggle-test-regenerate-missing",
+  "notes": "These evals test the PLAN behavior. Because Muggle MCP tools require live auth and a real project, the subagents can't actually execute the workflow — each prompt tells them to write a step-by-step plan instead. The assertions check whether the plan reflects the skill's non-negotiables (correct filter, AskQuestion-based selection, no auto-select, dispatch via the remote workflow tool, batch-failure tolerance, dashboard open-at-end).",
+  "evals": [
+    {
+      "id": 0,
+      "eval_name": "vague-catch-up-request",
+      "prompt": "I just finished importing a bunch of test cases from our PRD into our Muggle project 'Acme Checkout QA' and half of them never got actual scripts generated — they're still sitting there as drafts. Can you kick off script generation for the ones that need it?",
+      "files": [],
+      "assertions": [
+        { "name": "calls_auth_status_first", "text": "Plan starts by calling muggle-remote-auth-status (and login/poll if needed) before any other Muggle tool." },
+        { "name": "project_selection_via_AskQuestion", "text": "Plan calls muggle-remote-project-list and presents projects via AskQuestion rather than auto-selecting 'Acme Checkout QA' by name match." },
+        { "name": "default_filter_is_draft_and_generation_pending", "text": "Plan states that the status filter is DRAFT + GENERATION_PENDING and explicitly excludes GENERATING, ACTIVE, DEPRECATED, ARCHIVED, REPLAYING, and REPLAY_PENDING." },
+        { "name": "uses_test_case_list_paginated", "text": "Plan calls muggle-remote-test-case-list with pagination (or equivalent full-enumeration) for the project scan step." },
+        { "name": "test_case_get_before_dispatch", "text": "Plan calls muggle-remote-test-case-get for each candidate before dispatching generation, to obtain the full payload (goal, precondition, instructions, expectedResult, url)." },
+        { "name": "dispatch_via_remote_workflow_tool", "text": "Plan dispatches each regeneration via muggle-remote-workflow-start-test-script-generation (not a local Electron tool)." },
+        { "name": "candidate_list_via_AskQuestion_multi_select", "text": "Plan presents the candidate test cases via AskQuestion with multi-select (allow_multiple: true) so the user can deselect individuals." },
+        { "name": "final_confirmation_step", "text": "Plan includes a final yes/no confirmation AskQuestion before any dispatch, showing the count of test cases about to be regenerated." },
+        { "name": "batch_failure_tolerance", "text": "Plan explicitly states that a single dispatch failure does not abort the batch — failures are logged and the loop continues." },
+        { "name": "opens_dashboard_runs_page_at_end", "text": "Plan ends by opening the Muggle dashboard project runs page for the user to watch progress." }
+      ]
+    },
+    {
+      "id": 1,
+      "eval_name": "explicit-filter-override",
+      "prompt": "Our project 'Tanka Staging' has about 200 test cases. I want to regenerate scripts for everything that's not active — including the ones that are stuck in GENERATING, because those have been sitting there for two days and I'm pretty sure they're dead. Please walk me through what you'd do.",
+      "files": [],
+      "assertions": [
+        { "name": "calls_auth_status_first", "text": "Plan starts by calling muggle-remote-auth-status before any other Muggle tool." },
+        { "name": "project_selection_via_AskQuestion", "text": "Plan uses AskQuestion to let the user confirm project choice; does not auto-select 'Tanka Staging' by name match alone." },
+        { "name": "honors_override_to_include_generating", "text": "Plan explicitly honors the user's override and includes GENERATING in the filter for this run, noting that this is a deliberate override of the default filter." },
+        { "name": "still_excludes_active_deprecated_archived", "text": "Even with the override, the plan still excludes ACTIVE, DEPRECATED, ARCHIVED, REPLAY_PENDING, and REPLAYING — it only widens the filter to include GENERATING, not everything." },
+        { "name": "handles_large_candidate_list", "text": "Plan acknowledges that with ~200 test cases the candidate list may exceed 25 and describes paging or bulk-include handling (e.g., 'Include all N' tail option)." },
+        { "name": "dispatch_via_remote_workflow_tool", "text": "Plan dispatches each regeneration via muggle-remote-workflow-start-test-script-generation." },
+        { "name": "final_confirmation_step", "text": "Plan includes a final yes/no AskQuestion confirmation before any dispatch, showing the total count." },
+        { "name": "batch_failure_tolerance", "text": "Plan states that a single dispatch failure does not abort the batch." },
+        { "name": "opens_dashboard_runs_page_at_end", "text": "Plan ends by opening the Muggle dashboard project runs page." }
+      ]
+    },
+    {
+      "id": 2,
+      "eval_name": "small-project-confirmation",
+      "prompt": "can you bulk regen my muggle test cases that don't have scripts? The project is tiny — I think there are only like 6 or 7 test cases in DRAFT.",
+      "files": [],
+      "assertions": [
+        { "name": "calls_auth_status_first", "text": "Plan starts by calling muggle-remote-auth-status before any other Muggle tool." },
+        { "name": "project_selection_via_AskQuestion", "text": "Plan uses AskQuestion to let the user pick the project — does not infer it." },
+        { "name": "default_filter_is_draft_and_generation_pending", "text": "Plan states that the status filter is DRAFT + GENERATION_PENDING by default." },
+        { "name": "small_list_all_preselected", "text": "Plan describes presenting all candidates in a single AskQuestion with everything pre-checked (since the candidate list is ≤ 25)." },
+        { "name": "test_case_get_before_dispatch", "text": "Plan calls muggle-remote-test-case-get for each candidate before dispatching generation." },
+        { "name": "dispatch_via_remote_workflow_tool", "text": "Plan dispatches each regeneration via muggle-remote-workflow-start-test-script-generation." },
+        { "name": "final_confirmation_step", "text": "Plan includes a final yes/no AskQuestion confirmation before any dispatch." },
+        { "name": "batch_failure_tolerance", "text": "Plan states that a single dispatch failure does not abort the batch." },
+        { "name": "opens_dashboard_runs_page_at_end", "text": "Plan ends by opening the Muggle dashboard project runs page." }
+      ]
+    }
+  ]
+}

--- a/plugin/skills/muggle-test-regenerate-missing/evals/trigger-eval.json
+++ b/plugin/skills/muggle-test-regenerate-missing/evals/trigger-eval.json
@@ -1,0 +1,22 @@
+[
+  { "query": "ok so we just imported about 40 test cases from the PRD into our muggle project and most of them are sitting in DRAFT with no scripts attached — can you kick off script generation for all the ones that don't have an active script yet? project is 'Acme Checkout QA'", "should_trigger": true },
+  { "query": "bulk regen missing test scripts in my muggle project", "should_trigger": true },
+  { "query": "I looked at the test cases page in muggle and like 30 out of 80 are still showing as DRAFT. is there a way to batch-regenerate all the ones without an active script instead of clicking each one in the UI?", "should_trigger": true },
+  { "query": "can you fill in the gaps in my muggle project — i want every test case that doesn't have a working script to have one. the project is called 'internal-admin-e2e'", "should_trigger": true },
+  { "query": "all my muggle test cases without active scripts need a script now please", "should_trigger": true },
+  { "query": "regenerate every test case in 'tanka staging' that doesn't currently have an active test script attached. default filter is fine, just don't touch the ACTIVE ones.", "should_trigger": true },
+  { "query": "I have a ton of generation_pending and draft test cases in muggle — they've been stuck for days. kick off generation for all of them at once.", "should_trigger": true },
+  { "query": "rebuild the missing muggle scripts for my project, the inactive test cases need to be regenerated in one batch", "should_trigger": true },
+  { "query": "kick off muggle script generation for every test case that's still in DRAFT state — i don't want to go through them one by one in the dashboard", "should_trigger": true },
+  { "query": "bulk fill the empty test scripts across my whole project so they all become active", "should_trigger": true },
+  { "query": "I just pushed a new commit on branch users/stan/checkout-refactor — can you run the muggle e2e acceptance tests against my localhost dev server (it's on port 3000) and make sure nothing is broken before I open the PR?", "should_trigger": false },
+  { "query": "write me a playwright test for the checkout flow that covers the happy path — user adds item, enters address, pays with test card", "should_trigger": false },
+  { "query": "can you run a single muggle test against my localhost for the signup flow? I want to watch it in the visible Electron window, the dev server is on http://localhost:5173", "should_trigger": false },
+  { "query": "my muggle-ai-ui CI is failing — the test script for 'login with valid creds' keeps timing out. can you look at the action script, figure out why, and fix it?", "should_trigger": false },
+  { "query": "I have a cypress test suite in cypress/integration/** and a few markdown PRDs in docs/requirements. import them into muggle as use cases and test cases under my project 'Acme Checkout QA'", "should_trigger": false },
+  { "query": "what muggle projects do I have right now? just list them for me with their URLs", "should_trigger": false },
+  { "query": "create a new muggle test case for 'apply expired coupon shows error banner' under the Checkout Flow use case in project 'Acme Checkout QA'", "should_trigger": false },
+  { "query": "regen my package-lock.json and reinstall node_modules — something is off with the muggle-ai-works workspace after the dependabot merge", "should_trigger": false },
+  { "query": "check the status of my current muggle test script generation — i kicked off about 15 runs earlier and i want to know which ones finished and which are still running", "should_trigger": false },
+  { "query": "generate a brand new use case and some test cases from scratch for my muggle project using a plain-english description of our new onboarding flow", "should_trigger": false }
+]


### PR DESCRIPTION
## Summary

Adds a new plugin skill, `muggle-test-regenerate-missing`, that finds every test case in a Muggle project without an active script and dispatches remote test script generation for each — with explicit user approval on both project selection and the candidate list.

### Why

After importing a batch of test cases (e.g. from a PRD) or cleaning up a drifted project, users have been clicking through the dashboard test case by test case to kick off generation. This is a one-shot way to fill in the gaps from the CLI.

### How it works

1. Auth (`muggle-remote-auth-status` / `login` / `poll`).
2. User picks the project via `AskQuestion` (never auto-selected by name).
3. Paginated scan of every test case in the project via `muggle-remote-test-case-list`.
4. **Default filter: `DRAFT` + `GENERATION_PENDING`**. `GENERATING` is deliberately excluded to avoid racing an already-in-flight workflow. `ACTIVE`, `DEPRECATED`, `ARCHIVED`, `REPLAY_PENDING`, `REPLAYING` also excluded. Users can override if they want to widen.
5. User approves the candidate set via a pre-checked multi-select `AskQuestion`, then a final yes/no confirmation.
6. For each selected case: `muggle-remote-test-case-get` (to fetch the full payload — the list endpoint returns a slim shape), then `muggle-remote-workflow-start-test-script-generation`. Failures log and continue; the batch never aborts on a single bad dispatch.
7. Summary table + `open` the project runs page in the dashboard.

### Validation

Ran an in-session behavioral eval with 3 realistic prompts (vague catch-up, explicit filter override to include `GENERATING`, small-project case) against subagents with and without the skill. 28 total assertions covering the skill's non-negotiables.

| Config | Pass rate | Time | Tokens |
|---|---|---|---|
| **with_skill** | **100%** (28/28) | 121.0s ± 15.8s | 31,566 ± 579 |
| baseline | 53% (15/28) | 82.9s ± 16.7s | 23,987 ± 342 |
| delta | **+47 pp** | +38.1s | +7,579 |

Where the baseline agents most often failed:
- Auto-selecting the project when exactly one matched by name (all 3 baselines did this; skill version refuses)
- Skipping `muggle-remote-test-case-get` before dispatch (2/3 baselines)
- Not opening the dashboard at the end (3/3 baselines only offered it as a follow-up)
- Filter drift — one baseline widened to include `DEPRECATED`/`ARCHIVED`; another mistakenly *excluded* `GENERATION_PENDING`
- Per-case interactive pauses on failure instead of log-and-continue

### Packaging

- `plugin/skills/muggle-test-regenerate-missing/SKILL.md` ships with the next npm version via the existing `files: [..., "plugin"]` entry in `package.json`.
- Build (`npm run build`), typecheck, lint, and `verify:plugin` all pass on this branch.
- `dist/plugin/skills/muggle-test-regenerate-missing/` confirms the artifact lands in the shipped plugin directory.
- README and `plugin/README.md` updated to list the new skill.

## Test plan

- [ ] Reviewer reads `plugin/skills/muggle-test-regenerate-missing/SKILL.md` and confirms the filter semantics (`DRAFT + GENERATION_PENDING` by default, `GENERATING` excluded) match expectations.
- [ ] Invoke `/muggle:muggle-test-regenerate-missing` in Claude Code against a project that has at least one `DRAFT` test case; verify the `AskQuestion` project picker appears and nothing is auto-selected.
- [ ] Confirm the candidate picker is multi-select with items pre-checked and that deselecting works.
- [ ] Kill the flow at the final confirmation and verify no dispatches happen.
- [ ] Run the full flow and confirm the dashboard runs page opens at the end and the dispatches appear under the `muggle-test-regenerate-missing:` name prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)