### PR TITLE
fix(plugin): streamline muggle menu to 4 options

### DIFF
--- a/plugin/skills/muggle/SKILL.md
+++ b/plugin/skills/muggle/SKILL.md
@@ -9,13 +9,11 @@ Use this as the top-level Muggle command router.
 
 ## Menu
 
-When user asks for "muggle" with no specific subcommand, use `AskQuestion` to present the command set as clickable options:
+When user asks for "muggle" with no specific subcommand, use `AskQuestion` to present these four options:
 
-- "Test my changes — change-driven E2E acceptance testing (local or remote)" → `muggle-test`
-- "Test a feature on localhost — run a single E2E test locally" → `muggle-test-feature-local`
-- "Autonomous dev pipeline — requirements to PR" → `muggle-do`
-- "Health check — verify installation status" → `muggle-status`
-- "Repair — fix broken installation" → `muggle-repair`
+- "Test a feature — run E2E acceptance tests locally or remotely" → `muggle-test-feature-local` (local) or `muggle-test` (remote/change-driven)
+- "Build something — implement a feature with E2E acceptance tests and a visual PR" → `muggle-do`
+- "Health check — verify installation and fix issues" → `muggle-status` (then `muggle-repair` if issues found)
 - "Upgrade — update to latest version" → `muggle-upgrade`
 
 ## Routing
@@ -26,7 +24,8 @@ If the user intent clearly matches one command, route directly — no menu neede
 - repair/fix/install broken → `muggle-repair`
 - upgrade/update latest → `muggle-upgrade`
 - test my changes/acceptance test my work/test before push/post E2E acceptance results to PR/test on staging/test on preview → `muggle-test`
-- test localhost/validate single feature → `muggle-test-feature-local`
-- build/implement from request → `muggle-do`
+- test localhost/validate single feature/test a feature → `muggle-test-feature-local`
+- build/implement from request/end-to-end → `muggle-do`
+- post results to PR/attach walkthrough/visual evidence on PR → `muggle-pr-visual-walkthrough`
 
 If intent is ambiguous, use `AskQuestion` with the most likely options rather than asking the user to type a clarification.


### PR DESCRIPTION
## Summary
- Consolidate /muggle menu into 4 options that fit `AskUserQuestion` limit: test, build, health check, upgrade
- Merge status + repair into a single "Health check" flow
- Add routing for PR visual walkthrough

## Test plan
- [ ] Invoke `/muggle:muggle` and verify 4 options render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)