### PR TITLE
feat(install): upsert Cursor MCP config on postinstall and setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ This installs:
 npm install -g @muggleai/works
 ```
 
-Then configure your MCP client:
+For Cursor, that's it — the install automatically configures `~/.cursor/mcp.json` and syncs `muggle-*` skills to `~/.cursor/skills/`. Just restart Cursor.
+
+For other MCP clients, add this to your client's config:
 
 ```json
 {
@@ -71,7 +73,7 @@ Then configure your MCP client:
 }
 ```
 
-`npm install` also syncs `muggle-*` skills to `~/.cursor/skills/` for Cursor discovery. Claude slash commands are plugin-managed, so update those with `/plugin update muggleai@muggle-works`.
+Claude slash commands are plugin-managed, so update those with `/plugin update muggleai@muggle-works`.
 
 ### 2. Verify
 
@@ -519,7 +521,7 @@ muggle-ai-works/
 │   ├── verify-plugin-marketplace.mjs  # Validates plugin/marketplace consistency
 │   ├── verify-compatibility-contracts.mjs # Validates long-term surface contracts
 │   ├── verify-upgrade-experience.mjs  # Validates in-place upgrade behavior
-│   └── postinstall.mjs      #   npm postinstall (Electron app download)
+│   └── postinstall.mjs      #   npm postinstall (Electron app download, Cursor MCP config, skills sync)
 │
 ├── config/compatibility/     # Contract baselines (CLI/MCP/plugin/skills)
 ├── bin/                     # CLI entrypoint (muggle.js → dist/cli.js)

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -15,7 +15,7 @@ For npm installs:
 npm install -g @muggleai/works
 ```
 
-This updates the CLI and syncs `muggle-*` skills into `~/.cursor/skills/` for Cursor. Claude slash commands remain plugin-managed, so use `/plugin update muggleai@muggle-works` to refresh them.
+This updates the CLI, configures Cursor MCP (`~/.cursor/mcp.json`), and syncs `muggle-*` skills into `~/.cursor/skills/`. Claude slash commands remain plugin-managed, so use `/plugin update muggleai@muggle-works` to refresh them.
 
 ## Skills
 

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -754,8 +754,53 @@ async function extractTarGz(tarPath, destDir) {
     });
 }
 
+/**
+ * Upsert the muggle MCP server entry into ~/.cursor/mcp.json.
+ * Reads the existing config, merges in the muggle server, and writes back.
+ * Preserves any other MCP servers the user has configured.
+ */
+function upsertCursorMcpConfig() {
+    const cursorMcpConfigPath = join(homedir(), ".cursor", "mcp.json");
+    const cursorDir = join(homedir(), ".cursor");
+
+    /** @type {{ mcpServers?: Record<string, unknown> }} */
+    let config = {};
+
+    if (existsSync(cursorMcpConfigPath)) {
+        try {
+            const raw = readFileSync(cursorMcpConfigPath, "utf-8");
+            const parsed = JSON.parse(raw);
+
+            if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+                log(`Warning: ~/.cursor/mcp.json has unexpected shape, skipping MCP config upsert.`);
+                return;
+            }
+
+            config = parsed;
+        } catch (error) {
+            log(`Warning: ~/.cursor/mcp.json is invalid JSON, skipping MCP config upsert.`);
+            log(`  Parse error: ${error.message}`);
+            return;
+        }
+    }
+
+    if (!config.mcpServers) {
+        config.mcpServers = {};
+    }
+
+    config.mcpServers.muggle = {
+        command: "muggle",
+        args: ["serve"],
+    };
+
+    mkdirSync(cursorDir, { recursive: true });
+    writeFileSync(cursorMcpConfigPath, `${JSON.stringify(config, null, 2)}\n`, "utf-8");
+    log(`Cursor MCP config updated at ${cursorMcpConfigPath}`);
+}
+
 // Run postinstall
 initLogFile();
 removeVersionOverrideFile();
 syncCursorSkills();
