### PR TITLE
chore(release): @muggleai/works 4.8.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.7.0"
+      "version": "4.8.0"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.7.0"
+      "version": "4.8.0"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -554,12 +554,7 @@ CI/CD and publishing
 | `verify-end-user-upgrade.yml` | Weekly + manual | Existing-user upgrade validation (cleanup + re-download + health checks) |
 | `publish-works-to-npm.yml` | Tag `v*` or manual  | Verify (including release checksums), audit, smoke-install, publish to npm |
 
-
-```bash
-git tag v<version> && git push --tags
-# publish-works-to-npm.yml handles the rest
-```
-
+**Publishing `@muggleai/works`:** use the repo-level skill **`plugin/skills/muggle-works-npm-release/SKILL.md`** (bump + `pnpm run sync:versions`, local verify, `chore(release)` PR, merge, then `workflow_dispatch` with an explicit `version`). Do not rely on tagging alone while `package.json` / marketplace manifests on `master` are still old — CI can publish a version that does not match the checked-in manifests. Tag `v*` push remains a valid workflow trigger when it matches the merged release commit.
 
 Release tag strategy
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@muggleai/works",
     "mcpName": "io.github.multiplex-ai/muggle",
-    "version": "4.7.0",
+    "version": "4.8.0",
     "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
     "type": "module",
     "main": "dist/index.js",
@@ -42,14 +42,14 @@
         "test:watch": "vitest"
     },
     "muggleConfig": {
-        "electronAppVersion": "1.0.51",
+        "electronAppVersion": "1.0.55",
         "downloadBaseUrl": "https://github.com/multiplex-ai/muggle-ai-works/releases/download",
         "runtimeTargetDefault": "dev",
         "checksums": {
-            "darwin-arm64": "6be5d2ff37541d9933e065f94f04348d7e4be63f01896b334a108a755a79f770",
-            "darwin-x64": "5c381e68829a330eecb8bd6edb9e5fba820e995acafe7fe78474fd7c43174f40",
-            "win32-x64": "2c101c467f75e8d60482aad16ad3c1a1e8edecac9ae58cdf7f1ad74cdf1141f7",
-            "linux-x64": "efeed3f2caf1cd301e8cc503a8ebae1f604ce73f7325c43202dee1c8a858a8a8"
+            "darwin-arm64": "b489ecb3273d8c15727ab80430468099a41e58417ef0f853de435f13aff0d903",
+            "darwin-x64": "38a34f45a23a9b53e3383c1f016363a294a28c3abdc454da35a34f1b03ddc191",
+            "win32-x64": "795495f9ddaab676e60f0140651c04f8d375adbadd3258a387bc7c82581c6d76",
+            "linux-x64": "2005101c8b23bce055c2d059e0a123f2b795779fd88df3658fdd1b74f4684599"
         }
     },
     "dependencies": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/skills/muggle-works-npm-release/SKILL.md
+++ b/plugin/skills/muggle-works-npm-release/SKILL.md
@@ -7,9 +7,6 @@ description: >-
   dispatch publish-works-to-npm.yml—no local npm publish.
 ---
 
-Canonical source of truth: **`plugin/skills/muggle-works-npm-release/SKILL.md`**.
-Keep this `.cursor` copy aligned for local Cursor discovery.
-
 # Muggle Works — npm release (single playbook)
 
 Repo: **`multiplex-ai/muggle-ai-works`**. Workflow: **`.github/workflows/publish-works-to-npm.yml`** (“Publish Works to npm”). **Never** run local **`npm publish`** (OIDC trusted publishing in CI).

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "4.7.0",
+  "version": "4.8.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "4.7.0",
+      "version": "4.8.0",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
## Version
- **4.7.0 → 4.8.0** (minor)

## Rationale
- **Minor**: ships user-facing fix in #73 (`summaryStep` forwarded to cloud).

## Shipping
- #73 — fix(local-publish): forward summaryStep to the cloud

## Electron
- **1.0.51 → 1.0.55** (`muggleConfig.electronAppVersion` + four platform checksums from `electron-app-v1.0.55` / `checksums.txt`)

## Manifests
- `pnpm run sync:versions` updated: `.claude-plugin/marketplace.json`, `.cursor-plugin/marketplace.json`, `plugin/.claude-plugin/plugin.json`, `plugin/.cursor-plugin/plugin.json`, `server.json`

## Test plan
- [x] `pnpm run lint:check`
- [x] `pnpm run typecheck`
- [x] `pnpm test`
- [x] `pnpm run build`
- [x] `pnpm run verify:plugin`
- [x] `pnpm run verify:contracts`
- [x] `pnpm run verify:electron-release-checksums`

Made with [Cursor](https://cursor.com)