### PR TITLE
feat(pr-section): resolve gs:// screenshot URLs to HTTPS

### DIFF
--- a/src/cli/build-pr-section.ts
+++ b/src/cli/build-pr-section.ts
@@ -9,6 +9,7 @@
 import { ZodError } from "zod";
 
 import { buildPrSection, E2eReportSchema } from "./pr-section/index.js";
+import { resolveGsScreenshotUrls } from "./pr-section/resolve-urls.js";
 
 /** Default UTF-8 byte budget for the PR description. */
 export const DEFAULT_MAX_BODY_BYTES = 60_000;
@@ -66,7 +67,8 @@ export async function runBuildPrSection (opts: IRunOptions): Promise<number> {
     }
     return 1;
   }
-  const result = buildPrSection(report, { maxBodyBytes: opts.maxBodyBytes });
+  const resolvedReport = await resolveGsScreenshotUrls(report, { stderrWrite: opts.stderrWrite });
+  const result = buildPrSection(resolvedReport, { maxBodyBytes: opts.maxBodyBytes });
   opts.stdoutWrite(JSON.stringify({ body: result.body, comment: result.comment }));
   return 0;
 }

--- a/src/cli/pr-section/resolve-urls-types.ts
+++ b/src/cli/pr-section/resolve-urls-types.ts
@@ -1,0 +1,30 @@
+/**
+ * Types and constants for `resolve-urls.ts`.
+ *
+ * Kept separate from the business logic so that the service module only
+ * imports pure declarations, in line with the repo-wide preference for
+ * separating types/constants from the functions that use them.
+ */
+
+/** Options bag for {@link resolveGsScreenshotUrls}. */
+export interface IResolveUrlsOptions {
+  /** Sink for all user-facing diagnostics. The resolver never writes stdout. */
+  stderrWrite: (s: string) => void;
+}
+
+/** Shape of a successful response from `/v1/protected/storage/publicUrl`. */
+export interface IPublicUrlResponse {
+  resourceUrl?: unknown;
+}
+
+/** URI scheme that identifies a Google Cloud Storage path. */
+export const GS_SCHEME = "gs://";
+
+/** Sub-path on the prompt service that converts a gs:// URI to HTTPS. */
+export const PUBLIC_URL_PATH = "/v1/protected/storage/publicUrl";
+
+/** HTTP timeout (ms) for a single publicUrl resolution call. */
+export const RESOLVE_TIMEOUT_MS = 10_000;
+
+/** Log prefix used for every stderr line written by the resolver. */
+export const LOG_PREFIX = "build-pr-section";

