### PR TITLE
feat(mcp): bulk-preview MCP tools + use-case import migration

### DIFF
--- a/packages/mcps/src/mcp/e2e/contracts/index.ts
+++ b/packages/mcps/src/mcp/e2e/contracts/index.ts
@@ -202,6 +202,82 @@ export const UseCaseUpdateFromPromptInputSchema = z.object({
   instruction: z.string().min(1).describe("Natural language instruction to regenerate the use case from"),
 });
 
+/**
+ * Shape of a fully-specified use case, matching IUseCaseCreationRequest on the server.
+ * Used by muggle-remote-use-case-create to persist use cases returned by bulk-preview.
+ */
+export const UseCaseCreateInputSchema = z.object({
+  projectId: IdSchema.describe("Project ID (UUID) the use case belongs to"),
+  title: z.string().min(1).describe("Use case title"),
+  description: z.string().min(1).describe("Description of the use case, including actor and preconditions"),
+  userStory: z.string().min(1).describe("One-line user story from the end-user point of view"),
+  url: z.string().url().optional().describe("URL where the use case takes place (defaults to project URL)"),
+  useCaseBreakdown: z.array(z.object({
+    requirement: z.string().min(1).describe("One requirement of the use case"),
+    acceptanceCriteria: z.string().min(1).describe("Concrete, measurable acceptance criteria for the requirement"),
+  })).describe("Main/alternative/error flows broken down as requirement + acceptance criteria pairs"),
+  status: z.enum(["DRAFT", "IN_REVIEW", "APPROVED", "IMPLEMENTED", "ARCHIVED"]).describe("Use case status"),
+  priority: z.enum(["LOW", "MEDIUM", "HIGH", "CRITICAL"]).describe("Use case priority"),
+  source: z.enum(["PRD_FILE", "SITEMAP", "CRAWLER", "PROMPT", "MANUAL"]).describe("How this use case was produced"),
+  category: z.string().optional().describe("Optional category"),
+});
+
+// =============================================================================
+// Bulk Preview Schemas
+// =============================================================================
+
+/** One prompt inside a bulk-preview submit request. */
+export const BulkPreviewPromptSchema = z.object({
+  clientRef: z.string().max(128).optional().describe("Optional caller-supplied reference echoed back on results"),
+  instruction: z.string().min(1).max(4000).describe("Natural language instruction (max 4000 chars)"),
+});
+
+/** Submit a bulk-preview job that generates use cases from a batch of prompts. */
+export const BulkPreviewSubmitUseCaseInputSchema = z.object({
+  projectId: IdSchema.describe("Project ID (UUID) the use cases belong to"),
+  prompts: z.array(BulkPreviewPromptSchema).min(1).max(100).describe("Prompts to generate use cases from (max 100 per request)"),
+});
+
+/** Submit a bulk-preview job that generates test cases for a single use case from a batch of prompts. */
+export const BulkPreviewSubmitTestCaseInputSchema = z.object({
+  projectId: IdSchema.describe("Project ID (UUID)"),
+  useCaseId: IdSchema.describe("Parent use case ID (UUID) the test cases will belong to"),
+  prompts: z.array(BulkPreviewPromptSchema).min(1).max(100).describe("Prompts to generate test cases from (max 100 per request)"),
+});
+
+/** Bulk-preview job status values (mirrors server BulkPreviewJobStatus). */
+export const BulkPreviewJobStatusSchema = z.enum([
+  "queued",
+  "submitted",
+  "running",
+  "succeeded",
+  "partial",
+  "failed",
+  "cancelled",
+  "expired",
+]);
+
+/** Bulk-preview job kind values (mirrors server BulkPreviewJobKind). */
+export const BulkPreviewJobKindSchema = z.enum(["useCase", "testCase"]);
+
+export const BulkPreviewJobGetInputSchema = z.object({
+  projectId: IdSchema.describe("Project ID (UUID)"),
+  jobId: IdSchema.describe("Bulk-preview job ID (UUID)"),
+});
+
+export const BulkPreviewJobCancelInputSchema = z.object({
+  projectId: IdSchema.describe("Project ID (UUID)"),
+  jobId: IdSchema.describe("Bulk-preview job ID (UUID) to cancel"),
+});
+
+export const BulkPreviewJobListInputSchema = z.object({
+  projectId: IdSchema.describe("Project ID (UUID) to list bulk-preview jobs for"),
+  status: z.array(BulkPreviewJobStatusSchema).optional().describe("Optional filter — only return jobs matching any of these statuses"),
+  kind: BulkPreviewJobKindSchema.optional().describe("Optional filter — only return jobs of this kind"),
+  limit: z.number().int().min(1).max(100).optional().describe("Max jobs to return (default 20, max 100)"),
+  cursor: z.string().optional().describe("Pagination cursor returned by a previous call"),
+});
+
 // =============================================================================
 // Test Case Schemas
 // =============================================================================

