### PR TITLE
chore(release): @muggleai/works 4.10.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.9.2"
+      "version": "4.10.0"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.9.2"
+      "version": "4.10.0"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@muggleai/works",
     "mcpName": "io.github.multiplex-ai/muggle",
-    "version": "4.9.2",
+    "version": "4.10.0",
     "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
     "type": "module",
     "main": "dist/index.js",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "4.9.2",
+  "version": "4.10.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "4.9.2",
+  "version": "4.10.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "4.9.2",
+  "version": "4.10.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "4.9.2",
+      "version": "4.10.0",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
## Summary

- feat(preferences): organic 2-picker flow + last-project cache + defaultExecutionMode schema (#106)
- docs(skills): centralize preference gate prompts (#108)
- docs(skills): refactor preference gate UX and centralize execution (#111)
- chore(deps): bump production-dependencies group with 3 updates (#107)
- chore(deps): bump pnpm/action-setup from 5 to 6 (#101)
- chore(deps-dev): bump dev-dependencies group with 5 updates (#105)

## Version delta

`4.9.2` -> `4.10.0` (minor)

## Electron

Unchanged at `1.0.61` (latest on GitHub is `1.0.75` -- intentionally not bumped this release).

## Manifests touched by sync:versions

- `.claude-plugin/marketplace.json`
- `.cursor-plugin/marketplace.json`
- `plugin/.claude-plugin/plugin.json`
- `plugin/.cursor-plugin/plugin.json`
- `server.json`

## Test plan

- [x] `pnpm run lint:check` -- passed
- [x] `pnpm run typecheck` -- passed
- [x] `pnpm test` -- 48/48 passed
- [x] `pnpm run build` -- success
- [x] `pnpm run verify:plugin` -- passed
- [x] `pnpm run verify:contracts` -- passed
- [x] `pnpm run verify:electron-release-checksums` -- passed (electron-app-v1.0.61)