--- a/src/cli/pr-section/resolve-urls.ts
+++ b/src/cli/pr-section/resolve-urls.ts
@@ -1,0 +1,200 @@
+/**
+ * Resolve `gs://` screenshot URLs inside an {@link E2eReport} to public
+ * HTTPS URLs before the report is rendered into PR markdown.
+ *
+ * GitHub's markdown renderer cannot fetch `gs://` URIs, so any screenshot
+ * Muggle uploads to Google Cloud Storage renders as a broken image in the
+ * PR body. The prompt service exposes a conversion endpoint that returns a
+ * public Firebase Storage download URL (anonymous access via an embedded
+ * `?alt=media&token=<uuid>` query string) — we POST each unique gs:// URL
+ * to that endpoint and swap the results into a fresh report object.
+ *
+ * Best-effort by design: if credentials are missing, the prompt service is
+ * unreachable, or any single URL fails to resolve, the CLI logs a warning
+ * to stderr and returns the original URL untouched. This function must
+ * never throw — the caller is downstream of `E2eReportSchema.parse()` and
+ * treating a broken image as a hard CLI failure would regress the happy
+ * path unnecessarily.
+ */
+
+import axios from "axios";
+
+import type { ICallerCredentials } from "../../../packages/mcps/src/index.js";
+
+import {
+  GS_SCHEME,
+  LOG_PREFIX,
+  PUBLIC_URL_PATH,
+  RESOLVE_TIMEOUT_MS,
+  type IPublicUrlResponse,
+  type IResolveUrlsOptions,
+} from "./resolve-urls-types.js";
+import type { E2eReport, Step, TestResult } from "./types.js";
+
+function errMsg (e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+function isGsUrl (url: string): boolean {
+  return url.startsWith(GS_SCHEME);
+}
+
+/** Build the auth headers for a prompt service request. Mirrors upstream-client. */
+function buildAuthHeaders (credentials: ICallerCredentials): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (credentials.bearerToken) {
+    headers["Authorization"] = credentials.bearerToken.startsWith("Bearer ")
+      ? credentials.bearerToken
+      : `Bearer ${credentials.bearerToken}`;
+  }
+  if (credentials.apiKey) {
+    headers["x-api-key"] = credentials.apiKey;
+  }
+  return headers;
+}
+
+/** Collect every unique `gs://` screenshot URL in the report, in insertion order. */
+function collectGsUrls (report: E2eReport): string[] {
+  const seen = new Set<string>();
+  for (const test of report.tests) {
+    for (const step of test.steps) {
+      if (isGsUrl(step.screenshotUrl)) {
+        seen.add(step.screenshotUrl);
+      }
+    }
+  }
+  return Array.from(seen);
+}
+
+/**
+ * Resolve a single gs:// URL via the prompt service. Returns the HTTPS URL
+ * on success and `null` on any error (logging the reason to stderr).
+ */
+async function resolveOne (
+  gsUrl: string,
+  baseUrl: string,
+  headers: Record<string, string>,
+  stderrWrite: (s: string) => void,
+): Promise<string | null> {
+  try {
+    const response = await axios.post<IPublicUrlResponse>(
+      `${baseUrl}${PUBLIC_URL_PATH}`,
+      { resourceUrl: gsUrl },
+      {
+        headers: { ...headers, "Content-Type": "application/json" },
+        timeout: RESOLVE_TIMEOUT_MS,
+        validateStatus: () => true,
+      },
+    );
+    if (response.status === 200
+      && response.data
+      && typeof response.data.resourceUrl === "string"
+      && response.data.resourceUrl.length > 0) {
+      return response.data.resourceUrl;
+    }
+    const reason = response.status !== 200
+      ? `HTTP ${response.status}`
+      : "missing resourceUrl in response";
+    stderrWrite(`${LOG_PREFIX}: failed to resolve ${gsUrl}: ${reason}\n`);
+    return null;
+  } catch (err) {
+    stderrWrite(`${LOG_PREFIX}: failed to resolve ${gsUrl}: ${errMsg(err)}\n`);
+    return null;
+  }
+}
+
+/**
+ * Return a new `Step` whose `screenshotUrl` has been swapped through the
+ * resolution map when a mapping exists. Steps with no mapping (including
+ * every https:// step) are returned as-is to keep the diff minimal.
+ */
+function remapStep (step: Step, urlMap: Map<string, string>): Step {
+  const resolved = urlMap.get(step.screenshotUrl);
+  if (!resolved) {
+    return step;
+  }
+  return { ...step, screenshotUrl: resolved };
+}
+
+/**
+ * Return a new `TestResult` with freshly remapped `steps`. Preserves every
+ * other field (and the discriminated `status` so the zod union stays valid)
+ * via a shallow spread.
+ */
+function remapTest (test: TestResult, urlMap: Map<string, string>): TestResult {
+  return { ...test, steps: test.steps.map((s) => remapStep(s, urlMap)) };
+}
+
+/**
+ * Walk the report, POST every unique gs:// screenshot URL to the prompt
+ * service's publicUrl endpoint in parallel, and return a new report with
+ * the resolved HTTPS URLs swapped in. Never mutates the input report.
+ *
+ * On missing credentials or unexpected errors, logs a single stderr line
+ * and returns the original report unchanged.
+ */
+export async function resolveGsScreenshotUrls (
+  report: E2eReport,
+  opts: IResolveUrlsOptions,
+): Promise<E2eReport> {
+  const { stderrWrite } = opts;
+  try {
+    const gsUrls = collectGsUrls(report);
+    if (gsUrls.length === 0) {
+      return report;
+    }
+
+    // Dynamic import keeps the heavy `@muggleai/mcp` barrel (logger, config,
+    // auth) out of the build-pr-section happy path when there is nothing to
+    // resolve, and lets tests that don't touch gs:// URLs skip mocking it.
+    const mcps = await import("../../../packages/mcps/src/index.js");
+    const credentials = await mcps.getCallerCredentialsAsync();
+    if (!credentials.bearerToken && !credentials.apiKey) {
+      stderrWrite(
+        `${LOG_PREFIX}: no credentials available; run 'muggle login' to enable automatic gs:// URL resolution. `
+        + `Screenshots will render as broken images in GitHub.\n`,
+      );
+      return report;
+    }
+
+    const baseUrl = mcps.getConfig().e2e.promptServiceBaseUrl;
+    const headers = buildAuthHeaders(credentials);
+
+    const resolved = await Promise.all(
+      gsUrls.map((gsUrl) => resolveOne(gsUrl, baseUrl, headers, stderrWrite)),
+    );
+
+    const urlMap = new Map<string, string>();
+    let failureCount = 0;
+    for (let i = 0; i < gsUrls.length; i++) {
+      const https = resolved[i];
+      if (https) {
+        urlMap.set(gsUrls[i]!, https);
+      } else {
+        failureCount++;
+      }
+    }
+
+    if (failureCount > 0) {
+      stderrWrite(
+        `${LOG_PREFIX}: ${failureCount}/${gsUrls.length} gs:// URLs could not be resolved; `
+        + `those screenshots will render as broken images in GitHub\n`,
+      );
+    }
+
+    if (urlMap.size === 0) {
+      return report;
+    }
+
+    return {
+      ...report,
+      tests: report.tests.map((t) => remapTest(t, urlMap)),
+    };
+  } catch (err) {
+    stderrWrite(
+      `${LOG_PREFIX}: unexpected error while resolving gs:// URLs: ${errMsg(err)}; `
+      + `continuing with original report\n`,
+    );
+    return report;
+  }
+}

