### PR TITLE
chore(release): @muggleai/works 4.8.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.8.2"
+      "version": "4.8.3"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.8.2"
+      "version": "4.8.3"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@muggleai/works",
     "mcpName": "io.github.multiplex-ai/muggle",
-    "version": "4.8.2",
+    "version": "4.8.3",
     "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
     "type": "module",
     "main": "dist/index.js",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "4.8.2",
+  "version": "4.8.3",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "4.8.2",
+  "version": "4.8.3",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/skills/muggle-upgrade/SKILL.md
+++ b/plugin/skills/muggle-upgrade/SKILL.md
@@ -5,17 +5,29 @@ description: Update Muggle AI to latest version. Use when user types muggle upgr
 
 # Muggle Upgrade
 
-Update all Muggle AI components to the latest published version.
+Update all Muggle AI components to the latest published version. This means **both** the `@muggleai/works` CLI on npm **and** the Electron runner the CLI manages.
 
 ## Steps
 
 1. Run `/muggle:muggle-status` checks to capture current versions.
-2. Run `muggle upgrade` to check GitHub releases for the latest electron-app version and download it.
-3. Report the upgrade results:
-   - Previous version vs new version for each component.
-   - Whether the upgrade succeeded or failed.
-4. Run `/muggle:muggle-status` again to confirm everything is healthy after upgrade.
+
+2. Capture CLI versions:
+   - Installed CLI: `muggle --version`
+   - Latest on npm: `npm view @muggleai/works version`
+   - Detect install location: `npm ls -g @muggleai/works --depth=0` (falls back to `pnpm ls -g @muggleai/works` if not found)
+
+3. **If installed CLI < latest on npm**, upgrade the CLI itself before touching Electron:
+   - npm global install: `npm install -g @muggleai/works@latest`
+   - pnpm global install: `pnpm add -g @muggleai/works@latest`
+   - If neither is detected, report the situation and ask the user how the CLI was installed before proceeding.
+
+4. Run `muggle upgrade` to pull the Electron runner version that the (now-latest) CLI expects.
+   - Note: `muggle upgrade` only manages the Electron runner — it does NOT upgrade the CLI npm package. That is why step 3 must run first.
+
+5. Run `/muggle:muggle-status` again to confirm everything is healthy after upgrade.
 
 ## Output
 
-Show a before/after version comparison. If the upgrade fails at any step, report the error and suggest running `/muggle:muggle-repair`.
+Show a before/after table for **CLI**, **Electron runner**, **MCP server**, and **Auth**. Call out any version that did not change so the user understands what shipped vs what was already current.
+
+If the upgrade fails at any step, report the error and suggest running `/muggle:muggle-repair`.

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "4.8.2",
+  "version": "4.8.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "4.8.2",
+      "version": "4.8.3",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
## Summary

Patch release: **4.8.2 → 4.8.3**.

### Shipping
- **fix(skill): `muggle-upgrade` now upgrades the npm CLI before syncing Electron.** Previously the skill only ran `muggle upgrade`, which only manages the Electron runner — it does *not* touch `@muggleai/works` itself. Users running `/muggle:muggle-upgrade` would stay on a stale CLI, and (worse) the runner would re-pin to whatever the stale CLI declared, looking like a downgrade. The skill now: detects install method (npm/pnpm global) → upgrades the CLI to latest → runs `muggle upgrade` → re-runs status with a clear before/after table.
- chore(deps): bump pnpm/action-setup from 5 to 6 (#80)
- chore(deps-dev): bump dev-dependencies group, 5 updates (#81)

### Electron
Unchanged at **1.0.60** (already latest on GitHub releases).

### Manifests touched by sync:versions
- `package.json`
- `.claude-plugin/marketplace.json`
- `.cursor-plugin/marketplace.json`
- `plugin/.claude-plugin/plugin.json`
- `plugin/.cursor-plugin/plugin.json`
- `server.json`

## Verify checklist
- [x] `pnpm run lint:check`
- [x] `pnpm run typecheck`
- [x] `pnpm test` (48 passed)
- [x] `pnpm run build`
- [x] `pnpm run verify:plugin`
- [x] `pnpm run verify:contracts`
- [x] `pnpm run verify:electron-release-checksums` (1.0.60)

🤖 Generated with [Claude Code](https://claude.com/claude-code)