### PR TITLE
fix(local-publish): forward local runs' summaryStep to the cloud

### DIFF
--- a/packages/mcps/src/mcp/local/services/execution-service.ts
+++ b/packages/mcps/src/mcp/local/services/execution-service.ts
@@ -723,10 +723,12 @@ export async function executeTestGeneration(params: {
           `Generated script does not contain a valid 'steps' array. File: ${generatedScriptPath}`,
         );
       }
+      const generatedSummaryStep = generatedScript.summaryStep;
 
       storage.updateTestScript(localTestScript.id, {
         status: "generated",
         actionScript: generatedSteps,
+        summaryStep: generatedSummaryStep,
       });
 
       const artifactsDir = await moveResultsToArtifacts({

--- a/packages/mcps/src/mcp/local/types/project-types.ts
+++ b/packages/mcps/src/mcp/local/types/project-types.ts
@@ -151,6 +151,8 @@ export interface ILocalTestScript {
   actionScriptId?: string;
   /** Action script steps. */
   actionScript?: unknown[];
+  /** Optional summary step capturing run verdict, structured summary, and final screenshot. */
+  summaryStep?: unknown;
   /** Created timestamp. */
   createdAt: number;
   /** Updated timestamp. */

--- a/packages/mcps/src/mcp/local/types/run-result-storage-types.ts
+++ b/packages/mcps/src/mcp/local/types/run-result-storage-types.ts
@@ -99,6 +99,8 @@ export interface IRunResultStorageTestScript {
   goal?: string;
   /** Action script steps. */
   actionScript?: unknown[];
+  /** Optional summary step capturing run verdict, structured summary, and final screenshot. */
+  summaryStep?: unknown;
   /** Cloud action script ID (if published). */
   cloudActionScriptId?: string;
   /** Created timestamp. */

--- a/packages/mcps/src/mcp/local/types/storage-params.ts
+++ b/packages/mcps/src/mcp/local/types/storage-params.ts
@@ -386,6 +386,7 @@ export interface IUpdateLocalTestScriptParams {
     status: import("./enums.js").LocalTestScriptStatus;
     actionScriptId: string;
     actionScript: unknown[];
+    summaryStep: unknown;
   }>;
 }
 

--- a/packages/mcps/src/mcp/tools/local/tool-registry.ts
+++ b/packages/mcps/src/mcp/tools/local/tool-registry.ts
@@ -519,6 +519,7 @@ const publishTestScriptTool: ILocalMcpTool = {
               uploadedAt: uploadedAt,
             },
             actionScript: testScript.actionScript,
+            summaryStep: testScript.summaryStep,
             status: runResult.status === "passed" ? "passed" : "failed",
             executionTimeMs: runResult.executionTimeMs,
             errorMessage: runResult.errorMessage,

--- a/packages/mcps/src/test/publish-test-script.test.ts
+++ b/packages/mcps/src/test/publish-test-script.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Tests for muggle-local-publish-test-script.
+ *
+ * Covers the summaryStep plumbing: the tool must read summaryStep off the
+ * stored test script and forward it in the upload request body so the
+ * cloud action script retains the run verdict and final screenshot.
+ *
+ * See muggle-ai-prompt-service PR #405 for the companion backend fix.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../shared/config.js", () => ({
+  getConfig: () => ({
+    logLevel: "silent",
+    serverName: "test",
+    serverVersion: "0.0.0",
+    e2e: {
+      promptServiceBaseUrl: "http://test.invalid",
+      requestTimeoutMs: 1000,
+      workflowTimeoutMs: 1000,
+    },
+  }),
+}));
+
+vi.mock("../shared/logger.js", () => {
+  const noop = () => undefined;
+  const fakeLogger = {
+    info: noop,
+    warn: noop,
+    error: noop,
+    debug: noop,
+    verbose: noop,
+    silly: noop,
+    child: () => fakeLogger,
+  };
+  return {
+    getLogger: () => fakeLogger,
+    createChildLogger: () => fakeLogger,
+    resetLogger: noop,
+  };
+});
+
+vi.mock("../shared/auth.js", () => ({
+  getCallerCredentialsAsync: vi.fn(async () => ({ bearerToken: "test-token" })),
+}));
+
+const mockExecute = vi.fn();
+vi.mock("../mcp/e2e/upstream-client.js", () => ({
+  getPromptServiceClient: () => ({ execute: mockExecute }),
+}));
+
+const mockGetRunResult = vi.fn();
+const mockGetTestScript = vi.fn();
+const mockUpdateTestScript = vi.fn();
+const mockUpdateRunResult = vi.fn();
+const mockGetAuthStatus = vi.fn();
+
+vi.mock("../mcp/local/services/index.js", () => ({
+  cancelExecution: vi.fn(),
+  executeReplay: vi.fn(),
+  executeTestGeneration: vi.fn(),
+  getAuthService: () => ({ getAuthStatus: mockGetAuthStatus }),
+  getStorageService: () => ({
+    getDataDir: () => "/tmp",
+    getSessionsDir: () => "/tmp",
+  }),
+  getRunResultStorageService: () => ({
+    getRunResult: mockGetRunResult,
+    getTestScript: mockGetTestScript,
+    updateTestScript: mockUpdateTestScript,
+    updateRunResult: mockUpdateRunResult,
+  }),
+}));
+
+import { getTool } from "../mcp/tools/local/tool-registry.js";
+
+const RUN_ID = "11111111-1111-4111-8111-111111111111";
+const CLOUD_TEST_CASE_ID = "22222222-2222-4222-8222-222222222222";
+const TEST_SCRIPT_ID = "33333333-3333-4333-8333-333333333333";
+const PROJECT_ID = "44444444-4444-4444-8444-444444444444";
+const USE_CASE_ID = "55555555-5555-4555-8555-555555555555";
+const USER_ID = "auth0|test-user";
+
+const SUMMARY_STEP = {
+  briefExplanation: "Success. Pricing section verified.",
+  isSummaryStep: true,
+  operation: {
+    action: "halt",
+    screenshotUrl: "gs://bucket/summary.jpg",
+  },
+  comment: "Verdict: goal achieved.",
+  structuredSummary: {
+    summaryHeadline: "Pricing section verified",
+    status: "success",
+    keyFindings: [],
+    failureReason: null,
+    nextActions: [],
+    confidence: 1,
+  },
+};
+
+const STEPS = [
+  {
+    briefExplanation: "navigate",
+    operation: { action: "navigate", url: "http://localhost:3999/" },
+  },
+];
+
+/**
+ * Wire up a happy-path fixture for publishTestScriptTool. Individual tests
+ * may override specific fields before invoking the tool.
+ */
+function seedHappyPath({
+  includeSummaryStep,
+}: {
+  includeSummaryStep: boolean;
+}): void {
+  mockGetAuthStatus.mockReturnValue({
+    authenticated: true,
+    userId: USER_ID,
+    email: "test@example.com",
+    expiresAt: new Date(Date.now() + 60000).toISOString(),
+    isExpired: false,
+  });
+  mockGetRunResult.mockReturnValue({
+    id: RUN_ID,
+    testScriptId: TEST_SCRIPT_ID,
+    runType: "generation",
+    status: "passed",
+    projectId: PROJECT_ID,
+    useCaseId: USE_CASE_ID,
+    productionUrl: "https://staging.example.com/",
+    executionTimeMs: 63217,
+    localExecutionContext: {
+      originalUrl: "http://localhost:3999/",
+      productionUrl: "https://staging.example.com/",
+      machineHostname: "test-host",
+      osInfo: "darwin",
+      electronAppVersion: "1.0.51",
+      mcpServerVersion: "4.7.0",
+      localExecutionCompletedAt: Date.now(),
+    },
+  });
+  mockGetTestScript.mockReturnValue({
+    id: TEST_SCRIPT_ID,
+    name: "Test",
+    url: "http://localhost:3999/",
+    status: "generated",
+    cloudTestCaseId: CLOUD_TEST_CASE_ID,
+    actionScript: STEPS,
+    summaryStep: includeSummaryStep ? SUMMARY_STEP : undefined,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  });
+  mockExecute.mockResolvedValue({
+    data: {
+      workflowRuntimeId: "runtime-1",
+      workflowRunId: "run-1",
+      testScriptId: "cloud-ts-1",
+      actionScriptId: "cloud-as-1",
+      viewUrl: "https://www.muggle-ai.com/...",
+    },
+  });
+}
+
+describe("muggle-local-publish-test-script — summaryStep forwarding", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("forwards summaryStep in the upload body when present on the test script", async () => {
+    seedHappyPath({ includeSummaryStep: true });
+
+    const tool = getTool("muggle-local-publish-test-script");
+    expect(tool).toBeDefined();
+
+    const result = await tool!.execute({
+      input: { runId: RUN_ID, cloudTestCaseId: CLOUD_TEST_CASE_ID },
+      correlationId: "test-corr",
+    } as never);
+
+    expect(result.isError).toBe(false);
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+    const call = mockExecute.mock.calls[0];
+    const requestConfig = call[0] as { body: Record<string, unknown> };
+    expect(requestConfig.body).toMatchObject({
+      projectId: PROJECT_ID,
+      useCaseId: USE_CASE_ID,
+      testCaseId: CLOUD_TEST_CASE_ID,
+      actionScript: STEPS,
+      summaryStep: SUMMARY_STEP,
+    });
+  });
+
+  it("forwards undefined summaryStep when the test script does not have one", async () => {
+    seedHappyPath({ includeSummaryStep: false });
+
+    const tool = getTool("muggle-local-publish-test-script");
+    expect(tool).toBeDefined();
+
+    const result = await tool!.execute({
+      input: { runId: RUN_ID, cloudTestCaseId: CLOUD_TEST_CASE_ID },
+      correlationId: "test-corr",
+    } as never);
+
+    expect(result.isError).toBe(false);
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+    const requestConfig = mockExecute.mock.calls[0][0] as { body: Record<string, unknown> };
+    expect(requestConfig.body.summaryStep).toBeUndefined();
+    expect(requestConfig.body.actionScript).toEqual(STEPS);
+  });
+});


