### PR TITLE
feat: register acceptance-tester agent in plugin manifest

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -9,6 +9,13 @@
   "homepage": "https://www.muggletest.com",
   "repository": "https://github.com/multiplex-ai/muggle-ai-works",
   "license": "MIT",
+  "agents": [
+    {
+      "name": "acceptance-tester",
+      "path": "agents/acceptance-tester.md",
+      "description": "E2E acceptance testing agent — runs real-browser tests, reports structured results with blocking issues and suggested fixes, imports test artifacts, manages preferences, and operates the Muggle AI suite."
+    }
+  ],
   "keywords": [
     "acceptance-testing",
     "testing",

--- a/plugin/skills/muggle-test/SKILL.md
+++ b/plugin/skills/muggle-test/SKILL.md
@@ -440,3 +440,7 @@ This skill always uses **Mode A** (post to an existing PR); `muggle-do` is the o
 - **Always publish before opening browser** — the dashboard needs the published data to show results
 - **Delegate PR posting to `muggle-pr-visual-walkthrough`** — never inline the walkthrough markdown or call `gh pr comment` directly from this skill; ask the user and hand off
 - **Can be invoked at any state** — if the user already has a project or use cases set up, skip to the relevant step rather than re-doing everything
+
+## Agent Dispatch
+
+When used in a multi-agent team (e.g., muggle-ai-teams), this skill is available through the **acceptance-tester** agent at `plugin/agents/acceptance-tester.md`. Orchestrators can dispatch it via `Agent()` instead of invoking this skill directly. The agent wraps this skill and four others (muggle-test-import, muggle-preferences, muggle-repair, muggle-status) and returns structured test results with blocking issues and suggested fixes for coding agents to act on.


### PR DESCRIPTION
## Summary

- Register the `acceptance-tester` agent in `.claude-plugin/plugin.json` with `name`, `path`, and `description` so the plugin system can discover it during installation
- Add an "Agent Dispatch" section to `muggle-test/SKILL.md` pointing orchestrators to the acceptance-tester agent for multi-agent team workflows

Follows up on #96 which added the agent and preferences skill files but didn't register the agent in the manifest.

## Test plan

- [ ] Verify `plugin.json` is valid JSON after the change
- [ ] Verify the `agents[0].path` resolves to the actual file at `plugin/agents/acceptance-tester.md`
- [ ] Install plugin and confirm the agent is discoverable via the manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)