### PR TITLE
feat(preferences): organic 2-picker flow + last-project cache + defaultExecutionMode schema

### DIFF
--- a/packages/mcps/src/mcp/local/contracts/index.ts
+++ b/packages/mcps/src/mcp/local/contracts/index.ts
@@ -6,3 +6,4 @@ export { MuggleEntityIdSchema } from "../../contracts/muggle-entity-id-schema.js
 export * from "./project-schemas.js";
 export * from "./session-schemas.js";
 export * from "./preferences-schemas.js";
+export * from "./last-project-schemas.js";

--- a/packages/mcps/src/mcp/local/contracts/last-project-schemas.ts
+++ b/packages/mcps/src/mcp/local/contracts/last-project-schemas.ts
@@ -1,0 +1,35 @@
+/**
+ * Zod schemas for last-project cache MCP tools.
+ */
+
+import { z } from "zod";
+
+/** Input for muggle-local-last-project-get. */
+export const LastProjectGetInputSchema = z.object({
+  cwd: z
+    .string()
+    .describe("Project root directory whose last-used project to return."),
+});
+
+export type LastProjectGetInput = z.infer<typeof LastProjectGetInputSchema>;
+
+/** Input for muggle-local-last-project-set. */
+export const LastProjectSetInputSchema = z.object({
+  cwd: z
+    .string()
+    .describe("Project root directory to save the cached project to."),
+  projectId: z.string().min(1).describe("Muggle project ID."),
+  projectUrl: z.string().min(1).describe("Muggle project URL."),
+  projectName: z.string().min(1).describe("Muggle project name."),
+});
+
+export type LastProjectSetInput = z.infer<typeof LastProjectSetInputSchema>;
+
+/** Input for muggle-local-last-project-clear. */
+export const LastProjectClearInputSchema = z.object({
+  cwd: z
+    .string()
+    .describe("Project root directory whose last-used project cache to remove."),
+});
+
+export type LastProjectClearInput = z.infer<typeof LastProjectClearInputSchema>;

--- a/packages/mcps/src/mcp/local/contracts/preferences-schemas.ts
+++ b/packages/mcps/src/mcp/local/contracts/preferences-schemas.ts
@@ -5,18 +5,39 @@
 import { z } from "zod";
 
 import { PreferenceKey, PreferenceValue } from "../../../shared/preferences-types.js";
+import { PREFERENCE_ALLOWED_VALUES } from "../../../shared/preferences-constants.js";
 
 const preferenceKeyValues = Object.values(PreferenceKey) as [string, ...string[]];
 const preferenceValueValues = Object.values(PreferenceValue) as [string, ...string[]];
 
 /**
  * Input schema for muggle-local-preferences-set.
+ *
+ * Two-stage validation: enums verify key/value are individually valid,
+ * then `.refine()` checks the value is allowed for that specific key
+ * (e.g. `defaultExecutionMode` accepts `local`/`remote`/`ask`, not `always`/`never`).
  */
-export const PreferencesSetInputSchema = z.object({
-  key: z.enum(preferenceKeyValues).describe("The preference key to set."),
-  value: z.enum(preferenceValueValues).describe("The value: always, ask, or never."),
-  scope: z.enum(["global", "project"]).default("global").describe("Write to global (~/.muggle-ai/) or project (.muggle-ai/) preferences."),
-  cwd: z.string().optional().describe("Project root directory. Required when scope is 'project'."),
-});
+export const PreferencesSetInputSchema = z
+  .object({
+    key: z.enum(preferenceKeyValues).describe("The preference key to set."),
+    value: z
+      .enum(preferenceValueValues)
+      .describe("The value. Most keys accept always/ask/never; defaultExecutionMode accepts local/remote/ask."),
+    scope: z
+      .enum(["global", "project"])
+      .default("global")
+      .describe("Write to global (~/.muggle-ai/) or project (.muggle-ai/) preferences."),
+    cwd: z.string().optional().describe("Project root directory. Required when scope is 'project'."),
+  })
+  .superRefine((data, ctx) => {
+    const allowed = PREFERENCE_ALLOWED_VALUES[data.key as PreferenceKey] as readonly string[];
+    if (!allowed.includes(data.value)) {
+      ctx.addIssue({
+        code: "custom",
+        message: `Value "${data.value}" is not allowed for preference "${data.key}". Allowed: ${allowed.join(", ")}`,
+        path: ["value"],
+      });
+    }
+  });
 
 export type PreferencesSetInput = z.infer<typeof PreferencesSetInputSchema>;

