### PR TITLE
fix(pr-section): clarify dashboard link text

### DIFF
--- a/plugin/skills/muggle-test/SKILL.md
+++ b/plugin/skills/muggle-test/SKILL.md
@@ -243,7 +243,7 @@ Store every `viewUrl` — these are used in the next steps.
 ### Report summary
 
 ```
-Test Case                  Status    Duration   Steps   View on Muggle
+Test Case                  Status    Duration   Steps   View Steps on Muggle AI
 ─────────────────────────────────────────────────────────────────────────
 Login with valid creds     PASSED    12.3s      8       https://www.muggle-ai.com/...
 Login with invalid creds   PASSED    9.1s       6       https://www.muggle-ai.com/...

--- a/src/cli/pr-section/render.ts
+++ b/src/cli/pr-section/render.ts
@@ -230,7 +230,7 @@ function renderResultSummary (test: TestResult, projectId: string): string[] {
     lines.push(`**Error:** \`${safeInlineCode(test.error)}\``);
   }
   lines.push(`**Steps:** ${test.steps.length}`);
-  lines.push(`[View on Muggle AI dashboard →](${dashboardUrl})`);
+  lines.push(`[View steps on Muggle AI →](${dashboardUrl})`);
   return lines;
 }
 


### PR DESCRIPTION
## Summary
- Update PR comment link text from "View on Muggle AI dashboard →" to "View steps on Muggle AI →" in `render.ts`
- Update skill report summary column header from "View on Muggle" to "View Steps on Muggle AI" in `muggle-test` skill

## Test plan
- [ ] Run `muggle build-pr-section` with a sample report and verify the new link text appears
- [ ] Run `muggle-test` locally and confirm the summary table uses the updated column header

🤖 Generated with [Claude Code](https://claude.com/claude-code)