### PR TITLE
chore(release): @muggleai/works 4.5.0, Electron 1.0.47

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.4.0"
+      "version": "4.5.0"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.4.0"
+      "version": "4.5.0"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@muggleai/works",
     "mcpName": "io.github.multiplex-ai/muggle",
-    "version": "4.4.0",
+    "version": "4.5.0",
     "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
     "type": "module",
     "main": "dist/index.js",
@@ -42,14 +42,14 @@
         "test:watch": "vitest"
     },
     "muggleConfig": {
-        "electronAppVersion": "1.0.36",
+        "electronAppVersion": "1.0.47",
         "downloadBaseUrl": "https://github.com/multiplex-ai/muggle-ai-works/releases/download",
         "runtimeTargetDefault": "dev",
         "checksums": {
-            "darwin-arm64": "0466282dbccab499a42a1da13e4ff1883b58044de8c66858e77bad0cbee6979e",
-            "darwin-x64": "405730a320b8eb6ced6e250840b75758de32355705eedeeb81297aa3e211805a",
-            "win32-x64": "962fd484f8409b662ba71f24fdafb0a665f28e52b7066696f5c5d16ebc7ba1ed",
-            "linux-x64": "f3cd45b893fa7f90e0af1e5b911ce13bf9a7a25d038298cb1ff2465145f08abc"
+            "darwin-arm64": "f80b943ea5f05e7113d603ee8104c07be101a26092c4fa50ed6fcb37a0cbebff",
+            "darwin-x64": "3189a5c07087f9ba2ef03f99e3735055c00a752b2421ae9cffc113f04933da61",
+            "win32-x64": "d8e102fce024776262f856dfea0b12429e853689d29d03e27e54dbeffbe59725",
+            "linux-x64": "d7218dddcbab47f78c64fe438cf5bd129740f20f6ad160b615a648415f8faffc"
         }
     },
     "dependencies": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "4.4.0",
+  "version": "4.5.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "4.4.0",
+      "version": "4.5.0",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
## Summary
- Bump npm package from 4.4.0 → 4.5.0 (minor — new Electron + `feat` commits since 4.4.0)
- Update bundled desktop app to `electron-app-v1.0.47` with release checksums from the new [v1.0.47 release](https://github.com/multiplex-ai/muggle-ai-works/releases/tag/electron-app-v1.0.47)
- Synced plugin/marketplace manifests via `scripts/sync-versions.mjs`

## What's in 4.5.0 (since 4.4.0)
- feat(telemetry): runtime release tracking in works MCP client (Plan 5) (#59)
- refactor(mcp): flatten use-case-create-from-prompts to instructions: string[] (#60)
- refactor(skills): extract PR walkthrough into muggle-pr-visual-walkthrough (#61)
- refactor(skills): unify PR walkthrough rendering via muggle build-pr-section (#62)
- feat(mcps): real pagination defaults + remove test-script-list-paginated (#63)

## Test plan
- [x] `pnpm run verify:electron-release-checksums` — checksums.txt verified for electron-app-v1.0.47
- [x] `pnpm run lint:check` — clean
- [x] `pnpm test` — 33/33 passing
- [x] `pnpm run build` — release manifest 4.5.0, plugin artifact built

## Post-merge
Trigger `Publish Works to npm` workflow via `workflow_dispatch` with `version=4.5.0` (matches previous release pattern from 4.3.0 and 4.4.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)