### PR TITLE
feat(mcps): real pagination defaults + remove test-script-list-paginated

### DIFF
--- a/packages/mcps/package.json
+++ b/packages/mcps/package.json
@@ -16,6 +16,11 @@
     "build": "tsup --config tsup.config.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "lint": "echo \"mcp lint placeholder\"",
-    "test": "echo \"mcp test placeholder\""
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "*",
+    "typescript": "*"
   }
 }

--- a/packages/mcps/src/mcp/e2e/contracts/index.ts
+++ b/packages/mcps/src/mcp/e2e/contracts/index.ts
@@ -13,10 +13,37 @@ export * from "./local-run-schemas.js";
 // Common Schemas
 // =============================================================================
 
-/** Pagination input schema. */
+/**
+ * Pagination input schema shared by list tools.
+ *
+ * The backend honors these params: a list call with no arguments returns the first
+ * page of 10 items sorted by creation time (newest first). The response envelope
+ * carries `totalCount`, `totalPages`, and `hasMore` so the caller can page forward
+ * without guessing when to stop. Out-of-range pages return `data: []` rather than
+ * erroring.
+ */
 export const PaginationInputSchema = z.object({
-  page: z.number().int().positive().optional().describe("Page number (1-based)"),
-  pageSize: z.number().int().positive().max(100).optional().describe("Number of items per page"),
+  page: z
+    .number()
+    .int()
+    .positive()
+    .default(1)
+    .describe("Page number, 1-based. Defaults to 1 (the first page)."),
+  pageSize: z
+    .number()
+    .int()
+    .positive()
+    .max(100)
+    .default(10)
+    .describe("Number of items per page. Defaults to 10, max 100."),
+  sortBy: z
+    .enum(["createdAt", "updatedAt"])
+    .default("createdAt")
+    .describe("Field to sort by. Defaults to createdAt (stable under concurrent writes)."),
+  sortOrder: z
+    .enum(["asc", "desc"])
+    .default("desc")
+    .describe("Sort direction. Defaults to desc (newest first)."),
 });
 
 /**
@@ -328,10 +355,6 @@ export const TestScriptListInputSchema = z.object({
 export const TestScriptGetInputSchema = z.object({
   testScriptId: IdSchema.describe("Test script ID (UUID) to retrieve"),
 });
-
-export const TestScriptListPaginatedInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID (UUID) to list test scripts for"),
-}).merge(PaginationInputSchema);
 
 // =============================================================================
 // Action Script Schemas

--- a/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
+++ b/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
@@ -74,14 +74,20 @@ const projectTools: IQaToolDefinition[] = [
   },
   {
     name: "muggle-remote-project-list",
-    description: "List all projects accessible to the authenticated user.",
+    description:
+      "List projects accessible to the authenticated user. Returns up to 10 items per page by default (max 100). Response includes pagination metadata (totalCount, totalPages, hasMore) — check `hasMore` to decide whether to fetch additional pages.",
     inputSchema: schemas.ProjectListInputSchema,
     mapToUpstream: (input) => {
       const data = input as z.infer<typeof schemas.ProjectListInputSchema>;
       return {
         method: "GET",
         path: `${MUGGLE_TEST_PREFIX}/projects`,
-        queryParams: { page: data.page, pageSize: data.pageSize },
+        queryParams: {
+          page: data.page,
+          pageSize: data.pageSize,
+          sortBy: data.sortBy,
+          sortOrder: data.sortOrder,
+        },
       };
     },
   },
@@ -131,14 +137,21 @@ const useCaseTools: IQaToolDefinition[] = [
   },
   {
     name: "muggle-remote-use-case-list",
-    description: "List all use cases for a project.",
+    description:
+      "List use cases for a project. Returns up to 10 items per page by default (max 100). Response includes pagination metadata (totalCount, totalPages, hasMore) — check `hasMore` to decide whether to fetch additional pages.",
     inputSchema: schemas.UseCaseListInputSchema,
     mapToUpstream: (input) => {
       const data = input as z.infer<typeof schemas.UseCaseListInputSchema>;
       return {
         method: "GET",
         path: `${MUGGLE_TEST_PREFIX}/use-cases`,
-        queryParams: { projectId: data.projectId, page: data.page, pageSize: data.pageSize },
+        queryParams: {
+          projectId: data.projectId,
+          page: data.page,
+          pageSize: data.pageSize,
+          sortBy: data.sortBy,
+          sortOrder: data.sortOrder,
+        },
       };
     },
   },
@@ -239,14 +252,21 @@ const useCaseTools: IQaToolDefinition[] = [
 const testCaseTools: IQaToolDefinition[] = [
   {
     name: "muggle-remote-test-case-list",
-    description: "List test cases for a project.",
+    description:
+      "List test cases for a project. Returns up to 10 items per page by default (max 100). Response includes pagination metadata (totalCount, totalPages, hasMore) — check `hasMore` to decide whether to fetch additional pages.",
     inputSchema: schemas.TestCaseListInputSchema,
     mapToUpstream: (input) => {
       const data = input as z.infer<typeof schemas.TestCaseListInputSchema>;
       return {
         method: "GET",
         path: `${MUGGLE_TEST_PREFIX}/test-cases`,
-        queryParams: { projectId: data.projectId, page: data.page, pageSize: data.pageSize },
+        queryParams: {
+          projectId: data.projectId,
+          page: data.page,
+          pageSize: data.pageSize,
+          sortBy: data.sortBy,
+          sortOrder: data.sortOrder,
+        },
       };
     },
   },
@@ -385,14 +405,22 @@ const bulkPreviewTools: IQaToolDefinition[] = [
 const testScriptTools: IQaToolDefinition[] = [
   {
     name: "muggle-remote-test-script-list",
-    description: "List test scripts for a project, optionally filtered by test case.",
+    description:
+      "List test scripts for a project, optionally filtered by test case. Returns up to 10 items per page by default (max 100). Response includes pagination metadata (totalCount, totalPages, hasMore) — check `hasMore` to decide whether to fetch additional pages.",
     inputSchema: schemas.TestScriptListInputSchema,
     mapToUpstream: (input) => {
       const data = input as z.infer<typeof schemas.TestScriptListInputSchema>;
       return {
         method: "GET",
         path: `${MUGGLE_TEST_PREFIX}/test-scripts`,
-        queryParams: { projectId: data.projectId, testCaseId: data.testCaseId, page: data.page, pageSize: data.pageSize },
+        queryParams: {
+          projectId: data.projectId,
+          testCaseId: data.testCaseId,
+          page: data.page,
+          pageSize: data.pageSize,
+          sortBy: data.sortBy,
+          sortOrder: data.sortOrder,
+        },
       };
     },
   },
@@ -405,19 +433,6 @@ const testScriptTools: IQaToolDefinition[] = [
       return {
         method: "GET",
         path: `${MUGGLE_TEST_PREFIX}/test-scripts/${data.testScriptId}`,
-      };
-    },
-  },
-  {
-    name: "muggle-remote-test-script-list-paginated",
-    description: "List test scripts with full pagination support.",
-    inputSchema: schemas.TestScriptListPaginatedInputSchema,
-    mapToUpstream: (input) => {
-      const data = input as z.infer<typeof schemas.TestScriptListPaginatedInputSchema>;
-      return {
-        method: "GET",
-        path: `${MUGGLE_TEST_PREFIX}/test-scripts/paginated`,
-        queryParams: { projectId: data.projectId, page: data.page, pageSize: data.pageSize },
       };
     },
   },

--- a/packages/mcps/src/test/pagination-schema.test.ts
+++ b/packages/mcps/src/test/pagination-schema.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for PaginationInputSchema and the list-tool input schemas that merge it.
+ *
+ * Covers the design doc contract (see designs/list-endpoint-pagination.md):
+ *   - defaults: page=1, pageSize=10, sortBy=createdAt, sortOrder=desc
+ *   - pageSize capped at 100
+ *   - page must be a positive integer
+ *   - sortBy and sortOrder are constrained enums
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  PaginationInputSchema,
+  ProjectListInputSchema,
+  UseCaseListInputSchema,
+  TestCaseListInputSchema,
+  TestScriptListInputSchema,
+} from "../mcp/e2e/contracts/index.js";
+
+const VALID_UUID = "11111111-1111-4111-8111-111111111111";
+
+describe("PaginationInputSchema", () => {
+  it("applies all four defaults when nothing is provided", () => {
+    const parsed = PaginationInputSchema.parse({});
+    expect(parsed).toEqual({
+      page: 1,
+      pageSize: 10,
+      sortBy: "createdAt",
+      sortOrder: "desc",
+    });
+  });
+
+  it("rejects pageSize > 100", () => {
+    expect(() => PaginationInputSchema.parse({ pageSize: 200 })).toThrow();
+    expect(() => PaginationInputSchema.parse({ pageSize: 101 })).toThrow();
+  });
+
+  it("accepts pageSize up to the 100 cap", () => {
+    const parsed = PaginationInputSchema.parse({ pageSize: 100 });
+    expect(parsed.pageSize).toBe(100);
+  });
+
+  it("rejects page=0 and negative pages", () => {
+    expect(() => PaginationInputSchema.parse({ page: 0 })).toThrow();
+    expect(() => PaginationInputSchema.parse({ page: -1 })).toThrow();
+  });
+
+  it("rejects non-integer page", () => {
+    expect(() => PaginationInputSchema.parse({ page: 1.5 })).toThrow();
+  });
+
+  it("rejects unknown sortBy values", () => {
+    expect(() => PaginationInputSchema.parse({ sortBy: "bogus" })).toThrow();
+    expect(() => PaginationInputSchema.parse({ sortBy: "name" })).toThrow();
+  });
+
+  it("accepts the two legal sortBy values", () => {
+    expect(PaginationInputSchema.parse({ sortBy: "createdAt" }).sortBy).toBe("createdAt");
+    expect(PaginationInputSchema.parse({ sortBy: "updatedAt" }).sortBy).toBe("updatedAt");
+  });
+
+  it("rejects unknown sortOrder values", () => {
+    expect(() => PaginationInputSchema.parse({ sortOrder: "ascending" })).toThrow();
+  });
+
+  it("accepts the two legal sortOrder values", () => {
+    expect(PaginationInputSchema.parse({ sortOrder: "asc" }).sortOrder).toBe("asc");
+    expect(PaginationInputSchema.parse({ sortOrder: "desc" }).sortOrder).toBe("desc");
+  });
+
+  it("preserves explicit overrides", () => {
+    const parsed = PaginationInputSchema.parse({
+      page: 3,
+      pageSize: 25,
+      sortBy: "updatedAt",
+      sortOrder: "asc",
+    });
+    expect(parsed).toEqual({
+      page: 3,
+      pageSize: 25,
+      sortBy: "updatedAt",
+      sortOrder: "asc",
+    });
+  });
+});
+
+describe("list tool schemas inherit pagination defaults", () => {
+  it("ProjectListInputSchema applies pagination defaults with no input", () => {
+    const parsed = ProjectListInputSchema.parse({});
+    expect(parsed).toMatchObject({
+      page: 1,
+      pageSize: 10,
+      sortBy: "createdAt",
+      sortOrder: "desc",
+    });
+  });
+
+  it("UseCaseListInputSchema applies pagination defaults alongside required filters", () => {
+    const parsed = UseCaseListInputSchema.parse({ projectId: VALID_UUID });
+    expect(parsed).toMatchObject({
+      projectId: VALID_UUID,
+      page: 1,
+      pageSize: 10,
+      sortBy: "createdAt",
+      sortOrder: "desc",
+    });
+  });
+
+  it("TestCaseListInputSchema applies pagination defaults alongside required filters", () => {
+    const parsed = TestCaseListInputSchema.parse({ projectId: VALID_UUID });
+    expect(parsed).toMatchObject({
+      projectId: VALID_UUID,
+      page: 1,
+      pageSize: 10,
+      sortBy: "createdAt",
+      sortOrder: "desc",
+    });
+  });
+
+  it("TestScriptListInputSchema applies pagination defaults alongside optional filters", () => {
+    const parsed = TestScriptListInputSchema.parse({ projectId: VALID_UUID });
+    expect(parsed).toMatchObject({
+      projectId: VALID_UUID,
+      page: 1,
+      pageSize: 10,
+      sortBy: "createdAt",
+      sortOrder: "desc",
+    });
+  });
+
+  it("list schemas still reject invalid pagination params", () => {
+    expect(() => ProjectListInputSchema.parse({ pageSize: 500 })).toThrow();
+    expect(() =>
+      UseCaseListInputSchema.parse({ projectId: VALID_UUID, sortBy: "priority" })
+    ).toThrow();
+  });
+});

--- a/packages/mcps/src/test/tool-registry-pagination.test.ts
+++ b/packages/mcps/src/test/tool-registry-pagination.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Tests for the cloud E2E tool registry around the list-endpoint pagination contract.
+ *
+ * Covers:
+ *   - muggle-remote-test-script-list-paginated is removed
+ *   - snapshot of the four list-tool specs catches accidental drift
+ *   - smoke test per list tool: mocked upstream response is relayed unchanged
+ *
+ * See designs/list-endpoint-pagination.md Section 5 (MCP testing).
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Stub the logger and config modules so importing the tool registry does not
+// eagerly load the package.json muggleConfig (which lives in the repo root,
+// not in the mcps workspace package).
+vi.mock("../shared/config.js", () => ({
+  getConfig: () => ({
+    logLevel: "silent",
+    serverName: "test",
+    serverVersion: "0.0.0",
+    e2e: {
+      promptServiceBaseUrl: "http://test.invalid",
+      requestTimeoutMs: 1000,
+      workflowTimeoutMs: 1000,
+    },
+  }),
+}));
+
+vi.mock("../shared/logger.js", () => {
+  const noop = () => undefined;
+  const fakeLogger = {
+    info: noop,
+    warn: noop,
+    error: noop,
+    debug: noop,
+    verbose: noop,
+    silly: noop,
+    child: () => fakeLogger,
+  };
+  return {
+    getLogger: () => fakeLogger,
+    createChildLogger: () => fakeLogger,
+    resetLogger: noop,
+  };
+});
+
+// Mock upstream client before importing the tool registry so the singleton
+// getter hands back our fake. The fake's execute() is reset in beforeEach.
+const mockExecute = vi.fn();
+vi.mock("../mcp/e2e/upstream-client.js", () => ({
+  getPromptServiceClient: () => ({ execute: mockExecute }),
+}));
+
+// Mock credentials so executeQaTool doesn't try to read real auth state.
+vi.mock("../shared/auth.js", () => ({
+  getCallerCredentialsAsync: vi.fn(async () => ({ bearerToken: "test-token" })),
+}));
+
+import {
+  allQaToolDefinitions,
+  executeQaTool,
+  getQaToolByName,
+} from "../mcp/tools/e2e/tool-registry.js";
+
+const VALID_UUID = "11111111-1111-4111-8111-111111111111";
+const OTHER_UUID = "22222222-2222-4222-8222-222222222222";
+
+/** Expected contract phrasing in each of the four list-tool descriptions. */
+const PAGINATION_DESCRIPTION_FRAGMENT =
+  "Returns up to 10 items per page by default (max 100). Response includes pagination metadata (totalCount, totalPages, hasMore)";
+
+/** The four list tools that share PaginationInputSchema. */
+const LIST_TOOL_NAMES = [
+  "muggle-remote-project-list",
+  "muggle-remote-use-case-list",
+  "muggle-remote-test-case-list",
+  "muggle-remote-test-script-list",
+] as const;
+
+describe("cloud E2E tool registry — pagination", () => {
+  beforeEach(() => {
+    mockExecute.mockReset();
+  });
+
+  it("does not expose muggle-remote-test-script-list-paginated", () => {
+    expect(getQaToolByName("muggle-remote-test-script-list-paginated")).toBeUndefined();
+    const names = allQaToolDefinitions.map((t) => t.name);
+    expect(names).not.toContain("muggle-remote-test-script-list-paginated");
+  });
+
+  it("still exposes the four remaining list tools", () => {
+    for (const name of LIST_TOOL_NAMES) {
+      expect(getQaToolByName(name)).toBeDefined();
+    }
+  });
+
+  it("list-tool descriptions advertise the pagination contract (snapshot)", () => {
+    const snapshot = LIST_TOOL_NAMES.map((name) => {
+      const tool = getQaToolByName(name);
+      return { name, description: tool?.description };
+    });
+
+    // Per-field assertions catch accidental drift before snapshot diffing.
+    for (const entry of snapshot) {
+      expect(entry.description).toContain(PAGINATION_DESCRIPTION_FRAGMENT);
+    }
+
+    expect(snapshot).toMatchInlineSnapshot(`
+      [
+        {
+          "description": "List projects accessible to the authenticated user. Returns up to 10 items per page by default (max 100). Response includes pagination metadata (totalCount, totalPages, hasMore) — check \`hasMore\` to decide whether to fetch additional pages.",
+          "name": "muggle-remote-project-list",
+        },
+        {
+          "description": "List use cases for a project. Returns up to 10 items per page by default (max 100). Response includes pagination metadata (totalCount, totalPages, hasMore) — check \`hasMore\` to decide whether to fetch additional pages.",
+          "name": "muggle-remote-use-case-list",
+        },
+        {
+          "description": "List test cases for a project. Returns up to 10 items per page by default (max 100). Response includes pagination metadata (totalCount, totalPages, hasMore) — check \`hasMore\` to decide whether to fetch additional pages.",
+          "name": "muggle-remote-test-case-list",
+        },
+        {
+          "description": "List test scripts for a project, optionally filtered by test case. Returns up to 10 items per page by default (max 100). Response includes pagination metadata (totalCount, totalPages, hasMore) — check \`hasMore\` to decide whether to fetch additional pages.",
+          "name": "muggle-remote-test-script-list",
+        },
+      ]
+    `);
+  });
+
+  it("mapToUpstream forwards sortBy/sortOrder alongside page/pageSize for every list tool", () => {
+    const cases: Array<{
+      name: (typeof LIST_TOOL_NAMES)[number];
+      input: Record<string, unknown>;
+      expectedPath: string;
+      expectedExtraParams?: Record<string, unknown>;
+    }> = [
+      {
+        name: "muggle-remote-project-list",
+        input: { page: 2, pageSize: 25, sortBy: "updatedAt", sortOrder: "asc" },
+        expectedPath: "/v1/protected/muggle-test/projects",
+      },
+      {
+        name: "muggle-remote-use-case-list",
+        input: {
+          projectId: VALID_UUID,
+          page: 2,
+          pageSize: 25,
+          sortBy: "updatedAt",
+          sortOrder: "asc",
+        },
+        expectedPath: "/v1/protected/muggle-test/use-cases",
+        expectedExtraParams: { projectId: VALID_UUID },
+      },
+      {
+        name: "muggle-remote-test-case-list",
+        input: {
+          projectId: VALID_UUID,
+          page: 2,
+          pageSize: 25,
+          sortBy: "updatedAt",
+          sortOrder: "asc",
+        },
+        expectedPath: "/v1/protected/muggle-test/test-cases",
+        expectedExtraParams: { projectId: VALID_UUID },
+      },
+      {
+        name: "muggle-remote-test-script-list",
+        input: {
+          projectId: VALID_UUID,
+          testCaseId: OTHER_UUID,
+          page: 2,
+          pageSize: 25,
+          sortBy: "updatedAt",
+          sortOrder: "asc",
+        },
+        expectedPath: "/v1/protected/muggle-test/test-scripts",
+        expectedExtraParams: { projectId: VALID_UUID, testCaseId: OTHER_UUID },
+      },
+    ];
+
+    for (const c of cases) {
+      const tool = getQaToolByName(c.name)!;
+      const call = tool.mapToUpstream(c.input);
+      expect(call.method).toBe("GET");
+      expect(call.path).toBe(c.expectedPath);
+      expect(call.queryParams).toMatchObject({
+        page: 2,
+        pageSize: 25,
+        sortBy: "updatedAt",
+        sortOrder: "asc",
+        ...(c.expectedExtraParams ?? {}),
+      });
+    }
+  });
+
+  describe("smoke test: upstream envelope is relayed unchanged", () => {
+    const makeEnvelope = (label: string) => ({
+      data: [
+        { id: "row-1", label: `${label}-row-1` },
+        { id: "row-2", label: `${label}-row-2` },
+      ],
+      page: 1,
+      pageSize: 10,
+      totalCount: 23,
+      totalPages: 3,
+      hasMore: true,
+    });
+
+    const cases: Array<{
+      name: (typeof LIST_TOOL_NAMES)[number];
+      input: Record<string, unknown>;
+    }> = [
+      { name: "muggle-remote-project-list", input: {} },
+      { name: "muggle-remote-use-case-list", input: { projectId: VALID_UUID } },
+      { name: "muggle-remote-test-case-list", input: { projectId: VALID_UUID } },
+      { name: "muggle-remote-test-script-list", input: { projectId: VALID_UUID } },
+    ];
+
+    for (const c of cases) {
+      it(`${c.name} relays the paginated envelope unchanged`, async () => {
+        const envelope = makeEnvelope(c.name);
+        mockExecute.mockResolvedValueOnce({
+          statusCode: 200,
+          data: envelope,
+          headers: {},
+        });
+
+        const result = await executeQaTool(c.name, c.input, "test-correlation-id");
+        expect(result.isError).toBe(false);
+        const parsed = JSON.parse(result.content as string);
+        expect(parsed).toEqual(envelope);
+      });
+
+      it(`${c.name} invokes upstream with pagination defaults applied`, async () => {
+        mockExecute.mockResolvedValueOnce({
+          statusCode: 200,
+          data: makeEnvelope(c.name),
+          headers: {},
+        });
+
+        await executeQaTool(c.name, c.input, "test-correlation-id");
+
+        expect(mockExecute).toHaveBeenCalledOnce();
+        const [call] = mockExecute.mock.calls[0];
+        expect(call.method).toBe("GET");
+        expect(call.queryParams).toMatchObject({
+          page: 1,
+          pageSize: 10,
+          sortBy: "createdAt",
+          sortOrder: "desc",
+        });
+      });
+    }
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,7 +81,14 @@ importers:
 
   packages/commands: {}
 
-  packages/mcps: {}
+  packages/mcps:
+    devDependencies:
+      typescript:
+        specifier: '*'
+        version: 6.0.2
+      vitest:
+        specifier: '*'
+        version: 4.1.2(@types/node@25.5.2)(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.2)(esbuild@0.27.4)(tsx@4.21.0))
 
   packages/workflows:
     devDependencies:


### PR DESCRIPTION
## Summary

- `PaginationInputSchema` gains `.default(1)` on `page`, `.default(10)` on `pageSize`, and new `sortBy` (`createdAt|updatedAt`, default `createdAt`) / `sortOrder` (`asc|desc`, default `desc`) fields. **Defaults surface in the tool JSON Schema** so MCP agents see them in the spec.
- The 4 remaining list tools (`muggle-remote-project-list`, `-use-case-list`, `-test-case-list`, `-test-script-list`) advertise the pagination contract in their descriptions and forward all four params to the backend.
- `muggle-remote-test-script-list-paginated` and `TestScriptListPaginatedInputSchema` are **deleted**. `/test-scripts` is now the sole paginated entry point.

## Breaking contract change

The MCP tool schemas used to advertise `page`/`pageSize` without a default, and the backend silently ignored them. Now the contract is real, with a `pageSize=10` default. MCP agent responses will be ~10× smaller by default — this is the primary token-savings goal.

**Must deploy together with the other PRs:**
- Backend: multiplex-ai/muggle-ai-prompt-service#373
- UI: multiplex-ai/muggle-ai-ui#222

## Tests

- **27 new tests**: schema tests (defaults, rejection of out-of-range and bogus values, enum parsing), tool-registry snapshot that guards against drift and confirms `muggle-remote-test-script-list-paginated` removal, and one smoke test per list tool confirming the paginated envelope is relayed unchanged through `mapToUpstream` / `mapFromUpstream`.
- Baseline: `mcps` package placeholder `echo` test. Post-change: 27 passing. `turbo run test` workspace-wide: `workflows 4 passed, mcps 27 passed, commands placeholder`. Zero regressions.
- Pre-existing workspace typecheck failures in `@muggleai/commands` (missing `@types/node`) and cross-package composite-build errors are unchanged; none relate to this PR.

## Flag: devDependency versions

`vitest` and `typescript` are declared as `*` in `packages/mcps/package.json` to match the `@muggleai/workflows` pattern. They resolve via hoisting from the workspace root. If the repo ever moves to strict pnpm install, these should be pinned.

## Test plan

- [ ] `pnpm turbo run test` passes in `packages/mcps`
- [ ] Snapshot test fails loudly if anyone reintroduces `muggle-remote-test-script-list-paginated`
- [ ] Deploy in the same window as backend and UI PRs
- [ ] Smoke-test one list tool from the CLI against staging and confirm defaults kick in (pageSize=10 without params, envelope returned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)