### PR TITLE
chore(release): @muggleai/works 4.8.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.8.1"
+      "version": "4.8.2"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.8.1"
+      "version": "4.8.2"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@muggleai/works",
     "mcpName": "io.github.multiplex-ai/muggle",
-    "version": "4.8.1",
+    "version": "4.8.2",
     "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
     "type": "module",
     "main": "dist/index.js",
@@ -42,14 +42,14 @@
         "test:watch": "vitest"
     },
     "muggleConfig": {
-        "electronAppVersion": "1.0.59",
+        "electronAppVersion": "1.0.60",
         "downloadBaseUrl": "https://github.com/multiplex-ai/muggle-ai-works/releases/download",
         "runtimeTargetDefault": "dev",
         "checksums": {
-            "darwin-arm64": "c6da3f7f6b6875174a70a6c065554ed051ff99f731470e161ab71d9a9e568a87",
-            "darwin-x64": "ff93b24724fd415b99c40bcce2cc90a31e453a6408aad45a63480ff92606e7b0",
-            "win32-x64": "59bc67ea0a067fb4a204b87c73bf8cc387e705307f77ec96202822ff14b587fa",
-            "linux-x64": "714c93f586ac423377d9061924d2f703c175e3b541ef6ad22c96f6c20d3f4ea0"
+            "darwin-arm64": "a1e084b32ebc28fa823bcc9161959bd3618f0c5e45f41f946b5efa9192b8b15b",
+            "darwin-x64": "0605176a152b12149015b500b5d04dfaec06a5f3ed4d615d5442437cbaa2ba3a",
+            "win32-x64": "f6c9a243894720420229d37ff8915827e56c5aa2f21dd887a0f476d952698ad8",
+            "linux-x64": "4404163f56b664c1d8c040435ef981d1ff6583e2ba2e4b38ea4375afecd1c204"
         }
     },
     "dependencies": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "4.8.1",
+  "version": "4.8.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "4.8.1",
+      "version": "4.8.2",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
## Release: @muggleai/works 4.8.2 (patch)

### Version delta
- **4.8.1 → 4.8.2** (patch)
- Bump rationale: single user-facing change shipped as a patch per release owner's call.

### Shipping PRs
- #85 — feat(muggle-do): front-load decisions into a single pre-flight turn

### Electron bundle
- **Bumped** `muggleConfig.electronAppVersion` 1.0.59 → 1.0.60
- All four `muggleConfig.checksums` updated to match `electron-app-v1.0.60`:
  - `darwin-arm64`: `a1e084b32ebc28fa823bcc9161959bd3618f0c5e45f41f946b5efa9192b8b15b`
  - `darwin-x64`:   `0605176a152b12149015b500b5d04dfaec06a5f3ed4d615d5442437cbaa2ba3a`
  - `win32-x64`:    `f6c9a243894720420229d37ff8915827e56c5aa2f21dd887a0f476d952698ad8`
  - `linux-x64`:    `4404163f56b664c1d8c040435ef981d1ff6583e2ba2e4b38ea4375afecd1c204`

### Manifests touched by `pnpm run sync:versions`
- `.claude-plugin/marketplace.json`
- `.cursor-plugin/marketplace.json`
- `plugin/.claude-plugin/plugin.json`
- `plugin/.cursor-plugin/plugin.json`
- `server.json`
- `package.json` (version + muggleConfig)

### Coordinated follow-ups
- None in sibling repos.

### Test plan
- [x] `pnpm run lint:check`
- [x] `pnpm run typecheck`
- [x] `pnpm test`
- [x] `pnpm run build`
- [x] `pnpm run verify:plugin`
- [x] `pnpm run verify:contracts`
- [x] `pnpm run verify:electron-release-checksums` (verified against `electron-app-v1.0.60`)
- [ ] CI green
- [ ] Merge, then dispatch `publish-works-to-npm.yml` with `version=4.8.2`