### PR TITLE
feat(pr-section): number tests, summary-step caption, proxy-wrap screenshots

### DIFF
--- a/src/cli/pr-section/render.ts
+++ b/src/cli/pr-section/render.ts
@@ -3,9 +3,10 @@
  * No I/O, no length measurement, no overflow logic — see overflow.ts for that.
  *
  * Layout (two sections):
- *   1. Overview: counts + per-test name list, grouped by useCaseName when present.
- *   2. Per-test details: one <details> block per test (passed and failed alike), in
- *      report order, showing the ending screenshot and a compact result summary.
+ *   1. Overview: counts + per-test name list (numbered; grouped by useCaseName when present).
+ *   2. Per-test details: one <details> block per numbered test (passed and failed alike),
+ *      in report order, showing the ending screen (a caption-labelled screenshot) and
+ *      a compact result summary.
  */
 
 import type { E2eReport, Step, TestResult } from "./types.js";
@@ -15,6 +16,14 @@ export const DASHBOARD_URL_BASE =
 
 /** Width of the per-test ending screenshot inside each <details> block. */
 const DETAIL_IMAGE_WIDTH = 720;
+
+/** The screenshot + caption displayed inside each test's details block. */
+interface IEndingFrame {
+  /** HTTPS URL of the screenshot to render. */
+  url: string;
+  /** Short human-readable caption labelling what the screenshot shows. */
+  caption: string;
+}
 
 /** Compact counts for a report. */
 interface ICounts {
@@ -34,7 +43,7 @@ function statusEmoji (test: TestResult): string {
   return test.status === "passed" ? "✅" : "❌";
 }
 
-/** The "ending screenshot" for a test: failure-step for failed, last step for passed. */
+/** The "ending screenshot" step for a test: failure-step for failed, last step for passed. */
 function endingScreenshot (test: TestResult): Step | null {
   if (test.steps.length === 0) {
     return null;
@@ -50,6 +59,38 @@ function endingScreenshot (test: TestResult): Step | null {
   return test.steps[test.steps.length - 1];
 }
 
+/** Default caption text used when the caller doesn't provide one. */
+function defaultEndingCaption (test: TestResult): string {
+  if (test.status === "failed") {
+    return `Failure at step ${test.failureStepIndex}`;
+  }
+  return "Final page after the test completed";
+}
+
+/**
+ * Resolve the single screenshot + caption rendered inside a test's details block.
+ *
+ * Precedence: an explicit `endingScreenshotUrl` on the test wins (this is how
+ * a caller surfaces the action script's dedicated summary step), otherwise
+ * we fall back to the failure / last step from `steps[]`.
+ */
+function endingFrame (test: TestResult): IEndingFrame | null {
+  if (test.endingScreenshotUrl) {
+    return {
+      url: test.endingScreenshotUrl,
+      caption: test.endingScreenshotCaption ?? defaultEndingCaption(test),
+    };
+  }
+  const step = endingScreenshot(test);
+  if (!step) {
+    return null;
+  }
+  return {
+    url: step.screenshotUrl,
+    caption: test.endingScreenshotCaption ?? defaultEndingCaption(test),
+  };
+}
+
 /** Clickable full-width image. */
 function fullSizeImage (url: string, alt: string): string {
   return `<a href="${url}"><img src="${url}" width="${DETAIL_IMAGE_WIDTH}" alt="${alt}"></a>`;
@@ -63,8 +104,22 @@ function safeInlineCode (s: string): string {
 }
 
 /**
- * Render the overview section: header, counts line, and the per-test name list
- * (grouped by useCaseName when any test has one, otherwise flat).
+ * Build a `Map<testCaseId, testNumber>` so both the overview and the per-test
+ * details use the same 1-based numbering regardless of grouping. Tests without
+ * a testCaseId (shouldn't happen — schema requires it) are silently skipped.
+ */
+function buildTestNumbering (report: E2eReport): Map<string, number> {
+  const map = new Map<string, number>();
+  report.tests.forEach((t, i) => {
+    map.set(t.testCaseId, i + 1);
+  });
+  return map;
+}
+
+/**
+ * Render the overview section: header, counts line, and the per-test numbered
+ * name list (grouped by useCaseName when any test has one, otherwise flat).
+ * Numbering is global across groups so it matches the details block headings.
  */
 export function renderOverview (report: E2eReport): string {
   const { total, passed, failed } = countTests(report);
@@ -78,10 +133,11 @@ export function renderOverview (report: E2eReport): string {
     return lines.join("\n");
   }
   lines.push("", "**Tests run:**");
+  const numbering = buildTestNumbering(report);
   const anyGrouped = report.tests.some((t) => Boolean(t.useCaseName));
   if (!anyGrouped) {
     for (const t of report.tests) {
-      lines.push(`- ${statusEmoji(t)} ${t.name}`);
+      lines.push(`- **${numbering.get(t.testCaseId)}.** ${statusEmoji(t)} ${t.name}`);
     }
     return lines.join("\n");
   }
@@ -108,32 +164,37 @@ export function renderOverview (report: E2eReport): string {
   }
   for (const entry of flat) {
     if (entry.type === "test") {
-      lines.push(`- ${statusEmoji(entry.test)} ${entry.test.name}`);
+      lines.push(`- **${numbering.get(entry.test.testCaseId)}.** ${statusEmoji(entry.test)} ${entry.test.name}`);
     } else {
       lines.push(`- **${entry.key}**`);
       for (const t of groups.get(entry.key)!) {
-        lines.push(`  - ${statusEmoji(t)} ${t.name}`);
+        lines.push(`  - **${numbering.get(t.testCaseId)}.** ${statusEmoji(t)} ${t.name}`);
       }
     }
   }
   return lines.join("\n");
 }
 
-/** Render one `<details>` block for a test case (passed or failed). */
-export function renderTestDetails (test: TestResult, projectId: string): string {
-  const summary = renderSummaryLine(test);
-  const image = renderEndingImage(test);
+/**
+ * Render one `<details>` block for a test case (passed or failed).
+ *
+ * `testNumber` is the 1-based index used to prefix the collapsible summary line
+ * so it lines up with the numbered list in the overview section.
+ */
+export function renderTestDetails (test: TestResult, projectId: string, testNumber: number): string {
+  const summary = renderSummaryLine(test, testNumber);
+  const frameBlock = renderEndingFrame(test);
   const resultLines = renderResultSummary(test, projectId);
   const body: string[] = ["", "<br>", ""];
-  if (image) {
-    body.push(image, "");
+  if (frameBlock) {
+    body.push(...frameBlock, "");
   }
   body.push(...resultLines);
   return `<details>\n<summary>${summary}</summary>\n${body.join("\n")}\n\n</details>`;
 }
 
-function renderSummaryLine (test: TestResult): string {
-  const base = `${statusEmoji(test)} <b>${test.name}</b>`;
+function renderSummaryLine (test: TestResult, testNumber: number): string {
+  const base = `<b>${testNumber}. ${test.name}</b> ${statusEmoji(test)}`;
   const tail = " <i>▶ click to expand</i>";
   if (test.description) {
     return `${base} — ${test.description}${tail}`;
@@ -141,12 +202,22 @@ function renderSummaryLine (test: TestResult): string {
   return `${base}${tail}`;
 }
 
-function renderEndingImage (test: TestResult): string | null {
-  const step = endingScreenshot(test);
-  if (!step) {
+/**
+ * Render the ending-frame block: a bold caption line identifying what the
+ * screenshot shows, followed by the clickable full-width image. Returns null
+ * if there is nothing to render (e.g. an empty-steps passed test with no
+ * endingScreenshotUrl override).
+ */
+function renderEndingFrame (test: TestResult): string[] | null {
+  const frame = endingFrame(test);
+  if (!frame) {
     return null;
   }
-  return fullSizeImage(step.screenshotUrl, test.name);
+  return [
+    `**📸 Ending screen — ${frame.caption}**`,
+    "",
+    fullSizeImage(frame.url, test.name),
+  ];
 }
 
 function renderResultSummary (test: TestResult, projectId: string): string[] {
@@ -188,7 +259,7 @@ export function renderBody (report: E2eReport, opts: IRenderBodyOptions): string
       "_Full per-test details in the comment below — the PR description was too large to inline them._",
     ].join("\n");
   }
-  const detailBlocks = report.tests.map((t) => renderTestDetails(t, report.projectId));
+  const detailBlocks = report.tests.map((t, i) => renderTestDetails(t, report.projectId, i + 1));
   return [
     overview,
     "",
@@ -203,7 +274,7 @@ export function renderComment (report: E2eReport): string {
   if (report.tests.length === 0) {
     return "";
   }
-  const detailBlocks = report.tests.map((t) => renderTestDetails(t, report.projectId));
+  const detailBlocks = report.tests.map((t, i) => renderTestDetails(t, report.projectId, i + 1));
   return [
     "## E2E acceptance evidence (overflow)",
     "",

--- a/src/cli/pr-section/resolve-urls-types.ts
+++ b/src/cli/pr-section/resolve-urls-types.ts
@@ -28,3 +28,22 @@ export const RESOLVE_TIMEOUT_MS = 10_000;
 
 /** Log prefix used for every stderr line written by the resolver. */
 export const LOG_PREFIX = "build-pr-section";
+
+/**
+ * Public image-proxy prefix used to wrap resolved Firebase Storage URLs so
+ * GitHub's image proxy (Camo) sees a declared `Content-Type: image/jpeg`.
+ *
+ * Firebase download URLs serve whatever Content-Type is stored in the GCS
+ * object metadata — and the Muggle action-script uploader stores screenshots
+ * with `Content-Type: application/octet-stream`. Camo refuses to embed
+ * anything that isn't declared `image/*`, so the images render as broken
+ * icons in PR comments unless we route them through a proxy that re-serves
+ * the bytes with the correct header.
+ *
+ * `images.weserv.nl` is a free, widely-used public image proxy that reads the
+ * bytes and forwards them with the right `Content-Type` (and caches by URL).
+ * We keep the prefix as a constant so it's trivial to swap for a Muggle-owned
+ * proxy later, and so the root cause — fix the Content-Type at upload time in
+ * muggle-ai-teaching-service / the Electron app — is easy to link back to.
+ */
+export const IMAGE_PROXY_PREFIX = "https://images.weserv.nl/?url=";

--- a/src/cli/pr-section/resolve-urls.ts
+++ b/src/cli/pr-section/resolve-urls.ts
@@ -23,6 +23,7 @@ import type { ICallerCredentials } from "../../../packages/mcps/src/index.js";
 
 import {
   GS_SCHEME,
+  IMAGE_PROXY_PREFIX,
   LOG_PREFIX,
   PUBLIC_URL_PATH,
   RESOLVE_TIMEOUT_MS,
@@ -39,6 +40,23 @@ function isGsUrl (url: string): boolean {
   return url.startsWith(GS_SCHEME);
 }
 
+/**
+ * Wrap a resolved Firebase Storage URL in the public image proxy so GitHub's
+ * image proxy (Camo) sees a declared `Content-Type: image/jpeg`. Idempotent:
+ * URLs already wrapped with {@link IMAGE_PROXY_PREFIX} are returned untouched.
+ *
+ * This is a render-time workaround — the proper fix is for the action-script
+ * uploader in muggle-ai-teaching-service / the Electron app to set
+ * `Content-Type: image/jpeg` at upload time, after which this wrap can be
+ * removed without touching every caller.
+ */
+function wrapInImageProxy (url: string): string {
+  if (url.startsWith(IMAGE_PROXY_PREFIX)) {
+    return url;
+  }
+  return `${IMAGE_PROXY_PREFIX}${encodeURIComponent(url)}`;
+}
+
 /** Build the auth headers for a prompt service request. Mirrors upstream-client. */
 function buildAuthHeaders (credentials: ICallerCredentials): Record<string, string> {
   const headers: Record<string, string> = {};
@@ -53,7 +71,14 @@ function buildAuthHeaders (credentials: ICallerCredentials): Record<string, stri
   return headers;
 }
 
-/** Collect every unique `gs://` screenshot URL in the report, in insertion order. */
+/**
+ * Collect every unique `gs://` screenshot URL in the report, in insertion order.
+ *
+ * Walks both `steps[].screenshotUrl` and the optional per-test
+ * `endingScreenshotUrl` override — the latter is how a caller surfaces the
+ * action script's dedicated summary-step screenshot without stuffing it into
+ * `steps[]`.
+ */
 function collectGsUrls (report: E2eReport): string[] {
   const seen = new Set<string>();
   for (const test of report.tests) {
@@ -61,6 +86,9 @@ function collectGsUrls (report: E2eReport): string[] {
       if (isGsUrl(step.screenshotUrl)) {
         seen.add(step.screenshotUrl);
       }
+    }
+    if (test.endingScreenshotUrl && isGsUrl(test.endingScreenshotUrl)) {
+      seen.add(test.endingScreenshotUrl);
     }
   }
   return Array.from(seen);
@@ -117,12 +145,23 @@ function remapStep (step: Step, urlMap: Map<string, string>): Step {
 }
 
 /**
- * Return a new `TestResult` with freshly remapped `steps`. Preserves every
- * other field (and the discriminated `status` so the zod union stays valid)
- * via a shallow spread.
+ * Return a new `TestResult` with freshly remapped `steps` and, if present,
+ * a freshly remapped `endingScreenshotUrl`. Preserves every other field
+ * (and the discriminated `status` so the zod union stays valid) via a
+ * shallow spread.
  */
 function remapTest (test: TestResult, urlMap: Map<string, string>): TestResult {
-  return { ...test, steps: test.steps.map((s) => remapStep(s, urlMap)) };
+  const remapped: TestResult = {
+    ...test,
+    steps: test.steps.map((s) => remapStep(s, urlMap)),
+  };
+  if (test.endingScreenshotUrl) {
+    const resolved = urlMap.get(test.endingScreenshotUrl);
+    if (resolved) {
+      remapped.endingScreenshotUrl = resolved;
+    }
+  }
+  return remapped;
 }
 
 /**
@@ -169,7 +208,10 @@ export async function resolveGsScreenshotUrls (
     for (let i = 0; i < gsUrls.length; i++) {
       const https = resolved[i];
       if (https) {
-        urlMap.set(gsUrls[i]!, https);
+        // Wrap every resolved URL in the public image proxy so GitHub's Camo
+        // sees a proper Content-Type: image/jpeg header. See the note on
+        // IMAGE_PROXY_PREFIX in resolve-urls-types.ts for the root cause.
+        urlMap.set(gsUrls[i]!, wrapInImageProxy(https));
       } else {
         failureCount++;
       }

--- a/src/cli/pr-section/types.ts
+++ b/src/cli/pr-section/types.ts
@@ -21,6 +21,8 @@ const PassedTestSchema = z.object({
   steps: z.array(StepSchema),
   useCaseName: z.string().min(1).optional(),
   description: z.string().min(1).optional(),
+  endingScreenshotUrl: z.string().url().optional(),
+  endingScreenshotCaption: z.string().min(1).optional(),
 });
 
 const FailedTestSchema = z.object({
@@ -36,6 +38,8 @@ const FailedTestSchema = z.object({
   artifactsDir: z.string().min(1).optional(),
   useCaseName: z.string().min(1).optional(),
   description: z.string().min(1).optional(),
+  endingScreenshotUrl: z.string().url().optional(),
+  endingScreenshotCaption: z.string().min(1).optional(),
 });
 
 const TestResultSchema = z.discriminatedUnion("status", [

--- a/src/test/cli/pr-section/overflow.test.ts
+++ b/src/test/cli/pr-section/overflow.test.ts
@@ -65,9 +65,9 @@ describe("splitWithOverflow", () => {
     const fit = splitWithOverflow(report, { maxBodyBytes: 60_000 });
     expect(fit.comment).toBeNull();
     expect(fit.body).toContain("- **Create a New Project**");
-    expect(fit.body).toContain("  - ✅ User creates a new project with valid URL");
-    expect(fit.body).toContain("  - ❌ User receives error for invalid URL format");
-    expect(fit.body).toContain("  - ✅ Login with valid credentials");
+    expect(fit.body).toContain("  - **1.** ✅ User creates a new project with valid URL");
+    expect(fit.body).toContain("  - **2.** ❌ User receives error for invalid URL format");
+    expect(fit.body).toContain("  - **3.** ✅ Login with valid credentials");
 
     const spilled = splitWithOverflow(report, { maxBodyBytes: 500 });
     expect(spilled.comment).not.toBeNull();

--- a/src/test/cli/pr-section/render.test.ts
+++ b/src/test/cli/pr-section/render.test.ts
@@ -107,25 +107,26 @@ const allPassedNoMeta: E2eReport = {
 const emptyReport: E2eReport = { projectId: PROJECT_ID, tests: [] };
 
 describe("renderOverview", () => {
-  it("renders counts and a flat list when no test has a useCaseName", () => {
+  it("renders counts and a flat numbered list when no test has a useCaseName", () => {
     const md = renderOverview(flatReport);
     expect(md).toContain("## E2E Acceptance Results");
     expect(md).toContain("**2 tests ran — 1 passed / 1 failed**");
     expect(md).toContain("**Tests run:**");
-    expect(md).toContain("- ✅ Logout flow");
-    expect(md).toContain("- ❌ Checkout breaks");
-    // No nested use-case bullets.
-    expect(md).not.toMatch(/^- \*\*/m);
+    expect(md).toContain("- **1.** ✅ Logout flow");
+    expect(md).toContain("- **2.** ❌ Checkout breaks");
+    // No nested use-case bullets (but the numbering does start the bullet with **).
+    // So the "no group bullets" check is by the em-style: "- **Word**" with no digit.
+    expect(md).not.toMatch(/^- \*\*[A-Za-z]/m);
   });
 
-  it("groups tests by useCaseName when at least one test has one", () => {
+  it("groups tests by useCaseName with global numbering across groups", () => {
     const md = renderOverview(groupedReport);
     expect(md).toContain("**3 tests ran — 2 passed / 1 failed**");
     expect(md).toContain("- **Create a New Project**");
-    expect(md).toContain("  - ✅ User creates a new project with valid URL");
-    expect(md).toContain("  - ❌ User receives error for invalid URL format");
+    expect(md).toContain("  - **1.** ✅ User creates a new project with valid URL");
+    expect(md).toContain("  - **2.** ❌ User receives error for invalid URL format");
     expect(md).toContain("- **User Authentication**");
-    expect(md).toContain("  - ✅ Login with valid credentials");
+    expect(md).toContain("  - **3.** ✅ Login with valid credentials");
   });
 
   it("handles an empty report with a friendly placeholder", () => {
@@ -138,14 +139,15 @@ describe("renderOverview", () => {
 });
 
 describe("renderTestDetails", () => {
-  it("renders a passed test with description in the summary line", () => {
-    const md = renderTestDetails(passedWithDesc, PROJECT_ID);
+  it("renders a passed test with description and numbered summary line", () => {
+    const md = renderTestDetails(passedWithDesc, PROJECT_ID, 1);
     expect(md).toContain("<details>");
     expect(md).toContain("<summary>");
-    expect(md).toContain("✅ <b>User creates a new project with valid URL</b>");
+    expect(md).toContain("<b>1. User creates a new project with valid URL</b> ✅");
     expect(md).toContain("— Verify that a logged-in user can create a new project");
     expect(md).toContain("<i>▶ click to expand</i>");
-    // Ending screenshot = last step.
+    // Ending screenshot = last step, with a caption above it.
+    expect(md).toContain("**📸 Ending screen — Final page after the test completed**");
     expect(md).toContain('<img src="https://cdn/1-2.png" width="720"');
     expect(md).toContain("**Result:** ✅ PASSED");
     expect(md).toContain("**Steps:** 3");
@@ -154,24 +156,39 @@ describe("renderTestDetails", () => {
   });
 
   it("renders a passed test without description (no em-dash, no description text)", () => {
-    const md = renderTestDetails(passedNoMeta, PROJECT_ID);
-    expect(md).toContain("✅ <b>Logout flow</b> <i>▶ click to expand</i>");
+    const md = renderTestDetails(passedNoMeta, PROJECT_ID, 4);
+    expect(md).toContain("<b>4. Logout flow</b> ✅ <i>▶ click to expand</i>");
     // No " — " separator between name and the tail.
-    expect(md).not.toMatch(/<b>Logout flow<\/b> —/);
+    expect(md).not.toMatch(/<b>4\. Logout flow<\/b> ✅ —/);
   });
 
-  it("renders a failed test with error and failure-step screenshot", () => {
-    const md = renderTestDetails(failedWithDesc, PROJECT_ID);
-    expect(md).toContain("❌ <b>User receives error for invalid URL format</b>");
+  it("renders a failed test with error, numbered summary, and failure-step screenshot", () => {
+    const md = renderTestDetails(failedWithDesc, PROJECT_ID, 2);
+    expect(md).toContain("<b>2. User receives error for invalid URL format</b> ❌");
     expect(md).toContain("**Result:** ❌ FAILED at step 3");
     expect(md).toContain("**Error:** `Element not found: submit button`");
     expect(md).toContain("**Steps:** 4");
-    // Ending screenshot = failure step (stepIndex 3).
+    // Ending screenshot = failure step (stepIndex 3). Caption reflects failure.
+    expect(md).toContain("**📸 Ending screen — Failure at step 3**");
     expect(md).toContain('<img src="https://cdn/2-3.png"');
   });
 
+  it("uses endingScreenshotUrl + endingScreenshotCaption when provided on the test", () => {
+    const overrideTest: PassedTest = {
+      ...passedWithDesc,
+      endingScreenshotUrl: "https://cdn/summary.png",
+      endingScreenshotCaption: "Success. The goal is achieved.",
+    };
+    const md = renderTestDetails(overrideTest, PROJECT_ID, 1);
+    // Caption shows the caller-provided summary text, not the default.
+    expect(md).toContain("**📸 Ending screen — Success. The goal is achieved.**");
+    // Image uses the override URL, NOT the last step in steps[].
+    expect(md).toContain('<img src="https://cdn/summary.png"');
+    expect(md).not.toContain('<img src="https://cdn/1-2.png"');
+  });
+
   it("escapes backticks in the error message so inline code stays balanced", () => {
-    const md = renderTestDetails(failedNoMeta, PROJECT_ID);
+    const md = renderTestDetails(failedNoMeta, PROJECT_ID, 5);
     expect(md).toContain("**Error:**");
     // Raw backticks from the error must not appear unescaped in the rendered output.
     expect(md).not.toMatch(/Timeout waiting for `button/);
@@ -208,10 +225,11 @@ describe("renderBody", () => {
     expect(detailsCount).toBe(2);
   });
 
-  it("renders a flat list when no test has a useCaseName", () => {
+  it("renders a flat numbered list when no test has a useCaseName", () => {
     const body = renderBody(allPassedNoMeta, { inlineDetails: true });
-    expect(body).toContain("- ✅ Logout flow");
-    expect(body).not.toContain("- **");
+    expect(body).toContain("- **1.** ✅ Logout flow");
+    // No use-case group bullets (letter-prefixed, not digit-prefixed).
+    expect(body).not.toMatch(/^- \*\*[A-Za-z]/m);
   });
 
   it("empty report: no details, no horizontal rule", () => {

--- a/src/test/cli/pr-section/resolve-urls.test.ts
+++ b/src/test/cli/pr-section/resolve-urls.test.ts
@@ -23,11 +23,17 @@ vi.mock("../../../../packages/mcps/src/index.js", () => ({
 import axios from "axios";
 
 import { resolveGsScreenshotUrls } from "../../../cli/pr-section/resolve-urls.js";
+import { IMAGE_PROXY_PREFIX } from "../../../cli/pr-section/resolve-urls-types.js";
 import type { E2eReport } from "../../../cli/pr-section/types.js";
 import {
   getCallerCredentialsAsync,
   getConfig,
 } from "../../../../packages/mcps/src/index.js";
+
+/** Build the expected image-proxy-wrapped form of a resolved URL. */
+function wrapped (url: string): string {
+  return `${IMAGE_PROXY_PREFIX}${encodeURIComponent(url)}`;
+}
 
 const mockedAxiosPost = vi.mocked(axios.post);
 const mockedGetCredentials = vi.mocked(getCallerCredentialsAsync);
@@ -103,11 +109,12 @@ describe("resolveGsScreenshotUrls", () => {
     expect(stderr.lines).toEqual([]);
   });
 
-  it("only resolves gs:// URLs and leaves https:// URLs alone", async () => {
+  it("only resolves gs:// URLs and leaves https:// URLs alone; resolved URLs are image-proxy-wrapped", async () => {
     mockedGetCredentials.mockResolvedValue({ bearerToken: "tkn" });
+    const firebaseUrl = "https://firebasestorage.googleapis.com/v0/b/bucket/o/a.jpg?alt=media&token=abc";
     mockedAxiosPost.mockResolvedValue({
       status: 200,
-      data: { resourceUrl: "https://firebasestorage.googleapis.com/v0/b/bucket/o/a.jpg?alt=media&token=abc" },
+      data: { resourceUrl: firebaseUrl },
     });
     const report = makeReport([
       { screenshotUrl: "https://cdn.example.com/https.png" },
@@ -123,13 +130,54 @@ describe("resolveGsScreenshotUrls", () => {
       { resourceUrl: "gs://bucket/a.jpg" },
       expect.anything(),
     );
+    // Untouched https:// stays untouched.
     expect(result.tests[0]!.steps[0]!.screenshotUrl).toBe("https://cdn.example.com/https.png");
-    expect(result.tests[0]!.steps[1]!.screenshotUrl).toBe(
-      "https://firebasestorage.googleapis.com/v0/b/bucket/o/a.jpg?alt=media&token=abc",
-    );
+    // Resolved gs:// is wrapped through the public image proxy so Camo sees image/jpeg.
+    expect(result.tests[0]!.steps[1]!.screenshotUrl).toBe(wrapped(firebaseUrl));
     expect(stderr.lines).toEqual([]);
     // Report is a fresh object (not mutated).
     expect(result).not.toBe(report);
+  });
+
+  it("wraps endingScreenshotUrl through the image proxy too (surfacing the action script's summary step)", async () => {
+    mockedGetCredentials.mockResolvedValue({ bearerToken: "tkn" });
+    const firebaseUrl = "https://firebasestorage.googleapis.com/v0/b/bucket/o/summary.jpg?alt=media&token=s";
+    mockedAxiosPost.mockResolvedValue({ status: 200, data: { resourceUrl: firebaseUrl } });
+
+    const report: E2eReport = {
+      projectId: "p1",
+      tests: [
+        {
+          name: "A",
+          testCaseId: "tc-a",
+          runId: "r-a",
+          viewUrl: "https://example.com/a",
+          status: "passed",
+          steps: [
+            { stepIndex: 0, action: "navigate", screenshotUrl: "https://cdn.example.com/step0.png" },
+          ],
+          endingScreenshotUrl: "gs://bucket/summary.jpg",
+          endingScreenshotCaption: "Goal achieved",
+        },
+      ],
+    };
+    const stderr = makeStderr();
+
+    const result = await resolveGsScreenshotUrls(report, { stderrWrite: stderr.write });
+
+    // The summary-step URL was the only gs:// in the report, and it was sent to the resolver.
+    expect(mockedAxiosPost).toHaveBeenCalledTimes(1);
+    expect(mockedAxiosPost).toHaveBeenCalledWith(
+      PUBLIC_URL_ENDPOINT,
+      { resourceUrl: "gs://bucket/summary.jpg" },
+      expect.anything(),
+    );
+    // endingScreenshotUrl is resolved and then wrapped through the image proxy.
+    expect(result.tests[0]!.endingScreenshotUrl).toBe(wrapped(firebaseUrl));
+    // The non-gs step URL is left alone.
+    expect(result.tests[0]!.steps[0]!.screenshotUrl).toBe("https://cdn.example.com/step0.png");
+    // Caption passes through unchanged.
+    expect(result.tests[0]!.endingScreenshotCaption).toBe("Goal achieved");
   });
 
   it("logs a login hint and skips HTTP calls when no credentials are available", async () => {
@@ -184,7 +232,7 @@ describe("resolveGsScreenshotUrls", () => {
     expect(headers.Authorization).toBeUndefined();
   });
 
-  it("swaps successful URLs and keeps failed URLs (per-URL 401)", async () => {
+  it("swaps successful URLs (proxy-wrapped) and keeps failed URLs (per-URL 401)", async () => {
     mockedGetCredentials.mockResolvedValue({ bearerToken: "tkn" });
     mockedAxiosPost.mockImplementation(async (_url: string, body: unknown) => {
       const { resourceUrl } = body as { resourceUrl: string };
@@ -201,7 +249,7 @@ describe("resolveGsScreenshotUrls", () => {
 
     const result = await resolveGsScreenshotUrls(report, { stderrWrite: stderr.write });
 
-    expect(result.tests[0]!.steps[0]!.screenshotUrl).toBe("https://cdn.example.com/ok.jpg");
+    expect(result.tests[0]!.steps[0]!.screenshotUrl).toBe(wrapped("https://cdn.example.com/ok.jpg"));
     expect(result.tests[0]!.steps[1]!.screenshotUrl).toBe("gs://bucket/bad.jpg");
 
     const joined = stderr.lines.join("");
@@ -226,7 +274,7 @@ describe("resolveGsScreenshotUrls", () => {
 
     const result = await resolveGsScreenshotUrls(report, { stderrWrite: stderr.write });
 
-    expect(result.tests[0]!.steps[0]!.screenshotUrl).toBe("https://cdn.example.com/ok.jpg");
+    expect(result.tests[0]!.steps[0]!.screenshotUrl).toBe(wrapped("https://cdn.example.com/ok.jpg"));
     expect(result.tests[0]!.steps[1]!.screenshotUrl).toBe("gs://bucket/bad.jpg");
 
     const joined = stderr.lines.join("");
@@ -284,8 +332,8 @@ describe("resolveGsScreenshotUrls", () => {
     const result = await resolveGsScreenshotUrls(report, { stderrWrite: stderr.write });
 
     expect(mockedAxiosPost).toHaveBeenCalledTimes(1);
-    expect(result.tests[0]!.steps[0]!.screenshotUrl).toBe("https://cdn.example.com/dup.jpg");
-    expect(result.tests[1]!.steps[0]!.screenshotUrl).toBe("https://cdn.example.com/dup.jpg");
+    expect(result.tests[0]!.steps[0]!.screenshotUrl).toBe(wrapped("https://cdn.example.com/dup.jpg"));
+    expect(result.tests[1]!.steps[0]!.screenshotUrl).toBe(wrapped("https://cdn.example.com/dup.jpg"));
     expect(stderr.lines).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- Show the action script's dedicated **`summaryStep`** screenshot (via new optional `endingScreenshotUrl` + `endingScreenshotCaption` fields on `PassedTest`/`FailedTest`), instead of always picking `steps[last]`
- **Number tests** 1-based in both the overview list and each `<details>` summary so reviewers can cross-reference the two sections
- Render a bold **"📸 Ending screen — <caption>"** line above each image as a visual cue for what the frame shows — defaults to `Final page after the test completed` / `Failure at step N`
- **Wrap resolved Firebase Storage URLs through `images.weserv.nl`** so GitHub's image proxy (Camo) sees `Content-Type: image/jpeg`

## Why

Two bugs surfaced while rendering an E2E walkthrough on muggle-ai-ui#225:

1. **Screenshots rendered as broken icons in GitHub.** The action-script uploader (in muggle-ai-teaching-service / the Electron app) stores screenshots in GCS with `Content-Type: application/octet-stream`. Firebase download URLs serve whatever Content-Type is stored in the object metadata, and GitHub's Camo proxy refuses to embed anything that isn't declared `image/*`. The wrap through `images.weserv.nl` re-serves the bytes with `Content-Type: image/jpeg` so Camo is happy. **This is a render-time workaround** — the proper fix is to set `Content-Type: image/jpeg` at upload time in muggle-ai-teaching-service / the Electron app. Once that lands, the proxy wrap here can be removed by returning `url` directly from `wrapInImageProxy()` without touching a single caller (the `IMAGE_PROXY_PREFIX` constant is factored out precisely so it's a one-line revert).

2. **The thumbnail image was always the last step**, which for tests that end in a `halt` action shows the halt-label UI instead of the clean "success, goal achieved" frame the action script's top-level `summaryStep` captures. The schema now accepts an explicit `endingScreenshotUrl` override so callers can surface the `summaryStep.operation.screenshotUrl` they already have in hand. `collectGsUrls` / `remapTest` in `resolve-urls.ts` now walk that field so raw `gs://` URIs in it get the same resolve + wrap treatment as every step URI.

## Changes

| File | What |
|------|------|
| `src/cli/pr-section/types.ts` | Add optional `endingScreenshotUrl` + `endingScreenshotCaption` to `PassedTestSchema` / `FailedTestSchema` |
| `src/cli/pr-section/render.ts` | New `IEndingFrame` + `endingFrame()` — override wins, else falls back to failure/last step. `renderOverview` numbers tests globally across groups. `renderTestDetails` takes `testNumber` and prepends `**N.**`. New `renderEndingFrame` emits the `📸 Ending screen — <caption>` line above the image. |
| `src/cli/pr-section/resolve-urls-types.ts` | New `IMAGE_PROXY_PREFIX` constant with a long comment explaining the root cause and where the proper fix belongs |
| `src/cli/pr-section/resolve-urls.ts` | New idempotent `wrapInImageProxy` helper. `collectGsUrls` + `remapTest` now walk `endingScreenshotUrl`. Every resolved URL enters the map wrapped. |
| `src/test/cli/pr-section/render.test.ts` | Update overview/details assertions for numbering + new caption line. New test for the `endingScreenshotUrl`/`endingScreenshotCaption` override path. |
| `src/test/cli/pr-section/resolve-urls.test.ts` | Add `wrapped()` helper and proxy-wrap assertions across existing tests. New test for `endingScreenshotUrl` resolution + wrap. |
| `src/test/cli/pr-section/overflow.test.ts` | Update grouped-list numbering assertion |

## Test plan
- [x] `pnpm exec vitest run` — 48/48 passing (6 test files)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec eslint src/cli/pr-section src/test/cli/pr-section` — clean
- [x] `pnpm exec tsup` — build succeeds
- [x] End-to-end manual: fed a real `E2eReport` (2 tests, ~49 raw `gs://` URIs) through `bin/muggle.js build-pr-section` with `MUGGLE_MCP_PROMPT_SERVICE_TARGET=production`; zero stderr warnings, 49/49 URIs resolved + wrapped, rendered body posted to multiplex-ai/muggle-ai-ui#225 (images render, numbering correct, caption visible)
- [ ] Once merged + published, consumers of `muggle build-pr-section` get the behavior automatically; no schema-breaking changes (both new fields are optional)

## Follow-ups (separate repos)
- **muggle-ai-teaching-service / electron-app**: set `Content-Type: image/jpeg` on action-script screenshot uploads to GCS. Once that lands, remove `IMAGE_PROXY_PREFIX` from `wrapInImageProxy()` here.
- Optional backfill: one-time migration job that patches `contentType` metadata on existing objects in `muggle-ai-action-script-uswest1` via the GCS JSON API.