### PR TITLE
feat(auth): add forceNewSession to allow switching Auth0 accounts

### DIFF
--- a/packages/mcps/src/mcp/e2e/contracts/index.ts
+++ b/packages/mcps/src/mcp/e2e/contracts/index.ts
@@ -555,6 +555,7 @@ export const ApiKeyRevokeInputSchema = z.object({
 export const AuthLoginInputSchema = z.object({
   waitForCompletion: z.boolean().optional().describe("Whether to wait for browser login completion before returning. Default: true"),
   timeoutMs: z.number().int().positive().min(1000).max(900000).optional().describe("Maximum time to wait for login completion in milliseconds. Default: 120000"),
+  forceNewSession: z.boolean().optional().describe("Force a fresh login by clearing any existing Auth0 browser session before redirecting to the device activation page. Use this to switch accounts. Default: false"),
 });
 
 /**

--- a/packages/mcps/src/mcp/local/services/auth-service.ts
+++ b/packages/mcps/src/mcp/local/services/auth-service.ts
@@ -76,8 +76,9 @@ export class AuthService {
 
   /**
    * Start the device code flow.
+   * @param options.forceNewSession - Clear existing Auth0 browser session before login to allow account switching.
    */
-  async startDeviceCodeFlow(): Promise<IDeviceCodeResponse> {
+  async startDeviceCodeFlow(options?: { forceNewSession?: boolean }): Promise<IDeviceCodeResponse> {
     const logger = getLogger();
     const config = getConfig();
     const { domain, clientId, audience, scopes } = config.localQa.auth0;
@@ -129,8 +130,20 @@ export class AuthService {
       expiresAt: new Date(Date.now() + data.expires_in * 1000).toISOString(),
     });
 
+    let browserUrl = data.verification_uri_complete;
+
+    if (options?.forceNewSession) {
+      const logoutUrl = new URL(`https://${domain}/v2/logout`);
+      logoutUrl.searchParams.set("client_id", clientId);
+      logoutUrl.searchParams.set("returnTo", data.verification_uri_complete);
+      browserUrl = logoutUrl.toString();
+      logger.info("Force new session: opening logout-redirect URL", {
+        logoutUrl: browserUrl,
+      });
+    }
+
     const browserOpenResult = await openBrowserUrl({
-      url: data.verification_uri_complete,
+      url: browserUrl,
     });
 
     if (browserOpenResult.opened) {
@@ -138,7 +151,7 @@ export class AuthService {
     } else {
       logger.warn("Failed to open browser for device code login", {
         error: browserOpenResult.error,
-        verificationUriComplete: data.verification_uri_complete,
+        url: browserUrl,
       });
     }
 

--- a/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
+++ b/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
@@ -1423,7 +1423,9 @@ const authTools: IQaToolDefinition[] = [
       const data = input as z.infer<typeof schemas.AuthLoginInputSchema>;
       const authService = getAuthService();
 
-      const deviceCodeResponse = await authService.startDeviceCodeFlow();
+      const deviceCodeResponse = await authService.startDeviceCodeFlow({
+        forceNewSession: data.forceNewSession,
+      });
       const waitForCompletion = data.waitForCompletion ?? true;
 
       if (!waitForCompletion) {

--- a/packages/mcps/src/shared/auth.ts
+++ b/packages/mcps/src/shared/auth.ts
@@ -32,7 +32,7 @@ const logger = getLogger();
  * @returns Device code response with URLs and codes.
  * @throws Error if the device code request fails.
  */
-export async function startDeviceCodeFlow(config: IAuth0Config): Promise<IDeviceCodeResponse> {
+export async function startDeviceCodeFlow(config: IAuth0Config, options?: { forceNewSession?: boolean }): Promise<IDeviceCodeResponse> {
   const deviceCodeUrl = `https://${config.domain}/oauth/device/code`;
 
   try {
@@ -63,8 +63,18 @@ export async function startDeviceCodeFlow(config: IAuth0Config): Promise<IDevice
     });
 
     // Try to open browser automatically
+    let browserUrl = data.verification_uri_complete;
+
+    if (options?.forceNewSession) {
+      const logoutUrl = new URL(`https://${config.domain}/v2/logout`);
+      logoutUrl.searchParams.set("client_id", config.clientId);
+      logoutUrl.searchParams.set("returnTo", data.verification_uri_complete);
+      browserUrl = logoutUrl.toString();
+      logger.info("[Auth] Force new session: opening logout-redirect URL");
+    }
+
     const browserOpenResult = await openBrowserUrl({
-      url: data.verification_uri_complete,
+      url: browserUrl,
     });
 
     if (browserOpenResult.opened) {

--- a/plugin/skills/do/e2e-acceptance.md
+++ b/plugin/skills/do/e2e-acceptance.md
@@ -33,7 +33,12 @@ Read `localUrl` for each repo from the context. If it is not provided, ask the u
 ### Step 1: Check Authentication
 
 - `muggle-remote-auth-status`
-- If not signed in: `muggle-remote-auth-login` then `muggle-remote-auth-poll`
+- If **authenticated**: print the logged-in email and ask via `AskQuestion`:
+  > "You're logged in as **{email}**. Continue with this account?"
+  - Option 1: "Yes, continue"
+  - Option 2: "No, switch account"
+  If the user picks "switch account", call `muggle-remote-auth-login` with `forceNewSession: true` then `muggle-remote-auth-poll`.
+- If **not signed in or expired**: `muggle-remote-auth-login` then `muggle-remote-auth-poll`
 
 Do not skip or assume auth.
 

--- a/plugin/skills/muggle-test-feature-local/SKILL.md
+++ b/plugin/skills/muggle-test-feature-local/SKILL.md
@@ -27,7 +27,12 @@ The local URL only changes where the browser opens; it does not change the remot
 ### 1. Auth
 
 - `muggle-remote-auth-status`
-- If not signed in: `muggle-remote-auth-login` then `muggle-remote-auth-poll`
+- If **authenticated**: print the logged-in email and ask via `AskQuestion`:
+  > "You're logged in as **{email}**. Continue with this account?"
+  - Option 1: "Yes, continue"
+  - Option 2: "No, switch account"
+  If the user picks "switch account", call `muggle-remote-auth-login` with `forceNewSession: true` then `muggle-remote-auth-poll`.
+- If **not signed in or expired**: call `muggle-remote-auth-login` then `muggle-remote-auth-poll`.
   Do not skip or assume auth.
 
 ### 2. Targets (user must confirm)

--- a/plugin/skills/muggle-test-import/SKILL.md
+++ b/plugin/skills/muggle-test-import/SKILL.md
@@ -130,9 +130,12 @@ If the user wants changes, incorporate feedback, then ask again. Only proceed af
 
 Call `muggle-remote-auth-status` first.
 
-If already authenticated → skip to Step 5.
+If **already authenticated** → print the logged-in email and ask via `AskQuestion`:
+> "You're logged in as **{email}**. Continue with this account?"
+- Option 1: "Yes, continue" → skip to Step 5.
+- Option 2: "No, switch account" → call `muggle-remote-auth-login` with `forceNewSession: true`, then `muggle-remote-auth-poll`.
 
-If not authenticated:
+If **not authenticated**:
 1. Tell the user a browser window is about to open.
 2. Call `muggle-remote-auth-login` (opens browser automatically).
 3. Tell the user to complete login in the browser.

--- a/plugin/skills/muggle-test-regenerate-missing/SKILL.md
+++ b/plugin/skills/muggle-test-regenerate-missing/SKILL.md
@@ -40,8 +40,13 @@ Treat this filter as a default, not a law. If the user explicitly says "include 
 ### Step 1 — Authenticate
 
 1. Call `muggle-remote-auth-status`.
-2. If not authenticated or expired → call `muggle-remote-auth-login`, then poll with `muggle-remote-auth-poll`.
-3. Do not skip auth and do not assume a stale token still works.
+2. If **authenticated and not expired** → print the logged-in email and ask via `AskQuestion`:
+   > "You're logged in as **{email}**. Continue with this account?"
+   - Option 1: "Yes, continue"
+   - Option 2: "No, switch account"
+   If the user picks "switch account", call `muggle-remote-auth-login` with `forceNewSession: true`, then poll with `muggle-remote-auth-poll`.
+3. If **not authenticated or expired** → call `muggle-remote-auth-login`, then poll with `muggle-remote-auth-poll`.
+4. Do not skip auth and do not assume a stale token still works.
 
 If auth keeps failing, suggest the user run `muggle logout && muggle login` from a terminal.
 

--- a/plugin/skills/muggle-test/SKILL.md
+++ b/plugin/skills/muggle-test/SKILL.md
@@ -82,8 +82,12 @@ If no changes detected (clean tree), tell the user and ask what they want to tes
 ## Step 3: Authenticate
 
 1. Call `muggle-remote-auth-status`
-2. If authenticated and not expired → proceed
-3. If not authenticated or expired → call `muggle-remote-auth-login`
+2. If **authenticated and not expired** → print the logged-in email and ask via `AskQuestion`:
+   > "You're logged in as **{email}**. Continue with this account?"
+   - Option 1: "Yes, continue"
+   - Option 2: "No, switch account"
+   If the user picks "switch account", call `muggle-remote-auth-login` with `forceNewSession: true`, then `muggle-remote-auth-poll`.
+3. If **not authenticated or expired** → call `muggle-remote-auth-login`
 4. If login pending → call `muggle-remote-auth-poll`
 
 If auth fails repeatedly, suggest: `muggle logout && muggle login` from terminal.


### PR DESCRIPTION
## Summary
- Adds optional `forceNewSession` parameter to `muggle-remote-auth-login` MCP tool
- When true, opens Auth0's `/v2/logout?returnTo={activation_url}` instead of the activation URL directly, clearing the existing browser session before prompting for fresh credentials
- Fixes the issue where users cannot switch Auth0 accounts because the device code flow silently reuses the existing browser session

## Files changed
- `packages/mcps/src/mcp/e2e/contracts/index.ts` — added `forceNewSession` to `AuthLoginInputSchema`
- `packages/mcps/src/mcp/local/services/auth-service.ts` — logout-redirect URL construction when `forceNewSession` is true
- `packages/mcps/src/mcp/tools/e2e/tool-registry.ts` — pass-through to `startDeviceCodeFlow`
- `packages/mcps/src/shared/auth.ts` — same support in shared auth (used by CLI)

## Auth0 prerequisite
The `verification_uri_complete` domain (`https://{tenant}.auth0.com/activate?user_code=...`) must be listed in the Auth0 app's **Allowed Logout URLs** for the `/v2/logout` redirect to work.

## Test plan
- [ ] Call `muggle-remote-auth-login` without `forceNewSession` — existing behavior unchanged
- [ ] Call `muggle-remote-auth-login` with `forceNewSession: true` — browser opens logout URL, redirects to login page, user can enter different credentials
- [ ] Verify `returnTo` URL in Auth0 Allowed Logout URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)