--- a/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
+++ b/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
@@ -193,6 +193,43 @@ const useCaseTools: IQaToolDefinition[] = [
       };
     },
   },
+  {
+    name: "muggle-remote-use-case-create",
+    description: "Create a single use case from a fully-specified payload. Use this to persist use cases returned by muggle-remote-use-case-bulk-preview-submit — no LLM is invoked.",
+    inputSchema: schemas.UseCaseCreateInputSchema,
+    mapToUpstream: (input) => {
+      const data = input as z.infer<typeof schemas.UseCaseCreateInputSchema>;
+      return {
+        method: "POST",
+        path: `${MUGGLE_TEST_PREFIX}/use-cases`,
+        body: {
+          projectId: data.projectId,
+          title: data.title,
+          description: data.description,
+          userStory: data.userStory,
+          url: data.url,
+          useCaseBreakdown: data.useCaseBreakdown,
+          status: data.status,
+          priority: data.priority,
+          source: data.source,
+          category: data.category,
+        },
+      };
+    },
+  },
+  {
+    name: "muggle-remote-use-case-bulk-preview-submit",
+    description: "Submit an async bulk-preview job that uses the OpenAI Batch API to generate use cases from many prompts at ~50% of normal LLM cost. Returns a job ID immediately; poll with muggle-remote-bulk-preview-job-get until the job reaches a terminal status, then persist each successful result via muggle-remote-use-case-create.",
+    inputSchema: schemas.BulkPreviewSubmitUseCaseInputSchema,
+    mapToUpstream: (input) => {
+      const data = input as z.infer<typeof schemas.BulkPreviewSubmitUseCaseInputSchema>;
+      return {
+        method: "POST",
+        path: `${MUGGLE_TEST_PREFIX}/projects/${data.projectId}/use-cases/prompts/bulk-preview`,
+        body: { prompts: data.prompts },
+      };
+    },
+  },
 ];
 
 // =============================================================================
@@ -274,6 +311,68 @@ const testCaseTools: IQaToolDefinition[] = [
           category: data.category || "Functional",
           automated: data.automated ?? true,
         },