### PR DESCRIPTION
## Summary

Local test generation writes `action-script.json` with both `steps[]` and a top-level `summaryStep` (run verdict, structured summary, final screenshot). The publish path was extracting only `.steps` in `execution-service.ts` and sending only `actionScript` in the upload body, silently dropping `summaryStep`.

### Symptoms on the dashboard before this fix

For any published local run, the Test Script Generation Details Modal showed:

- **Generation Summary:** \`N/A\`
- **Final Screenshot:** \`No result page screenshot available\`
- **Last visual step** in the Steps tab: missing its "after" screenshot

All three are read off \`actionScript.summaryStep\` in the UI:
- \`overview-evidence.ts:extractScreenshotUri\` reads \`summaryStep.operation.screenshotUrl\` for the final screenshot
- \`use-steps-with-screenshots.ts\` falls back to \`summaryStep\`'s screenshot for the last visual step's "after" view

### Changes

- **execution-service.ts**: also read \`generatedScript.summaryStep\` from \`gen_*.json\` and pass it into \`updateTestScript\`
- **tool-registry.ts** (\`publishTestScriptTool\`): add \`summaryStep: testScript.summaryStep\` to the upload body
- **Type plumbing** in \`IRunResultStorageTestScript\`, \`ILocalTestScript\`, \`IUpdateLocalTestScriptParams\`: \`summaryStep?: unknown\`

Storage is a pass-through JSON dump, so round-trip works with no other persistence changes.

### Companion PR (required)

Backend: [multiplex-ai/muggle-ai-prompt-service#405](https://github.com/multiplex-ai/muggle-ai-prompt-service/pull/405) — accepts \`summaryStep\` on \`ILocalRunUploadRequest\` and forwards it to \`createActionScriptAsync\` → \`IActionScript.summaryStep\`. Ship that first.

## Test plan

- [x] New vitest: \`muggle-local-publish-test-script\` forwards \`summaryStep\` in the upload body when the test script has one
- [x] New vitest: \`muggle-local-publish-test-script\` forwards \`undefined\` when the test script has no \`summaryStep\`
- [x] \`pnpm --filter @muggleai/mcp test\` — all 29 tests pass
- [x] \`pnpm --filter @muggleai/mcp typecheck\` — clean
- [x] \`npm run lint:workspace\` — clean
- [ ] CI green
- [ ] After merging both PRs: \`muggle test\` end-to-end, verify dashboard shows Generation Summary, Final Screenshot, and last-step "after" screenshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)