--- a/src/test/cli/pr-section/resolve-urls.test.ts
+++ b/src/test/cli/pr-section/resolve-urls.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Tests for `resolveGsScreenshotUrls`. Mocks axios plus the `@muggleai/mcp`
+ * helpers the resolver depends on (`getCallerCredentialsAsync`, `getConfig`).
+ *
+ * Each scenario seeds axios's `post` response (or rejection) and checks the
+ * three observable outputs: (1) the returned report object, (2) the URL set
+ * passed to axios, (3) the lines written to the injected `stderrWrite` sink.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("axios", () => ({
+  default: {
+    post: vi.fn(),
+  },
+}));
+
+vi.mock("../../../../packages/mcps/src/index.js", () => ({
+  getCallerCredentialsAsync: vi.fn(),
+  getConfig: vi.fn(),
+}));
+
+import axios from "axios";
+
+import { resolveGsScreenshotUrls } from "../../../cli/pr-section/resolve-urls.js";
+import type { E2eReport } from "../../../cli/pr-section/types.js";
+import {
+  getCallerCredentialsAsync,
+  getConfig,
+} from "../../../../packages/mcps/src/index.js";
+
+const mockedAxiosPost = vi.mocked(axios.post);
+const mockedGetCredentials = vi.mocked(getCallerCredentialsAsync);
+const mockedGetConfig = vi.mocked(getConfig);
+
+const BASE_URL = "https://prompt.example.invalid";
+const PUBLIC_URL_ENDPOINT = `${BASE_URL}/v1/protected/storage/publicUrl`;
+
+function makeConfig() {
+  return {
+    serverName: "test",
+    serverVersion: "0.0.0",
+    logLevel: "silent",
+    auth0: { domain: "", clientId: "", audience: "", scope: "" },
+    e2e: {
+      promptServiceBaseUrl: BASE_URL,
+      requestTimeoutMs: 1000,
+      workflowTimeoutMs: 1000,
+    },
+    localQa: {} as never,
+  } as never;
+}
+
+function makeReport(steps: Array<{ screenshotUrl: string }>): E2eReport {
+  return {
+    projectId: "p1",
+    tests: [
+      {
+        name: "A",
+        testCaseId: "tc-a",
+        runId: "r-a",
+        viewUrl: "https://example.com/a",
+        status: "passed",
+        steps: steps.map((s, i) => ({
+          stepIndex: i,
+          action: `step ${i}`,
+          screenshotUrl: s.screenshotUrl,
+        })),
+      },
+    ],
+  };
+}
+
+function makeStderr() {
+  const lines: string[] = [];
+  return {
+    lines,
+    write: (s: string) => {
+      lines.push(s);
+    },
+  };
+}
+
+describe("resolveGsScreenshotUrls", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedGetConfig.mockReturnValue(makeConfig());
+  });
+
+  it("returns the report unchanged when there are no gs:// URLs", async () => {
+    const report = makeReport([
+      { screenshotUrl: "https://cdn.example.com/a0.png" },
+      { screenshotUrl: "https://cdn.example.com/a1.png" },
+    ]);
+    const stderr = makeStderr();
+
+    const result = await resolveGsScreenshotUrls(report, { stderrWrite: stderr.write });
+
+    expect(result).toBe(report);
+    expect(result.tests[0]!.steps).toBe(report.tests[0]!.steps);
+    expect(mockedAxiosPost).not.toHaveBeenCalled();
+    expect(mockedGetCredentials).not.toHaveBeenCalled();
+    expect(stderr.lines).toEqual([]);
+  });
+
+  it("only resolves gs:// URLs and leaves https:// URLs alone", async () => {
+    mockedGetCredentials.mockResolvedValue({ bearerToken: "tkn" });
+    mockedAxiosPost.mockResolvedValue({
+      status: 200,
+      data: { resourceUrl: "https://firebasestorage.googleapis.com/v0/b/bucket/o/a.jpg?alt=media&token=abc" },
+    });
+    const report = makeReport([
+      { screenshotUrl: "https://cdn.example.com/https.png" },
+      { screenshotUrl: "gs://bucket/a.jpg" },
+    ]);
+    const stderr = makeStderr();
+
+    const result = await resolveGsScreenshotUrls(report, { stderrWrite: stderr.write });
+
+    expect(mockedAxiosPost).toHaveBeenCalledTimes(1);
+    expect(mockedAxiosPost).toHaveBeenCalledWith(
+      PUBLIC_URL_ENDPOINT,
+      { resourceUrl: "gs://bucket/a.jpg" },
+      expect.anything(),
+    );
+    expect(result.tests[0]!.steps[0]!.screenshotUrl).toBe("https://cdn.example.com/https.png");
+    expect(result.tests[0]!.steps[1]!.screenshotUrl).toBe(
+      "https://firebasestorage.googleapis.com/v0/b/bucket/o/a.jpg?alt=media&token=abc",
+    );
+    expect(stderr.lines).toEqual([]);
+    // Report is a fresh object (not mutated).
+    expect(result).not.toBe(report);
+  });
+
+  it("logs a login hint and skips HTTP calls when no credentials are available", async () => {
+    mockedGetCredentials.mockResolvedValue({});
+    const report = makeReport([{ screenshotUrl: "gs://bucket/x.jpg" }]);
+    const stderr = makeStderr();
+
+    const result = await resolveGsScreenshotUrls(report, { stderrWrite: stderr.write });
+
+    expect(result).toBe(report);
+    expect(mockedAxiosPost).not.toHaveBeenCalled();
+    expect(stderr.lines).toHaveLength(1);
+    expect(stderr.lines[0]).toMatch(/muggle login/);
+    expect(stderr.lines[0]).toMatch(/build-pr-section:/);
+  });
+
+  it("sends Authorization: Bearer when credentials contain a bearer token", async () => {
+    mockedGetCredentials.mockResolvedValue({ bearerToken: "my-jwt" });
+    mockedAxiosPost.mockResolvedValue({
+      status: 200,
+      data: { resourceUrl: "https://example.com/resolved.jpg" },
+    });
+    const report = makeReport([{ screenshotUrl: "gs://bucket/x.jpg" }]);
+    const stderr = makeStderr();
+
+    await resolveGsScreenshotUrls(report, { stderrWrite: stderr.write });
+
+    expect(mockedAxiosPost).toHaveBeenCalledTimes(1);
+    const [, , config] = mockedAxiosPost.mock.calls[0]!;
+    expect(config).toBeDefined();
+    const headers = (config as { headers: Record<string, string> }).headers;
+    expect(headers.Authorization).toBe("Bearer my-jwt");
+    expect(headers["x-api-key"]).toBeUndefined();
+    expect((config as { timeout: number }).timeout).toBe(10_000);
+    expect((config as { validateStatus: (s: number) => boolean }).validateStatus(500)).toBe(true);
+  });
+
+  it("sends x-api-key when credentials contain an api key", async () => {
+    mockedGetCredentials.mockResolvedValue({ apiKey: "sk-test" });
+    mockedAxiosPost.mockResolvedValue({
+      status: 200,
+      data: { resourceUrl: "https://example.com/resolved.jpg" },
+    });
+    const report = makeReport([{ screenshotUrl: "gs://bucket/x.jpg" }]);
+    const stderr = makeStderr();
+
+    await resolveGsScreenshotUrls(report, { stderrWrite: stderr.write });
+
+    const [, , config] = mockedAxiosPost.mock.calls[0]!;
+    const headers = (config as { headers: Record<string, string> }).headers;
+    expect(headers["x-api-key"]).toBe("sk-test");
+    expect(headers.Authorization).toBeUndefined();
+  });
+
+  it("swaps successful URLs and keeps failed URLs (per-URL 401)", async () => {
+    mockedGetCredentials.mockResolvedValue({ bearerToken: "tkn" });
+    mockedAxiosPost.mockImplementation(async (_url: string, body: unknown) => {
+      const { resourceUrl } = body as { resourceUrl: string };
+      if (resourceUrl === "gs://bucket/ok.jpg") {
+        return { status: 200, data: { resourceUrl: "https://cdn.example.com/ok.jpg" } };
+      }
+      return { status: 401, data: { error: "unauthorized" } };
+    });
+    const report = makeReport([
+      { screenshotUrl: "gs://bucket/ok.jpg" },
+      { screenshotUrl: "gs://bucket/bad.jpg" },
+    ]);
+    const stderr = makeStderr();
+
+    const result = await resolveGsScreenshotUrls(report, { stderrWrite: stderr.write });
+
+    expect(result.tests[0]!.steps[0]!.screenshotUrl).toBe("https://cdn.example.com/ok.jpg");
+    expect(result.tests[0]!.steps[1]!.screenshotUrl).toBe("gs://bucket/bad.jpg");
+
+    const joined = stderr.lines.join("");
+    expect(joined).toMatch(/failed to resolve gs:\/\/bucket\/bad\.jpg: HTTP 401/);
+    expect(joined).toMatch(/1\/2 gs:\/\/ URLs could not be resolved/);
+  });
+
+  it("treats a network error on one URL as a per-URL failure (warn and continue)", async () => {
+    mockedGetCredentials.mockResolvedValue({ bearerToken: "tkn" });
+    mockedAxiosPost.mockImplementation(async (_url: string, body: unknown) => {
+      const { resourceUrl } = body as { resourceUrl: string };
+      if (resourceUrl === "gs://bucket/ok.jpg") {
+        return { status: 200, data: { resourceUrl: "https://cdn.example.com/ok.jpg" } };
+      }
+      throw new Error("ECONNRESET");
+    });
+    const report = makeReport([
+      { screenshotUrl: "gs://bucket/ok.jpg" },
+      { screenshotUrl: "gs://bucket/bad.jpg" },
+    ]);
+    const stderr = makeStderr();
+
+    const result = await resolveGsScreenshotUrls(report, { stderrWrite: stderr.write });
+
+    expect(result.tests[0]!.steps[0]!.screenshotUrl).toBe("https://cdn.example.com/ok.jpg");
+    expect(result.tests[0]!.steps[1]!.screenshotUrl).toBe("gs://bucket/bad.jpg");
+
+    const joined = stderr.lines.join("");
+    expect(joined).toMatch(/failed to resolve gs:\/\/bucket\/bad\.jpg: ECONNRESET/);
+    expect(joined).toMatch(/1\/2 gs:\/\/ URLs could not be resolved/);
+  });
+
+  it("catches unexpected errors from getCallerCredentialsAsync and returns the original report", async () => {
+    mockedGetCredentials.mockRejectedValue(new Error("config corrupt"));
+    const report = makeReport([{ screenshotUrl: "gs://bucket/x.jpg" }]);
+    const stderr = makeStderr();
+
+    const result = await resolveGsScreenshotUrls(report, { stderrWrite: stderr.write });
+
+    expect(result).toBe(report);
+    expect(mockedAxiosPost).not.toHaveBeenCalled();
+    expect(stderr.lines).toHaveLength(1);
+    expect(stderr.lines[0]).toMatch(/unexpected error/);
+    expect(stderr.lines[0]).toMatch(/config corrupt/);
+  });
+
+  it("deduplicates identical gs:// URLs across tests so each is resolved exactly once", async () => {
+    mockedGetCredentials.mockResolvedValue({ bearerToken: "tkn" });
+    mockedAxiosPost.mockResolvedValue({
+      status: 200,
+      data: { resourceUrl: "https://cdn.example.com/dup.jpg" },
+    });
+    const report: E2eReport = {
+      projectId: "p1",
+      tests: [
+        {
+          name: "A",
+          testCaseId: "tc-a",
+          runId: "r-a",
+          viewUrl: "https://example.com/a",
+          status: "passed",
+          steps: [
+            { stepIndex: 0, action: "one", screenshotUrl: "gs://bucket/dup.jpg" },
+          ],
+        },
+        {
+          name: "B",
+          testCaseId: "tc-b",
+          runId: "r-b",
+          viewUrl: "https://example.com/b",
+          status: "passed",
+          steps: [
+            { stepIndex: 0, action: "two", screenshotUrl: "gs://bucket/dup.jpg" },
+          ],
+        },
+      ],
+    };
+    const stderr = makeStderr();
+
+    const result = await resolveGsScreenshotUrls(report, { stderrWrite: stderr.write });
+
+    expect(mockedAxiosPost).toHaveBeenCalledTimes(1);
+    expect(result.tests[0]!.steps[0]!.screenshotUrl).toBe("https://cdn.example.com/dup.jpg");
+    expect(result.tests[1]!.steps[0]!.screenshotUrl).toBe("https://cdn.example.com/dup.jpg");
+    expect(stderr.lines).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- `muggle build-pr-section` now walks every `step.screenshotUrl` in the incoming report and converts `gs://` URIs to public Firebase Storage download URLs via `POST /v1/protected/storage/publicUrl` on the prompt service. GitHub's markdown renderer can fetch those URLs anonymously (they embed an `?alt=media&token=<uuid>`) so screenshots now render inline in PR comments instead of appearing broken.
- New module `src/cli/pr-section/resolve-urls.ts` owns the resolution logic. It dedupes URLs, POSTs them in parallel with a 10s timeout, honours both bearer-token and `x-api-key` credentials (matching `upstream-client.ts`), and returns a fresh report object — it never mutates the input.
- **Best-effort by design**: missing credentials, network errors, non-200 responses, or unexpected exceptions are all caught and logged to stderr (`build-pr-section: ...`). The CLI never hard-fails because of resolver issues; unresolved URLs fall through to the renderer as-is. A summary line (`N/M gs:// URLs could not be resolved`) is written whenever any URL fails.
- Constants and option interfaces live in a sibling `resolve-urls-types.ts` per the repo's types-separate-from-logic convention.
- The mcps barrel is pulled in via dynamic import so the build-pr-section happy path (and the existing test that exercises it with only `https://` URLs) doesn't eagerly load the logger/config singletons.

## Test plan

- [x] New unit suite `src/test/cli/pr-section/resolve-urls.test.ts` (9 cases) covering: no gs:// URLs, mixed https/gs, no credentials, bearer token header, api key header, per-URL 401, per-URL network error, unexpected throw from `getCallerCredentialsAsync`, and deduplication across tests.
- [x] `pnpm run lint:check` — clean.
- [x] `pnpm run typecheck` — clean.
- [x] `pnpm test` — 42 passed / 0 failed (7 files), including all 9 new tests and the existing `build-pr-section.test.ts` cases.
- [x] `pnpm run build` — tsup + release manifest + plugin build all succeed.

## Notes for the reviewer

- PR 2 (format rewrite) is happening in parallel against `src/cli/pr-section/{render,overflow,selectors,types,index}.ts`. This PR does not touch any of those files, so conflicts should be trivial — whichever lands second should rebase.
- `typecheck:workspace` has pre-existing failures on master (unrelated `packages/commands` bootstrap / unbuilt mcps `dist`) that this PR neither introduces nor fixes.
- Not publishing to npm — npm releases go through CI/CD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)