### PR TITLE
chore(release): @muggleai/works 4.7.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.6.1"
+      "version": "4.7.0"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.6.1"
+      "version": "4.7.0"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@muggleai/works",
     "mcpName": "io.github.multiplex-ai/muggle",
-    "version": "4.6.1",
+    "version": "4.7.0",
     "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
     "type": "module",
     "main": "dist/index.js",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "4.6.1",
+  "version": "4.7.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "4.6.1",
+  "version": "4.7.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "4.6.1",
+  "version": "4.7.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "4.6.1",
+      "version": "4.7.0",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
## Summary
Bumps the npm package from **4.6.1 → 4.7.0**.

Minor bump because the only commit on master since 4.6.1 is #71, which adds new capabilities behind optional schema fields (non-breaking). No Electron bundle change — \`electronAppVersion\` stays at \`1.0.51\` with identical checksums.

## Shipping in 4.7.0

- **#71** \`feat(pr-section): number tests, show summary-step image with caption, proxy-wrap screenshots\`
  - Adds optional \`endingScreenshotUrl\` + \`endingScreenshotCaption\` to \`PassedTest\` / \`FailedTest\` so callers can surface the action script's top-level \`summaryStep\` instead of \`steps[last]\`
  - Numbers tests \`- **1.** ✅ Name\` in the overview list and \`<b>1. Name</b>\` in each \`<details>\` header, so reviewers can cross-reference the two sections
  - Renders a bold \`📸 Ending screen — <caption>\` line above each image as a visual cue for what the frame shows
  - Wraps resolved Firebase Storage URLs through \`images.weserv.nl\` so GitHub's image proxy (Camo) sees \`Content-Type: image/jpeg\`
  - This last piece is a render-time workaround; the root-cause fix ships in multiplex-ai/muggle-ai-teaching-service#131 (set \`Content-Type: image/jpeg\` at upload time). Once that lands + existing objects are backfilled, the wrap can be removed by returning the resolved URL directly from \`wrapInImageProxy()\` — \`IMAGE_PROXY_PREFIX\` is factored out for a one-line revert.

## Version propagation

Every file the repo cares about has been bumped via \`scripts/sync-versions.mjs\` (invoked as part of \`pnpm run build\`):

| File | |
|---|---|
| \`package.json\` | \`@muggleai/works\` top-level version |
| \`.claude-plugin/marketplace.json\` | Claude Code plugin marketplace entry |
| \`.cursor-plugin/marketplace.json\` | Cursor plugin marketplace entry |
| \`plugin/.claude-plugin/plugin.json\` | Claude Code plugin source manifest (build target \`dist/plugin/.claude-plugin/plugin.json\`) |
| \`plugin/.cursor-plugin/plugin.json\` | Cursor plugin source manifest |
| \`server.json\` | MCP registry manifest (\`version\` + \`packages[].version\`) |

## Test plan
- [x] \`pnpm run lint:check\` — clean
- [x] \`pnpm run typecheck\` — clean
- [x] \`pnpm test\` — 48/48 passing (6 test files)
- [x] \`pnpm run build\` — tsup + release-manifest + sync-versions + build-plugin all succeed
- [x] \`pnpm run verify:plugin\` — plugin marketplace consistency OK
- [x] \`pnpm run verify:contracts\` — compatibility contracts OK
- [ ] After merge: dispatch \`publish-works-to-npm.yml\` against master and confirm npm shows 4.7.0 with provenance attestation

## Note on the workflow I almost dispatched first

I initially kicked off \`publish-works-to-npm.yml\` with \`--field version=4.7.0\` against a master still at 4.6.1. Reasoning was "the workflow runs \`npm version\` in its own checkout before packing, so the published tarball is internally consistent" — which is true, but it leaves master's \`package.json\`, plugin manifests, and \`server.json\` lying about the latest release until the next \`chore(release)\` lands. That's out of step with the pattern #67 / #70 have set and with the "re-pull master right before dispatching publish; size bump to what's actually shipping" rule. I cancelled that run and cut this PR instead so master and npm stay in lockstep.