### PR TITLE
chore(release): @muggleai/works 4.9.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.8.4"
+      "version": "4.9.0"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.8.4"
+      "version": "4.9.0"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@muggleai/works",
     "mcpName": "io.github.multiplex-ai/muggle",
-    "version": "4.8.4",
+    "version": "4.9.0",
     "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
     "type": "module",
     "main": "dist/index.js",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "4.8.4",
+  "version": "4.9.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "4.8.4",
+  "version": "4.9.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "4.8.4",
+  "version": "4.9.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "4.8.4",
+      "version": "4.9.0",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
## Release: @muggleai/works 4.9.0

**Version delta:** 4.8.4 → 4.9.0 (minor)

### Shipping
- **feat: user preferences system** — types, service, MCP tool, hook injection, default write on setup, gated decision pattern in all skills (PRs #95–#97)
- **feat: acceptance-tester agent** for orchestrator-dispatched QA (PRs #96–#97)
- **feat: muggle-test-prepare skill** (PR #94)
- **fix: streamline muggle menu** to 4-option AskQuestion limit (PR #93)
- **chore:** gitignore skill eval workspace and artifacts

### Electron
Unchanged at **1.0.61**

### Manifests touched by sync:versions
- `.claude-plugin/marketplace.json`
- `.cursor-plugin/marketplace.json`
- `plugin/.claude-plugin/plugin.json`
- `plugin/.cursor-plugin/plugin.json`
- `server.json`

### Test plan
- [x] `pnpm run lint:check` — pass
- [x] `pnpm run typecheck` — pass
- [x] `pnpm test` — 48/48 pass
- [x] `pnpm run build` — pass
- [x] `pnpm run verify:plugin` — pass
- [x] `pnpm run verify:contracts` — pass
- [x] `pnpm run verify:electron-release-checksums` — pass