### PR TITLE
refactor(mcp): flatten use-case-create-from-prompts to instructions: string[]

### DIFF
--- a/packages/mcps/src/mcp/e2e/contracts/index.ts
+++ b/packages/mcps/src/mcp/e2e/contracts/index.ts
@@ -191,9 +191,7 @@ export const UseCasePromptPreviewInputSchema = z.object({
 
 export const UseCaseCreateFromPromptsInputSchema = z.object({
   projectId: IdSchema.describe("Project ID (UUID) to create use cases for"),
-  prompts: z.array(z.object({
-    instruction: z.string().min(1).describe("Natural language instruction describing the use case"),
-  })).min(1).describe("Array of prompts to generate use cases from"),
+  instructions: z.array(z.string().min(1)).min(1).describe("Natural-language instructions — one use case is generated per string (e.g., [\"As a user, I can log in\"])"),
 });
 
 export const UseCaseUpdateFromPromptInputSchema = z.object({

--- a/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
+++ b/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
@@ -176,7 +176,10 @@ const useCaseTools: IQaToolDefinition[] = [
       return {
         method: "POST",
         path: `${MUGGLE_TEST_PREFIX}/projects/${data.projectId}/use-cases/prompts/bulk`,
-        body: { projectId: data.projectId, prompts: data.prompts },
+        body: {
+          projectId: data.projectId,
+          prompts: data.instructions.map((instruction) => ({ instruction })),
+        },
       };
     },
   },

--- a/plugin/skills/muggle-test-feature-local/SKILL.md
+++ b/plugin/skills/muggle-test-feature-local/SKILL.md
@@ -57,7 +57,16 @@ Prompt for projects: "Pick the project to group this test into:"
 - **Project — Create new project:** Collect `projectName`, `description`, and `url` (may be the local app URL, e.g. `http://localhost:3999`). Call `muggle-remote-project-create`. Use the returned `projectId` and continue.
 - **Use case — Create new use case:** User provides a natural-language instruction (or you reuse their testing goal).
   1. `muggle-remote-use-case-prompt-preview` with `projectId`, `instruction` — show preview; get confirmation via `AskQuestion`.
-  2. `muggle-remote-use-case-create-from-prompts` with `projectId`, `prompts: [{ instruction }]` — persist. Use the created use case id and continue to test-case selection.
+  2. `muggle-remote-use-case-create-from-prompts` with `projectId`, `prompts` — persist. Use the created use case id and continue to test-case selection.
+
+     **`prompts` MUST be a real JSON array literal, not a stringified JSON.** The schema is `Array<{ instruction: string }>` and rejects strings with `"expected array, received string"`. Pass it as:
+     ```json
+     {
+       "projectId": "<uuid>",
+       "prompts": [{ "instruction": "<the user's natural-language instruction>" }]
+     }
+     ```
+     Do **not** wrap `prompts` in extra quotes (e.g. `"prompts": "[{\"instruction\":...}]"` will fail). The same rule applies to every other tool with an array/object parameter — pass them as native JSON values, never as stringified JSON.
 - **Test case — Create new test case** (requires a chosen `useCaseId`): User provides an instruction describing what to test.
   1. `muggle-remote-test-case-generate-from-prompt` with `projectId`, `useCaseId`, `instruction` — **preview only** (server test-case prompt preview); show the returned draft(s); get confirmation via `AskQuestion`.
   2. Persist the accepted draft with `muggle-remote-test-case-create`, mapping preview fields into the required properties (`title`, `description`, `goal`, `expectedResult`, `url`, etc.). Then continue from **section 4** with that `testCaseId`.

--- a/plugin/skills/muggle-test-feature-local/SKILL.md
+++ b/plugin/skills/muggle-test-feature-local/SKILL.md
@@ -57,16 +57,7 @@ Prompt for projects: "Pick the project to group this test into:"
 - **Project — Create new project:** Collect `projectName`, `description`, and `url` (may be the local app URL, e.g. `http://localhost:3999`). Call `muggle-remote-project-create`. Use the returned `projectId` and continue.
 - **Use case — Create new use case:** User provides a natural-language instruction (or you reuse their testing goal).
   1. `muggle-remote-use-case-prompt-preview` with `projectId`, `instruction` — show preview; get confirmation via `AskQuestion`.
-  2. `muggle-remote-use-case-create-from-prompts` with `projectId`, `prompts` — persist. Use the created use case id and continue to test-case selection.
-
-     **`prompts` MUST be a real JSON array literal, not a stringified JSON.** The schema is `Array<{ instruction: string }>` and rejects strings with `"expected array, received string"`. Pass it as:
-     ```json
-     {
-       "projectId": "<uuid>",
-       "prompts": [{ "instruction": "<the user's natural-language instruction>" }]
-     }
-     ```
-     Do **not** wrap `prompts` in extra quotes (e.g. `"prompts": "[{\"instruction\":...}]"` will fail). The same rule applies to every other tool with an array/object parameter — pass them as native JSON values, never as stringified JSON.
+  2. `muggle-remote-use-case-create-from-prompts` with `projectId` and `instructions: ["<the user's natural-language instruction>"]` — persist. Use the created use case id and continue to test-case selection.
 - **Test case — Create new test case** (requires a chosen `useCaseId`): User provides an instruction describing what to test.
   1. `muggle-remote-test-case-generate-from-prompt` with `projectId`, `useCaseId`, `instruction` — **preview only** (server test-case prompt preview); show the returned draft(s); get confirmation via `AskQuestion`.
   2. Persist the accepted draft with `muggle-remote-test-case-create`, mapping preview fields into the required properties (`title`, `description`, `goal`, `expectedResult`, `url`, etc.). Then continue from **section 4** with that `testCaseId`.

--- a/plugin/skills/muggle-test/SKILL.md
+++ b/plugin/skills/muggle-test/SKILL.md
@@ -117,7 +117,16 @@ The user MUST explicitly tell you which use case(s) to use.
 1. Ask the user to describe the use case in plain English
 2. Call `muggle-remote-use-case-create-from-prompts`:
    - `projectId`: The project ID
-   - `prompts`: Array of `{ instruction: "..." }` with the user's description
+   - `prompts`: A native JSON array — `[{ "instruction": "<user's description>" }]`
+
+   **`prompts` MUST be a real JSON array literal, not a stringified JSON.** The schema is `Array<{ instruction: string }>` and rejects strings with `"expected array, received string"`. Correct shape:
+   ```json
+   {
+     "projectId": "<uuid>",
+     "prompts": [{ "instruction": "<the user's natural-language instruction>" }]
+   }
+   ```
+   Do **not** wrap `prompts` in extra quotes (e.g. `"prompts": "[{\"instruction\":...}]"` will fail). The same rule applies to every other tool with an array/object parameter — pass them as native JSON values, never as stringified JSON.
 3. Present the created use case and confirm it's correct
 
 ## Step 6: Select Test Case (User Must Choose)

--- a/plugin/skills/muggle-test/SKILL.md
+++ b/plugin/skills/muggle-test/SKILL.md
@@ -117,16 +117,7 @@ The user MUST explicitly tell you which use case(s) to use.
 1. Ask the user to describe the use case in plain English
 2. Call `muggle-remote-use-case-create-from-prompts`:
    - `projectId`: The project ID
-   - `prompts`: A native JSON array — `[{ "instruction": "<user's description>" }]`
-
-   **`prompts` MUST be a real JSON array literal, not a stringified JSON.** The schema is `Array<{ instruction: string }>` and rejects strings with `"expected array, received string"`. Correct shape:
-   ```json
-   {
-     "projectId": "<uuid>",
-     "prompts": [{ "instruction": "<the user's natural-language instruction>" }]
-   }
-   ```
-   Do **not** wrap `prompts` in extra quotes (e.g. `"prompts": "[{\"instruction\":...}]"` will fail). The same rule applies to every other tool with an array/object parameter — pass them as native JSON values, never as stringified JSON.
+   - `instructions`: A plain array of strings, one per use case — e.g. `["<user's description>"]`
 3. Present the created use case and confirm it's correct
 
 ## Step 6: Select Test Case (User Must Choose)


### PR DESCRIPTION
## Summary

Root-causes a recurring issue where agents mis-called `muggle-remote-use-case-create-from-prompts` by passing `prompts` as a stringified JSON instead of a native array (`"expected array, received string"`).

Commit history walks the fix:

1. **`docs(skills): clarify prompts must be a native JSON array`** — documented the workaround in `muggle-test` + `muggle-test-feature-local` SKILL.md files. This is a symptom patch.
2. **`refactor(mcp): flatten use-case-create-from-prompts to instructions: string[]`** — root-causes it. The `prompts` parameter was `Array<{ instruction: string }>` — a single-field object wrapper that added no value and invited LLM/MCP-client stringification. Flattening to `instructions: string[]` removes the nested object entirely. Array-of-string is the shape clients rarely mis-serialize. The stringification warning added in commit 1 is deleted because the footgun is gone.

Server API is unchanged — the mapper converts `instructions` to the upstream `prompts: [{ instruction }]` body shape internally.

## Other schemas checked

Only 2 other `z.array(z.object(...))` patterns exist in the MCP surface, both legitimate (multi-field inner objects):

- `UseCaseCreateInputSchema.useCaseBreakdown` — `{ requirement, acceptanceCriteria }` — kept
- `BulkPreviewPromptSchema` (used by `BulkPreviewSubmit*InputSchema`) — `{ clientRef?, instruction }` — kept

No other skill docs reference the stringification workaround.

## Breaking change

The `muggle-remote-use-case-create-from-prompts` input parameter renames from `prompts: Array<{instruction}>` → `instructions: string[]`. Callers must update. Upstream HTTP API is untouched.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (33 passing)
- [x] `pnpm run lint:check`
- [x] `pnpm run verify:contracts`
- [ ] Live call `muggle-remote-use-case-create-from-prompts` with the new shape after merge