+upsertCursorMcpConfig();
 downloadElectronApp().catch(logError);

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -389,7 +389,7 @@ function runDiagnostics (): ICheckResult[] {
     name: "Cursor MCP Config",
     passed: cursorMcpConfigValidationResult.passed,
     description: cursorMcpConfigValidationResult.description,
-    suggestion: "Re-run npm install -g @muggleai/works to refresh ~/.cursor/mcp.json",
+    suggestion: "Run 'muggle setup' to configure ~/.cursor/mcp.json",
   });
 
   return results;

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -4,9 +4,9 @@
  */
 
 import { execFile } from "child_process";
-import { createWriteStream, existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { createWriteStream, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import * as path from "path";
-import { arch, platform } from "os";
+import { arch, homedir, platform } from "os";
 import { pipeline } from "stream/promises";
 
 import {
@@ -244,6 +244,50 @@ function cleanupFailedInstall(versionDir: string): void {
 }
 
 /**
+ * Upsert the muggle MCP server entry into ~/.cursor/mcp.json.
+ * Reads the existing config, merges in the muggle server, and writes back.
+ * Preserves any other MCP servers the user has configured.
+ */
+function upsertCursorMcpConfig(): void {
+  const cursorMcpConfigPath = path.join(homedir(), ".cursor", "mcp.json");
+  const cursorDir = path.join(homedir(), ".cursor");
+
+  let config: Record<string, unknown> = {};
+
+  if (existsSync(cursorMcpConfigPath)) {
+    try {
+      const raw = readFileSync(cursorMcpConfigPath, "utf-8");
+      const parsed: unknown = JSON.parse(raw);
+
+      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+        console.log("Warning: ~/.cursor/mcp.json has unexpected shape, skipping MCP config upsert.");
+        return;
+      }
+
+      config = parsed as Record<string, unknown>;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.log("Warning: ~/.cursor/mcp.json is invalid JSON, skipping MCP config upsert.");
+      console.log(`  Parse error: ${message}`);
+      return;
+    }
+  }
+
+  if (!config.mcpServers || typeof config.mcpServers !== "object") {
+    config.mcpServers = {};
+  }
+
+  (config.mcpServers as Record<string, unknown>).muggle = {
+    command: "muggle",
+    args: ["serve"],
+  };
+
+  mkdirSync(cursorDir, { recursive: true });
+  writeFileSync(cursorMcpConfigPath, `${JSON.stringify(config, null, 2)}\n`, "utf-8");
+  console.log(`Cursor MCP config updated at ${cursorMcpConfigPath}`);
+}
+
+/**
  * Execute the setup command.
  * @param options - Command options.
  */
@@ -251,6 +295,9 @@ export async function setupCommand(options: ISetupOptions): Promise<void> {
   const version = getElectronAppVersion();
   const versionDir = getElectronAppDir(version);
   const platformKey = getPlatformKey();
+
+  // Ensure Cursor MCP config is up to date regardless of Electron state
+  upsertCursorMcpConfig();
 
   // Check if already installed
   if (!options.force && isElectronAppInstalled()) {


### PR DESCRIPTION
## Summary
- `npm install -g @muggleai/works` now auto-writes the `muggle` MCP server entry into `~/.cursor/mcp.json`, making the install truly one-line for Cursor users
- `muggle setup` does the same upsert as a fallback for `--ignore-scripts` environments
- Existing MCP servers in the config are preserved (read-merge-write, not overwrite)
- Gracefully skips on invalid JSON or unexpected file shape
- Fixes `muggle doctor` suggestion to say `muggle setup` instead of the misleading "re-run npm install"

## Test plan
- [ ] Run `npm install -g @muggleai/works` on a machine with no `~/.cursor/mcp.json` — verify it creates the file with the muggle entry
- [ ] Run on a machine with existing `~/.cursor/mcp.json` containing other servers — verify muggle entry is added and others preserved
- [ ] Run `muggle setup` — verify MCP config is upserted even when Electron is already installed
- [ ] Run `muggle doctor` — verify the suggestion text says `muggle setup`
- [ ] Corrupt `~/.cursor/mcp.json` with invalid JSON — verify warning is logged and file is not overwritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)