### PR TITLE
chore(ci): revert pnpm/action-setup v6 → v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           node-version: "22"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v5
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -49,7 +49,7 @@ jobs:
           node-version: "22"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v5
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -76,7 +76,7 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v5
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -103,7 +103,7 @@ jobs:
           node-version: "22"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v5
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -127,7 +127,7 @@ jobs:
           node-version: "22"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v5
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/publish-works-to-npm.yml
+++ b/.github/workflows/publish-works-to-npm.yml
@@ -60,7 +60,7 @@ jobs:
           node-version: "22"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v5
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -93,7 +93,7 @@ jobs:
           node-version: "22"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v5
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/verify-end-user-upgrade.yml
+++ b/.github/workflows/verify-end-user-upgrade.yml
@@ -19,7 +19,7 @@ jobs:
           node-version: "22"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v5
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

Revert pnpm/action-setup from v6 (introduced by #80) back to v5 across all three workflows.

## Why

`pnpm install --frozen-lockfile` in v6 fails on our v9.0 lockfile with:
\`\`\`
ERR_PNPM_BROKEN_LOCKFILE  The lockfile at "pnpm-lock.yaml" is broken: expected a single document in the stream, but found more
\`\`\`

- Last green publish on master: **4.8.2** (used v5)
- First failing run: **4.8.3** publish — and CI on master has been red since #80 merged
- Locally `pnpm install --frozen-lockfile` works fine with pnpm 10.0.0; the problem is specific to v6's pnpm version detection / installation

This unblocks the 4.8.3 publish (already merged to master, awaiting npm dispatch).

## Files
- `.github/workflows/ci.yml` (5 occurrences)
- `.github/workflows/publish-works-to-npm.yml` (2 occurrences)
- `.github/workflows/verify-end-user-upgrade.yml` (1 occurrence)

Pipeline-only — no app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)