### PR TITLE
fix: move optimize-descriptions skill out of published plugin surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,13 +571,7 @@ Optimizing agent-facing descriptions
 
 AI agents decide which tools to use based on text in MCP server instructions, hook context injection, skill descriptions, tool descriptions, and plugin metadata. If these don't match what users actually say, agents won't reach for muggle tools.
 
-The `/muggle:optimize-descriptions` skill documents the full optimization process:
-
-```
-/muggle:optimize-descriptions
-```
-
-This is an **internal-only skill** (not published to customers). It covers:
+The `optimize-descriptions` skill documents the full optimization process. It lives at `internal/skills/optimize-descriptions/SKILL.md` — an internal-only skill that does **not** ship via npm or the plugin marketplace. To use it as a slash command on a dev machine, symlink or copy the folder into `~/.claude/skills/`. It covers:
 
 - The five layers of agent-facing text and where each lives in the codebase
 - How to write descriptions that match real user intent ("test my signup flow" not "execute test generation")
@@ -611,7 +605,7 @@ python3 -m scripts.run_eval \
   --verbose
 ```
 
-See `plugin/skills/optimize-descriptions/SKILL.md` for the full guide.
+See `internal/skills/optimize-descriptions/SKILL.md` for the full guide.
 
 ---
 

--- a/internal/skills/optimize-descriptions/SKILL.md
+++ b/internal/skills/optimize-descriptions/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: optimize-descriptions
-description: Optimize Muggle AI's customer-facing text (MCP tool descriptions, skill descriptions, plugin metadata, hooks) so that AI agents prioritize muggle tools for E2E acceptance testing, UI validation, and browser testing. Internal tool — not published to customers.
-disable-model-invocation: true
+description: Optimize Muggle AI's customer-facing text (MCP tool descriptions, skill descriptions, plugin metadata, hooks) so that AI agents prioritize muggle tools for E2E acceptance testing, UI validation, and browser testing. Internal tool — lives outside the published plugin surface.
 ---
 
 # Optimize Agent-Facing Descriptions


### PR DESCRIPTION
## Summary

- `plugin/skills/optimize-descriptions/SKILL.md` claimed to be an internal tool, but the repo was shipping it three ways:
  - `package.json` `files` array includes `plugin/`, so it went into every `@muggleai/works` npm tarball
  - `scripts/build-plugin.mjs` `cpSync`'s `plugin/` → `dist/plugin/`, so it also landed in `dist/`
  - `.claude-plugin/marketplace.json` points the `muggleai` plugin at `./plugin`, so plugin-marketplace installs exposed it
- `disable-model-invocation: true` only stops agents from auto-triggering; it does not exclude the file from shipping
- Move the skill to `internal/skills/optimize-descriptions/` — outside both `files` and `build-plugin.mjs`'s copy root
- Drop the self-contradicting "not published to customers" line and the redundant `disable-model-invocation` from the frontmatter now that the statement is structurally true
- Update the two README references to the new path, and note how to re-expose the slash command on a dev machine (symlink into `~/.claude/skills/`)

## Test plan

- [ ] `npm pack --dry-run` (or inspect the shipped tarball) confirms `optimize-descriptions/SKILL.md` is no longer inside `plugin/` or `dist/plugin/`
- [ ] `.claude-plugin/marketplace.json` still resolves — plugin install of `muggleai@muggle-works` lists only customer-facing skills
- [ ] README links to `internal/skills/optimize-descriptions/SKILL.md` resolve on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)