### PR TITLE
fix(mcp): resolve electron-app path on every call

### DIFF
--- a/packages/mcps/src/mcp/local/services/execution-service.ts
+++ b/packages/mcps/src/mcp/local/services/execution-service.ts
@@ -13,7 +13,12 @@ import * as fs from "fs/promises";
 import * as os from "node:os";
 import * as path from "path";
 
-import { getConfig, getElectronAppDir, getElectronAppVersion } from "../../../shared/config.js";
+import {
+  getConfig,
+  getElectronAppDir,
+  getElectronAppVersion,
+  resolveElectronAppPathOrNull,
+} from "../../../shared/config.js";
 import { getLogger } from "../../../shared/logger.js";
 import type { TestCaseDetails, TestScriptDetails } from "../contracts/project-schemas.js";
 import { getAuthService, getRunResultStorageService, getStorageService } from "./index.js";
@@ -294,39 +299,42 @@ async function writeExecutionLogs(params: {
 }
 
 /**
- * Resolve the electron-app binary path from config.
+ * Resolve the electron-app binary path on every call.
+ *
+ * Re-resolves from the filesystem each invocation so a long-running MCP
+ * server picks up `muggle upgrade` / `muggle setup` changes without a
+ * process restart.
+ *
  * Throws a detailed error if the binary cannot be found.
  */
 function getElectronAppPathOrThrow(): string {
-  const config = getConfig();
-  const electronAppPath = config.localQa.electronAppPath;
-
-  if (!electronAppPath || electronAppPath.trim() === "") {
-    const version = getElectronAppVersion();
-    const versionDir = getElectronAppDir(version);
-    const envPath = process.env.ELECTRON_APP_PATH;
-
-    const errorLines = [
-      "Electron app binary not found.",
-      "",
-      `  Expected version: ${version}`,
-      `  Checked directory: ${versionDir}`,
-    ];
-
-    if (envPath) {
-      errorLines.push(`  ELECTRON_APP_PATH: ${envPath} (not found or invalid)`);
-    } else {
-      errorLines.push("  ELECTRON_APP_PATH: (not set)");
-    }
-
-    errorLines.push("");
-    errorLines.push("To fix this, run: muggle setup");
-    errorLines.push("Or set ELECTRON_APP_PATH to the path of the MuggleAI executable.");
-
-    throw new Error(errorLines.join("\n"));
+  const electronAppPath = resolveElectronAppPathOrNull();
+  if (electronAppPath && electronAppPath.trim() !== "") {
+    return electronAppPath;
   }
 
-  return electronAppPath;
+  const version = getElectronAppVersion();
+  const versionDir = getElectronAppDir(version);
+  const envPath = process.env.ELECTRON_APP_PATH;
+
+  const errorLines = [
+    "Electron app binary not found.",
+    "",
+    `  Expected version: ${version}`,
+    `  Checked directory: ${versionDir}`,
+  ];
+
+  if (envPath) {
+    errorLines.push(`  ELECTRON_APP_PATH: ${envPath} (not found or invalid)`);
+  } else {
+    errorLines.push("  ELECTRON_APP_PATH: (not set)");
+  }
+
+  errorLines.push("");
+  errorLines.push("To fix this, run: muggle setup");
+  errorLines.push("Or set ELECTRON_APP_PATH to the path of the MuggleAI executable.");
+
+  throw new Error(errorLines.join("\n"));
 }
 
 /**

--- a/packages/mcps/src/mcp/local/types/config-types.ts
+++ b/packages/mcps/src/mcp/local/types/config-types.ts
@@ -18,8 +18,6 @@ export interface ILocalQaConfig {
   tempDir: string;
   /** OAuth session file path (OAuth tokens with refresh). */
   oauthSessionFilePath: string;
-  /** Electron app path. */
-  electronAppPath?: string;
   /** Web service URL. */
   webServiceUrl: string;
   /** Prompt service URL. */

--- a/packages/mcps/src/shared/config.ts
+++ b/packages/mcps/src/shared/config.ts
@@ -253,9 +253,13 @@ function getSystemElectronAppPath(): string | null {
 
 /**
  * Resolve the electron-app executable path if available.
+ *
+ * Resolves from the filesystem on every call — no caching. Long-running MCP
+ * servers must pick up `muggle upgrade` / `muggle setup` changes without
+ * needing a process restart.
  * @returns The path to the electron-app executable, or null when not installed.
  */
-function resolveElectronAppPathOrNull(): string | null {
+export function resolveElectronAppPathOrNull(): string | null {
   // 1. Check environment override
   const customPath = process.env.ELECTRON_APP_PATH;
   if (customPath && fs.existsSync(customPath)) {
@@ -442,7 +446,6 @@ function buildLocalQaConfig(): ILocalQaConfig {
     tempDir: path.join(dataDir, "temp"),
     apiKeyFilePath: path.join(dataDir, API_KEY_FILE),
     oauthSessionFilePath: path.join(dataDir, "oauth-session.json"),
-    electronAppPath: resolveElectronAppPathOrNull(),
     webServicePath: resolveWebServicePath(),
     webServicePidFile: path.join(dataDir, "web-service.pid"),
     auth0: {

--- a/packages/mcps/src/shared/types.ts
+++ b/packages/mcps/src/shared/types.ts
@@ -94,8 +94,6 @@ export interface ILocalQaConfig {
   apiKeyFilePath: string;
   /** Path to OAuth session file (OAuth tokens with refresh). */
   oauthSessionFilePath: string;
-  /** Path to electron-app executable (null if not installed). */
-  electronAppPath: string | null;
   /** Path to web-service entry point (null if not found). */
   webServicePath: string | null;
   /** Path to web-service PID file. */


### PR DESCRIPTION
## Summary

- The MCP server cached the resolved electron-app binary path in `muggleConfigCache.localQa.electronAppPath` at first config read. When `muggle upgrade` / `muggle setup` later changed the binary on disk, the cache stayed and `getElectronAppPathOrThrow` kept reporting *"Electron app binary not found"* until the long-running MCP process was restarted.
- Resolve from the filesystem on every call. Cost is one `fs.existsSync` per spawn — negligible vs launching Electron. `resolveElectronAppPathOrNull` is now exported and called directly from `getElectronAppPathOrThrow`.
- Drops `electronAppPath` from `ILocalQaConfig` (shared) and from the duplicate `local/types/config-types.ts` interface. The path no longer belongs in cached config.

## Repro that motivated this

1. MCP server connects with binary missing on disk → cache pins `electronAppPath: null`.
2. `muggle upgrade` installs the binary at the expected path.
3. Any `muggle-local-execute-test-generation` call still throws "binary not found" — only a full Claude Code quit+reopen unblocks the user.

After this change, step 3 succeeds without restart.

## Out of scope

- The CLI `muggle setup --force` static-checksum bug surfaced during the same session (expected `987d…` vs real `1eda…` for Electron 1.0.75) is unrelated and tracked separately.
- A CLI npm package bump (e.g. 4.9 → 4.10) still requires a Claude Code restart — that's a Node fundamental (loaded code doesn't reload), not a caching choice.

## Test plan

- [x] `pnpm typecheck` (root) — clean
- [x] `pnpm --filter @muggleai/mcp typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` (root) — 48/48 pass
- [x] `pnpm --filter @muggleai/mcp test` — 70/70 pass
- [ ] Manual repro on a fresh checkout: missing binary → run upgrade → execute test without restarting Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)