--- a/packages/mcps/src/mcp/tools/local/tool-registry.ts
+++ b/packages/mcps/src/mcp/tools/local/tool-registry.ts
@@ -25,6 +25,9 @@ import {
   TestScriptGetInputSchema,
   PublishTestScriptInputSchema,
   PreferencesSetInputSchema,
+  LastProjectGetInputSchema,
+  LastProjectSetInputSchema,
+  LastProjectClearInputSchema,
 } from "../../local/contracts/index.js";
 import {
   resolvePreferences,
@@ -32,6 +35,12 @@ import {
   formatPreferencesOneLiner,
 } from "../../../shared/preferences.js";
 import { PREFERENCES_FILE_NAME } from "../../../shared/preferences-constants.js";
+import {
+  readLastProject,
+  writeLastProject,
+  clearLastProject,
+  LAST_PROJECT_FILE_NAME,
+} from "../../../shared/last-project.js";
 import {
   cancelExecution,
   executeReplay,
@@ -622,6 +631,99 @@ const preferencesSetTool: ILocalMcpTool = {
 };
 
 // ========================================
+// Last-Project Cache Tools
+// ========================================
+
+const lastProjectGetTool: ILocalMcpTool = {
+  name: "muggle-local-last-project-get",
+  description:
+    "Get the cached last-used Muggle project for a repo (read from <cwd>/.muggle-ai/last-project.json). " +
+    "Returns the project ID, URL, name, and saved-at timestamp, or null if no cache exists. " +
+    "Skills consult this when 'autoSelectProject = always' to silently reuse the project the user picked previously, instead of presenting the project picker every time.",
+  inputSchema: LastProjectGetInputSchema,
+  execute: async (ctx) => {
+    const logger = createChildLogger(ctx.correlationId);
+    logger.info("Executing muggle-local-last-project-get");
+
+    const input = LastProjectGetInputSchema.parse(ctx.input);
+    const cached = readLastProject(input.cwd);
+
+    if (!cached) {
+      const content = [
+        "No cached last-used project for this repo.",
+        "",
+        `Looked at: \`${input.cwd}/.muggle-ai/${LAST_PROJECT_FILE_NAME}\``,
+        "",
+        "The cache is populated when a user picks an existing project AND chooses 'Yes, save it' on the memory picker (the autoSelectProject preference).",
+      ].join("\n");
+      return { content: content, isError: false };
+    }
+
+    const content = [
+      "**Cached last-used project:**",
+      "",
+      `- ID: \`${cached.projectId}\``,
+      `- URL: ${cached.projectUrl}`,
+      `- Name: ${cached.projectName}`,
+      `- Saved at: ${cached.savedAt}`,
+    ].join("\n");
+    return { content: content, isError: false };
+  },
+};
+
+const lastProjectSetTool: ILocalMcpTool = {
+  name: "muggle-local-last-project-set",
+  description:
+    "Save the user's selected Muggle project as the cached last-used project for this repo. " +
+    "Writes to <cwd>/.muggle-ai/last-project.json. Subsequent skill invocations honor 'autoSelectProject = always' " +
+    "by silently reusing this entry — no project picker shown. Always pair this call with " +
+    "'muggle-local-preferences-set autoSelectProject=always' when the user chose 'Yes, save it'.",
+  inputSchema: LastProjectSetInputSchema,
+  execute: async (ctx) => {
+    const logger = createChildLogger(ctx.correlationId);
+    logger.info("Executing muggle-local-last-project-set");
+
+    const input = LastProjectSetInputSchema.parse(ctx.input);
+    writeLastProject(input.cwd, {
+      projectId: input.projectId,
+      projectUrl: input.projectUrl,
+      projectName: input.projectName,
+    });
+
+    const content = [
+      `Cached **${input.projectName}** as the last-used project for this repo.`,
+      "",
+      `Written to: \`${input.cwd}/.muggle-ai/${LAST_PROJECT_FILE_NAME}\``,
+      "",
+      "Skills will silently reuse this project on future runs when `autoSelectProject = always`.",
+    ].join("\n");
+    return { content: content, isError: false };
+  },
+};
+
+const lastProjectClearTool: ILocalMcpTool = {
+  name: "muggle-local-last-project-clear",
+  description:
+    "Remove the cached last-used project for this repo. After this, `autoSelectProject = always` will fall through to ask " +
+    "until the user picks a new project. No-op if no cache exists.",
+  inputSchema: LastProjectClearInputSchema,
+  execute: async (ctx) => {
+    const logger = createChildLogger(ctx.correlationId);
+    logger.info("Executing muggle-local-last-project-clear");
+
+    const input = LastProjectClearInputSchema.parse(ctx.input);
+    clearLastProject(input.cwd);
+
+    const content = [
+      "Cleared the cached last-used project for this repo.",
+      "",
+      `Path: \`${input.cwd}/.muggle-ai/${LAST_PROJECT_FILE_NAME}\``,
+    ].join("\n");
+    return { content: content, isError: false };
+  },
+};
+
+// ========================================
 // All Tools Registry
 // ========================================
 
@@ -647,6 +749,10 @@ export const allLocalQaTools: ILocalMcpTool[] = [
   publishTestScriptTool,
   // Preferences tools
   preferencesSetTool,
+  // Last-project cache tools (per-repo "last used Muggle project")
+  lastProjectGetTool,
+  lastProjectSetTool,
+  lastProjectClearTool,
 ];
 
 /**

--- a/packages/mcps/src/shared/last-project.ts
+++ b/packages/mcps/src/shared/last-project.ts
@@ -1,0 +1,106 @@
+/**
+ * Per-repo last-used Muggle project cache.
+ *
+ * Stored at `<repo>/.muggle-ai/last-project.json`. Honors the
+ * `autoSelectProject = always` preference: when set, skills can silently reuse
+ * the project that the user most recently picked for this repo, instead of
+ * presenting the project picker every time.
+ *
+ * Skills consume this via the `Muggle Last Project` line injected into session
+ * context by the SessionStart hook (zero tokens). MCP tools import this module
+ * directly (zero tokens).
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { getLogger } from "./logger.js";
+
+/** Per-repo cache file name. */
+export const LAST_PROJECT_FILE_NAME = "last-project.json";
+/** Per-repo cache directory name (shared with project preferences). */
+export const LAST_PROJECT_DIR_NAME = ".muggle-ai";
+/** Schema version for future migrations. */
+export const LAST_PROJECT_VERSION = 1;
+
+/** A cached "last used project" record for a single repo. */
+export interface ILastProject {
+  projectId: string;
+  projectUrl: string;
+  projectName: string;
+  /** ISO-8601 timestamp of when this entry was last written. */
+  savedAt: string;
+}
+
+/** On-disk file shape. */
+export interface ILastProjectFile {
+  version: number;
+  lastProject: ILastProject;
+}
+
+/**
+ * Read the cached last project for a repo.
+ *
+ * Returns null if the file does not exist or fails to parse.
+ */
+export function readLastProject(cwd: string): ILastProject | null {
+  const filePath = path.join(cwd, LAST_PROJECT_DIR_NAME, LAST_PROJECT_FILE_NAME);
+  try {
+    if (!fs.existsSync(filePath)) {
+      return null;
+    }
+    const raw = JSON.parse(fs.readFileSync(filePath, "utf-8")) as ILastProjectFile;
+    return raw.lastProject ?? null;
+  } catch (error) {
+    getLogger().warn("Failed to read last-project file", {
+      path: filePath,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+/**
+ * Write the cached last project for a repo.
+ *
+ * Creates the `.muggle-ai/` directory if it doesn't exist. `savedAt` is set
+ * automatically; the caller only provides project identity fields.
+ */
+export function writeLastProject(
+  cwd: string,
+  lastProject: Omit<ILastProject, "savedAt">,
+): void {
+  const dir = path.join(cwd, LAST_PROJECT_DIR_NAME);
+  fs.mkdirSync(dir, { recursive: true });
+  const filePath = path.join(dir, LAST_PROJECT_FILE_NAME);
+  const file: ILastProjectFile = {
+    version: LAST_PROJECT_VERSION,
+    lastProject: { ...lastProject, savedAt: new Date().toISOString() },
+  };
+  fs.writeFileSync(filePath, `${JSON.stringify(file, null, 2)}\n`, "utf-8");
+}
+
+/**
+ * Remove the cached last project for a repo. No-op if the file does not exist.
+ */
+export function clearLastProject(cwd: string): void {
+  const filePath = path.join(cwd, LAST_PROJECT_DIR_NAME, LAST_PROJECT_FILE_NAME);
+  if (fs.existsSync(filePath)) {
+    fs.unlinkSync(filePath);
+  }
+}
+
+/**
+ * Format a cached last project as a compact one-liner for session context.
+ *
+ * Returns an empty string if no cache exists. Quoting handles project names
+ * that contain spaces or unusual characters.
+ */
+export function formatLastProjectOneLiner(cwd: string): string {
+  const cached = readLastProject(cwd);
+  if (!cached) {
+    return "";
+  }
+  const safeName = cached.projectName.replace(/"/g, '\\"');
+  return `Muggle Last Project: id=${cached.projectId} url=${cached.projectUrl} name="${safeName}"`;
+}

--- a/packages/mcps/src/shared/preferences-constants.ts
+++ b/packages/mcps/src/shared/preferences-constants.ts
@@ -34,6 +34,38 @@ export const DEFAULT_PREFERENCES: IPreferences = {
   [PreferenceKey.VerboseOutput]: PreferenceValue.Ask,
 };
 
+const ALWAYS_ASK_NEVER = [
+  PreferenceValue.Always,
+  PreferenceValue.Ask,
+  PreferenceValue.Never,
+] as const;
+
+const LOCAL_REMOTE_ASK = [
+  PreferenceValue.Local,
+  PreferenceValue.Remote,
+  PreferenceValue.Ask,
+] as const;
+
+/**
+ * Per-key allowed values. Most preferences accept `always`/`ask`/`never`.
+ * `defaultExecutionMode` is the exception: it accepts `local`/`remote`/`ask`
+ * because "always" / "never" don't meaningfully describe a binary mode choice.
+ */
+export const PREFERENCE_ALLOWED_VALUES: Record<PreferenceKey, readonly PreferenceValue[]> = {
+  [PreferenceKey.AutoLogin]: ALWAYS_ASK_NEVER,
+  [PreferenceKey.AutoSelectProject]: ALWAYS_ASK_NEVER,
+  [PreferenceKey.ShowElectronBrowser]: ALWAYS_ASK_NEVER,
+  [PreferenceKey.OpenTestResultsAfterRun]: ALWAYS_ASK_NEVER,
+  [PreferenceKey.DefaultExecutionMode]: LOCAL_REMOTE_ASK,
+  [PreferenceKey.AutoPublishLocalResults]: ALWAYS_ASK_NEVER,
+  [PreferenceKey.SuggestRelatedUseCases]: ALWAYS_ASK_NEVER,
+  [PreferenceKey.SuggestRelatedTestCases]: ALWAYS_ASK_NEVER,
+  [PreferenceKey.AutoDetectChanges]: ALWAYS_ASK_NEVER,
+  [PreferenceKey.PostPRVisualWalkthrough]: ALWAYS_ASK_NEVER,
+  [PreferenceKey.CheckForUpdates]: ALWAYS_ASK_NEVER,
+  [PreferenceKey.VerboseOutput]: ALWAYS_ASK_NEVER,
+};
+
 /** Human-readable schema for each preference — used in setup wizard and validation. */
 export const PREFERENCES_SCHEMA: Record<PreferenceKey, IPreferenceSchemaEntry> = {
   [PreferenceKey.AutoLogin]: {

--- a/packages/mcps/src/shared/preferences-types.ts
+++ b/packages/mcps/src/shared/preferences-types.ts
@@ -33,7 +33,12 @@ export enum PreferenceKey {
 }
 
 /**
- * Allowed values for every preference knob.
+ * Allowed values for preference knobs.
+ *
+ * Most knobs use `Always` / `Ask` / `Never`. A few use domain-specific values:
+ *  - `DefaultExecutionMode` uses `Local` / `Remote` / `Ask`.
+ *
+ * Per-key validity is enforced via `PREFERENCE_ALLOWED_VALUES` in preferences-constants.ts.
  */
 export enum PreferenceValue {
   /** Proceed without asking. */
@@ -42,6 +47,10 @@ export enum PreferenceValue {
   Ask = "ask",
   /** Skip without asking. */
   Never = "never",
+  /** For DefaultExecutionMode: always run tests on the local Electron browser. */
+  Local = "local",
+  /** For DefaultExecutionMode: always run tests in the Muggle cloud. */
+  Remote = "remote",
 }
 
 /**

--- a/packages/mcps/src/shared/preferences.ts
+++ b/packages/mcps/src/shared/preferences.ts
@@ -12,13 +12,13 @@ import { getDataDir } from "./data-dir.js";
 import { getLogger } from "./logger.js";
 import {
   PreferenceKey,
-  PreferenceValue,
   type IPartialPreferences,
   type IPreferences,
   type IPreferencesFile,
 } from "./preferences-types.js";
 import {
   DEFAULT_PREFERENCES,
+  PREFERENCE_ALLOWED_VALUES,
   PREFERENCES_FILE_NAME,
   PREFERENCES_PROJECT_DIR_NAME,
   PREFERENCES_VERSION,
@@ -157,12 +157,16 @@ export function resetPreference(
 }
 
 /**
- * Validate that a key and value are valid preferences.
+ * Validate that a key and value are valid preferences. Per-key validation:
+ * each key has its own set of allowed values (see PREFERENCE_ALLOWED_VALUES).
  */
 export function validatePreference(key: string, value: string): boolean {
   const validKeys = Object.values(PreferenceKey) as string[];
-  const validValues = Object.values(PreferenceValue) as string[];
-  return validKeys.includes(key) && validValues.includes(value);
+  if (!validKeys.includes(key)) {
+    return false;
+  }
+  const allowed = PREFERENCE_ALLOWED_VALUES[key as PreferenceKey] as readonly string[];
+  return allowed.includes(value);
 }
 
 /**

--- a/packages/mcps/src/test/last-project.test.ts
+++ b/packages/mcps/src/test/last-project.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tests for the per-repo last-project cache.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import {
+  LAST_PROJECT_FILE_NAME,
+  LAST_PROJECT_DIR_NAME,
+  LAST_PROJECT_VERSION,
+  clearLastProject,
+  formatLastProjectOneLiner,
+  readLastProject,
+  writeLastProject,
+} from "../shared/last-project.js";
+import {
+  LastProjectGetInputSchema,
+  LastProjectSetInputSchema,
+  LastProjectClearInputSchema,
+} from "../mcp/local/contracts/last-project-schemas.js";
+
+describe("last-project constants", () => {
+  it("uses last-project.json as the file name", () => {
+    expect(LAST_PROJECT_FILE_NAME).toBe("last-project.json");
+  });
+
+  it("uses .muggle-ai as the dir name (shared with prefs)", () => {
+    expect(LAST_PROJECT_DIR_NAME).toBe(".muggle-ai");
+  });
+
+  it("starts at schema version 1", () => {
+    expect(LAST_PROJECT_VERSION).toBe(1);
+  });
+});
+
+describe("last-project cache", () => {
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "muggle-last-project-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  describe("readLastProject", () => {
+    it("returns null when no cache exists", () => {
+      expect(readLastProject(projectDir)).toBeNull();
+    });
+
+    it("returns the cached project when written", () => {
+      writeLastProject(projectDir, {
+        projectId: "proj-123",
+        projectUrl: "https://app.example.com",
+        projectName: "Example",
+      });
+      const cached = readLastProject(projectDir);
+      expect(cached).not.toBeNull();
+      expect(cached?.projectId).toBe("proj-123");
+      expect(cached?.projectUrl).toBe("https://app.example.com");
+      expect(cached?.projectName).toBe("Example");
+      expect(cached?.savedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+  });
+
+  describe("writeLastProject", () => {
+    it("creates the .muggle-ai directory if missing", () => {
+      writeLastProject(projectDir, {
+        projectId: "p1",
+        projectUrl: "https://x.com",
+        projectName: "X",
+      });
+      expect(fs.existsSync(path.join(projectDir, LAST_PROJECT_DIR_NAME))).toBe(true);
+    });
+
+    it("writes a versioned file shape", () => {
+      writeLastProject(projectDir, {
+        projectId: "p1",
+        projectUrl: "https://x.com",
+        projectName: "X",
+      });
+      const filePath = path.join(projectDir, LAST_PROJECT_DIR_NAME, LAST_PROJECT_FILE_NAME);
+      const raw = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+      expect(raw.version).toBe(1);
+      expect(raw.lastProject.projectId).toBe("p1");
+    });
+
+    it("overwrites an existing cache file", () => {
+      writeLastProject(projectDir, { projectId: "p1", projectUrl: "u1", projectName: "n1" });
+      writeLastProject(projectDir, { projectId: "p2", projectUrl: "u2", projectName: "n2" });
+      const cached = readLastProject(projectDir);
+      expect(cached?.projectId).toBe("p2");
+    });
+  });
+
+  describe("clearLastProject", () => {
+    it("removes the cache file", () => {
+      writeLastProject(projectDir, { projectId: "p1", projectUrl: "u", projectName: "n" });
+      clearLastProject(projectDir);
+      expect(readLastProject(projectDir)).toBeNull();
+    });
+
+    it("is a no-op when no cache exists", () => {
+      expect(() => clearLastProject(projectDir)).not.toThrow();
+    });
+  });
+
+  describe("formatLastProjectOneLiner", () => {
+    it("returns empty string when no cache", () => {
+      expect(formatLastProjectOneLiner(projectDir)).toBe("");
+    });
+
+    it("formats a one-liner suitable for session context", () => {
+      writeLastProject(projectDir, {
+        projectId: "proj-abc",
+        projectUrl: "https://app.example.com",
+        projectName: "Example App",
+      });
+      const line = formatLastProjectOneLiner(projectDir);
+      expect(line).toBe(
+        'Muggle Last Project: id=proj-abc url=https://app.example.com name="Example App"',
+      );
+    });
+
+    it("escapes quotes in project names", () => {
+      writeLastProject(projectDir, {
+        projectId: "p1",
+        projectUrl: "https://x.com",
+        projectName: 'Has "quotes"',
+      });
+      const line = formatLastProjectOneLiner(projectDir);
+      expect(line).toContain('name="Has \\"quotes\\""');
+    });
+  });
+});
+
+describe("LastProjectGetInputSchema", () => {
+  it("requires cwd", () => {
+    expect(() => LastProjectGetInputSchema.parse({})).toThrow();
+  });
+
+  it("accepts a valid input", () => {
+    const r = LastProjectGetInputSchema.parse({ cwd: "/some/repo" });
+    expect(r.cwd).toBe("/some/repo");
+  });
+});
+
+describe("LastProjectSetInputSchema", () => {
+  it("requires all fields", () => {
+    expect(() => LastProjectSetInputSchema.parse({ cwd: "/x" })).toThrow();
+    expect(() =>
+      LastProjectSetInputSchema.parse({
+        cwd: "/x",
+        projectId: "p1",
+        projectUrl: "u",
+      }),
+    ).toThrow();
+  });
+
+  it("accepts a valid input", () => {
+    const r = LastProjectSetInputSchema.parse({
+      cwd: "/repo",
+      projectId: "p1",
+      projectUrl: "https://x.com",
+      projectName: "n",
+    });
+    expect(r.projectId).toBe("p1");
+  });
+
+  it("rejects empty strings", () => {
+    expect(() =>
+      LastProjectSetInputSchema.parse({
+        cwd: "/repo",
+        projectId: "",
+        projectUrl: "u",
+        projectName: "n",
+      }),
+    ).toThrow();
+  });
+});
+
+describe("LastProjectClearInputSchema", () => {
+  it("requires cwd", () => {
+    expect(() => LastProjectClearInputSchema.parse({})).toThrow();
+  });
+
+  it("accepts a valid input", () => {
+    const r = LastProjectClearInputSchema.parse({ cwd: "/some/repo" });
+    expect(r.cwd).toBe("/some/repo");
+  });
+});

--- a/packages/mcps/src/test/preferences.test.ts
+++ b/packages/mcps/src/test/preferences.test.ts
@@ -14,6 +14,7 @@ import {
 import { PreferencesSetInputSchema } from "../mcp/local/contracts/preferences-schemas.js";
 import {
   DEFAULT_PREFERENCES,
+  PREFERENCE_ALLOWED_VALUES,
   PREFERENCES_FILE_NAME,
   PREFERENCES_SCHEMA,
   PREFERENCES_VERSION,
@@ -53,14 +54,40 @@ describe("PreferenceKey enum", () => {
 });
 
 describe("PreferenceValue enum", () => {
-  it("has exactly 3 values", () => {
-    expect(Object.values(PreferenceValue)).toHaveLength(3);
+  it("has exactly 5 values (always/ask/never + local/remote)", () => {
+    expect(Object.values(PreferenceValue)).toHaveLength(5);
   });
 
-  it("contains always, ask, never", () => {
+  it("contains always, ask, never, local, remote", () => {
     expect(PreferenceValue.Always).toBe("always");
     expect(PreferenceValue.Ask).toBe("ask");
     expect(PreferenceValue.Never).toBe("never");
+    expect(PreferenceValue.Local).toBe("local");
+    expect(PreferenceValue.Remote).toBe("remote");
+  });
+});
+
+describe("PREFERENCE_ALLOWED_VALUES", () => {
+  it("has an entry for every PreferenceKey", () => {
+    for (const key of Object.values(PreferenceKey)) {
+      expect(PREFERENCE_ALLOWED_VALUES[key]).toBeDefined();
+      expect(PREFERENCE_ALLOWED_VALUES[key].length).toBeGreaterThan(0);
+    }
+  });
+
+  it("uses always/ask/never for most keys", () => {
+    const usual = [PreferenceValue.Always, PreferenceValue.Ask, PreferenceValue.Never];
+    expect(PREFERENCE_ALLOWED_VALUES[PreferenceKey.AutoLogin]).toEqual(usual);
+    expect(PREFERENCE_ALLOWED_VALUES[PreferenceKey.VerboseOutput]).toEqual(usual);
+    expect(PREFERENCE_ALLOWED_VALUES[PreferenceKey.CheckForUpdates]).toEqual(usual);
+  });
+
+  it("uses local/remote/ask for defaultExecutionMode", () => {
+    expect(PREFERENCE_ALLOWED_VALUES[PreferenceKey.DefaultExecutionMode]).toEqual([
+      PreferenceValue.Local,
+      PreferenceValue.Remote,
+      PreferenceValue.Ask,
+    ]);
   });
 });
 
@@ -155,10 +182,10 @@ describe("PreferencesService", () => {
       fs.mkdirSync(overrideDir, { recursive: true });
       fs.writeFileSync(
         path.join(overrideDir, "preferences.json"),
-        JSON.stringify({ version: 1, preferences: { defaultExecutionMode: "always" } }),
+        JSON.stringify({ version: 1, preferences: { defaultExecutionMode: "local" } }),
       );
       const prefs = readProjectPreferences(projectDir);
-      expect(prefs.defaultExecutionMode).toBe("always");
+      expect(prefs.defaultExecutionMode).toBe("local");
     });
   });
 
@@ -191,10 +218,10 @@ describe("PreferencesService", () => {
     });
 
     it("writes project preferences file", () => {
-      writePreferences({ defaultExecutionMode: "always" }, "project", globalDir, projectDir);
+      writePreferences({ defaultExecutionMode: "local" }, "project", globalDir, projectDir);
       const overridePath = path.join(projectDir, ".muggle-ai", "preferences.json");
       const raw = JSON.parse(fs.readFileSync(overridePath, "utf-8"));
-      expect(raw.preferences.defaultExecutionMode).toBe("always");
+      expect(raw.preferences.defaultExecutionMode).toBe("local");
     });
   });
 
@@ -222,9 +249,26 @@ describe("PreferencesService", () => {
   });
 
   describe("validatePreference", () => {
-    it("accepts valid key and value", () => {
+    it("accepts valid key and value (always/ask/never keys)", () => {
       expect(validatePreference("autoLogin", "always")).toBe(true);
       expect(validatePreference("verboseOutput", "never")).toBe(true);
+      expect(validatePreference("autoLogin", "ask")).toBe(true);
+    });
+
+    it("accepts local/remote/ask for defaultExecutionMode", () => {
+      expect(validatePreference("defaultExecutionMode", "local")).toBe(true);
+      expect(validatePreference("defaultExecutionMode", "remote")).toBe(true);
+      expect(validatePreference("defaultExecutionMode", "ask")).toBe(true);
+    });
+
+    it("rejects always/never for defaultExecutionMode", () => {
+      expect(validatePreference("defaultExecutionMode", "always")).toBe(false);
+      expect(validatePreference("defaultExecutionMode", "never")).toBe(false);
+    });
+
+    it("rejects local/remote for keys that don't accept them", () => {
+      expect(validatePreference("autoLogin", "local")).toBe(false);
+      expect(validatePreference("verboseOutput", "remote")).toBe(false);
     });
 
     it("rejects invalid key", () => {
@@ -275,6 +319,27 @@ describe("PreferencesSetInputSchema", () => {
   it("rejects invalid value", () => {
     expect(() =>
       PreferencesSetInputSchema.parse({ key: "autoLogin", value: "sometimes" }),
+    ).toThrow();
+  });
+
+  it("accepts local/remote for defaultExecutionMode", () => {
+    expect(
+      PreferencesSetInputSchema.parse({ key: "defaultExecutionMode", value: "local" }).value,
+    ).toBe("local");
+    expect(
+      PreferencesSetInputSchema.parse({ key: "defaultExecutionMode", value: "remote" }).value,
+    ).toBe("remote");
+  });
+
+  it("rejects always for defaultExecutionMode", () => {
+    expect(() =>
+      PreferencesSetInputSchema.parse({ key: "defaultExecutionMode", value: "always" }),
+    ).toThrow();
+  });
+
+  it("rejects local for autoLogin", () => {
+    expect(() =>
+      PreferencesSetInputSchema.parse({ key: "autoLogin", value: "local" }),
     ).toThrow();
   });
 });

--- a/plugin/scripts/ensure-electron-app.sh
+++ b/plugin/scripts/ensure-electron-app.sh
@@ -100,7 +100,30 @@ else
   prefs_file_note="\\n\\nMuggle Preferences: not configured. Run \\\`muggle setup\\\` or tell the agent to set preferences."
 fi
 
-context="<EXTREMELY_IMPORTANT>\nYou have access to Muggle AI — a real-browser E2E acceptance testing tool.\n\nWhenever the user asks you to test, validate, verify, or check if their web app works — use the muggle MCP tools. This includes:\n- Testing user flows (signup, login, checkout, forms, dashboards)\n- Verifying UI changes didn't break anything\n- Running regression tests after code changes\n- Validating frontend behavior on localhost or a dev server\n- Checking if a feature works before merging a PR\n\nMuggle launches a real Electron browser that clicks buttons, fills forms, navigates pages, and captures screenshots. It generates replayable test scripts that persist across sessions.\n\nDo NOT write test code (Playwright, Cypress, Selenium) or try to test UI manually when muggle tools are available. Use the muggle skill or muggle MCP tools instead — they are faster, capture visual evidence, and produce reusable test scripts.\n\nTrigger phrases: 'test my app', 'check if it works', 'run E2E acceptance tests', 'validate the UI', 'verify the flow', 'regression test', 'make sure it still works', 'test before merging'.\n</EXTREMELY_IMPORTANT>${upgrade_notice}${prefs_file_note}"
+# --- Last-project cache injection ---
+# Per-repo "last used Muggle project" cache. Lives at <cwd>/.muggle-ai/last-project.json
+# and is honored by skills when autoSelectProject = always.
+last_project_line=""
+last_project_note=""
+last_project_line=$(node -e "
+  const fs = require('fs');
+  const path = require('path');
+  try {
+    const cwd = process.env.CLAUDE_CWD || process.env.CURSOR_CWD || process.cwd();
+    const lpPath = path.join(cwd, '.muggle-ai', 'last-project.json');
+    if (!fs.existsSync(lpPath)) { console.log(''); return; }
+    const raw = JSON.parse(fs.readFileSync(lpPath, 'utf-8'));
+    const lp = raw && raw.lastProject;
+    if (!lp || !lp.projectId) { console.log(''); return; }
+    const safeName = String(lp.projectName || '').replace(/\"/g, '\\\\\"');
+    console.log('Muggle Last Project: id=' + lp.projectId + ' url=' + lp.projectUrl + ' name=\"' + safeName + '\"');
+  } catch { console.log(''); }
+" 2>/dev/null || true)
+if [ -n "$last_project_line" ]; then
+  last_project_note="\\n\\n${last_project_line}"
+fi
+
+context="<EXTREMELY_IMPORTANT>\nYou have access to Muggle AI — a real-browser E2E acceptance testing tool.\n\nWhenever the user asks you to test, validate, verify, or check if their web app works — use the muggle MCP tools. This includes:\n- Testing user flows (signup, login, checkout, forms, dashboards)\n- Verifying UI changes didn't break anything\n- Running regression tests after code changes\n- Validating frontend behavior on localhost or a dev server\n- Checking if a feature works before merging a PR\n\nMuggle launches a real Electron browser that clicks buttons, fills forms, navigates pages, and captures screenshots. It generates replayable test scripts that persist across sessions.\n\nDo NOT write test code (Playwright, Cypress, Selenium) or try to test UI manually when muggle tools are available. Use the muggle skill or muggle MCP tools instead — they are faster, capture visual evidence, and produce reusable test scripts.\n\nTrigger phrases: 'test my app', 'check if it works', 'run E2E acceptance tests', 'validate the UI', 'verify the flow', 'regression test', 'make sure it still works', 'test before merging'.\n</EXTREMELY_IMPORTANT>${upgrade_notice}${prefs_file_note}${last_project_note}"
 
 escaped_context=$(escape_for_json "$context")
 

--- a/plugin/skills/muggle-pr-visual-walkthrough/SKILL.md
+++ b/plugin/skills/muggle-pr-visual-walkthrough/SKILL.md
@@ -19,20 +19,15 @@ Rendering is always done by `muggle build-pr-section`, a battle-tested CLI that 
 
 ## Preferences
 
-User preferences are available in the session context (injected at session start). Look for the line starting with `Muggle Preferences` — it contains key=value pairs like `autoLogin=ask showElectronBrowser=always ...`.
+User preferences are injected by the SessionStart hook into a `Muggle Preferences` line in session context (key=value pairs). Resolution: defaults → `~/.muggle-ai/preferences.json` (global) → `<repo>/.muggle-ai/preferences.json` (project). Treat absent prefs as `ask`.
 
-If no preferences line is present, treat all preferences as `"ask"`.
+This skill is invoked by callers (`muggle-test`, `muggle-test-feature-local`, `muggle-do`) **after** the caller has already consulted `postPRVisualWalkthrough` and decided to post. Therefore **the gating happens upstream, not in this skill** — by the time this skill runs, the user has already said "post the walkthrough" (either via `postPRVisualWalkthrough = always` or by explicitly picking "Yes, post to PR" in the caller's 2-picker flow).
 
-When you reach a decision gated by a preference:
-- **`always`** → proceed without asking the user
-- **`never`** → skip without asking the user  
-- **`ask`** → ask the user, then offer: "Want me to remember this choice for future sessions?" If yes, call `muggle-local-preferences-set` with the key, their chosen value, and scope `global`.
+| Preference | Where it's gated | Decision it gates |
+|------------|------------------|-------------------|
+| `postPRVisualWalkthrough` | Caller skill (e.g. `muggle-test` Step 9, `muggle-test-feature-local` Step 10) | Post visual walkthrough to PR |
 
-This skill uses these preferences:
-
-| Preference | Decision it gates |
-|------------|------------------|
-| `postPRVisualWalkthrough` | Post visual walkthrough to PR |
+The full 2-picker flow lives in the caller's SKILL.md. This skill only renders and posts.
 
 ## Input contract: the `E2eReport` JSON
 

--- a/plugin/skills/muggle-preferences/SKILL.md
+++ b/plugin/skills/muggle-preferences/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   defaults, or manage muggle config. Triggers on: 'muggle preferences',
   'show muggle settings', 'change muggle preference', 'set autoLogin to
   always', 'muggle config', 'reset muggle preferences', 'show my muggle
-  settings', 'configure muggle'.
+  settings', 'configure muggle', 'muggle setup'.
 ---
 
 # Muggle Preferences
@@ -15,19 +15,22 @@ View, set, or reset the preference knobs that control Muggle AI behavior.
 
 ## Operations
 
-Parse the user's request to determine which operation to perform:
+Parse the user's request to decide which operation to run:
 
-- **List** — user wants to see current values (default when no specific change requested)
-- **Set** — user wants to change a specific preference
-- **Reset** — user wants to restore a preference (or all preferences) to defaults
+- **List** — show current values. Default when no change is requested.
+- **Configure** — interactive picker. Default when the user wants to change preferences but hasn't named a specific one (e.g. "muggle setup", "configure muggle", "change my preferences").
+- **Set** — direct set when the user names a key+value (e.g. "set autoLogin to always").
+- **Reset** — restore preferences to default (`ask`).
+
+## Reading current values
+
+Read preferences from session context. Look for the line starting with `Muggle Preferences` — it contains key=value pairs like `autoLogin=ask showElectronBrowser=always ...`.
+
+If no preferences line is present, treat all preferences as `"ask"` (the default).
 
 ## List
 
-1. Read preferences from session context. Look for the line starting with `Muggle Preferences` — it contains key=value pairs like `autoLogin=ask showElectronBrowser=always ...`.
-
-   If no preferences line is present, treat all preferences as `"ask"` (the default).
-
-2. Present all 12 preferences in a table:
+Present all 12 preferences in this table, filling each `Value` column from session context:
 
 ```
 Muggle AI — Preferences
@@ -51,9 +54,101 @@ Values: always (proceed without asking) · ask (prompt each time) · never (skip
 Scope:  global (~/.muggle-ai/) or project (.muggle-ai/ in repo root)
 ```
 
-## Set
+## Configure (interactive picker)
 
-1. Parse the requested key and value from the user's message.
+Use this whenever the user wants to change preferences without naming a specific key. The flow runs in a single `AskUserQuestion` call so the user can toggle preferences with the keyboard instead of typing key names.
+
+### Step 1 — show current state
+
+Print the preference table from the **List** section so the user sees what's set today.
+
+### Step 2 — tell the user how to drive the picker
+
+Print this instruction block verbatim before calling `AskUserQuestion`:
+
+```
+How to use this picker:
+  ↑/↓        move between options
+  space      toggle a preference (selected = set to `always`)
+  tab        move to the next question
+  enter      confirm
+
+Anything you don't toggle keeps its current value. After this picker
+you can tell me which (if any) should instead be set to `never`.
+```
+
+### Step 3 — call AskUserQuestion
+
+Make a single `AskUserQuestion` call with these 4 questions. Group preferences so each question stays within the 4-option limit.
+
+- **Question 1** — `header: "Auth & session"`, `multiSelect: true`
+  Question text: `Which of these should auto-proceed (set to "always")?`
+  Options (label / description):
+  - `autoLogin` — Reuse saved credentials without prompting
+  - `autoSelectProject` — Reuse last-used project for this repo
+  - `checkForUpdates` — Check for newer Muggle version at session start
+  - `verboseOutput` — Show detailed progress logs during execution
+
+- **Question 2** — `header: "Test run"`, `multiSelect: true`
+  Question text: `Which of these should auto-proceed (set to "always")?`
+  Options:
+  - `showElectronBrowser` — Show browser window during local tests
+  - `openTestResultsAfterRun` — Open results page on dashboard after a local run
+  - `autoPublishLocalResults` — Upload local results to Muggle cloud
+  - `autoDetectChanges` — Scan local git changes and map to affected test cases
+
+- **Question 3** — `header: "Suggestions & PR"`, `multiSelect: true`
+  Question text: `Which of these should auto-proceed (set to "always")?`
+  Options (3 — `defaultExecutionMode` is intentionally **excluded** here because it doesn't accept "always"; it's handled separately in Question 4):
+  - `suggestRelatedUseCases` — Suggest related use cases after creating/running one
+  - `suggestRelatedTestCases` — Suggest related test cases after creating/running one
+  - `postPRVisualWalkthrough` — Post visual walkthrough with screenshots to PR
+
+- **Question 4** — `header: "Default mode"`, `multiSelect: false`
+  Question text: `Default execution mode for muggle-test? (preference: defaultExecutionMode)`
+  Options:
+  - `Local — run on my computer (Electron)` → `defaultExecutionMode = local`
+  - `Remote — run in the Muggle cloud` → `defaultExecutionMode = remote`
+  - `Ask each time` → `defaultExecutionMode = ask` (don't change)
+
+- **Question 5** — `header: "Scope"`, `multiSelect: false`
+  Question text: `Where should these preferences be saved?`
+  Options:
+  - `Global (all repos)` — Saved to ~/.muggle-ai/, applies everywhere
+  - `This project only` — Saved to .muggle-ai/ in this repo
+
+> **Note**: `AskUserQuestion` allows up to 4 questions per call. If you need 5, split into two sequential calls: Q1+Q2+Q3+Q4 first, then Q5 (scope).
+
+### Step 4 — apply selections
+
+For every preference the user toggled across **questions 1–3**, call `muggle-local-preferences-set` with:
+- `key`: the preference name
+- `value`: `"always"`
+- `scope`: `"global"` or `"project"` based on the scope question (Q5)
+- `cwd`: current working directory if scope is `"project"`
+
+For **Question 4** (defaultExecutionMode), call `muggle-local-preferences-set` only if the user picked "Local" or "Remote" (skip if they picked "Ask each time"):
+- `key: "defaultExecutionMode"`
+- `value: "local"` or `"remote"` based on choice
+- `scope`: from Q5
+- `cwd`: current working directory if scope is `"project"`
+- `cwd`: current working directory (required when scope is `"project"`)
+
+### Step 5 — offer the `never` follow-up
+
+After applying, ask: `Want any of these set to "never" (auto-skip without asking)? Name them, e.g. "never on autoPublishLocalResults", or say "no".`
+
+If the user names keys, call `muggle-local-preferences-set` with `value: "never"` and the same scope.
+
+### Step 6 — confirm
+
+Print a short summary of what changed: `Set autoLogin=always, openTestResultsAfterRun=always (global).`
+
+## Set (direct)
+
+When the user names both key and value (e.g. "set autoLogin to always", "make showElectronBrowser never for this project"):
+
+1. Parse the key and value from the user's message.
 
 2. Validate the key is one of: `autoLogin`, `autoSelectProject`, `showElectronBrowser`, `openTestResultsAfterRun`, `defaultExecutionMode`, `autoPublishLocalResults`, `suggestRelatedUseCases`, `suggestRelatedTestCases`, `autoDetectChanges`, `postPRVisualWalkthrough`, `checkForUpdates`, `verboseOutput`.
 
@@ -65,11 +160,7 @@ Scope:  global (~/.muggle-ai/) or project (.muggle-ai/ in repo root)
    - Default to `global`.
    - If the user says "for this project", "project-level", or "just this repo", use `project` scope and pass `cwd` as the current working directory.
 
-5. Call `muggle-local-preferences-set` with:
-   - `key`: The preference key
-   - `value`: The chosen value
-   - `scope`: `"global"` or `"project"`
-   - `cwd`: Current working directory (required when scope is `"project"`)
+5. Call `muggle-local-preferences-set` with the key, value, scope, and (if project scope) `cwd`.
 
 6. Confirm: `Set {key} to {value} ({scope}).`
 

--- a/plugin/skills/muggle-status/SKILL.md
+++ b/plugin/skills/muggle-status/SKILL.md
@@ -9,20 +9,22 @@ Run a full health check and report results.
 
 ## Preferences
 
-User preferences are available in the session context (injected at session start). Look for the line starting with `Muggle Preferences` — it contains key=value pairs like `autoLogin=ask showElectronBrowser=always ...`.
+User preferences are injected by the SessionStart hook into a `Muggle Preferences` line in session context (key=value pairs). Resolution: defaults → `~/.muggle-ai/preferences.json` (global) → `<repo>/.muggle-ai/preferences.json` (project). Treat absent prefs as `ask`.
 
-If no preferences line is present, treat all preferences as `"ask"`.
+**At every preference-gated step below**, apply this rule:
 
-When you reach a decision gated by a preference:
-- **`always`** → proceed without asking the user
-- **`never`** → skip without asking the user  
-- **`ask`** → ask the user, then offer: "Want me to remember this choice for future sessions?" If yes, call `muggle-local-preferences-set` with the key, their chosen value, and scope `global`.
+- `always` → perform the auto-action silently. **Skip both pickers.**
+- `never` → skip the action silently. **Skip both pickers.**
+- `ask` (or absent) → run the **2-picker flow**:
+  1. **Picker 1** (`AskQuestion`): the substantive choice for this step. Each option maps to either `always` or `never`.
+  2. **Picker 2** (`AskQuestion`): `"Remember this? Next time I'll automatically <action description> without asking. (preference: <key> = <value>)"` with options:
+     - "Yes, save it"
+     - "No, just for this run"
+  3. On **"Yes, save it"** → call `muggle-local-preferences-set` with `key`, the value chosen in Picker 1, `scope: "global"`.
 
-This skill uses these preferences:
-
-| Preference | Decision it gates |
-|------------|------------------|
-| `checkForUpdates` | Check for newer Muggle version |
+| Preference | Step | Decision it gates |
+|------------|------|-------------------|
+| `checkForUpdates` | Check 4 | Check for newer Muggle version |
 
 ## Checks
 
@@ -32,7 +34,18 @@ This skill uses these preferences:
 
 3. **Authentication** — call `muggle-remote-auth-status`. Report whether credentials are valid and when they expire.
 
-4. **CLI version** — capture installed (`muggle --version`) and latest (`npm view @muggleai/works version`). Compare with `sort -V`; flag as out-of-date only when latest is strictly greater.
+4. **CLI version** (gated by `checkForUpdates`) — apply the gate (see Preferences for the full 2-picker flow):
+   - **`checkForUpdates = always`** → run the version check silently and report. Skip both pickers.
+   - **`checkForUpdates = never`** → skip this check entirely; render the row as `[skip]  check disabled by preference`. Skip both pickers.
+   - **`checkForUpdates = ask` (or absent)** → run the 2-picker flow:
+     - **Picker 1**: `"Check npm for a newer Muggle version? Requires a network call."`
+       - "Yes, check" → maps to `checkForUpdates = always`. Run the check.
+       - "No, skip" → maps to `checkForUpdates = never`. Render `[skip]`.
+     - **Picker 2**: `"Remember this? Next time I'll automatically <check for updates | skip the check> without asking. (preference: checkForUpdates = <always|never>)"`
+       - "Yes, save it" → call `muggle-local-preferences-set` with `key: "checkForUpdates"`, `value: "<always|never>"`, `scope: "global"`.
+       - "No, just for this run" → continue without saving.
+
+   When the check runs: capture installed (`muggle --version`) and latest (`npm view @muggleai/works version`). Compare with `sort -V`; flag as out-of-date only when latest is strictly greater.
 
 ## Output
 

--- a/plugin/skills/muggle-test-feature-local/SKILL.md
+++ b/plugin/skills/muggle-test-feature-local/SKILL.md
@@ -24,38 +24,59 @@ The local URL only changes where the browser opens; it does not change the remot
 
 ## Preferences
 
-User preferences are available in the session context (injected at session start). Look for the line starting with `Muggle Preferences` — it contains key=value pairs like `autoLogin=ask showElectronBrowser=always ...`.
+User preferences are injected by the SessionStart hook into a `Muggle Preferences` line in session context (key=value pairs). Resolution: defaults → `~/.muggle-ai/preferences.json` (global) → `<repo>/.muggle-ai/preferences.json` (project). Treat absent prefs as `ask`.
 
-If no preferences line is present, treat all preferences as `"ask"`.
+**At every preference-gated step below**, apply this rule:
 
-When you reach a decision gated by a preference:
-- **`always`** → proceed without asking the user
-- **`never`** → skip without asking the user  
-- **`ask`** → ask the user, then offer: "Want me to remember this choice for future sessions?" If yes, call `muggle-local-preferences-set` with the key, their chosen value, and scope `global`.
+- `always` → perform the auto-action silently. **Skip both pickers.**
+- `never` → skip the action silently. **Skip both pickers.**
+- `ask` (or absent) → run the **2-picker flow**:
+  1. **Picker 1** (`AskQuestion`): the substantive choice for this step. Each option maps to either `always` or `never`.
+  2. **Picker 2** (`AskQuestion`): `"Remember this? Next time I'll automatically <action description> without asking. (preference: <key> = <value>)"` with options:
+     - "Yes, save it"
+     - "No, just for this run"
+  3. On **"Yes, save it"** → call `muggle-local-preferences-set` with `key`, the value chosen in Picker 1, `scope: "global"`.
 
-This skill uses these preferences:
+The `<action description>` and the substantive options are step-specific — see each gated step below.
 
-| Preference | Decision it gates |
-|------------|------------------|
-| `autoLogin` | Reuse saved credentials when auth is required |
-| `autoSelectProject` | Reuse last-used Muggle project for this repo |
-| `showElectronBrowser` | Show Electron browser window during local E2E tests |
-| `openTestResultsAfterRun` | Open results page on Muggle dashboard after run |
+| Preference | Step | Decision it gates |
+|------------|------|-------------------|
+| `autoLogin` | 1 | Reuse saved credentials when auth is required |
+| `autoSelectProject` | 2 | Reuse last-used Muggle project for this repo |
+| `showElectronBrowser` | 7 | Show Electron browser window during local E2E tests |
+| `openTestResultsAfterRun` | 8 | Open results page on Muggle dashboard after run |
 
 ## Workflow
 
-### 1. Auth
+### 1. Auth (gated by `autoLogin`)
 
 - `muggle-remote-auth-status`
-- If **authenticated**: print the logged-in email and ask via `AskQuestion`:
-  > "You're logged in as **{email}**. Continue with this account?"
-  - Option 1: "Yes, continue"
-  - Option 2: "No, switch account"
-  If the user picks "switch account", call `muggle-remote-auth-login` with `forceNewSession: true` then `muggle-remote-auth-poll`.
+- If **authenticated**, apply the `autoLogin` gate (see Preferences for the full 2-picker flow):
+  - **`autoLogin = always`** → continue with the saved session silently. Skip both pickers.
+  - **`autoLogin = never`** → call `muggle-remote-auth-login` with `forceNewSession: true`, then `muggle-remote-auth-poll`. Skip both pickers.
+  - **`autoLogin = ask` (or absent)** → run the 2-picker flow:
+    - **Picker 1**: `"You're logged in as {email}. Continue with this account?"`
+      - "Yes, continue" → maps to `autoLogin = always`. Proceed with the saved session.
+      - "No, switch account" → maps to `autoLogin = never`. Call `muggle-remote-auth-login` with `forceNewSession: true`, then `muggle-remote-auth-poll`.
+    - **Picker 2**: `"Remember this? Next time I'll automatically <reuse your saved login | force a fresh login> without asking. (preference: autoLogin = <always|never>)"`
+      - "Yes, save it" → call `muggle-local-preferences-set` with `key: "autoLogin"`, `value: "<always|never>"`, `scope: "global"`.
+      - "No, just for this run" → continue without saving.
 - If **not signed in or expired**: call `muggle-remote-auth-login` then `muggle-remote-auth-poll`.
   Do not skip or assume auth.
 
 ### 2. Targets (user must confirm)
+
+The per-repo project cache lives at `<cwd>/.muggle-ai/last-project.json` (via the `muggle-local-last-project-get` / `muggle-local-last-project-set` MCP tools). Look for `Muggle Last Project: id=… url=… name="…"` in session context.
+
+For project selection: apply the `autoSelectProject` gate (see Preferences):
+- **`autoSelectProject = always`** with the `Muggle Last Project` line present → use that `projectId` silently. Skip both pickers and skip to use case selection. If no cache line is present, fall through to `ask`.
+- **`autoSelectProject = never`** → always present the full project list; skip Picker 2 (memory).
+- **`autoSelectProject = ask` (or absent)** → present the full project list (Picker 1), then offer Picker 2 only after a successful pick of an existing project (skip Picker 2 if user picked "Create new project"):
+  - Picker 2: `"Remember this? Next time I'll automatically reuse this project for this repo without asking. (preference: autoSelectProject = always)"`
+    - **"Yes, save it"** → make BOTH calls:
+      1. `muggle-local-preferences-set` with `key: "autoSelectProject"`, `value: "always"`, `scope: "global"`.
+      2. `muggle-local-last-project-set` with `cwd`, `projectId`, `projectUrl`, `projectName`.
+    - "No, just for this run" → continue without saving.
 
 Ask the user to pick **project**, **use case**, and **test case** (do not infer).
 
@@ -153,14 +174,34 @@ The MCP client often uses a **default wait of 300000 ms (5 minutes)** for `muggl
 - **`Electron execution timed out after 300000ms`:** Orchestration wait too short — see **`timeoutMs`** above.
 - **Exit code 26** (and messages like **LLM failed to generate / replay action script**): Often corresponds to a completed exploration whose **outcome was goal not achievable** (`goal_not_achievable`, summary with `halt`) — e.g. verifying "view script after a successful run" when **no run or script exists yet** in the UI. Use `muggle-local-run-result-get` and read the **summary / structured summary**; do not assume an Electron crash. **Fix:** choose a **project that already has** completed runs and scripts, or **change the test case** so preconditions match what localhost can satisfy (e.g. include steps to create and run a test first, or assert only empty-state UI when no runs exist).
 
-### 7. Execute (no approval prompt)
+### 7. Execute (no approval prompt; `showUi` gated by `showElectronBrowser`)
 
-Call `muggle-local-execute-test-generation` or `muggle-local-execute-replay` directly. **Do not** ask the user to re-approve the Electron launch — the user choosing this skill in the first place is the approval. The browser defaults to visible; only pass `showUi: false` if the user explicitly asked for headless.
+Call `muggle-local-execute-test-generation` or `muggle-local-execute-replay` directly. **Do not** ask the user to re-approve the Electron launch — the user choosing this skill in the first place is the approval.
 
-### 8. After successful generation only
+Apply the `showElectronBrowser` gate to decide whether to pass `showUi: false`:
+- **`showElectronBrowser = always`** → omit `showUi` (defaults to visible). Skip both pickers.
+- **`showElectronBrowser = never`** → pass `showUi: false` (headless). Skip both pickers.
+- **`showElectronBrowser = ask` (or absent)** → only ask if the user has not already stated a preference in this session. Otherwise default to visible. If asking, run the 2-picker flow:
+  - **Picker 1**: `"Show the Electron browser window during this run?"`
+    - "Yes, show the browser" → maps to `showElectronBrowser = always`. Omit `showUi`.
+    - "No, run headless" → maps to `showElectronBrowser = never`. Pass `showUi: false`.
+  - **Picker 2**: `"Remember this? Next time I'll automatically <show the browser | run headless> without asking. (preference: showElectronBrowser = <always|never>)"`
+    - "Yes, save it" → call `muggle-local-preferences-set` with `key: "showElectronBrowser"`, `value: "<always|never>"`, `scope: "global"`.
+    - "No, just for this run" → continue without saving.
+
+### 8. After successful generation only (open `viewUrl` gated by `openTestResultsAfterRun`)
 
 - `muggle-local-publish-test-script`
-- Open returned `viewUrl` for the user (`open "<viewUrl>"` on macOS or OS equivalent).
+- Apply the `openTestResultsAfterRun` gate to decide whether to open the returned `viewUrl`:
+  - **`openTestResultsAfterRun = always`** → open `viewUrl` automatically (`open "<viewUrl>"` on macOS or OS equivalent). Skip both pickers.
+  - **`openTestResultsAfterRun = never`** → don't open. Just print the URL so the user can copy it. Skip both pickers.
+  - **`openTestResultsAfterRun = ask` (or absent)** → run the 2-picker flow:
+    - **Picker 1**: `"Open the run on Muggle dashboard now?"`
+      - "Yes, open it" → maps to `openTestResultsAfterRun = always`. Open `viewUrl`.
+      - "No, just print the URL" → maps to `openTestResultsAfterRun = never`. Print and continue.
+    - **Picker 2**: `"Remember this? Next time I'll automatically <open the dashboard | print the URL only> without asking. (preference: openTestResultsAfterRun = <always|never>)"`
+      - "Yes, save it" → call `muggle-local-preferences-set` with `key: "openTestResultsAfterRun"`, `value: "<always|never>"`, `scope: "global"`.
+      - "No, just for this run" → continue without saving.
 
 ### 9. Report
 

--- a/plugin/skills/muggle-test-import/SKILL.md
+++ b/plugin/skills/muggle-test-import/SKILL.md
@@ -20,23 +20,27 @@ in a Muggle project via the API.
 
 ## Preferences
 
-User preferences are available in the session context (injected at session start). Look for the line starting with `Muggle Preferences` — it contains key=value pairs like `autoLogin=ask showElectronBrowser=always ...`.
+User preferences are injected by the SessionStart hook into a `Muggle Preferences` line in session context (key=value pairs). Resolution: defaults → `~/.muggle-ai/preferences.json` (global) → `<repo>/.muggle-ai/preferences.json` (project). Treat absent prefs as `ask`.
 
-If no preferences line is present, treat all preferences as `"ask"`.
+**At every preference-gated step below**, apply this rule:
 
-When you reach a decision gated by a preference:
-- **`always`** → proceed without asking the user
-- **`never`** → skip without asking the user  
-- **`ask`** → ask the user, then offer: "Want me to remember this choice for future sessions?" If yes, call `muggle-local-preferences-set` with the key, their chosen value, and scope `global`.
+- `always` → perform the auto-action silently. **Skip both pickers.**
+- `never` → skip the action silently. **Skip both pickers.**
+- `ask` (or absent) → run the **2-picker flow**:
+  1. **Picker 1** (`AskQuestion`): the substantive choice for this step. Each option maps to either `always` or `never`.
+  2. **Picker 2** (`AskQuestion`): `"Remember this? Next time I'll automatically <action description> without asking. (preference: <key> = <value>)"` with options:
+     - "Yes, save it"
+     - "No, just for this run"
+  3. On **"Yes, save it"** → call `muggle-local-preferences-set` with `key`, the value chosen in Picker 1, `scope: "global"`.
 
-This skill uses these preferences:
+The `<action description>` and the substantive options are step-specific — see each gated step below.
 
-| Preference | Decision it gates |
-|------------|------------------|
-| `autoLogin` | Reuse saved credentials when auth is required |
-| `autoSelectProject` | Reuse last-used Muggle project for this repo |
-| `suggestRelatedUseCases` | Suggest related use cases after import |
-| `suggestRelatedTestCases` | Suggest related test cases after import |
+| Preference | Step | Decision it gates |
+|------------|------|-------------------|
+| `autoLogin` | 4 | Reuse saved credentials when auth is required |
+| `autoSelectProject` | 5 | Reuse last-used Muggle project for this repo |
+| `suggestRelatedUseCases` | 7 | Suggest related use cases after import |
+| `suggestRelatedTestCases` | 7 | Suggest related test cases after import |
 
 ## Concepts
 
@@ -146,14 +150,20 @@ If the user wants changes, incorporate feedback, then ask again. Only proceed af
 
 ---
 
-## Step 4 — Authenticate
+## Step 4 — Authenticate (gated by `autoLogin`)
 
 Call `muggle-remote-auth-status` first.
 
-If **already authenticated** → print the logged-in email and ask via `AskQuestion`:
-> "You're logged in as **{email}**. Continue with this account?"
-- Option 1: "Yes, continue" → skip to Step 5.
-- Option 2: "No, switch account" → call `muggle-remote-auth-login` with `forceNewSession: true`, then `muggle-remote-auth-poll`.
+If **already authenticated** → apply the `autoLogin` gate (see Preferences for the full 2-picker flow):
+- **`autoLogin = always`** → skip to Step 5 silently. Skip both pickers.
+- **`autoLogin = never`** → call `muggle-remote-auth-login` with `forceNewSession: true`, then `muggle-remote-auth-poll`. Skip both pickers.
+- **`autoLogin = ask` (or absent)** → run the 2-picker flow:
+  - **Picker 1**: `"You're logged in as {email}. Continue with this account?"`
+    - "Yes, continue" → maps to `autoLogin = always`. Skip to Step 5.
+    - "No, switch account" → maps to `autoLogin = never`. Call `muggle-remote-auth-login` with `forceNewSession: true`, then `muggle-remote-auth-poll`.
+  - **Picker 2**: `"Remember this? Next time I'll automatically <reuse your saved login | force a fresh login> without asking. (preference: autoLogin = <always|never>)"`
+    - "Yes, save it" → call `muggle-local-preferences-set` with `key: "autoLogin"`, `value: "<always|never>"`, `scope: "global"`.
+    - "No, just for this run" → continue without saving.
 
 If **not authenticated**:
 1. Tell the user a browser window is about to open.
@@ -163,14 +173,28 @@ If **not authenticated**:
 
 ---
 
-## Step 5 — Pick or create a project
+## Step 5 — Pick or create a project (gated by `autoSelectProject`)
 
 A **project** is where all your imported use cases, test cases, and future test results are grouped on the Muggle AI dashboard.
 
-1. Call `muggle-remote-project-list`
+The per-repo project cache lives at `<cwd>/.muggle-ai/last-project.json` (via the `muggle-local-last-project-get` / `muggle-local-last-project-set` MCP tools). Look for `Muggle Last Project: id=… url=… name="…"` in session context.
+
+Apply the `autoSelectProject` gate (see Preferences for the full 2-picker flow):
+- **`autoSelectProject = always`** with the `Muggle Last Project` line present → use that `projectId` silently. Skip both pickers and skip to Step 6. If no cache line is present, fall through to `ask`.
+- **`autoSelectProject = never`** → always present the full project list; skip Picker 2 (memory).
+- **`autoSelectProject = ask` (or absent)** → present the project list (Picker 1), then offer Picker 2 only after a successful pick of an existing project (skip Picker 2 if user picked "Create new project"):
+  - Picker 2: `"Remember this? Next time I'll automatically reuse this project for this repo without asking. (preference: autoSelectProject = always)"`
+    - **"Yes, save it"** → make BOTH calls:
+      1. `muggle-local-preferences-set` with `key: "autoSelectProject"`, `value: "always"`, `scope: "global"`.
+      2. `muggle-local-last-project-set` with `cwd`, `projectId`, `projectUrl`, `projectName`.
+    - "No, just for this run" → continue without saving.
+
+### Logic
+
+1. Call `muggle-remote-project-list` (only when not satisfied by the `always` cache).
 2. Use `AskQuestion` to present all projects as clickable options. Include the project URL in each label. Always include a "Create new project" option at the end.
 
-   Prompt: "Pick the project to import into:"
+   Prompt: `"Pick the project to import into:"`
 
 3. **If creating a new project**, propose values based on what you learned from the source files:
    - **Name**: infer the app name from filenames, URLs, or document headings (e.g., "Acme App")
@@ -392,3 +416,43 @@ Imported: 3 use cases · 8 test cases
 
 Next step: run /muggle:do to generate executable browser test scripts for these test cases.
 ```
+
+### Step 8 — Optional follow-up suggestions
+
+Two preferences gate optional follow-ups: `suggestRelatedUseCases` and `suggestRelatedTestCases`. Both are independent — handle each in turn.
+
+#### 8a — Related use cases (gated by `suggestRelatedUseCases`)
+
+The query is: "from the use cases already in this project, which ones are *not* in the import set but look related to it?" — surface them so the user can decide whether their import missed something the project already tracks.
+
+Apply the gate:
+- **`suggestRelatedUseCases = always`** → run the query and present silently. Skip both pickers.
+- **`suggestRelatedUseCases = never`** → skip. Skip both pickers.
+- **`suggestRelatedUseCases = ask` (or absent)** → run the 2-picker flow:
+  - **Picker 1**: `"Want me to surface related use cases already in this project that you might have missed?"`
+    - "Yes, suggest related" → maps to `suggestRelatedUseCases = always`. Run the query.
+    - "No, skip" → maps to `suggestRelatedUseCases = never`. Skip.
+  - **Picker 2**: `"Remember this? Next time I'll automatically <surface related use cases | skip the suggestion> without asking. (preference: suggestRelatedUseCases = <always|never>)"`
+    - "Yes, save it" → call `muggle-local-preferences-set` with `key: "suggestRelatedUseCases"`, `value: "<always|never>"`, `scope: "global"`.
+    - "No, just for this run" → continue without saving.
+
+When running the query:
+1. Call `muggle-remote-use-case-list` for the project.
+2. Filter out any use case whose `useCaseId` is in the set you just imported in Step 6 (Pass 1).
+3. Rank the remainder by semantic relevance to the imported titles/descriptions (substring overlap, shared keywords — best-effort, no LLM call needed).
+4. Present the top 3-5 via `AskQuestion` with `allow_multiple: true`. Label each with `<title> — <one-line description>`.
+5. For any the user selects, prompt to add follow-up test cases (treat each as a Pass 2 invocation: `muggle-remote-test-case-bulk-preview-submit` → poll → persist via `muggle-remote-test-case-create`).
+6. If the filtered list is empty (the import covers everything in the project), say so and skip.
+
+#### 8b — Related test cases (gated by `suggestRelatedTestCases`)
+
+For each use case the user just created, surface other test cases already attached that the import didn't add — same idea, scoped to a single use case.
+
+Apply the gate the same way as 8a (substitute `suggestRelatedTestCases` for the key, "surface related test cases" / "skip the suggestion" for the action description).
+
+When running the query, for each use case in the import:
+1. Call `muggle-remote-test-case-list-by-use-case` with that `useCaseId`.
+2. Filter out any test case you just created in Pass 2 of Step 6.
+3. Present the remainder via `AskQuestion` with `allow_multiple: true`, labeled `[<priority>] <title> — <goal>`.
+4. For any the user selects: nothing to create (they already exist) — just confirm to the user that those tests are now part of their Muggle project alongside the imported ones.
+5. If a use case has no extra test cases, skip it silently.

--- a/plugin/skills/muggle-test-regenerate-missing/SKILL.md
+++ b/plugin/skills/muggle-test-regenerate-missing/SKILL.md
@@ -11,21 +11,25 @@ Execution is **remote only** — Muggle's cloud generates the scripts in paralle
 
 ## Preferences
 
-User preferences are available in the session context (injected at session start). Look for the line starting with `Muggle Preferences` — it contains key=value pairs like `autoLogin=ask showElectronBrowser=always ...`.
+User preferences are injected by the SessionStart hook into a `Muggle Preferences` line in session context (key=value pairs). Resolution: defaults → `~/.muggle-ai/preferences.json` (global) → `<repo>/.muggle-ai/preferences.json` (project). Treat absent prefs as `ask`.
 
-If no preferences line is present, treat all preferences as `"ask"`.
+**At every preference-gated step below**, apply this rule:
 
-When you reach a decision gated by a preference:
-- **`always`** → proceed without asking the user
-- **`never`** → skip without asking the user  
-- **`ask`** → ask the user, then offer: "Want me to remember this choice for future sessions?" If yes, call `muggle-local-preferences-set` with the key, their chosen value, and scope `global`.
+- `always` → perform the auto-action silently. **Skip both pickers.**
+- `never` → skip the action silently. **Skip both pickers.**
+- `ask` (or absent) → run the **2-picker flow**:
+  1. **Picker 1** (`AskQuestion`): the substantive choice for this step. Each option maps to either `always` or `never`.
+  2. **Picker 2** (`AskQuestion`): `"Remember this? Next time I'll automatically <action description> without asking. (preference: <key> = <value>)"` with options:
+     - "Yes, save it"
+     - "No, just for this run"
+  3. On **"Yes, save it"** → call `muggle-local-preferences-set` with `key`, the value chosen in Picker 1, `scope: "global"`.
 
-This skill uses these preferences:
+The `<action description>` and the substantive options are step-specific — see each gated step below.
 
-| Preference | Decision it gates |
-|------------|------------------|
-| `autoLogin` | Reuse saved credentials when auth is required |
-| `autoSelectProject` | Reuse last-used Muggle project for this repo |
+| Preference | Step | Decision it gates |
+|------------|------|-------------------|
+| `autoLogin` | 1 | Reuse saved credentials when auth is required |
+| `autoSelectProject` | 2 | Reuse last-used Muggle project for this repo |
 
 ## Concept: what counts as "no active script"
 
@@ -55,24 +59,43 @@ Treat this filter as a default, not a law. If the user explicitly says "include 
 
 ## Workflow
 
-### Step 1 — Authenticate
+### Step 1 — Authenticate (gated by `autoLogin`)
 
 1. Call `muggle-remote-auth-status`.
-2. If **authenticated and not expired** → print the logged-in email and ask via `AskQuestion`:
-   > "You're logged in as **{email}**. Continue with this account?"
-   - Option 1: "Yes, continue"
-   - Option 2: "No, switch account"
-   If the user picks "switch account", call `muggle-remote-auth-login` with `forceNewSession: true`, then poll with `muggle-remote-auth-poll`.
+2. If **authenticated and not expired** → apply the `autoLogin` gate (see Preferences for the full 2-picker flow):
+   - **`autoLogin = always`** → continue with the saved session silently. Skip both pickers.
+   - **`autoLogin = never`** → call `muggle-remote-auth-login` with `forceNewSession: true`, then poll with `muggle-remote-auth-poll`. Skip both pickers.
+   - **`autoLogin = ask` (or absent)** → run the 2-picker flow:
+     - **Picker 1**: `"You're logged in as {email}. Continue with this account?"`
+       - "Yes, continue" → maps to `autoLogin = always`. Proceed with the saved session.
+       - "No, switch account" → maps to `autoLogin = never`. Call `muggle-remote-auth-login` with `forceNewSession: true`, then poll with `muggle-remote-auth-poll`.
+     - **Picker 2**: `"Remember this? Next time I'll automatically <reuse your saved login | force a fresh login> without asking. (preference: autoLogin = <always|never>)"`
+       - "Yes, save it" → call `muggle-local-preferences-set` with `key: "autoLogin"`, `value: "<always|never>"`, `scope: "global"`.
+       - "No, just for this run" → continue without saving.
 3. If **not authenticated or expired** → call `muggle-remote-auth-login`, then poll with `muggle-remote-auth-poll`.
 4. Do not skip auth and do not assume a stale token still works.
 
 If auth keeps failing, suggest the user run `muggle logout && muggle login` from a terminal.
 
-### Step 2 — Select Project (user must choose)
+### Step 2 — Select Project (gated by `autoSelectProject`)
 
 A **project** is the unit on the Muggle AI dashboard that groups test cases, scripts, and runs. The user must pick the one to scan — never auto-select from repo name, branch, or URL heuristics.
 
-1. Call `muggle-remote-project-list`.
+The per-repo project cache lives at `<cwd>/.muggle-ai/last-project.json` (via the `muggle-local-last-project-get` / `muggle-local-last-project-set` MCP tools). Look for `Muggle Last Project: id=… url=… name="…"` in session context.
+
+Apply the `autoSelectProject` gate (see Preferences for the full 2-picker flow):
+- **`autoSelectProject = always`** with the `Muggle Last Project` line present → use that `projectId` silently. Skip both pickers and proceed to Step 3. If no cache line is present, fall through to `ask`.
+- **`autoSelectProject = never`** → always present the full project list; skip Picker 2 (memory).
+- **`autoSelectProject = ask` (or absent)** → present the project list (Picker 1), then offer Picker 2 only after a successful pick of an existing project (skip Picker 2 if user picked "Create new project"):
+  - Picker 2: `"Remember this? Next time I'll automatically reuse this project for this repo without asking. (preference: autoSelectProject = always)"`
+    - **"Yes, save it"** → make BOTH calls:
+      1. `muggle-local-preferences-set` with `key: "autoSelectProject"`, `value: "always"`, `scope: "global"`.
+      2. `muggle-local-last-project-set` with `cwd`, `projectId`, `projectUrl`, `projectName`.
+    - "No, just for this run" → continue without saving.
+
+### Logic
+
+1. Call `muggle-remote-project-list` (only when not satisfied by the `always` cache).
 2. Use `AskQuestion` to present projects as clickable options. Include the project URL in each label so the user can disambiguate. Always include "Create new project" as the last option.
 3. Wait for explicit selection.
 4. If the user picks "Create new project": collect `projectName`, `description`, and `url`, then call `muggle-remote-project-create`.

--- a/plugin/skills/muggle-test/SKILL.md
+++ b/plugin/skills/muggle-test/SKILL.md
@@ -34,25 +34,29 @@ Every test case verifies exactly **one** user-observable behavior. Never bundle 
 
 ## Preferences
 
-User preferences are available in the session context (injected at session start). Look for the line starting with `Muggle Preferences` — it contains key=value pairs like `autoLogin=ask showElectronBrowser=always ...`.
+User preferences are injected by the SessionStart hook into a `Muggle Preferences` line in session context (key=value pairs). Resolution: defaults → `~/.muggle-ai/preferences.json` (global) → `<repo>/.muggle-ai/preferences.json` (project). Treat absent prefs as `ask`.
 
-If no preferences line is present, treat all preferences as `"ask"`.
+**At every preference-gated step below**, apply this rule:
 
-When you reach a decision gated by a preference:
-- **`always`** → proceed without asking the user
-- **`never`** → skip without asking the user  
-- **`ask`** → ask the user, then offer: "Want me to remember this choice for future sessions?" If yes, call `muggle-local-preferences-set` with the key, their chosen value, and scope `global`.
+- `always` → perform the auto-action silently. **Skip both pickers.**
+- `never` → skip the action silently. **Skip both pickers.**
+- `ask` (or absent) → run the **2-picker flow**:
+  1. **Picker 1** (`AskQuestion`): the substantive choice for this step. Each option's value maps to either `always` or `never` (e.g. "Yes, continue" → `always`, "No, switch account" → `never`).
+  2. **Picker 2** (`AskQuestion`): `"Remember this? Next time I'll automatically <action description> without asking. (preference: <key> = <value>)"` with options:
+     - "Yes, save it"
+     - "No, just for this run"
+  3. On **"Yes, save it"** → call `muggle-local-preferences-set` with `key`, the value chosen in Picker 1, `scope: "global"`.
 
-This skill uses these preferences:
+The `<action description>` and the substantive options are step-specific — see each gated step below.
 
-| Preference | Decision it gates |
-|------------|------------------|
-| `autoLogin` | Reuse saved credentials when auth is required |
-| `autoSelectProject` | Reuse last-used Muggle project for this repo |
-| `autoDetectChanges` | Scan local git changes and map to affected test cases |
-| `defaultExecutionMode` | Default to local or remote test execution |
-| `autoPublishLocalResults` | Upload local results to Muggle cloud after run |
-| `postPRVisualWalkthrough` | Post visual walkthrough to PR after results are available |
+| Preference | Step | Decision it gates |
+|------------|------|-------------------|
+| `autoLogin` | 3 | Reuse saved credentials when auth is required |
+| `autoSelectProject` | 4 | Reuse last-used Muggle project for this repo |
+| `autoDetectChanges` | 2 | Scan local git changes and map to affected test cases |
+| `defaultExecutionMode` | 1 | Default to local or remote test execution |
+| `autoPublishLocalResults` | 7A | Upload local results to Muggle cloud after run |
+| `postPRVisualWalkthrough` | 9 | Post visual walkthrough to PR after results are available |
 
 ## Step 1: Confirm Scope of Work (Always First)
 
@@ -72,19 +76,41 @@ Signs the user wants this: mentions "localhost", "local", "my machine", "dev ser
 
 Signs the user wants this: mentions "preview", "staging", "deployed", "preview URL", "test on preview", "test the deployment", or provides a non-localhost URL.
 
-### Confirming
+### Confirming (gated by `defaultExecutionMode`)
 
-If the user's intent is clear, state back what you understood and use `AskQuestion` to confirm:
-- Option 1: "Yes, proceed"
-- Option 2: "Switch to [the other mode]"
+This preference uses a domain-specific value set: **`local`** / **`remote`** / **`ask`** (not `always`/`never`). Apply the gate:
 
-If ambiguous, use `AskQuestion` to let the user choose:
-- Option 1: "On my computer — test your localhost dev server in a browser on your machine"
-- Option 2: "In the cloud — test remotely targeting your deployed preview/staging URL"
+- **`defaultExecutionMode = local`** → proceed in Local mode silently. Skip both pickers.
+- **`defaultExecutionMode = remote`** → proceed in Remote mode silently. Skip both pickers.
+- **`defaultExecutionMode = ask` (or absent)** → run the 2-picker flow:
+  - **Picker 1** (`AskQuestion`):
+    - If the user's intent is clear, state back what you understood and confirm:
+      - "Yes, proceed" → use the inferred mode; this is a confirmation of a one-shot intent, **do NOT show Picker 2**.
+      - "Switch to [the other mode]" → use the other mode; correction, **do NOT show Picker 2**.
+    - If ambiguous, ask the user to pick the mode:
+      - "On my computer — test your localhost dev server in a browser on your machine" → maps to `defaultExecutionMode = local`
+      - "In the cloud — test remotely targeting your deployed preview/staging URL" → maps to `defaultExecutionMode = remote`
+  - **Picker 2** (`AskQuestion`, ambiguous-case only): `"Remember this? Next time I'll automatically run in <Local|Remote> mode without asking. (preference: defaultExecutionMode = <local|remote>)"`
+    - "Yes, save it" → call `muggle-local-preferences-set` with `key: "defaultExecutionMode"`, `value: "<local|remote>"`, `scope: "global"`.
+    - "No, just for this run" → continue without saving.
 
 Only proceed after the user selects an option.
 
-## Step 2: Detect Local Changes
+## Step 2: Detect Local Changes (gated by `autoDetectChanges`)
+
+See Preferences section for the full 2-picker flow.
+
+- **`autoDetectChanges = always`** → run the git scan automatically. Skip both pickers; continue to the analysis below.
+- **`autoDetectChanges = never`** → skip the git scan entirely. Ask the user directly: "What would you like to test?" Then jump to Step 3.
+- **`autoDetectChanges = ask` (or absent)** → run the 2-picker flow:
+  - **Picker 1** (`AskQuestion`): `"Scan local git changes to scope the test run?"`
+    - "Yes, scan changes" → maps to `autoDetectChanges = always`. Proceed with the analysis below.
+    - "No, I'll specify what to test" → maps to `autoDetectChanges = never`. Ask the user directly and jump to Step 3.
+  - **Picker 2** (`AskQuestion`): `"Remember this? Next time I'll automatically <scan local git changes | skip the scan and ask you> without asking. (preference: autoDetectChanges = <always|never>)"`
+    - "Yes, save it" → call `muggle-local-preferences-set` with `key: "autoDetectChanges"`, `value: "<always|never>"`, `scope: "global"`.
+    - "No, just for this run" → continue without saving.
+
+### Analysis (when scan is enabled)
 
 Analyze the working directory to understand what changed.
 
@@ -104,36 +130,60 @@ If no changes detected (clean tree), tell the user and ask what they want to tes
 ## Step 3: Authenticate
 
 1. Call `muggle-remote-auth-status`
-2. If **authenticated and not expired** → print the logged-in email and ask via `AskQuestion`:
-   > "You're logged in as **{email}**. Continue with this account?"
-   - Option 1: "Yes, continue"
-   - Option 2: "No, switch account"
-   If the user picks "switch account", call `muggle-remote-auth-login` with `forceNewSession: true`, then `muggle-remote-auth-poll`.
+2. If **authenticated and not expired** → **gated by `autoLogin`** (see Preferences section for the full 2-picker flow):
+   - **`autoLogin = always`** → continue with the saved session silently. Skip both pickers.
+   - **`autoLogin = never`** → call `muggle-remote-auth-login` with `forceNewSession: true`, then `muggle-remote-auth-poll`. Skip both pickers.
+   - **`autoLogin = ask` (or absent)** → run the 2-picker flow:
+     - **Picker 1**: `"You're logged in as {email}. Continue with this account?"`
+       - "Yes, continue" → maps to `autoLogin = always`. Proceed with the saved session.
+       - "No, switch account" → maps to `autoLogin = never`. Call `muggle-remote-auth-login` with `forceNewSession: true`, then `muggle-remote-auth-poll`.
+     - **Picker 2**: `"Remember this? Next time I'll automatically <reuse your saved login | force a fresh login> without asking. (preference: autoLogin = <always|never>)"`
+       - "Yes, save it" → call `muggle-local-preferences-set` with `key: "autoLogin"`, `value: "<always|never>"`, `scope: "global"`.
+       - "No, just for this run" → continue without saving.
 3. If **not authenticated or expired** → call `muggle-remote-auth-login`
 4. If login pending → call `muggle-remote-auth-poll`
 
 If auth fails repeatedly, suggest: `muggle logout && muggle login` from terminal.
 
-## Step 4: Select Project (User Must Choose)
+## Step 4: Select Project (gated by `autoSelectProject`)
 
 A **project** is where all your test results, use cases, and test scripts are grouped on the Muggle AI dashboard. Pick the project that matches what you're working on.
 
-1. Call `muggle-remote-project-list`
-2. Use `AskQuestion` to present all projects as clickable options. Include the project URL in each label so the user can identify the right one. Always include a "Create new project" option at the end.
+The per-repo cache lives at `<cwd>/.muggle-ai/last-project.json` (managed via the `muggle-local-last-project-get` / `muggle-local-last-project-set` MCP tools). Look for the `Muggle Last Project: id=… url=… name="…"` line in session context — if present, that's this repo's cached pick.
 
-   Example labels:
-   - "MUGGLE AI STAGING 1 — https://staging.muggle-ai.com/"
-   - "Tanka Testing — https://www.tanka.ai"
-   - "Create new project"
+Apply the gate (see Preferences for the standard 2-picker flow):
 
-   Prompt: "Pick the project to group this test run into:"
+- **`autoSelectProject = always`**:
+  - If the `Muggle Last Project` line is in session context → use that `projectId` silently. Skip both pickers and skip to Step 5. (Optionally call `muggle-local-last-project-get` with `cwd` to verify and re-fetch the URL/name if needed.)
+  - If no cache line is present → fall through to `ask` (the user has never picked one for this repo yet).
+- **`autoSelectProject = never`** → always present the full project list; skip Picker 2 (memory).
+- **`autoSelectProject = ask` (or absent)** → run the 2-picker flow:
+  - **Picker 1** (`AskQuestion`): present all projects as clickable options. Include the project URL in each label. Always include a "Create new project" option at the end.
 
-3. **Wait for the user to explicitly choose** — do NOT auto-select based on repo name or URL matching
+    Example labels:
+    - "MUGGLE AI STAGING 1 — https://staging.muggle-ai.com/"
+    - "Tanka Testing — https://www.tanka.ai"
+    - "Create new project"
+
+    Prompt: `"Pick the project to group this test run into:"`
+
+  - **Picker 2** (`AskQuestion`, only after a successful pick of an existing project — skip if user picked "Create new project"): `"Remember this? Next time I'll automatically reuse this project for this repo without asking. (preference: autoSelectProject = always)"`
+    - **"Yes, save it"** → make BOTH calls:
+      1. `muggle-local-preferences-set` with `key: "autoSelectProject"`, `value: "always"`, `scope: "global"`.
+      2. `muggle-local-last-project-set` with `cwd` (current working directory), `projectId`, `projectUrl`, `projectName`.
+      Both calls together establish the silent-reuse behavior for future sessions.
+    - **"No, just for this run"** → continue without saving.
+
+### Logic
+
+1. Resolve the chosen project per the gate above.
+2. Call `muggle-remote-project-list` only when the gate doesn't already give a `projectId` from the cache.
+3. **Wait for the user to explicitly choose** when presenting the picker — do NOT auto-select based on repo name or URL matching.
 4. **If user chooses "Create new project"**:
    - Ask for `projectName`, `description`, and the production/preview URL
    - Call `muggle-remote-project-create`
 
-Store the `projectId` only after user confirms.
+Store the `projectId` only after user confirms (or after silent reuse from the cache).
 
 ## Step 5: Select Use Case (Best-Effort Shortlist)
 
@@ -250,7 +300,21 @@ If a generation fails, log it and continue to the next. Do not abort the batch.
 
 For every `runId`, issue all `muggle-local-run-result-get` calls in parallel. Extract: status, duration, step count, `artifactsDir`.
 
-### Publish each run to cloud (in parallel)
+### Publish each run to cloud (gated by `autoPublishLocalResults`)
+
+See Preferences section for the full 2-picker flow.
+
+- **`autoPublishLocalResults = always`** → publish all runs silently. Skip both pickers; proceed to the publish logic below.
+- **`autoPublishLocalResults = never`** → skip publishing entirely. Skip both pickers; jump to the report summary. **Note**: Step 8 (open dashboard), Step 9 (PR walkthrough), and any per-step screenshot fetches that depend on cloud-side data will be unavailable. Tell the user.
+- **`autoPublishLocalResults = ask` (or absent)** → run the 2-picker flow:
+  - **Picker 1** (`AskQuestion`): `"Upload these local results to Muggle cloud? Required for the dashboard view, PR walkthrough, and team visibility."`
+    - "Yes, publish" → maps to `autoPublishLocalResults = always`. Proceed with the publish logic.
+    - "No, keep local-only" → maps to `autoPublishLocalResults = never`. Skip publishing.
+  - **Picker 2** (`AskQuestion`): `"Remember this? Next time I'll automatically <upload local results to Muggle cloud | keep results local-only> without asking. (preference: autoPublishLocalResults = <always|never>)"`
+    - "Yes, save it" → call `muggle-local-preferences-set` with `key: "autoPublishLocalResults"`, `value: "<always|never>"`, `scope: "global"`.
+    - "No, just for this run" → continue without saving.
+
+### Publish logic (when publishing is enabled)
 
 For every completed run, issue all `muggle-local-publish-test-script` calls in parallel (single message, multiple tool calls):
 - `runId`: The local run ID
@@ -377,18 +441,23 @@ Assemble the report:
 
 See the shared skill for the full schema (including the failed-test shape with `failureStepIndex` and `error`).
 
-### 9b: Ask the user
+### 9b: Ask the user (gated by `postPRVisualWalkthrough`)
 
-Use `AskQuestion`:
+See Preferences section for the full 2-picker flow.
 
-> "Post a visual walkthrough of these results to the PR? Reviewers can click each test case to see step-by-step screenshots on the Muggle AI dashboard."
-
-- Option 1: "Yes, post to PR"
-- Option 2: "Skip"
+- **`postPRVisualWalkthrough = always`** → proceed straight to 9c silently (post the walkthrough). Skip both pickers.
+- **`postPRVisualWalkthrough = never`** → skip the walkthrough silently. Stop here.
+- **`postPRVisualWalkthrough = ask` (or absent)** → run the 2-picker flow:
+  - **Picker 1** (`AskQuestion`): `"Post a visual walkthrough of these results to the PR? Reviewers can click each test case to see step-by-step screenshots on the Muggle AI dashboard."`
+    - "Yes, post to PR" → maps to `postPRVisualWalkthrough = always`. Proceed to 9c.
+    - "Skip" → maps to `postPRVisualWalkthrough = never`. Stop here.
+  - **Picker 2** (`AskQuestion`): `"Remember this? Next time I'll automatically <post the visual walkthrough | skip posting it> without asking. (preference: postPRVisualWalkthrough = <always|never>)"`
+    - "Yes, save it" → call `muggle-local-preferences-set` with `key: "postPRVisualWalkthrough"`, `value: "<always|never>"`, `scope: "global"`.
+    - "No, just for this run" → continue without saving.
 
 ### 9c: Invoke the shared skill in Mode A
 
-If the user chooses "Yes, post to PR", invoke the `muggle-pr-visual-walkthrough` skill via the `Skill` tool. With the `E2eReport` already in context, the skill will:
+If 9b resolved to "post" (either via `postPRVisualWalkthrough = always` or the user picking "Yes, post to PR"), invoke the `muggle-pr-visual-walkthrough` skill via the `Skill` tool. With the `E2eReport` already in context, the skill will:
 
 1. Call `muggle build-pr-section` to render the markdown block (fit-vs-overflow automatic)
 2. Find the PR via `gh pr view`

--- a/plugin/skills/muggle/SKILL.md
+++ b/plugin/skills/muggle/SKILL.md
@@ -9,20 +9,11 @@ Use this as the top-level Muggle command router.
 
 ## Preferences
 
-User preferences are available in the session context (injected at session start). Look for the line starting with `Muggle Preferences` — it contains key=value pairs like `autoLogin=ask showElectronBrowser=always ...`.
+User preferences are injected by the SessionStart hook into a `Muggle Preferences` line in session context (key=value pairs). Resolution: defaults → `~/.muggle-ai/preferences.json` (global) → `<repo>/.muggle-ai/preferences.json` (project). Treat absent prefs as `ask`.
 
-If no preferences line is present, treat all preferences as `"ask"`.
+This router skill itself does not gate any decision on a preference — it just routes user intent to a downstream skill. Each downstream skill consults its own preferences. For example, `checkForUpdates` is consulted by `muggle-status` (Check 4), not here.
 
-When you reach a decision gated by a preference:
-- **`always`** → proceed without asking the user
-- **`never`** → skip without asking the user  
-- **`ask`** → ask the user, then offer: "Want me to remember this choice for future sessions?" If yes, call `muggle-local-preferences-set` with the key, their chosen value, and scope `global`.
-
-This skill uses these preferences:
-
-| Preference | Decision it gates |
-|------------|------------------|
-| `checkForUpdates` | Check for newer Muggle version |
+If the user types "muggle" with no subcommand and you want to surface a contextual hint about the update-check pref, defer to `muggle-status` rather than reimplementing the gate in this router.
 
 ## Menu
 


### PR DESCRIPTION
## Summary

Three connected changes that make Muggle preferences fill organically as users
hit them, and add the storage that lets `autoSelectProject=always` actually
skip the project picker on repeat runs.

### 1. Organic 2-picker flow across 7 skills

Every preference-gated decision now uses two `AskQuestion` pickers:

- **Picker 1**: substantive choice (e.g. \"Continue as {email}?\" / \"Switch account\"). Each option maps to either `always` or `never`.
- **Picker 2**: contextual memory prompt — `\"Remember this? Next time I'll automatically <action> without asking. (preference: <key> = <value>)\"` → \"Yes, save it\" / \"No, just for this run\".

On \"Yes, save it\" the skill calls `muggle-local-preferences-set` with the chosen value at global scope. Replaces the previous generic \"Want me to remember this for future sessions?\" line that didn't tell the user *which* preference they were toggling.

Affects: `muggle-test`, `muggle-test-feature-local`, `muggle-test-import`, `muggle-test-regenerate-missing`, `muggle-status`, `muggle-pr-visual-walkthrough`, and the `muggle` router.

### 2. `muggle-preferences` bulk wizard rewrite

Switched from \"type \`set X to Y\`\" to a no-typing `AskUserQuestion` picker — three multi-select groups of 4 prefs + a scope picker. `defaultExecutionMode` is split into its own single-select question (Local / Remote / Ask each time) since it doesn't fit always/never semantics.

### 3. `defaultExecutionMode` schema fix (per-key allowed values)

The pref now accepts `local`/`remote`/`ask` instead of being shoehorned into `always`/`ask`/`never`. Implementation: `PREFERENCE_ALLOWED_VALUES` map in `preferences-constants.ts` + Zod `superRefine` on `PreferencesSetInputSchema`. Other 11 keys keep their `always`/`ask`/`never` set.

### 4. `autoSelectProject` storage layer

New per-repo cache at `<cwd>/.muggle-ai/last-project.json` (id + url + name + savedAt). Three new MCP tools: `muggle-local-last-project-get`, `-set`, `-clear`. `SessionStart` hook injects a `Muggle Last Project: id=… url=… name=\"…\"` line so skills can detect the cache without an extra round-trip. The 4 project-picking skills now write both the preference *and* the cache on \"Yes, save it\", and read the cache on subsequent runs to skip the picker silently when `autoSelectProject=always`.

## Verification

- `pnpm --filter @muggleai/mcp typecheck` — clean
- `pnpm --filter @muggleai/mcp test` — **99/99 passing** (added `last-project.test.ts`; updated `preferences.test.ts` for the new enum + per-key validation)

## Test plan

- [ ] Set `autoLogin = ask`, run `/muggle:muggle-test`, verify Picker 1 + Picker 2 appear with the preference key visible in Picker 2
- [ ] Pick \"Yes, save it\" → confirm `~/.muggle-ai/preferences.json` has `autoLogin: \"always\"`
- [ ] Re-run `/muggle:muggle-test` — Picker 1 should not appear (silent reuse)
- [ ] Run `/muggle:muggle-preferences` → verify wizard uses the picker UI and `defaultExecutionMode` shows Local/Remote/Ask options (not always/never)
- [ ] Pick a project and \"Yes, save it\" → verify `<repo>/.muggle-ai/last-project.json` is created
- [ ] Restart Claude Code session → verify `Muggle Last Project: …` line appears in session context
- [ ] Re-run a project-picking skill — should skip the project picker silently

## Out of scope

- `IPreferences` type-level looseness (`Record<PreferenceKey, PreferenceValue>` allows any value for any key at the type level; runtime validation catches it). Tightening would require per-key types — deferred.
- A migration path for any pre-existing `defaultExecutionMode = always` entries. None should exist in the wild yet (the pref system is recent and `defaultExecutionMode` was previously only documented, not exercised).

🤖 Generated with [Claude Code](https://claude.com/claude-code)