+      };
+    },
+  },
+  {
+    name: "muggle-remote-test-case-bulk-preview-submit",
+    description: "Submit an async bulk-preview job that uses the OpenAI Batch API to generate test cases for a single use case from many prompts at ~50% of normal LLM cost. Returns a job ID immediately; poll with muggle-remote-bulk-preview-job-get until the job reaches a terminal status, then persist each successful result via muggle-remote-test-case-create. Note: one input prompt may fan out to 1–5 test cases.",
+    inputSchema: schemas.BulkPreviewSubmitTestCaseInputSchema,
+    mapToUpstream: (input) => {
+      const data = input as z.infer<typeof schemas.BulkPreviewSubmitTestCaseInputSchema>;
+      return {
+        method: "POST",
+        path: `${MUGGLE_TEST_PREFIX}/projects/${data.projectId}/use-cases/${data.useCaseId}/test-cases/prompts/bulk-preview`,
+        body: { prompts: data.prompts },
+      };
+    },
+  },
+];
+
+// =============================================================================
+// Bulk Preview Job Tools
+// =============================================================================
+
+const bulkPreviewTools: IQaToolDefinition[] = [
+  {
+    name: "muggle-remote-bulk-preview-job-get",
+    description: "Get the current status and (when terminal) results of a bulk-preview job. Poll this after submitting a bulk-preview job — every 10–15 seconds is fine. Terminal statuses: succeeded, partial, failed, cancelled, expired.",
+    inputSchema: schemas.BulkPreviewJobGetInputSchema,
+    mapToUpstream: (input) => {
+      const data = input as z.infer<typeof schemas.BulkPreviewJobGetInputSchema>;
+      return {
+        method: "GET",
+        path: `${MUGGLE_TEST_PREFIX}/projects/${data.projectId}/bulk-preview-jobs/${data.jobId}`,
+      };
+    },
+  },
+  {
+    name: "muggle-remote-bulk-preview-job-list",
+    description: "List bulk-preview jobs for a project, optionally filtered by status or kind.",
+    inputSchema: schemas.BulkPreviewJobListInputSchema,
+    mapToUpstream: (input) => {
+      const data = input as z.infer<typeof schemas.BulkPreviewJobListInputSchema>;
+      return {
+        method: "GET",
+        path: `${MUGGLE_TEST_PREFIX}/projects/${data.projectId}/bulk-preview-jobs`,
+        queryParams: {
+          status: data.status?.join(","),
+          kind: data.kind,
+          limit: data.limit,
+          cursor: data.cursor,
+        },
+      };
+    },
+  },
+  {
+    name: "muggle-remote-bulk-preview-job-cancel",
+    description: "Request cancellation of a bulk-preview job. Cancellation is cooperative — the harvester picks it up on its next tick and moves the job to status=cancelled.",
+    inputSchema: schemas.BulkPreviewJobCancelInputSchema,
+    mapToUpstream: (input) => {
+      const data = input as z.infer<typeof schemas.BulkPreviewJobCancelInputSchema>;
+      return {
+        method: "DELETE",
+        path: `${MUGGLE_TEST_PREFIX}/projects/${data.projectId}/bulk-preview-jobs/${data.jobId}`,
       };
     },
   },
@@ -1409,6 +1508,7 @@ export const allQaToolDefinitions: IQaToolDefinition[] = [
   ...projectTools,
   ...useCaseTools,
   ...testCaseTools,
+  ...bulkPreviewTools,
   ...testScriptTools,
   ...actionScriptTools,
   ...workflowTools,

--- a/plugin/skills/muggle-test-import/SKILL.md
+++ b/plugin/skills/muggle-test-import/SKILL.md
@@ -162,6 +162,9 @@ A **project** is where all your imported use cases, test cases, and future test 
 
 Import in two passes using bulk-preview. Show progress to the user as you go.
 
+Both passes use Muggle's async bulk-preview MCP tools, which route prompts through OpenAI's
+Batch API for roughly ~50% of normal LLM cost. The flow is always: **submit → poll → persist**.
+
 ### Path A — Native PRD upload (for document files)
 
 If the source is a PRD or design document, use Muggle's built-in processing pipeline:
@@ -199,63 +202,31 @@ If the upload or processing fails, fall back to Path B manual extraction.
 
 Run both passes below for Playwright, Cypress, or other test scripts.
 
-### Pass 1 — Create use cases (Path B only)
+### Shared limits (both passes)
 
-Call `muggle-remote-use-case-create-from-prompts` with all use cases in a single batch:
+- Maximum 100 prompts per submit call. If you have more, split into batches of 100 and submit sequentially.
+- Maximum 4000 characters per `instruction`.
+- Maximum 3 in-flight bulk-preview jobs per project (the submit tool will error if exceeded).
 
-```
-projectId: <chosen project ID>
-prompts: [
-  { instruction: "<Use case name> — <one-sentence description of what this use case covers>" },
-  ...
-]
-```
+### Shared error handling (both passes)
 
-After the call returns, collect the use case IDs from the response.
-If IDs are not in the response, call `muggle-remote-use-case-list` and match by name.
+The bulk-preview submit and get/cancel MCP tools surface structured error codes — look for
+these on any tool result and act accordingly:
 
-> **Note:** Use case creation still uses the sequential `create-from-prompts` MCP tool because no direct-create MCP tool exists for use cases yet. Only Pass 2 (test cases) uses the new bulk-preview endpoint for ~50% LLM cost savings. When a direct-create tool is added for use cases, Pass 1 can be migrated to the same bulk-preview flow.
-
-### Pass 2 — Generate and create test cases
-
-For each use case, submit its test cases as a single bulk-preview job:
-
-```
-POST /projects/<projectId>/use-cases/<useCaseId>/test-cases/prompts/bulk-preview
-Authorization: Bearer <token>
-Content-Type: application/json
-
-{
-  "prompts": [
-    {
-      "clientRef": "tc-0",
-      "instruction": "<title> | goal: <goal> | expectedResult: <expectedResult> | precondition: <precondition> | priority: <HIGH|MEDIUM|LOW> | url: <url>"
-    },
-    ...
-  ]
-}
-```
-
-Limits to enforce before submitting:
-- Maximum 100 prompts per request. If you have more, split into batches of 100 and submit sequentially.
-- Maximum 4000 characters per instruction.
-- Maximum 3 in-flight jobs per project (HTTP 429 if exceeded).
-
-**Handle submission errors:**
-
-| HTTP status | What happened | What to do |
+| Error code / symptom | What happened | What to do |
 |---|---|---|
-| `202 Accepted` | Job queued successfully | Proceed to polling |
-| `404 Not Found` | `BULK_PREVIEW_ENABLED` flag is off on the server | Tell the user: "The bulk-preview feature is not enabled on this server. Ask an admin to set `BULK_PREVIEW_ENABLED=true`." Stop. |
-| `409 Conflict` with `error: "QUOTA_EXCEEDED_PREFLIGHT"` | Batch is too large for the account's quota | Show: "Your quota allows at most `<maxPromptsAllowed>` prompts in this batch (current headroom: `<headroom>`). Please reduce the number of test cases and try again." Stop. |
-| `429 Too Many Requests` | Already 3 in-flight jobs for this project | Tell the user: "There are already 3 preview jobs in progress for this project. Wait for them to finish, then retry." Stop. |
-| `413 Payload Too Large` | Body exceeds 1 MB | Tell the user: "The request payload is too large. Try splitting into smaller batches." Stop. |
+| `TOO_MANY_IN_FLIGHT_JOBS` (HTTP 429) | Already 3 in-flight jobs for this project | Tell the user: "There are already 3 bulk-preview jobs in progress for this project. Wait for them to finish, then retry." Stop. |
+| `QUOTA_EXCEEDED_PREFLIGHT` (HTTP 409) | Batch would blow past the account's quota for this resource | Show: "Your quota allows at most `<maxPromptsAllowed>` prompts in this batch (current headroom: `<headroom>`). Please reduce the batch and try again." Stop. |
+| `NOT_FOUND` on submit (HTTP 404) | Project or parent use case does not exist, or this server version doesn't expose bulk-preview yet | Tell the user which — double-check the IDs you passed. If you're confident the IDs are right, ask the user to make sure the prompt-service is up to date. Stop. |
+| `VALIDATION_ERROR` (HTTP 400) | A prompt exceeds limits (e.g. >4000 chars) or the prompt list is empty | Fix the offending prompts and retry. |
+| Payload > 1 MB (HTTP 413) | Body too large | Split into smaller batches. |
 
-**Poll for completion** (`GET /projects/<projectId>/bulk-preview-jobs/<jobId>`):
+### Shared polling loop
 
-Poll every 15 seconds. Show progress:
+After a successful submit, poll with `muggle-remote-bulk-preview-job-get` (inputs: `projectId`,
+`jobId`) every 15 seconds. Show progress like:
 ```
-Generating test case previews for "User Authentication"... (status: running, elapsed: 30s)
+Generating previews for "User Authentication"... (status: running, elapsed: 30s)
 ```
 
 `status` values and what to do:
@@ -265,7 +236,7 @@ Generating test case previews for "User Authentication"... (status: running, ela
 | `queued` | No | Keep polling |
 | `submitted` | No | Keep polling |
 | `running` | No | Keep polling |
-| `succeeded` | Yes | All prompts processed — proceed |
+| `succeeded` | Yes | All prompts processed — proceed to persist results |
 | `partial` | Yes | Some prompts succeeded — show summary, ask user whether to proceed |
 | `failed` | Yes | Job failed entirely — show `error.message` and stop |
 | `cancelled` | Yes | Job was cancelled — stop |
@@ -273,39 +244,93 @@ Generating test case previews for "User Authentication"... (status: running, ela
 
 **If status is `partial`**, show:
 ```
-Preview completed with partial results: <N> of <promptCount> test cases generated successfully.
+Preview completed with partial results: <N> of <promptCount> generated successfully.
 
 Failed items:
-  - [tc-1] "Checkout with expired card": <error message>
+  - [<clientRef>] "<source text>": <error message>
 
 Proceed with the <N> successful items, or cancel to review?
 ```
-Use `AskQuestion` with options "Proceed with successful items" / "Cancel import". Only continue if the user chooses to proceed.
+Use `AskQuestion` with options "Proceed with successful items" / "Cancel import". Only continue
+if the user chooses to proceed.
 
-**Process results** (at `succeeded` or `partial` after user confirms):
+If you need to abort an in-flight job, call `muggle-remote-bulk-preview-job-cancel` — the
+server picks up the request cooperatively within one harvester tick.
 
-Each successful result has this shape:
-```jsonc
-{ "clientRef": "tc-0", "index": 0, "status": "success", "testCases": [ /* ITestCaseCreationRequest[] — fan-out 1–5 */ ] }
-```
+### Pass 1 — Create use cases (Path B only)
 
-Note: one input prompt may produce 1–5 test case items (fan-out). For each item in `result.testCases`, call `muggle-remote-test-case-create`:
+1. Call `muggle-remote-use-case-bulk-preview-submit` with one prompt per use case:
+   ```
+   projectId: <chosen project ID>
+   prompts: [
+     { clientRef: "uc-0", instruction: "<Use case name> — <one-sentence description>" },
+     ...
+   ]
+   ```
+   The call returns `{ jobId, status, kind, promptCount }`.
 
-```
-projectId: <project ID>
-useCaseId: <use case ID>
-title:          <from testCase.title>
-description:    <from testCase.description>
-goal:           <from testCase.goal>
-expectedResult: <from testCase.expectedResult>
-precondition:   <from testCase.precondition>
-priority:       <from testCase.priority>
-url:            <from testCase.url>
-```
+2. Run the **Shared polling loop** above until the job reaches a terminal status.
+
+3. For each successful result (shape: `{ clientRef, index, status: "success", useCase: IUseCaseCreationRequest }`),
+   call `muggle-remote-use-case-create` to persist it — no LLM is invoked, so this is fast and free:
+   ```
+   projectId:        <project ID>
+   title:            <from useCase.title>
+   description:      <from useCase.description>
+   userStory:        <from useCase.userStory>
+   url:              <from useCase.url>         # optional
+   useCaseBreakdown: <from useCase.useCaseBreakdown>
+   status:           <from useCase.status>       # e.g. DRAFT
+   priority:         <from useCase.priority>     # e.g. MEDIUM
+   source:           <from useCase.source>       # e.g. PROMPT
+   category:         <from useCase.category>     # optional
+   ```
+
+4. Collect the returned `useCaseId` of each created use case — you'll need it for Pass 2.
+   It is safe to persist use cases in parallel once the job is terminal.
+
+### Pass 2 — Generate and create test cases
+
+For each use case, run a bulk-preview job to generate its test cases.
+
+1. Call `muggle-remote-test-case-bulk-preview-submit`:
+   ```
+   projectId: <project ID>
+   useCaseId: <use case ID>
+   prompts: [
+     {
+       clientRef: "tc-0",
+       instruction: "<title> | goal: <goal> | expectedResult: <expectedResult> | precondition: <precondition> | priority: <HIGH|MEDIUM|LOW> | url: <url>"
+     },
+     ...
+   ]
+   ```
+
+2. Run the **Shared polling loop** above until the job reaches a terminal status.
+
+3. Each successful result has this shape (note the fan-out):
+   ```jsonc
+   { "clientRef": "tc-0", "index": 0, "status": "success", "testCases": [ /* ITestCaseCreationRequest[] — fan-out 1–5 */ ] }
+   ```
+   One input prompt may produce 1–5 test case items. For each item in `result.testCases`, call
+   `muggle-remote-test-case-create`:
+   ```
+   projectId:      <project ID>
+   useCaseId:      <use case ID>
+   title:          <from testCase.title>
+   description:    <from testCase.description>
+   goal:           <from testCase.goal>
+   expectedResult: <from testCase.expectedResult>
+   precondition:   <from testCase.precondition>
+   priority:       <from testCase.priority>
+   url:            <from testCase.url>
+   ```
 
 Print progress: `Creating test cases for "User Authentication"... (1/3)`
 
-It is safe to create test cases for different use cases in parallel — do so when you have many to create. However, submit bulk-preview jobs for use cases **sequentially** to avoid exceeding the 3 in-flight job cap.
+It is safe to create test cases for different use cases in parallel once their bulk-preview
+jobs have reached a terminal status. However, **submit** bulk-preview jobs sequentially to
+avoid exceeding the 3 in-flight job cap per project.
 
 ---
 


### PR DESCRIPTION
## Summary
- Wraps the six prompt-service bulk-preview endpoints as `muggle-remote-*` MCP tools (submit/get/list/cancel + a no-LLM `use-case-create` to persist previews).
- Rewires `plugin/skills/muggle-test-import` so **both** passes drive bulk-preview: Pass 1 (use cases) now uses `use-case-bulk-preview-submit` → poll → `use-case-create`, matching Pass 2 (test cases) and picking up the ~50% LLM cost savings from the OpenAI Batch API end-to-end.
- Drops the stale `BULK_PREVIEW_ENABLED` 404 handling row — the flag was removed in multiplex-ai/muggle-ai-prompt-service#357, so that error path no longer applies.

## New MCP tools
| Tool | Verb + path |
|---|---|
| `muggle-remote-use-case-create` | `POST /v1/protected/muggle-test/use-cases` |
| `muggle-remote-use-case-bulk-preview-submit` | `POST /projects/:projectId/use-cases/prompts/bulk-preview` |
| `muggle-remote-test-case-bulk-preview-submit` | `POST /projects/:projectId/use-cases/:useCaseId/test-cases/prompts/bulk-preview` |
| `muggle-remote-bulk-preview-job-get` | `GET  /projects/:projectId/bulk-preview-jobs/:jobId` |
| `muggle-remote-bulk-preview-job-list` | `GET  /projects/:projectId/bulk-preview-jobs` |
| `muggle-remote-bulk-preview-job-cancel` | `DELETE /projects/:projectId/bulk-preview-jobs/:jobId` |

Schemas live in `packages/mcps/src/mcp/e2e/contracts/index.ts`; tool definitions in `packages/mcps/src/mcp/tools/e2e/tool-registry.ts`; `bulkPreviewTools` is wired into `allQaToolDefinitions`.

## SKILL.md cleanup
- Extracts shared limits / error handling / polling loop so both passes reference them instead of duplicating.
- Documents cooperative cancel via `muggle-remote-bulk-preview-job-cancel`.
- Keeps Path A (native PRD upload) unchanged — it already bypasses Pass 1.

## Test plan
- [x] `pnpm --filter @muggleai/mcp typecheck` — clean
- [x] `pnpm --filter @muggleai/mcp build` — 205.45 KB ESM bundle, clean
- [x] `pnpm -w lint` — clean
- [x] `pnpm -w typecheck` — clean
- [ ] Manual smoke of the updated `/muggle-test-import` skill against staging once this ships (pick a small repo, run both passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)