### PR TITLE
chore(release): @muggleai/works 4.9.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.9.1"
+      "version": "4.9.2"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.9.1"
+      "version": "4.9.2"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@muggleai/works",
     "mcpName": "io.github.multiplex-ai/muggle",
-    "version": "4.9.1",
+    "version": "4.9.2",
     "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
     "type": "module",
     "main": "dist/index.js",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "4.9.1",
+  "version": "4.9.2",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"
@@ -9,13 +9,6 @@
   "homepage": "https://www.muggletest.com",
   "repository": "https://github.com/multiplex-ai/muggle-ai-works",
   "license": "MIT",
-  "agents": [
-    {
-      "name": "acceptance-tester",
-      "path": "agents/acceptance-tester.md",
-      "description": "E2E acceptance testing agent — runs real-browser tests, reports structured results with blocking issues and suggested fixes, imports test artifacts, manages preferences, and operates the Muggle AI suite."
-    }
-  ],
   "keywords": [
     "acceptance-testing",
     "testing",

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "4.9.1",
+  "version": "4.9.2",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/agents/acceptance-tester.md
+++ b/plugin/agents/acceptance-tester.md
@@ -1,14 +1,7 @@
 ---
 name: acceptance-tester
-description: >-
-  E2E acceptance testing agent — runs real-browser tests against web apps and
-  reports structured results with blocking issues and suggested fixes. Also
-  imports existing test artifacts, manages Muggle preferences, and operates
-  the Muggle AI suite (status checks, repairs). Dispatch this agent when the
-  team needs acceptance test feedback, test coverage for a feature, or Muggle
-  suite operations.
+description: "E2E acceptance testing agent — runs real-browser tests against web apps and reports structured results with blocking issues and suggested fixes. Also imports existing test artifacts, manages Muggle preferences, and operates the Muggle AI suite (status checks, repairs). Dispatch this agent when the team needs acceptance test feedback, test coverage for a feature, or Muggle suite operations."
 model: sonnet
-tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
 ---
 
 # Acceptance Tester

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "4.9.1",
+  "version": "4.9.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "4.9.1",
+      "version": "4.9.2",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
## Version delta

`4.9.1` → `4.9.2` (patch)

## What's shipping

- **fix:** Remove explicit `agents` key from `plugin/.claude-plugin/plugin.json` — the key with `"path": "agents/acceptance-tester.md"` caused a Claude Code load error because the path was resolved relative to the `.claude-plugin/` directory where the file doesn't exist. Working plugins (superpowers, code-simplifier) use auto-discovery instead. This was the root cause of the acceptance-tester agent not appearing in `/agents`.
- **fix:** Clean up `plugin/agents/acceptance-tester.md` frontmatter — inline the description (was `>-` block scalar) and remove a stray `tools` line that was not present in the cache version.

## Electron bundle

Unchanged — `electronAppVersion` not modified.

## Manifests touched by sync:versions

- `.claude-plugin/marketplace.json`
- `.cursor-plugin/marketplace.json`
- `plugin/.claude-plugin/plugin.json`
- `plugin/.cursor-plugin/plugin.json`
- `server.json`

## Test plan

- [x] `pnpm run lint:check` — green
- [x] `pnpm run typecheck` — green
- [x] `pnpm test` — 48/48 passed
- [x] `pnpm run build` — clean
- [x] `pnpm run verify:plugin` — passed
- [x] `pnpm run verify:contracts` — passed
- [ ] Merge PR then dispatch `publish-works-to-npm.yml` with `version=4.9.2`
- [ ] Confirm `npm view @muggleai/works version` returns `4.9.2`