### PR TITLE
feat(localDevHost): MCP cache tools + skill wiring

### DIFF
--- a/packages/mcps/src/mcp/contracts/muggle-entity-id-schema.ts
+++ b/packages/mcps/src/mcp/contracts/muggle-entity-id-schema.ts
@@ -1,5 +1,5 @@
 /**
- * Shared Zod schema for Muggle entity identifiers stored as UUIDs.
+ * Shared Zod schema for Muggle Test entity identifiers stored as UUIDs.
  *
  * Used for cloud resource IDs (projects, use cases, test cases, scripts, secrets, workflows)
  * and for local run-result / test-script record filenames (randomUUID).
@@ -8,6 +8,6 @@
 import { z } from "zod";
 
 /**
- * UUID string schema — single source of truth for Muggle ID validation across MCP contracts.
+ * UUID string schema — single source of truth for Muggle Test ID validation across MCP contracts.
  */
 export const MuggleEntityIdSchema = z.string().uuid();

--- a/packages/mcps/src/mcp/local/contracts/index.ts
+++ b/packages/mcps/src/mcp/local/contracts/index.ts
@@ -7,3 +7,4 @@ export * from "./project-schemas.js";
 export * from "./session-schemas.js";
 export * from "./preferences-schemas.js";
 export * from "./last-project-schemas.js";
+export * from "./last-host-schemas.js";

--- a/packages/mcps/src/mcp/local/contracts/last-host-schemas.ts
+++ b/packages/mcps/src/mcp/local/contracts/last-host-schemas.ts
@@ -1,0 +1,22 @@
+/** Zod schemas for last-host cache MCP tools. */
+
+import { z } from "zod";
+
+export const LastHostGetInputSchema = z.object({
+  cwd: z.string().describe("Project root directory whose last-used host to return."),
+});
+
+export type LastHostGetInput = z.infer<typeof LastHostGetInputSchema>;
+
+export const LastHostSetInputSchema = z.object({
+  cwd: z.string().describe("Project root directory to save the cached host to."),
+  host: z.string().min(1).describe("Local dev server URL (e.g. http://localhost:3000)."),
+});
+
+export type LastHostSetInput = z.infer<typeof LastHostSetInputSchema>;
+
+export const LastHostClearInputSchema = z.object({
+  cwd: z.string().describe("Project root directory whose last-used host cache to remove."),
+});
+
+export type LastHostClearInput = z.infer<typeof LastHostClearInputSchema>;

--- a/packages/mcps/src/mcp/local/contracts/last-project-schemas.ts
+++ b/packages/mcps/src/mcp/local/contracts/last-project-schemas.ts
@@ -18,9 +18,9 @@ export const LastProjectSetInputSchema = z.object({
   cwd: z
     .string()
     .describe("Project root directory to save the cached project to."),
-  projectId: z.string().min(1).describe("Muggle project ID."),
-  projectUrl: z.string().min(1).describe("Muggle project URL."),
-  projectName: z.string().min(1).describe("Muggle project name."),
+  projectId: z.string().min(1).describe("Muggle Test project ID."),
+  projectUrl: z.string().min(1).describe("Muggle Test project URL."),
+  projectName: z.string().min(1).describe("Muggle Test project name."),
 });
 
 export type LastProjectSetInput = z.infer<typeof LastProjectSetInputSchema>;

--- a/packages/mcps/src/mcp/tools/local/tool-registry.ts
+++ b/packages/mcps/src/mcp/tools/local/tool-registry.ts
@@ -727,7 +727,7 @@ const lastHostGetTool: ILocalMcpTool = {
   description:
     "Get the cached last-used local dev server URL for a repo (read from <cwd>/.muggle-ai/last-host.json). " +
     "Returns the URL and saved-at timestamp, or null if no cache exists. " +
-    "Skills consult this when 'localDevHost = always' to silently reuse the URL the user used previously.",
+    "Skills consult this when 'autoSelectLocalHost = always' to silently reuse the URL the user used previously.",
   inputSchema: LastHostGetInputSchema,
   execute: async (ctx) => {
     const logger = createChildLogger(ctx.correlationId);
@@ -760,7 +760,7 @@ const lastHostSetTool: ILocalMcpTool = {
   description:
     "Save the user's chosen local dev server URL as the cached last-used host for this repo. " +
     "Writes to <cwd>/.muggle-ai/last-host.json. Call this on every host pick (independent of 'Remember this URL?' Picker 2) " +
-    "so future runs can offer 'Use {lastHost}' regardless of whether the user opted to set localDevHost=always.",
+    "so future runs can offer 'Use {lastHost}' regardless of whether the user opted to set autoSelectLocalHost=always.",
   inputSchema: LastHostSetInputSchema,
   execute: async (ctx) => {
     const logger = createChildLogger(ctx.correlationId);
@@ -779,7 +779,7 @@ const lastHostSetTool: ILocalMcpTool = {
 const lastHostClearTool: ILocalMcpTool = {
   name: "muggle-local-last-host-clear",
   description:
-    "Remove the cached last-used host for this repo. After this, `localDevHost = always` will fall through to ask " +
+    "Remove the cached last-used host for this repo. After this, `autoSelectLocalHost = always` will fall through to ask " +
     "until the user picks a new URL. No-op if no cache exists.",
   inputSchema: LastHostClearInputSchema,
   execute: async (ctx) => {

--- a/packages/mcps/src/mcp/tools/local/tool-registry.ts
+++ b/packages/mcps/src/mcp/tools/local/tool-registry.ts
@@ -632,7 +632,7 @@ const preferencesSetTool: ILocalMcpTool = {
 const lastProjectGetTool: ILocalMcpTool = {
   name: "muggle-local-last-project-get",
   description:
-    "Get the cached last-used Muggle project for a repo (read from <cwd>/.muggle-ai/last-project.json). " +
+    "Get the cached last-used Muggle Test project for a repo (read from <cwd>/.muggle-ai/last-project.json). " +
     "Returns the project ID, URL, name, and saved-at timestamp, or null if no cache exists. " +
     "Skills consult this when 'autoSelectProject = always' to silently reuse the project the user picked previously, instead of presenting the project picker every time.",
   inputSchema: LastProjectGetInputSchema,
@@ -669,7 +669,7 @@ const lastProjectGetTool: ILocalMcpTool = {
 const lastProjectSetTool: ILocalMcpTool = {
   name: "muggle-local-last-project-set",
   description:
-    "Save the user's selected Muggle project as the cached last-used project for this repo. " +
+    "Save the user's selected Muggle Test project as the cached last-used project for this repo. " +
     "Writes to <cwd>/.muggle-ai/last-project.json. Subsequent skill invocations honor 'autoSelectProject = always' " +
     "by silently reusing this entry — no project picker shown. Always pair this call with " +
     "'muggle-local-preferences-set autoSelectProject=always' when the user chose 'Yes, save it'.",
@@ -822,7 +822,7 @@ export const allLocalQaTools: ILocalMcpTool[] = [
   publishTestScriptTool,
   // Preferences tools
   preferencesSetTool,
-  // Last-project cache tools (per-repo "last used Muggle project")
+  // Last-project cache tools (per-repo "last used Muggle Test project")
   lastProjectGetTool,
   lastProjectSetTool,
   lastProjectClearTool,

--- a/packages/mcps/src/mcp/tools/local/tool-registry.ts
+++ b/packages/mcps/src/mcp/tools/local/tool-registry.ts
@@ -28,6 +28,9 @@ import {
   LastProjectGetInputSchema,
   LastProjectSetInputSchema,
   LastProjectClearInputSchema,
+  LastHostGetInputSchema,
+  LastHostSetInputSchema,
+  LastHostClearInputSchema,
 } from "../../local/contracts/index.js";
 import { writePreferences } from "../../../shared/preferences.js";
 import {
@@ -36,6 +39,12 @@ import {
   clearLastProject,
   LAST_PROJECT_FILE_NAME,
 } from "../../../shared/last-project.js";
+import {
+  readLastHost,
+  writeLastHost,
+  clearLastHost,
+  LAST_HOST_FILE_NAME,
+} from "../../../shared/last-host.js";
 import {
   cancelExecution,
   executeReplay,
@@ -710,6 +719,84 @@ const lastProjectClearTool: ILocalMcpTool = {
 };
 
 // ========================================
+// Last-Host Cache Tools
+// ========================================
+
+const lastHostGetTool: ILocalMcpTool = {
+  name: "muggle-local-last-host-get",
+  description:
+    "Get the cached last-used local dev server URL for a repo (read from <cwd>/.muggle-ai/last-host.json). " +
+    "Returns the URL and saved-at timestamp, or null if no cache exists. " +
+    "Skills consult this when 'localDevHost = always' to silently reuse the URL the user used previously.",
+  inputSchema: LastHostGetInputSchema,
+  execute: async (ctx) => {
+    const logger = createChildLogger(ctx.correlationId);
+    logger.info("Executing muggle-local-last-host-get");
+
+    const input = LastHostGetInputSchema.parse(ctx.input);
+    const cached = readLastHost(input.cwd);
+
+    if (!cached) {
+      const content = [
+        "No cached last-used host for this repo.",
+        "",
+        `Looked at: \`${input.cwd}/.muggle-ai/${LAST_HOST_FILE_NAME}\``,
+      ].join("\n");
+      return { content: content, isError: false };
+    }
+
+    const content = [
+      "**Cached last-used host:**",
+      "",
+      `- URL: ${cached.host}`,
+      `- Saved at: ${cached.savedAt}`,
+    ].join("\n");
+    return { content: content, isError: false };
+  },
+};
+
+const lastHostSetTool: ILocalMcpTool = {
+  name: "muggle-local-last-host-set",
+  description:
+    "Save the user's chosen local dev server URL as the cached last-used host for this repo. " +
+    "Writes to <cwd>/.muggle-ai/last-host.json. Call this on every host pick (independent of 'Remember this URL?' Picker 2) " +
+    "so future runs can offer 'Use {lastHost}' regardless of whether the user opted to set localDevHost=always.",
+  inputSchema: LastHostSetInputSchema,
+  execute: async (ctx) => {
+    const logger = createChildLogger(ctx.correlationId);
+    logger.info("Executing muggle-local-last-host-set");
+
+    const input = LastHostSetInputSchema.parse(ctx.input);
+    writeLastHost(input.cwd, input.host);
+
+    return {
+      content: `Cached **${input.host}** as the last-used host for this repo.`,
+      isError: false,
+    };
+  },
+};
+
+const lastHostClearTool: ILocalMcpTool = {
+  name: "muggle-local-last-host-clear",
+  description:
+    "Remove the cached last-used host for this repo. After this, `localDevHost = always` will fall through to ask " +
+    "until the user picks a new URL. No-op if no cache exists.",
+  inputSchema: LastHostClearInputSchema,
+  execute: async (ctx) => {
+    const logger = createChildLogger(ctx.correlationId);
+    logger.info("Executing muggle-local-last-host-clear");
+
+    const input = LastHostClearInputSchema.parse(ctx.input);
+    clearLastHost(input.cwd);
+
+    return {
+      content: `Cleared the cached last-used host for this repo.`,
+      isError: false,
+    };
+  },
+};
+
+// ========================================
 // All Tools Registry
 // ========================================
 
@@ -739,6 +826,10 @@ export const allLocalQaTools: ILocalMcpTool[] = [
   lastProjectGetTool,
   lastProjectSetTool,
   lastProjectClearTool,
+  // Last-host cache tools (per-repo "last used local dev server URL")
+  lastHostGetTool,
+  lastHostSetTool,
+  lastHostClearTool,
 ];
 
 /**

--- a/packages/mcps/src/shared/last-host.ts
+++ b/packages/mcps/src/shared/last-host.ts
@@ -71,5 +71,5 @@ export function formatLastHostOneLiner(cwd: string): string {
   if (!cached) {
     return "";
   }
-  return `Muggle Last Host: ${cached.host}`;
+  return `Muggle Test Last Host: ${cached.host}`;
 }

--- a/packages/mcps/src/shared/last-host.ts
+++ b/packages/mcps/src/shared/last-host.ts
@@ -1,7 +1,7 @@
 /**
  * Per-repo last-used local dev server URL cache.
  *
- * Lives at `<repo>/.muggle-ai/last-host.json`. Honors `localDevHost = always`:
+ * Lives at `<repo>/.muggle-ai/last-host.json`. Honors `autoSelectLocalHost = always`:
  * when set, skills silently reuse the URL the user used last time in this repo
  * instead of prompting again. Cache is updated on every pick — independent of
  * the "Remember this URL?" Picker 2 — so `Use {lastHost}` always shows the

--- a/packages/mcps/src/shared/last-host.ts
+++ b/packages/mcps/src/shared/last-host.ts
@@ -1,0 +1,75 @@
+/**
+ * Per-repo last-used local dev server URL cache.
+ *
+ * Lives at `<repo>/.muggle-ai/last-host.json`. Honors `localDevHost = always`:
+ * when set, skills silently reuse the URL the user used last time in this repo
+ * instead of prompting again. Cache is updated on every pick — independent of
+ * the "Remember this URL?" Picker 2 — so `Use {lastHost}` always shows the
+ * most recent run's URL.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { getLogger } from "./logger.js";
+
+export const LAST_HOST_FILE_NAME = "last-host.json";
+export const LAST_HOST_DIR_NAME = ".muggle-ai";
+export const LAST_HOST_VERSION = 1;
+
+export interface ILastHost {
+  host: string;
+  savedAt: string;
+}
+
+export interface ILastHostFile {
+  version: number;
+  lastHost: ILastHost;
+}
+
+/** Read the cached last host. Null if missing or unparseable. */
+export function readLastHost(cwd: string): ILastHost | null {
+  const filePath = path.join(cwd, LAST_HOST_DIR_NAME, LAST_HOST_FILE_NAME);
+  try {
+    if (!fs.existsSync(filePath)) {
+      return null;
+    }
+    const raw = JSON.parse(fs.readFileSync(filePath, "utf-8")) as ILastHostFile;
+    return raw.lastHost ?? null;
+  } catch (error) {
+    getLogger().warn("Failed to read last-host file", {
+      path: filePath,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+/** Write the cached last host. Creates the `.muggle-ai/` dir if needed. */
+export function writeLastHost(cwd: string, host: string): void {
+  const dir = path.join(cwd, LAST_HOST_DIR_NAME);
+  fs.mkdirSync(dir, { recursive: true });
+  const filePath = path.join(dir, LAST_HOST_FILE_NAME);
+  const file: ILastHostFile = {
+    version: LAST_HOST_VERSION,
+    lastHost: { host, savedAt: new Date().toISOString() },
+  };
+  fs.writeFileSync(filePath, `${JSON.stringify(file, null, 2)}\n`, "utf-8");
+}
+
+/** Remove the cached last host. No-op if missing. */
+export function clearLastHost(cwd: string): void {
+  const filePath = path.join(cwd, LAST_HOST_DIR_NAME, LAST_HOST_FILE_NAME);
+  if (fs.existsSync(filePath)) {
+    fs.unlinkSync(filePath);
+  }
+}
+
+/** Compact one-liner for session context. Empty string if no cache. */
+export function formatLastHostOneLiner(cwd: string): string {
+  const cached = readLastHost(cwd);
+  if (!cached) {
+    return "";
+  }
+  return `Muggle Last Host: ${cached.host}`;
+}

--- a/packages/mcps/src/shared/last-project.ts
+++ b/packages/mcps/src/shared/last-project.ts
@@ -1,12 +1,12 @@
 /**
- * Per-repo last-used Muggle project cache.
+ * Per-repo last-used Muggle Test project cache.
  *
  * Stored at `<repo>/.muggle-ai/last-project.json`. Honors the
  * `autoSelectProject = always` preference: when set, skills can silently reuse
  * the project that the user most recently picked for this repo, instead of
  * presenting the project picker every time.
  *
- * Skills consume this via the `Muggle Last Project` line injected into session
+ * Skills consume this via the `Muggle Test Last Project` line injected into session
  * context by the SessionStart hook (zero tokens). MCP tools import this module
  * directly (zero tokens).
  */
@@ -102,5 +102,5 @@ export function formatLastProjectOneLiner(cwd: string): string {
     return "";
   }
   const safeName = cached.projectName.replace(/"/g, '\\"');
-  return `Muggle Last Project: id=${cached.projectId} url=${cached.projectUrl} name="${safeName}"`;
+  return `Muggle Test Last Project: id=${cached.projectId} url=${cached.projectUrl} name="${safeName}"`;
 }

--- a/packages/mcps/src/shared/preferences-constants.ts
+++ b/packages/mcps/src/shared/preferences-constants.ts
@@ -22,7 +22,7 @@ export const PREFERENCES_VERSION = 1;
 export const DEFAULT_PREFERENCES: IPreferences = {
   [PreferenceKey.AutoLogin]: PreferenceValue.Ask,
   [PreferenceKey.AutoSelectProject]: PreferenceValue.Ask,
-  [PreferenceKey.LocalDevHost]: PreferenceValue.Ask,
+  [PreferenceKey.AutoSelectLocalHost]: PreferenceValue.Ask,
   [PreferenceKey.ShowElectronBrowser]: PreferenceValue.Ask,
   [PreferenceKey.OpenTestResultsAfterRun]: PreferenceValue.Ask,
   [PreferenceKey.DefaultExecutionMode]: PreferenceValue.Ask,
@@ -55,7 +55,7 @@ const LOCAL_REMOTE_ASK = [
 export const PREFERENCE_ALLOWED_VALUES: Record<PreferenceKey, readonly PreferenceValue[]> = {
   [PreferenceKey.AutoLogin]: ALWAYS_ASK_NEVER,
   [PreferenceKey.AutoSelectProject]: ALWAYS_ASK_NEVER,
-  [PreferenceKey.LocalDevHost]: ALWAYS_ASK_NEVER,
+  [PreferenceKey.AutoSelectLocalHost]: ALWAYS_ASK_NEVER,
   [PreferenceKey.ShowElectronBrowser]: ALWAYS_ASK_NEVER,
   [PreferenceKey.OpenTestResultsAfterRun]: ALWAYS_ASK_NEVER,
   [PreferenceKey.DefaultExecutionMode]: LOCAL_REMOTE_ASK,
@@ -76,7 +76,7 @@ export const PREFERENCES_SCHEMA: Record<PreferenceKey, IPreferenceSchemaEntry> =
   [PreferenceKey.AutoSelectProject]: {
     description: "When a skill needs a Muggle Test project and one was used previously in this repo, reuse it without prompting",
   },
-  [PreferenceKey.LocalDevHost]: {
+  [PreferenceKey.AutoSelectLocalHost]: {
     description: "When running local tests, reuse the dev server URL from the previous run in this repo without prompting",
   },
   [PreferenceKey.ShowElectronBrowser]: {

--- a/packages/mcps/src/shared/preferences-constants.ts
+++ b/packages/mcps/src/shared/preferences-constants.ts
@@ -74,7 +74,7 @@ export const PREFERENCES_SCHEMA: Record<PreferenceKey, IPreferenceSchemaEntry> =
     description: "When a tool requires auth and saved credentials exist, reuse them without prompting",
   },
   [PreferenceKey.AutoSelectProject]: {
-    description: "When a skill needs a Muggle project and one was used previously in this repo, reuse it without prompting",
+    description: "When a skill needs a Muggle Test project and one was used previously in this repo, reuse it without prompting",
   },
   [PreferenceKey.LocalDevHost]: {
     description: "When running local tests, reuse the dev server URL from the previous run in this repo without prompting",
@@ -83,13 +83,13 @@ export const PREFERENCES_SCHEMA: Record<PreferenceKey, IPreferenceSchemaEntry> =
     description: "When running local E2E tests, show the Electron browser window",
   },
   [PreferenceKey.OpenTestResultsAfterRun]: {
-    description: "After a local E2E test run completes, open the per-run results page on Muggle dashboard",
+    description: "After a local E2E test run completes, open the per-run results page on Muggle Test dashboard",
   },
   [PreferenceKey.DefaultExecutionMode]: {
     description: "When a skill supports both local and remote test execution, which to default to",
   },
   [PreferenceKey.AutoPublishLocalResults]: {
-    description: "After a local E2E test run completes, upload results to Muggle cloud for team visibility",
+    description: "After a local E2E test run completes, upload results to Muggle Test cloud for team visibility",
   },
   [PreferenceKey.SuggestRelatedUseCases]: {
     description: "After creating or running a use case, suggest related use cases to add",
@@ -104,7 +104,7 @@ export const PREFERENCES_SCHEMA: Record<PreferenceKey, IPreferenceSchemaEntry> =
     description: "After test results are available, post visual walkthrough comment with screenshots to the PR",
   },
   [PreferenceKey.CheckForUpdates]: {
-    description: "At session start, check if a newer Muggle version is available and notify",
+    description: "At session start, check if a newer Muggle Test version is available and notify",
   },
   [PreferenceKey.VerboseOutput]: {
     description: "Show detailed progress logs during skill and tool execution",

--- a/packages/mcps/src/shared/preferences-types.ts
+++ b/packages/mcps/src/shared/preferences-types.ts
@@ -8,17 +8,17 @@
 export enum PreferenceKey {
   /** Reuse saved credentials when a tool requires auth. */
   AutoLogin = "autoLogin",
-  /** Reuse the last-used Muggle project for this repo. */
+  /** Reuse the last-used Muggle Test project for this repo. */
   AutoSelectProject = "autoSelectProject",
   /** Reuse the last-used local dev server URL for this repo. */
   LocalDevHost = "localDevHost",
   /** Show the Electron browser window during local E2E tests. */
   ShowElectronBrowser = "showElectronBrowser",
-  /** Open the per-run results page on Muggle dashboard after local test completion. */
+  /** Open the per-run results page on Muggle Test dashboard after local test completion. */
   OpenTestResultsAfterRun = "openTestResultsAfterRun",
   /** Default to local or remote test execution. */
   DefaultExecutionMode = "defaultExecutionMode",
-  /** Upload local test results to Muggle cloud for team visibility. */
+  /** Upload local test results to Muggle Test cloud for team visibility. */
   AutoPublishLocalResults = "autoPublishLocalResults",
   /** Suggest related use cases after creating or running one. */
   SuggestRelatedUseCases = "suggestRelatedUseCases",
@@ -28,7 +28,7 @@ export enum PreferenceKey {
   AutoDetectChanges = "autoDetectChanges",
   /** Post visual walkthrough comment with screenshots to the PR. */
   PostPRVisualWalkthrough = "postPRVisualWalkthrough",
-  /** Check for newer Muggle versions at session start. */
+  /** Check for newer Muggle Test versions at session start. */
   CheckForUpdates = "checkForUpdates",
   /** Show detailed progress logs during execution. */
   VerboseOutput = "verboseOutput",
@@ -51,7 +51,7 @@ export enum PreferenceValue {
   Never = "never",
   /** For DefaultExecutionMode: always run tests on the local Electron browser. */
   Local = "local",
-  /** For DefaultExecutionMode: always run tests in the Muggle cloud. */
+  /** For DefaultExecutionMode: always run tests in the Muggle Test cloud. */
   Remote = "remote",
 }
 

--- a/packages/mcps/src/shared/preferences-types.ts
+++ b/packages/mcps/src/shared/preferences-types.ts
@@ -11,7 +11,7 @@ export enum PreferenceKey {
   /** Reuse the last-used Muggle Test project for this repo. */
   AutoSelectProject = "autoSelectProject",
   /** Reuse the last-used local dev server URL for this repo. */
-  LocalDevHost = "localDevHost",
+  AutoSelectLocalHost = "autoSelectLocalHost",
   /** Show the Electron browser window during local E2E tests. */
   ShowElectronBrowser = "showElectronBrowser",
   /** Open the per-run results page on Muggle Test dashboard after local test completion. */

--- a/packages/mcps/src/shared/types.ts
+++ b/packages/mcps/src/shared/types.ts
@@ -17,7 +17,7 @@ export interface IMuggleConfigChecksums {
 }
 
 /**
- * Muggle config from package.json.
+ * Muggle Test config from package.json.
  */
 export interface IMuggleConfig {
   /** Electron app version. */

--- a/packages/mcps/src/test/last-host.test.ts
+++ b/packages/mcps/src/test/last-host.test.ts
@@ -100,7 +100,7 @@ describe("last-host cache", () => {
     it("formats a one-liner suitable for session context", () => {
       writeLastHost(projectDir, "http://localhost:3000");
       expect(formatLastHostOneLiner(projectDir)).toBe(
-        "Muggle Last Host: http://localhost:3000",
+        "Muggle Test Last Host: http://localhost:3000",
       );
     });
   });

--- a/packages/mcps/src/test/last-host.test.ts
+++ b/packages/mcps/src/test/last-host.test.ts
@@ -1,0 +1,143 @@
+/** Tests for the per-repo last-host cache. */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import {
+  LAST_HOST_FILE_NAME,
+  LAST_HOST_DIR_NAME,
+  LAST_HOST_VERSION,
+  clearLastHost,
+  formatLastHostOneLiner,
+  readLastHost,
+  writeLastHost,
+} from "../shared/last-host.js";
+import {
+  LastHostGetInputSchema,
+  LastHostSetInputSchema,
+  LastHostClearInputSchema,
+} from "../mcp/local/contracts/last-host-schemas.js";
+
+describe("last-host constants", () => {
+  it("uses last-host.json as the file name", () => {
+    expect(LAST_HOST_FILE_NAME).toBe("last-host.json");
+  });
+
+  it("uses .muggle-ai as the dir name (shared with prefs and last-project)", () => {
+    expect(LAST_HOST_DIR_NAME).toBe(".muggle-ai");
+  });
+
+  it("starts at schema version 1", () => {
+    expect(LAST_HOST_VERSION).toBe(1);
+  });
+});
+
+describe("last-host cache", () => {
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "muggle-last-host-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  describe("readLastHost", () => {
+    it("returns null when no cache exists", () => {
+      expect(readLastHost(projectDir)).toBeNull();
+    });
+
+    it("returns the cached host when written", () => {
+      writeLastHost(projectDir, "http://localhost:3000");
+      const cached = readLastHost(projectDir);
+      expect(cached).not.toBeNull();
+      expect(cached?.host).toBe("http://localhost:3000");
+      expect(cached?.savedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+  });
+
+  describe("writeLastHost", () => {
+    it("creates the .muggle-ai directory if missing", () => {
+      writeLastHost(projectDir, "http://localhost:3000");
+      expect(fs.existsSync(path.join(projectDir, LAST_HOST_DIR_NAME))).toBe(true);
+    });
+
+    it("writes a versioned file shape", () => {
+      writeLastHost(projectDir, "http://localhost:3000");
+      const filePath = path.join(projectDir, LAST_HOST_DIR_NAME, LAST_HOST_FILE_NAME);
+      const raw = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+      expect(raw.version).toBe(1);
+      expect(raw.lastHost.host).toBe("http://localhost:3000");
+    });
+
+    it("overwrites an existing cache file", () => {
+      writeLastHost(projectDir, "http://localhost:3000");
+      writeLastHost(projectDir, "http://localhost:5173");
+      expect(readLastHost(projectDir)?.host).toBe("http://localhost:5173");
+    });
+  });
+
+  describe("clearLastHost", () => {
+    it("removes the cache file", () => {
+      writeLastHost(projectDir, "http://localhost:3000");
+      clearLastHost(projectDir);
+      expect(readLastHost(projectDir)).toBeNull();
+    });
+
+    it("is a no-op when no cache exists", () => {
+      expect(() => clearLastHost(projectDir)).not.toThrow();
+    });
+  });
+
+  describe("formatLastHostOneLiner", () => {
+    it("returns empty string when no cache", () => {
+      expect(formatLastHostOneLiner(projectDir)).toBe("");
+    });
+
+    it("formats a one-liner suitable for session context", () => {
+      writeLastHost(projectDir, "http://localhost:3000");
+      expect(formatLastHostOneLiner(projectDir)).toBe(
+        "Muggle Last Host: http://localhost:3000",
+      );
+    });
+  });
+});
+
+describe("LastHostGetInputSchema", () => {
+  it("requires cwd", () => {
+    expect(() => LastHostGetInputSchema.parse({})).toThrow();
+  });
+
+  it("accepts a valid input", () => {
+    expect(LastHostGetInputSchema.parse({ cwd: "/repo" }).cwd).toBe("/repo");
+  });
+});
+
+describe("LastHostSetInputSchema", () => {
+  it("requires cwd and host", () => {
+    expect(() => LastHostSetInputSchema.parse({ cwd: "/x" })).toThrow();
+    expect(() => LastHostSetInputSchema.parse({ host: "u" })).toThrow();
+  });
+
+  it("rejects empty host", () => {
+    expect(() => LastHostSetInputSchema.parse({ cwd: "/x", host: "" })).toThrow();
+  });
+
+  it("accepts a valid input", () => {
+    const r = LastHostSetInputSchema.parse({ cwd: "/repo", host: "http://localhost:3000" });
+    expect(r.host).toBe("http://localhost:3000");
+  });
+});
+
+describe("LastHostClearInputSchema", () => {
+  it("requires cwd", () => {
+    expect(() => LastHostClearInputSchema.parse({})).toThrow();
+  });
+
+  it("accepts a valid input", () => {
+    expect(LastHostClearInputSchema.parse({ cwd: "/repo" }).cwd).toBe("/repo");
+  });
+});

--- a/packages/mcps/src/test/last-project.test.ts
+++ b/packages/mcps/src/test/last-project.test.ts
@@ -122,7 +122,7 @@ describe("last-project cache", () => {
       });
       const line = formatLastProjectOneLiner(projectDir);
       expect(line).toBe(
-        'Muggle Last Project: id=proj-abc url=https://app.example.com name="Example App"',
+        'Muggle Test Last Project: id=proj-abc url=https://app.example.com name="Example App"',
       );
     });
 

--- a/packages/mcps/src/test/preferences.test.ts
+++ b/packages/mcps/src/test/preferences.test.ts
@@ -40,7 +40,7 @@ describe("PreferenceKey enum", () => {
   it("contains all expected keys", () => {
     expect(PreferenceKey.AutoLogin).toBe("autoLogin");
     expect(PreferenceKey.AutoSelectProject).toBe("autoSelectProject");
-    expect(PreferenceKey.LocalDevHost).toBe("localDevHost");
+    expect(PreferenceKey.AutoSelectLocalHost).toBe("autoSelectLocalHost");
     expect(PreferenceKey.ShowElectronBrowser).toBe("showElectronBrowser");
     expect(PreferenceKey.OpenTestResultsAfterRun).toBe("openTestResultsAfterRun");
     expect(PreferenceKey.DefaultExecutionMode).toBe("defaultExecutionMode");

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -23,7 +23,7 @@ Type `muggle` to discover the full command family.
 
 | Skill | What it does |
 |:---|:---|
-| `/muggle:muggle` | Router and menu for all Muggle commands. |
+| `/muggle:muggle` | Router and menu for all Muggle Test commands. |
 | `/muggle:muggle-do` | Autonomous dev pipeline: requirements, code, unit tests, E2E acceptance tests, PR. |
 | `/muggle:muggle-test` | Change-driven E2E acceptance router: detects code changes, maps to use cases, runs test generation locally or remotely, publishes to dashboard, opens in browser, posts E2E acceptance results to PR. |
 | `/muggle:muggle-test-feature-local` | Test a feature on localhost with AI-driven browser automation. Offers publish to cloud after each run. |

--- a/plugin/agents/acceptance-tester.md
+++ b/plugin/agents/acceptance-tester.md
@@ -1,12 +1,12 @@
 ---
 name: acceptance-tester
-description: "E2E acceptance testing agent — runs real-browser tests against web apps and reports structured results with blocking issues and suggested fixes. Also imports existing test artifacts, manages Muggle preferences, and operates the Muggle AI suite (status checks, repairs). Dispatch this agent when the team needs acceptance test feedback, test coverage for a feature, or Muggle suite operations."
+description: "E2E acceptance testing agent — runs real-browser tests against web apps and reports structured results with blocking issues and suggested fixes. Also imports existing test artifacts, manages Muggle Test preferences, and operates the Muggle AI suite (status checks, repairs). Dispatch this agent when the team needs acceptance test feedback, test coverage for a feature, or Muggle Test suite operations."
 model: sonnet
 ---
 
 # Acceptance Tester
 
-You are the team's acceptance testing specialist. You run real-browser end-to-end tests against web apps using Muggle AI and report structured results that coding agents can act on. You also manage test artifacts, user preferences, and the Muggle installation itself.
+You are the team's acceptance testing specialist. You run real-browser end-to-end tests against web apps using Muggle AI and report structured results that coding agents can act on. You also manage test artifacts, user preferences, and the Muggle Test installation itself.
 
 You operate through skills — never call raw MCP tools directly.
 
@@ -16,9 +16,9 @@ You operate through skills — never call raw MCP tools directly.
 |-------|-------------|
 | `muggle-test` | Run acceptance tests. Auto-routes between local (Electron browser on localhost) and remote (cloud execution on preview/staging URL). Handles change detection, test case selection, execution, and result collection. |
 | `muggle-test-import` | Import existing test artifacts into Muggle Test — Playwright specs, Cypress tests, PRDs, Gherkin feature files, test plan documents. |
-| `muggle-preferences` | View, set, or reset the 12 preference knobs that control Muggle behavior. |
-| `muggle-repair` | Diagnose and fix broken Muggle installation components. |
-| `muggle-status` | Check health of the Muggle installation — Electron app, MCP server, auth, CLI version. |
+| `muggle-preferences` | View, set, or reset the 12 preference knobs that control Muggle Test behavior. |
+| `muggle-repair` | Diagnose and fix broken Muggle Test installation components. |
+| `muggle-status` | Check health of the Muggle Test installation — Electron app, MCP server, auth, CLI version. |
 
 Select the skill based on what the orchestrator asks you to do. If the task doesn't clearly map to one skill, ask for clarification.
 
@@ -44,7 +44,7 @@ Always return two sections:
 ## Test Summary
 - **Tests:** {total} total — {passed} passed, {failed} failed
 - **Verdict:** PASS | FAIL
-- **Dashboard:** {link to Muggle dashboard, if results were published}
+- **Dashboard:** {link to Muggle Test dashboard, if results were published}
 ```
 
 **Section 2 — Per-Test Highlights**

--- a/plugin/scripts/ensure-electron-app.sh
+++ b/plugin/scripts/ensure-electron-app.sh
@@ -77,8 +77,9 @@ if [ -f "$prefs_global_file" ]; then
     try {
       const g = JSON.parse(fs.readFileSync('${prefs_global_file}', 'utf-8')).preferences || {};
       const defaults = {
-        autoLogin:'ask', autoSelectProject:'ask', showElectronBrowser:'ask',
-        openTestResultsAfterRun:'ask', defaultExecutionMode:'ask', autoPublishLocalResults:'ask',
+        autoLogin:'ask', autoSelectProject:'ask', autoSelectLocalHost:'ask',
+        showElectronBrowser:'ask', openTestResultsAfterRun:'ask',
+        defaultExecutionMode:'ask', autoPublishLocalResults:'ask',
         suggestRelatedUseCases:'ask', suggestRelatedTestCases:'ask', autoDetectChanges:'ask',
         postPRVisualWalkthrough:'ask', checkForUpdates:'ask', verboseOutput:'ask'
       };
@@ -126,7 +127,7 @@ fi
 # --- Last-host cache injection ---
 # Per-repo cache of the local dev server URL the user picked on the previous
 # run. Lives at <cwd>/.muggle-ai/last-host.json. Skills silently reuse it
-# when the user has set the localDevHost preference to "always".
+# when the user has set the autoSelectLocalHost preference to "always".
 last_host_line=""
 last_host_note=""
 last_host_line=$(node -e "

--- a/plugin/scripts/ensure-electron-app.sh
+++ b/plugin/scripts/ensure-electron-app.sh
@@ -90,18 +90,18 @@ if [ -f "$prefs_global_file" ]; then
       const hasProject = Object.keys(p).length > 0;
       const note = hasProject ? ', project overrides active' : '';
       const line = Object.entries(merged).map(([k,v]) => k+'='+v).join(' ');
-      console.log('Muggle Preferences (~/.muggle-ai/preferences.json' + note + '):\\\\n' + line);
+      console.log('Muggle Test Preferences (~/.muggle-ai/preferences.json' + note + '):\\\\n' + line);
     } catch { console.log(''); }
   " 2>/dev/null || true)
   if [ -n "$prefs_line" ]; then
     prefs_file_note="\\n\\n${prefs_line}"
   fi
 else
-  prefs_file_note="\\n\\nMuggle Preferences: not configured. Run \\\`muggle setup\\\` or tell the agent to set preferences."
+  prefs_file_note="\\n\\nMuggle Test Preferences: not configured. Run \\\`muggle setup\\\` or tell the agent to set preferences."
 fi
 
 # --- Last-project cache injection ---
-# Per-repo "last used Muggle project" cache. Lives at <cwd>/.muggle-ai/last-project.json
+# Per-repo "last used Muggle Test project" cache. Lives at <cwd>/.muggle-ai/last-project.json
 # and is honored by skills when autoSelectProject = always.
 last_project_line=""
 last_project_note=""
@@ -116,7 +116,7 @@ last_project_line=$(node -e "
     const lp = raw && raw.lastProject;
     if (!lp || !lp.projectId) { console.log(''); return; }
     const safeName = String(lp.projectName || '').replace(/\"/g, '\\\\\"');
-    console.log('Muggle Last Project: id=' + lp.projectId + ' url=' + lp.projectUrl + ' name=\"' + safeName + '\"');
+    console.log('Muggle Test Last Project: id=' + lp.projectId + ' url=' + lp.projectUrl + ' name=\"' + safeName + '\"');
   } catch { console.log(''); }
 " 2>/dev/null || true)
 if [ -n "$last_project_line" ]; then
@@ -138,14 +138,14 @@ last_host_line=$(node -e "
     const raw = JSON.parse(fs.readFileSync(lhPath, 'utf-8'));
     const lh = raw && raw.lastHost;
     if (!lh || !lh.host) { console.log(''); return; }
-    console.log('Muggle Last Host: ' + lh.host);
+    console.log('Muggle Test Last Host: ' + lh.host);
   } catch { console.log(''); }
 " 2>/dev/null || true)
 if [ -n "$last_host_line" ]; then
   last_host_note="\\n\\n${last_host_line}"
 fi
 
-context="<EXTREMELY_IMPORTANT>\nYou have access to Muggle AI — a real-browser E2E acceptance testing tool.\n\nWhenever the user asks you to test, validate, verify, or check if their web app works — use the muggle MCP tools. This includes:\n- Testing user flows (signup, login, checkout, forms, dashboards)\n- Verifying UI changes didn't break anything\n- Running regression tests after code changes\n- Validating frontend behavior on localhost or a dev server\n- Checking if a feature works before merging a PR\n\nMuggle launches a real Electron browser that clicks buttons, fills forms, navigates pages, and captures screenshots. It generates replayable test scripts that persist across sessions.\n\nDo NOT write test code (Playwright, Cypress, Selenium) or try to test UI manually when muggle tools are available. Use the muggle skill or muggle MCP tools instead — they are faster, capture visual evidence, and produce reusable test scripts.\n\nTrigger phrases: 'test my app', 'check if it works', 'run E2E acceptance tests', 'validate the UI', 'verify the flow', 'regression test', 'make sure it still works', 'test before merging'.\n</EXTREMELY_IMPORTANT>${upgrade_notice}${prefs_file_note}${last_project_note}${last_host_note}"
+context="<EXTREMELY_IMPORTANT>\nYou have access to Muggle AI — a real-browser E2E acceptance testing tool.\n\nWhenever the user asks you to test, validate, verify, or check if their web app works — use the muggle MCP tools. This includes:\n- Testing user flows (signup, login, checkout, forms, dashboards)\n- Verifying UI changes didn't break anything\n- Running regression tests after code changes\n- Validating frontend behavior on localhost or a dev server\n- Checking if a feature works before merging a PR\n\nMuggle Test launches a real Electron browser that clicks buttons, fills forms, navigates pages, and captures screenshots. It generates replayable test scripts that persist across sessions.\n\nDo NOT write test code (Playwright, Cypress, Selenium) or try to test UI manually when muggle tools are available. Use the muggle skill or muggle MCP tools instead — they are faster, capture visual evidence, and produce reusable test scripts.\n\nTrigger phrases: 'test my app', 'check if it works', 'run E2E acceptance tests', 'validate the UI', 'verify the flow', 'regression test', 'make sure it still works', 'test before merging'.\n</EXTREMELY_IMPORTANT>${upgrade_notice}${prefs_file_note}${last_project_note}${last_host_note}"
 
 escaped_context=$(escape_for_json "$context")
 

--- a/plugin/scripts/ensure-electron-app.sh
+++ b/plugin/scripts/ensure-electron-app.sh
@@ -124,8 +124,9 @@ if [ -n "$last_project_line" ]; then
 fi
 
 # --- Last-host cache injection ---
-# Per-repo "last used local dev server URL" cache. Lives at <cwd>/.muggle-ai/last-host.json
-# and is honored by skills when localDevHost = always.
+# Per-repo cache of the local dev server URL the user picked on the previous
+# run. Lives at <cwd>/.muggle-ai/last-host.json. Skills silently reuse it
+# when the user has set the localDevHost preference to "always".
 last_host_line=""
 last_host_note=""
 last_host_line=$(node -e "

--- a/plugin/scripts/ensure-electron-app.sh
+++ b/plugin/scripts/ensure-electron-app.sh
@@ -123,7 +123,29 @@ if [ -n "$last_project_line" ]; then
   last_project_note="\\n\\n${last_project_line}"
 fi
 
-context="<EXTREMELY_IMPORTANT>\nYou have access to Muggle AI — a real-browser E2E acceptance testing tool.\n\nWhenever the user asks you to test, validate, verify, or check if their web app works — use the muggle MCP tools. This includes:\n- Testing user flows (signup, login, checkout, forms, dashboards)\n- Verifying UI changes didn't break anything\n- Running regression tests after code changes\n- Validating frontend behavior on localhost or a dev server\n- Checking if a feature works before merging a PR\n\nMuggle launches a real Electron browser that clicks buttons, fills forms, navigates pages, and captures screenshots. It generates replayable test scripts that persist across sessions.\n\nDo NOT write test code (Playwright, Cypress, Selenium) or try to test UI manually when muggle tools are available. Use the muggle skill or muggle MCP tools instead — they are faster, capture visual evidence, and produce reusable test scripts.\n\nTrigger phrases: 'test my app', 'check if it works', 'run E2E acceptance tests', 'validate the UI', 'verify the flow', 'regression test', 'make sure it still works', 'test before merging'.\n</EXTREMELY_IMPORTANT>${upgrade_notice}${prefs_file_note}${last_project_note}"
+# --- Last-host cache injection ---
+# Per-repo "last used local dev server URL" cache. Lives at <cwd>/.muggle-ai/last-host.json
+# and is honored by skills when localDevHost = always.
+last_host_line=""
+last_host_note=""
+last_host_line=$(node -e "
+  const fs = require('fs');
+  const path = require('path');
+  try {
+    const cwd = process.env.CLAUDE_CWD || process.env.CURSOR_CWD || process.cwd();
+    const lhPath = path.join(cwd, '.muggle-ai', 'last-host.json');
+    if (!fs.existsSync(lhPath)) { console.log(''); return; }
+    const raw = JSON.parse(fs.readFileSync(lhPath, 'utf-8'));
+    const lh = raw && raw.lastHost;
+    if (!lh || !lh.host) { console.log(''); return; }
+    console.log('Muggle Last Host: ' + lh.host);
+  } catch { console.log(''); }
+" 2>/dev/null || true)
+if [ -n "$last_host_line" ]; then
+  last_host_note="\\n\\n${last_host_line}"
+fi
+
+context="<EXTREMELY_IMPORTANT>\nYou have access to Muggle AI — a real-browser E2E acceptance testing tool.\n\nWhenever the user asks you to test, validate, verify, or check if their web app works — use the muggle MCP tools. This includes:\n- Testing user flows (signup, login, checkout, forms, dashboards)\n- Verifying UI changes didn't break anything\n- Running regression tests after code changes\n- Validating frontend behavior on localhost or a dev server\n- Checking if a feature works before merging a PR\n\nMuggle launches a real Electron browser that clicks buttons, fills forms, navigates pages, and captures screenshots. It generates replayable test scripts that persist across sessions.\n\nDo NOT write test code (Playwright, Cypress, Selenium) or try to test UI manually when muggle tools are available. Use the muggle skill or muggle MCP tools instead — they are faster, capture visual evidence, and produce reusable test scripts.\n\nTrigger phrases: 'test my app', 'check if it works', 'run E2E acceptance tests', 'validate the UI', 'verify the flow', 'regression test', 'make sure it still works', 'test before merging'.\n</EXTREMELY_IMPORTANT>${upgrade_notice}${prefs_file_note}${last_project_note}${last_host_note}"
 
 escaped_context=$(escape_for_json "$context")
 

--- a/plugin/skills/do/e2e-acceptance.md
+++ b/plugin/skills/do/e2e-acceptance.md
@@ -26,7 +26,7 @@ This guarantees E2E acceptance tests always run — no dependency on cloud repla
 You receive everything from `state.md` already — pre-flight resolved it:
 
 - `localUrl` — the locally running dev server URL
-- `projectId` — the chosen Muggle project
+- `projectId` — the chosen Muggle Test project
 - The validation strategy (`local-e2e`, `staging-replay`, `unit-only`, `skip`)
 - Test-user credential status (existing / new / skip)
 - The list of changed repos, files, and a summary of changes

--- a/plugin/skills/do/pre-flight.md
+++ b/plugin/skills/do/pre-flight.md
@@ -17,7 +17,7 @@ Start the turn with:
 You receive:
 
 - The user's task description (from `$ARGUMENTS`).
-- The list of configured repos (names + paths) from the Muggle config.
+- The list of configured repos (names + paths) from the Muggle Test config.
 - Any session directory that already exists (resumption case).
 
 ## Silent detection (do this first — no user prompts)
@@ -28,9 +28,9 @@ Before asking anything, gather every fact you can resolve without the user:
 2. **Current branch and default branch** for each candidate repo. Run `git -C <repo> symbolic-ref refs/remotes/origin/HEAD --short` and `git -C <repo> branch --show-current`. If the current branch is the default, the pre-flight must collect a new branch name.
 3. **Running dev server.** Scan common dev ports — `lsof -iTCP -sTCP:LISTEN -nP | grep -E ':(3000|3001|3999|4200|5173|8080)'` — and hit `/` with `curl -s -o /dev/null -w "%{http_code}"` to confirm 2xx.
 4. **Running backend.** If the repo's `.env.local` (or equivalent) declares a backend URL (e.g. `REACT_APP_BACKEND_BASE_URL=http://localhost:5050`), probe the health endpoint; note up/down.
-5. **Muggle MCP auth.** Call `muggle-remote-auth-status`. If expired, you will ask to re-auth in the questionnaire.
-6. **Candidate Muggle projects.** Call `muggle-remote-project-list` and rank by semantic match against the task description and the repo's dev URL.
-7. **Existing test-user secrets.** For each candidate Muggle project, call `muggle-remote-secret-list` and note whether `managed_profile_email` / `managed_profile_password` exist.
+5. **Muggle Test MCP auth.** Call `muggle-remote-auth-status`. If expired, you will ask to re-auth in the questionnaire.
+6. **Candidate Muggle Test projects.** Call `muggle-remote-project-list` and rank by semantic match against the task description and the repo's dev URL.
+7. **Existing test-user secrets.** For each candidate Muggle Test project, call `muggle-remote-secret-list` and note whether `managed_profile_email` / `managed_profile_password` exist.
 8. **Auth0 tenant in use for local dev.** Grep the repo's env file for `*AUTH0_DOMAIN*`; record the tenant. This tells the user whether the staging-tenant test user will work or not.
 
 ## The consolidated questionnaire
@@ -41,16 +41,16 @@ Present **one `AskQuestion`** (or the platform's structured-selection equivalent
 2. **Repo(s) to modify** — pre-selected with the best silent match. "Confirm <repo>" / "Change repo" / "Multi-repo (list them)".
 3. **Branch name** — default: `users/<user>/<slug>` derived from the task. "Use default" / "Use different name (type)".
 4. **Validation strategy** — the single most important question. Options:
-   - **Local E2E** (Muggle Electron against a running localhost) — default if a dev server was detected.
+   - **Local E2E** (Muggle Test Electron against a running localhost) — default if a dev server was detected.
    - **Staging replay** — for changes already deployed to a preview URL.
    - **Unit tests only** — skip E2E, acceptable for pure refactors or backend-only changes.
    - **Skip validation** — explicit opt-out; the PR title gets `[UNVERIFIED]`.
 5. **Local URL** — only if validation is Local E2E. Default: the detected port. "Confirm `<detected>`" / "Type a different URL".
 6. **Backend reachable?** — only if validation is Local E2E and a backend URL is declared. If the health probe failed, ask "Start the backend now and I'll re-probe" / "Proceed anyway" / "Skip to unit tests only".
-7. **Muggle project** — pre-selected with the best silent match. "Use <top match>" / "Use a different existing project (list)" / "Create new".
+7. **Muggle Test project** — pre-selected with the best silent match. "Use <top match>" / "Use a different existing project (list)" / "Create new".
 8. **Test-user credentials** — only if validation is Local E2E AND the Auth0 tenant in the repo differs from the tenant the managed secrets were created under. Options: "Reuse existing secrets (may fail if tenant mismatch — will surface failure)" / "Create new secrets for this tenant (provide email + password)" / "Switch to staging replay".
 9. **PR target branch** — default: the repo's default branch. "Use default" / "Target a different branch".
-10. **Re-auth Muggle MCP?** — only if auth was missing/expired. "Log in now" / "Abort".
+10. **Re-auth Muggle Test MCP?** — only if auth was missing/expired. "Log in now" / "Abort".
 
 If fewer than two of the above need the user, still gather them in a single turn — never open a second round.
 
@@ -73,7 +73,7 @@ After the user answers, write **`state.md`** with every resolved value, verbatim
 - Validation: <strategy>
 - Local URL: <url or N/A>
 - Backend status: <up | down | N/A>
-- Muggle project: <name> (<uuid>)
+- Muggle Test project: <name> (<uuid>)
 - Test credentials: <existing | new | skip>
 - PR target: <branch>
 - Auth status: <ok | re-authed | N/A>

--- a/plugin/skills/muggle-do/SKILL.md
+++ b/plugin/skills/muggle-do/SKILL.md
@@ -4,9 +4,9 @@ description: Unified Muggle AI workflow entry point. Use when user types muggle 
 disable-model-invocation: true
 ---
 
-# Muggle Do
+# Muggle Test Do
 
-Muggle Do runs a battle-tested autonomous dev cycle: **pre-flight → requirements → impact analysis → validate code → unit tests → E2E acceptance → open PR**.
+Muggle Test Do runs a battle-tested autonomous dev cycle: **pre-flight → requirements → impact analysis → validate code → unit tests → E2E acceptance → open PR**.
 
 The design goal is **fire and review**: the user answers one consolidated pre-flight questionnaire, then walks away. Every subsequent stage runs unattended until completion or a genuine blocker.
 
@@ -39,7 +39,7 @@ Treat `$ARGUMENTS` as the user command:
 
 ## Front-loading (stage 1 non-negotiable)
 
-All ambiguity — task scope, repo selection, validation strategy, localhost URL, backend health, Muggle project, test-user credentials, branch name, PR target — is resolved in a **single** pre-flight turn. See `pre-flight.md` for the exact questionnaire.
+All ambiguity — task scope, repo selection, validation strategy, localhost URL, backend health, Muggle Test project, test-user credentials, branch name, PR target — is resolved in a **single** pre-flight turn. See `pre-flight.md` for the exact questionnaire.
 
 **Red-flag behaviors (do not do):**
 

--- a/plugin/skills/muggle-pr-visual-walkthrough/SKILL.md
+++ b/plugin/skills/muggle-pr-visual-walkthrough/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: muggle-pr-visual-walkthrough
-description: Renders and posts a visual walkthrough of Muggle AI E2E acceptance test results to a PR — per-test-case dashboard links, step-by-step screenshots, and pass/fail summary — using the `muggle build-pr-section` CLI for deterministic formatting with automatic fit-vs-overflow. Use at the end of any Muggle test run (local or remote) to give PR reviewers clickable visual evidence that user flows work. Triggers on 'post results to PR', 'attach walkthrough to PR', 'share E2E screenshots on the PR', 'add visual walkthrough to PR'.
+description: Renders and posts a visual walkthrough of Muggle AI E2E acceptance test results to a PR — per-test-case dashboard links, step-by-step screenshots, and pass/fail summary — using the `muggle build-pr-section` CLI for deterministic formatting with automatic fit-vs-overflow. Use at the end of any Muggle Test test run (local or remote) to give PR reviewers clickable visual evidence that user flows work. Triggers on 'post results to PR', 'attach walkthrough to PR', 'share E2E screenshots on the PR', 'add visual walkthrough to PR'.
 ---
 
-# Muggle PR Visual Walkthrough
+# Muggle Test PR Visual Walkthrough
 
 Renders a visual walkthrough of Muggle AI E2E acceptance test results and posts it to a PR. Each test case is linked to its detail page on the Muggle AI dashboard, so PR reviewers can click through to see step-by-step screenshots and action scripts — not just a pass/fail flag.
 
-This is the **canonical PR-walkthrough workflow** shared across every Muggle entry point:
+This is the **canonical PR-walkthrough workflow** shared across every Muggle Test entry point:
 
 | Caller | Mode | When to invoke |
 | :--- | :--- | :--- |

--- a/plugin/skills/muggle-preferences/SKILL.md
+++ b/plugin/skills/muggle-preferences/SKILL.md
@@ -2,14 +2,14 @@
 name: muggle-preferences
 description: >-
   View, set, or reset Muggle AI preferences that control testing behavior.
-  Use when user asks to see preferences, change a setting, configure Muggle
+  Use when user asks to see preferences, change a setting, configure Muggle Test
   defaults, or manage muggle config. Triggers on: 'muggle preferences',
   'show muggle settings', 'change muggle preference', 'set autoLogin to
   always', 'muggle config', 'reset muggle preferences', 'show my muggle
   settings', 'configure muggle', 'muggle setup'.
 ---
 
-# Muggle Preferences
+# Muggle Test Preferences
 
 Pick the operation, then read its op file for the procedure.
 
@@ -23,7 +23,7 @@ Pick the operation, then read its op file for the procedure.
 
 ## Shared context (all ops)
 
-- **Current values**: session-context line `Muggle Preferences key=value …`. Default `ask`.
+- **Current values**: session-context line `Muggle Test Preferences key=value …`. Default `ask`.
 - **Per-key files**: `preference-gates/<key>.md`. Key list = `ls preference-gates/*.md` minus `README.md`.
 - **Allowed values**: `always`/`never`/`ask` (or `local`/`remote`/`ask` for `defaultExecutionMode`).
 - **Scope**: `global` default; `project` if user says "for this project" / "just this repo" (pass `cwd`).

--- a/plugin/skills/muggle-preferences/ops/configure.md
+++ b/plugin/skills/muggle-preferences/ops/configure.md
@@ -29,7 +29,7 @@ For each option: label = key name, description = first paragraph of `preference-
 - `multiSelect: true`, `header: "Test setup"` — `localDevHost`, `autoDetectChanges`
 - `multiSelect: true`, `header: "Test run"` — `showElectronBrowser`, `openTestResultsAfterRun`, `autoPublishLocalResults`
 - `multiSelect: true`, `header: "Suggestions & PR"` — `suggestRelatedUseCases`, `suggestRelatedTestCases`, `postPRVisualWalkthrough`
-- `multiSelect: false`, `header: "Default mode"` — `defaultExecutionMode`. Options: `Local — run on my computer` (`local`), `Remote — run in the Muggle cloud` (`remote`), `Ask each time` (don't change).
+- `multiSelect: false`, `header: "Default mode"` — `defaultExecutionMode`. Options: `Local — run on my computer` (`local`), `Remote — run in the Muggle Test cloud` (`remote`), `Ask each time` (don't change).
 - `multiSelect: false`, `header: "Scope"` — final scope question. Options: `Global (all repos)` (~/.muggle-ai/), `This project only` (.muggle-ai/ in repo).
 
 `AskUserQuestion` accepts up to 4 questions per call — split into two calls if needed (categories first, scope second).

--- a/plugin/skills/muggle-preferences/ops/configure.md
+++ b/plugin/skills/muggle-preferences/ops/configure.md
@@ -26,7 +26,7 @@ you can tell me which (if any) should instead be set to `never`.
 For each option: label = key name, description = first paragraph of `preference-gates/<key>.md`. Multi-select question text = `Which of these should auto-proceed (set to "always")?`; selected = `always`.
 
 - `multiSelect: true`, `header: "Auth & session"` — `autoLogin`, `autoSelectProject`, `checkForUpdates`, `verboseOutput`
-- `multiSelect: true`, `header: "Test setup"` — `localDevHost`, `autoDetectChanges`
+- `multiSelect: true`, `header: "Test setup"` — `autoSelectLocalHost`, `autoDetectChanges`
 - `multiSelect: true`, `header: "Test run"` — `showElectronBrowser`, `openTestResultsAfterRun`, `autoPublishLocalResults`
 - `multiSelect: true`, `header: "Suggestions & PR"` — `suggestRelatedUseCases`, `suggestRelatedTestCases`, `postPRVisualWalkthrough`
 - `multiSelect: false`, `header: "Default mode"` — `defaultExecutionMode`. Options: `Local — run on my computer` (`local`), `Remote — run in the Muggle Test cloud` (`remote`), `Ask each time` (don't change).

--- a/plugin/skills/muggle-preferences/preference-gates/README.md
+++ b/plugin/skills/muggle-preferences/preference-gates/README.md
@@ -10,7 +10,7 @@ which uses `local` / `remote` / `ask`).
 
 ## Resolution
 
-`SessionStart` injects a `Muggle Preferences` line (`key=value` pairs) from
+`SessionStart` injects a `Muggle Test Preferences` line (`key=value` pairs) from
 `~/.muggle-ai/preferences.json` (global) overlaid by
 `<repo>/.muggle-ai/preferences.json` (project). Absent → treat as `ask`.
 

--- a/plugin/skills/muggle-preferences/preference-gates/autoPublishLocalResults.md
+++ b/plugin/skills/muggle-preferences/preference-gates/autoPublishLocalResults.md
@@ -1,8 +1,8 @@
 # `autoPublishLocalResults`
 
-Upload local run artifacts to the Muggle cloud, or keep them local.
+Upload local run artifacts to the Muggle Test cloud, or keep them local.
 
-**Picker 1** — header `Share results?`, question `"Upload these results to the Muggle dashboard?"`
+**Picker 1** — header `Share results?`, question `"Upload these results to the Muggle Test dashboard?"`
 - `Upload them` — `Needed for the dashboard view, PR walkthrough, and team visibility.` → `always`
 - `Keep local-only` — `Stay on this machine — no dashboard view or PR walkthrough.` → `never`
 

--- a/plugin/skills/muggle-preferences/preference-gates/autoSelectLocalHost.md
+++ b/plugin/skills/muggle-preferences/preference-gates/autoSelectLocalHost.md
@@ -1,4 +1,4 @@
-# `localDevHost`
+# `autoSelectLocalHost`
 
 Reuse the saved local dev server URL for this repo, or pick one each run. Substitute `{lastHost}` (the URL used in the previous run for this repo — omit the option entirely when no cache exists) and `{suggestedHost}` (auto-detected from running ports, e.g. `http://localhost:3000`).
 
@@ -11,7 +11,7 @@ Cache lives at `<cwd>/.muggle-ai/last-host.json`. The calling skill **always** u
 
 **Picker 2 — overrides shared template.** Fires after the user picks a URL.
 - Header `Remember this URL?`, question `"Always use {chosenHost} for this repo from now on, without asking?"`
-- `Yes, always` (sub: `You can change this later in muggle preferences.`) → `muggle-local-preferences-set` (`localDevHost=always`, global). The cache is already up to date.
+- `Yes, always` (sub: `You can change this later in muggle preferences.`) → `muggle-local-preferences-set` (`autoSelectLocalHost=always`, global). The cache is already up to date.
 - `Just this once` (sub: `I'll ask again next time.`) → don't save the preference. The cache still updates.
 
 **Silent action**

--- a/plugin/skills/muggle-preferences/preference-gates/checkForUpdates.md
+++ b/plugin/skills/muggle-preferences/preference-gates/checkForUpdates.md
@@ -1,8 +1,8 @@
 # `checkForUpdates`
 
-Check npm for a newer Muggle version at session start.
+Check npm for a newer Muggle Test version at session start.
 
-**Picker 1** — header `Update check`, question `"Check for a newer Muggle version (one quick network call)?"`
+**Picker 1** — header `Update check`, question `"Check for a newer Muggle Test version (one quick network call)?"`
 - `Check now` — `Flags if you're behind.` → `always`
 - `Skip check` — `Saves a network call at session start.` → `never`
 

--- a/plugin/skills/muggle-preferences/preference-gates/defaultExecutionMode.md
+++ b/plugin/skills/muggle-preferences/preference-gates/defaultExecutionMode.md
@@ -4,7 +4,7 @@ Default place to run tests when the user's request is ambiguous.
 
 **Picker 1** — header `Where to run tests?`, question `"On your computer or in the cloud?"`
 - `On my computer` — `Real browser on localhost. Faster feedback while developing.` → `local`
-- `In the cloud` — `Muggle's cloud runs against a preview/staging URL.` → `remote`
+- `In the cloud` — `Muggle Test's cloud runs against a preview/staging URL.` → `remote`
 
 If the user's intent is already clear (e.g. "test on staging"), skip Picker 1
 — confirm with `"Yes, proceed in <mode>"` / `"Switch to <other mode>"` and

--- a/plugin/skills/muggle-repair/SKILL.md
+++ b/plugin/skills/muggle-repair/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: muggle-repair
-description: Diagnose and fix a broken Muggle AI installation. Use when user types muggle repair or asks to fix Muggle setup.
+description: Diagnose and fix a broken Muggle AI installation. Use when user types muggle repair or asks to fix Muggle Test setup.
 ---
 
-# Muggle Repair
+# Muggle Test Repair
 
 Automatically diagnose and fix broken components.
 

--- a/plugin/skills/muggle-status/SKILL.md
+++ b/plugin/skills/muggle-status/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: muggle-status
-description: Check health of the Muggle AI installation. Use when user types muggle status, asks for Muggle health, MCP health, or auth validity.
+description: Check health of the Muggle AI installation. Use when user types muggle status, asks for Muggle Test health, MCP health, or auth validity.
 ---
 
-# Muggle Status
+# Muggle Test Status
 
 Run a full health check and report results.
 
@@ -13,7 +13,7 @@ Gates run per `preference-gates/README.md`.
 
 | Preference | Step | Decision it gates |
 |------------|------|-------------------|
-| `checkForUpdates` | Check 4 | Check for newer Muggle version |
+| `checkForUpdates` | Check 4 | Check for newer Muggle Test version |
 
 ## Checks
 

--- a/plugin/skills/muggle-test-feature-local/SKILL.md
+++ b/plugin/skills/muggle-test-feature-local/SKILL.md
@@ -5,7 +5,7 @@ description: Run a real-browser end-to-end (E2E) acceptance test against localho
 
 # Muggle Test Feature Local
 
-**Goal:** Run or generate an end-to-end test against a **local URL** using Muggle's Electron browser.
+**Goal:** Run or generate an end-to-end test against a **local URL** using Muggle Test's Electron browser.
 
 | Scope | MCP tools |
 | :---- | :-------- |
@@ -29,10 +29,10 @@ Gates run per `preference-gates/README.md`.
 | Preference | Step | Decision it gates |
 |------------|------|-------------------|
 | `autoLogin` | 1 | Reuse saved credentials when auth is required |
-| `autoSelectProject` | 2 | Reuse last-used Muggle project for this repo |
+| `autoSelectProject` | 2 | Reuse last-used Muggle Test project for this repo |
 | `localDevHost` | 4 | Reuse last-used local dev server URL for this repo |
 | `showElectronBrowser` | 7 | Show Electron browser window during local E2E tests |
-| `openTestResultsAfterRun` | 8 | Open results page on Muggle dashboard after run |
+| `openTestResultsAfterRun` | 8 | Open results page on Muggle Test dashboard after run |
 | `postPRVisualWalkthrough` | 10 | Post visual walkthrough to PR after results |
 
 ## Workflow
@@ -47,9 +47,9 @@ Gates run per `preference-gates/README.md`.
 
 ### 2. Targets (user must confirm)
 
-The per-repo project cache lives at `<cwd>/.muggle-ai/last-project.json` (via the `muggle-local-last-project-get` / `muggle-local-last-project-set` MCP tools). Look for `Muggle Last Project: id=… url=… name="…"` in session context.
+The per-repo project cache lives at `<cwd>/.muggle-ai/last-project.json` (via the `muggle-local-last-project-get` / `muggle-local-last-project-set` MCP tools). Look for `Muggle Test Last Project: id=… url=… name="…"` in session context.
 
-Gate `autoSelectProject` (per `preference-gates/README.md`). Cache: `Muggle Last Project` session line.
+Gate `autoSelectProject` (per `preference-gates/README.md`). Cache: `Muggle Test Last Project` session line.
 - `always` + cache → use cached `projectId`, skip to use case selection. No cache → fall through to `ask`.
 - `never` → full project list; skip Picker 2.
 - `ask` → project list picker (see gate file for spec + Picker 2 override). Skip Picker 2 if "Create new project".
@@ -97,9 +97,9 @@ This step is especially important when the user's app depends on sibling service
 
 ### 4. Local URL (gated by `localDevHost`)
 
-Cache lookup: `muggle-local-last-host-get` (or read the `Muggle Last Host: <url>` line from session context). Auto-detect a suggested URL by checking common ports (e.g., `lsof -iTCP -sTCP:LISTEN -nP | grep -E ':(3000|3001|4200|5173|8080)'`).
+Cache lookup: `muggle-local-last-host-get` (or read the `Muggle Test Last Host: <url>` line from session context). Auto-detect a suggested URL by checking common ports (e.g., `lsof -iTCP -sTCP:LISTEN -nP | grep -E ':(3000|3001|4200|5173|8080)'`).
 
-Gate `localDevHost` (per `preference-gates/README.md` + `preference-gates/localDevHost.md`). Cache: `Muggle Last Host:` session line.
+Gate `localDevHost` (per `preference-gates/README.md` + `preference-gates/localDevHost.md`). Cache: `Muggle Test Last Host:` session line.
 - `always` + cache → use cached `{lastHost}` silently. No cache → fall through to `ask`.
 - `never` → always run Picker 1; skip Picker 2.
 - `ask` → run Picker 1 from the gate file (options: `Use {lastHost}` if cached / `Use {suggestedHost}` if detected / `Type a URL`). After the user picks, run Picker 2 from the gate file.

--- a/plugin/skills/muggle-test-feature-local/SKILL.md
+++ b/plugin/skills/muggle-test-feature-local/SKILL.md
@@ -30,7 +30,7 @@ Gates run per `preference-gates/README.md`.
 |------------|------|-------------------|
 | `autoLogin` | 1 | Reuse saved credentials when auth is required |
 | `autoSelectProject` | 2 | Reuse last-used Muggle Test project for this repo |
-| `localDevHost` | 4 | Reuse last-used local dev server URL for this repo |
+| `autoSelectLocalHost` | 4 | Reuse last-used local dev server URL for this repo |
 | `showElectronBrowser` | 7 | Show Electron browser window during local E2E tests |
 | `openTestResultsAfterRun` | 8 | Open results page on Muggle Test dashboard after run |
 | `postPRVisualWalkthrough` | 10 | Post visual walkthrough to PR after results |
@@ -95,14 +95,14 @@ Before detecting the local URL, verify that the services the user needs are actu
 
 This step is especially important when the user's app depends on sibling services (a backend API, an auth service, etc.) that may not be running yet. The prepare skill handles discovery, startup, and cleanup so this skill doesn't have to.
 
-### 4. Local URL (gated by `localDevHost`)
+### 4. Local URL (gated by `autoSelectLocalHost`)
 
-Skill responsibilities (the rest is in `preference-gates/localDevHost.md`):
+Skill responsibilities (the rest is in `preference-gates/autoSelectLocalHost.md`):
 - **Read the cache**: `Muggle Test Last Host: <url>` session-context line, or `muggle-local-last-host-get`. Pass as `{lastHost}` substitution.
 - **Auto-detect a suggested URL**: `lsof -iTCP -sTCP:LISTEN -nP | grep -E ':(3000|3001|4200|5173|8080)'`. Pass as `{suggestedHost}`.
 - **Save the cache**: call `muggle-local-last-host-set` after the user picks (the gate file requires this on every pick).
 
-Gate `localDevHost` per `preference-gates/README.md` + `preference-gates/localDevHost.md`.
+Gate `autoSelectLocalHost` per `preference-gates/README.md` + `preference-gates/autoSelectLocalHost.md`.
 
 Remind them: local URL is only the execution target, not tied to cloud project config.
 

--- a/plugin/skills/muggle-test-feature-local/SKILL.md
+++ b/plugin/skills/muggle-test-feature-local/SKILL.md
@@ -30,6 +30,7 @@ Gates run per `preference-gates/README.md`.
 |------------|------|-------------------|
 | `autoLogin` | 1 | Reuse saved credentials when auth is required |
 | `autoSelectProject` | 2 | Reuse last-used Muggle project for this repo |
+| `localDevHost` | 4 | Reuse last-used local dev server URL for this repo |
 | `showElectronBrowser` | 7 | Show Electron browser window during local E2E tests |
 | `openTestResultsAfterRun` | 8 | Open results page on Muggle dashboard after run |
 | `postPRVisualWalkthrough` | 10 | Post visual walkthrough to PR after results |
@@ -94,13 +95,16 @@ Before detecting the local URL, verify that the services the user needs are actu
 
 This step is especially important when the user's app depends on sibling services (a backend API, an auth service, etc.) that may not be running yet. The prepare skill handles discovery, startup, and cleanup so this skill doesn't have to.
 
-### 4. Local URL
+### 4. Local URL (gated by `localDevHost`)
 
-Try to auto-detect the dev server URL by checking running terminals or common ports (e.g., `lsof -iTCP -sTCP:LISTEN -nP | grep -E ':(3000|3001|4200|5173|8080)'`). If a likely URL is found, present it as a clickable default via `AskQuestion`:
-- Option 1: "http://localhost:3000" (or whatever was detected)
-- Option 2: "Other — let me type a URL"
+Cache lookup: `muggle-local-last-host-get` (or read the `Muggle Last Host: <url>` line from session context). Auto-detect a suggested URL by checking common ports (e.g., `lsof -iTCP -sTCP:LISTEN -nP | grep -E ':(3000|3001|4200|5173|8080)'`).
 
-If nothing detected, ask as free text: "Your local app should be running. What's the URL? (e.g., http://localhost:3000)"
+Gate `localDevHost` (per `preference-gates/README.md` + `preference-gates/localDevHost.md`). Cache: `Muggle Last Host:` session line.
+- `always` + cache → use cached `{lastHost}` silently. No cache → fall through to `ask`.
+- `never` → always run Picker 1; skip Picker 2.
+- `ask` → run Picker 1 from the gate file (options: `Use {lastHost}` if cached / `Use {suggestedHost}` if detected / `Type a URL`). After the user picks, run Picker 2 from the gate file.
+
+Always call `muggle-local-last-host-set` with the resolved URL — independent of Picker 2 — so future runs can offer `Use {lastHost}`.
 
 Remind them: local URL is only the execution target, not tied to cloud project config.
 

--- a/plugin/skills/muggle-test-feature-local/SKILL.md
+++ b/plugin/skills/muggle-test-feature-local/SKILL.md
@@ -97,14 +97,12 @@ This step is especially important when the user's app depends on sibling service
 
 ### 4. Local URL (gated by `localDevHost`)
 
-Cache lookup: `muggle-local-last-host-get` (or read the `Muggle Test Last Host: <url>` line from session context). Auto-detect a suggested URL by checking common ports (e.g., `lsof -iTCP -sTCP:LISTEN -nP | grep -E ':(3000|3001|4200|5173|8080)'`).
+Skill responsibilities (the rest is in `preference-gates/localDevHost.md`):
+- **Read the cache**: `Muggle Test Last Host: <url>` session-context line, or `muggle-local-last-host-get`. Pass as `{lastHost}` substitution.
+- **Auto-detect a suggested URL**: `lsof -iTCP -sTCP:LISTEN -nP | grep -E ':(3000|3001|4200|5173|8080)'`. Pass as `{suggestedHost}`.
+- **Save the cache**: call `muggle-local-last-host-set` after the user picks (the gate file requires this on every pick).
 
-Gate `localDevHost` (per `preference-gates/README.md` + `preference-gates/localDevHost.md`). Cache: `Muggle Test Last Host:` session line.
-- `always` + cache → use cached `{lastHost}` silently. No cache → fall through to `ask`.
-- `never` → always run Picker 1; skip Picker 2.
-- `ask` → run Picker 1 from the gate file (options: `Use {lastHost}` if cached / `Use {suggestedHost}` if detected / `Type a URL`). After the user picks, run Picker 2 from the gate file.
-
-Always call `muggle-local-last-host-set` with the resolved URL — independent of Picker 2 — so future runs can offer `Use {lastHost}`.
+Gate `localDevHost` per `preference-gates/README.md` + `preference-gates/localDevHost.md`.
 
 Remind them: local URL is only the execution target, not tied to cloud project config.
 

--- a/plugin/skills/muggle-test-import/SKILL.md
+++ b/plugin/skills/muggle-test-import/SKILL.md
@@ -4,11 +4,11 @@ description: >
   Bring existing tests and test artifacts INTO Muggle Test — from Playwright, Cypress, PRDs,
   Gherkin feature files, test plan docs, Notion exports, or any source.
   TRIGGER when: user wants to import/migrate/load/upload/add/convert existing test files or
-  test docs into Muggle — e.g. "import my playwright tests", "migrate from cypress to muggle",
+  test docs into Muggle Test — e.g. "import my playwright tests", "migrate from cypress to muggle",
   "upload my PRD to muggle", "add my e2e specs to our muggle project", "load these test cases
   into muggle", "turn this feature file into muggle test cases", "create muggle test cases from
   my PRD", "track my specs in muggle", or any .spec.ts/.cy.js/.feature/.md file + muggle.
-  DO NOT TRIGGER when: user wants to run/replay Muggle scripts, scan a site, generate new
+  DO NOT TRIGGER when: user wants to run/replay Muggle Test scripts, scan a site, generate new
   tests from scratch, or check existing test results.
 ---
 
@@ -16,7 +16,7 @@ description: >
 
 This skill migrates existing test artifacts into Muggle Test. It reads your source files,
 structures them into use cases and test cases, gets your approval, then creates everything
-in a Muggle project via the API.
+in a Muggle Test project via the API.
 
 ## Preferences
 
@@ -25,7 +25,7 @@ Gates run per `preference-gates/README.md`.
 | Preference | Step | Decision it gates |
 |------------|------|-------------------|
 | `autoLogin` | 4 | Reuse saved credentials when auth is required |
-| `autoSelectProject` | 5 | Reuse last-used Muggle project for this repo |
+| `autoSelectProject` | 5 | Reuse last-used Muggle Test project for this repo |
 | `suggestRelatedUseCases` | 8a | Suggest related use cases after import |
 | `suggestRelatedTestCases` | 8b | Suggest related test cases after import |
 
@@ -61,7 +61,7 @@ The extraction strategy depends on the file type. Choose the right path before r
 
 ### Path A — PRD / design documents (preferred for document sources)
 
-Muggle has a native PRD processing workflow that extracts use cases more accurately than
+Muggle Test has a native PRD processing workflow that extracts use cases more accurately than
 manual parsing. Use this path for `.md`, `.txt`, `.pdf`, or any prose document.
 
 After authentication and project selection (Steps 4–5), come back and:
@@ -131,7 +131,7 @@ Use `AskQuestion` to confirm:
 
 If the user wants changes, incorporate feedback, then ask again. Only proceed after explicit approval.
 
-> For Path A (native PRD upload): present the use case/test case list that Muggle extracted
+> For Path A (native PRD upload): present the use case/test case list that Muggle Test extracted
 > after the processing workflow completes, and ask the user to confirm before adding any
 > extra test cases manually.
 
@@ -157,9 +157,9 @@ If **not authenticated**:
 
 A **project** is where all your imported use cases, test cases, and future test results are grouped on the Muggle AI dashboard.
 
-The per-repo project cache lives at `<cwd>/.muggle-ai/last-project.json` (via the `muggle-local-last-project-get` / `muggle-local-last-project-set` MCP tools). Look for `Muggle Last Project: id=… url=… name="…"` in session context.
+The per-repo project cache lives at `<cwd>/.muggle-ai/last-project.json` (via the `muggle-local-last-project-get` / `muggle-local-last-project-set` MCP tools). Look for `Muggle Test Last Project: id=… url=… name="…"` in session context.
 
-Gate `autoSelectProject` (per `preference-gates/README.md`). Cache: `Muggle Last Project` session line.
+Gate `autoSelectProject` (per `preference-gates/README.md`). Cache: `Muggle Test Last Project` session line.
 - `always` + cache → use cached `projectId`, skip to Step 6. No cache → fall through to `ask`.
 - `never` → full project list; skip Picker 2.
 - `ask` → project list picker (see gate file for spec + Picker 2 override). Skip Picker 2 if "Create new project".
@@ -184,12 +184,12 @@ Gate `autoSelectProject` (per `preference-gates/README.md`). Cache: `Muggle Last
 
 Import in two passes using bulk-preview. Show progress to the user as you go.
 
-Both passes use Muggle's async bulk-preview MCP tools, which route prompts through OpenAI's
+Both passes use Muggle Test's async bulk-preview MCP tools, which route prompts through OpenAI's
 Batch API for roughly ~50% of normal LLM cost. The flow is always: **submit → poll → persist**.
 
 ### Path A — Native PRD upload (for document files)
 
-If the source is a PRD or design document, use Muggle's built-in processing pipeline:
+If the source is a PRD or design document, use Muggle Test's built-in processing pipeline:
 
 1. Read the file and base64-encode its content:
    ```bash
@@ -365,7 +365,7 @@ When all imports are done, print a clean summary. Include:
 - A link to the project overview
 - If any items failed during preview (partial status), list them so the user can retry
 
-Construct view URLs using the Muggle dashboard URL pattern:
+Construct view URLs using the Muggle Test dashboard URL pattern:
 - Project test cases: `https://www.muggle-ai.com/muggleTestV0/dashboard/projects/<projectId>/testcases`
 - Use case within project: `https://www.muggle-ai.com/muggleTestV0/dashboard/projects/<projectId>/testcases?useCaseId=<useCaseId>`
 
@@ -424,5 +424,5 @@ When running the query, for each use case in the import:
 1. Call `muggle-remote-test-case-list-by-use-case` with that `useCaseId`.
 2. Filter out any test case you just created in Pass 2 of Step 6.
 3. Present the remainder via `AskQuestion` with `allow_multiple: true`, labeled `[<priority>] <title> — <goal>`.
-4. For any the user selects: nothing to create (they already exist) — just confirm to the user that those tests are now part of their Muggle project alongside the imported ones.
+4. For any the user selects: nothing to create (they already exist) — just confirm to the user that those tests are now part of their Muggle Test project alongside the imported ones.
 5. If a use case has no extra test cases, skip it silently.

--- a/plugin/skills/muggle-test-regenerate-missing/SKILL.md
+++ b/plugin/skills/muggle-test-regenerate-missing/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: muggle-test-regenerate-missing
-description: "Bulk-regenerate test scripts for every test case in a Muggle AI project that doesn't currently have an active script. Scans the project, finds test cases stuck in DRAFT or GENERATION_PENDING (no usable script attached), shows the user the list, and on approval kicks off bulk remote test script generation via the Muggle cloud. Use this skill whenever the user asks to 'regenerate missing scripts', 'fill in missing test scripts', 'generate scripts for test cases without one', 'regen all the test cases that don't have scripts', 'rebuild scripts for stale test cases', 'fix test cases with no script', 'bulk regenerate', or any phrasing that means 'kick off script generation across a project for the cases that need it'. Triggers on: 'regenerate missing test scripts', 'generate scripts for all empty test cases', 'fill the gaps in my test scripts', 'bulk test script regen', 'all my test cases without active scripts'. This is the go-to skill for project-wide script catch-up — it handles discovery, filtering, confirmation, and remote workflow dispatch end-to-end."
+description: "Bulk-regenerate test scripts for every test case in a Muggle AI project that doesn't currently have an active script. Scans the project, finds test cases stuck in DRAFT or GENERATION_PENDING (no usable script attached), shows the user the list, and on approval kicks off bulk remote test script generation via the Muggle Test cloud. Use this skill whenever the user asks to 'regenerate missing scripts', 'fill in missing test scripts', 'generate scripts for test cases without one', 'regen all the test cases that don't have scripts', 'rebuild scripts for stale test cases', 'fix test cases with no script', 'bulk regenerate', or any phrasing that means 'kick off script generation across a project for the cases that need it'. Triggers on: 'regenerate missing test scripts', 'generate scripts for all empty test cases', 'fill the gaps in my test scripts', 'bulk test script regen', 'all my test cases without active scripts'. This is the go-to skill for project-wide script catch-up — it handles discovery, filtering, confirmation, and remote workflow dispatch end-to-end."
 ---
 
 # Muggle Test — Regenerate Missing Test Scripts
 
 A bulk maintenance skill for Muggle AI projects. It finds every test case in a project that does **not** currently have an active (ready-to-run) test script, shows the list to the user, and on approval triggers a remote test script generation workflow for each one. Useful after creating a batch of new test cases or when cleaning up a project that has drifted.
 
-Execution is **remote only** — Muggle's cloud generates the scripts in parallel against the project URL. The user's machine is not involved beyond making API calls.
+Execution is **remote only** — Muggle Test's cloud generates the scripts in parallel against the project URL. The user's machine is not involved beyond making API calls.
 
 ## Preferences
 
@@ -16,11 +16,11 @@ Gates run per `preference-gates/README.md`.
 | Preference | Step | Decision it gates |
 |------------|------|-------------------|
 | `autoLogin` | 1 | Reuse saved credentials when auth is required |
-| `autoSelectProject` | 2 | Reuse last-used Muggle project for this repo |
+| `autoSelectProject` | 2 | Reuse last-used Muggle Test project for this repo |
 
 ## Concept: what counts as "no active script"
 
-In the Muggle data model, a test case carries a status that reflects whether it has a usable script attached:
+In the Muggle Test data model, a test case carries a status that reflects whether it has a usable script attached:
 
 | Status | Meaning | Regenerate? |
 |:-------|:--------|:-----------:|
@@ -61,9 +61,9 @@ If auth keeps failing, suggest the user run `muggle logout && muggle login` from
 
 A **project** is the unit on the Muggle AI dashboard that groups test cases, scripts, and runs. The user must pick the one to scan — never auto-select from repo name, branch, or URL heuristics.
 
-The per-repo project cache lives at `<cwd>/.muggle-ai/last-project.json` (via the `muggle-local-last-project-get` / `muggle-local-last-project-set` MCP tools). Look for `Muggle Last Project: id=… url=… name="…"` in session context.
+The per-repo project cache lives at `<cwd>/.muggle-ai/last-project.json` (via the `muggle-local-last-project-get` / `muggle-local-last-project-set` MCP tools). Look for `Muggle Test Last Project: id=… url=… name="…"` in session context.
 
-Gate `autoSelectProject` (per `preference-gates/README.md`). Cache: `Muggle Last Project` session line.
+Gate `autoSelectProject` (per `preference-gates/README.md`). Cache: `Muggle Test Last Project` session line.
 - `always` + cache → use cached `projectId`, proceed to Step 3. No cache → fall through to `ask`.
 - `never` → full project list; skip Picker 2.
 - `ask` → project list picker (see gate file for spec + Picker 2 override). Skip Picker 2 if "Create new project".
@@ -125,7 +125,7 @@ Default behavior:
 
 After selection, call `AskQuestion` once more for a final confirmation:
 
-> "About to start remote test script generation for **N** test cases against `<projectUrl>`. This will consume Muggle workflow budget. Proceed?"
+> "About to start remote test script generation for **N** test cases against `<projectUrl>`. This will consume Muggle Test workflow budget. Proceed?"
 >
 > - "Yes, start all N"
 > - "No, cancel"

--- a/plugin/skills/muggle-test/SKILL.md
+++ b/plugin/skills/muggle-test/SKILL.md
@@ -40,7 +40,7 @@ Gates run per `preference-gates/README.md`.
 |------------|------|-------------------|
 | `autoLogin` | 3 | Reuse saved credentials when auth is required |
 | `autoSelectProject` | 4 | Reuse last-used Muggle Test project for this repo |
-| `localDevHost` | 7A | Reuse last-used local dev server URL for this repo |
+| `autoSelectLocalHost` | 7A | Reuse last-used local dev server URL for this repo |
 | `autoDetectChanges` | 2 | Scan local git changes and map to affected test cases |
 | `defaultExecutionMode` | 1 | Default to local or remote test execution |
 | `autoPublishLocalResults` | 7A | Upload local results to Muggle Test cloud after run |
@@ -204,14 +204,14 @@ Wait for user confirmation before moving to execution.
 
 ## Step 7A: Execute — Local Mode
 
-### Pre-flight question — Local URL (gated by `localDevHost`)
+### Pre-flight question — Local URL (gated by `autoSelectLocalHost`)
 
-Skill responsibilities (the rest is in `preference-gates/localDevHost.md`):
+Skill responsibilities (the rest is in `preference-gates/autoSelectLocalHost.md`):
 - **Read the cache**: `Muggle Test Last Host: <url>` session-context line, or `muggle-local-last-host-get`. Pass as `{lastHost}` substitution.
 - **Auto-detect a suggested URL**: `lsof -iTCP -sTCP:LISTEN -nP | grep -E ':(3000|3001|4200|5173|8080)'`. Pass as `{suggestedHost}`.
 - **Save the cache**: call `muggle-local-last-host-set` after the user picks (the gate file requires this on every pick).
 
-Gate `localDevHost` per `preference-gates/README.md` + `preference-gates/localDevHost.md`.
+Gate `autoSelectLocalHost` per `preference-gates/README.md` + `preference-gates/autoSelectLocalHost.md`.
 
 ### Pre-flight visibility (gated by `showElectronBrowser`)
 

--- a/plugin/skills/muggle-test/SKILL.md
+++ b/plugin/skills/muggle-test/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: muggle-test
-description: "Run change-driven E2E acceptance testing using Muggle AI — detects local code changes, maps them to use cases, and generates test scripts either locally (real browser on localhost) or remotely (cloud execution on a preview/staging URL). Publishes results to Muggle dashboard, opens them in the browser, and posts E2E acceptance summaries with screenshots to the PR. Use this skill whenever the user wants to test their changes, run E2E acceptance tests on recent work, validate what they've been working on, or check if their code changes broke anything. Triggers on: 'test my changes', 'run tests on my changes', 'acceptance test my work', 'check my changes', 'validate my changes', 'test before I push', 'make sure my changes work', 'regression test my changes', 'test on preview', 'test on staging'. This is the go-to skill for change-driven E2E acceptance testing — it handles everything from change detection to test execution to result reporting."
+description: "Run change-driven E2E acceptance testing using Muggle AI — detects local code changes, maps them to use cases, and generates test scripts either locally (real browser on localhost) or remotely (cloud execution on a preview/staging URL). Publishes results to Muggle Test dashboard, opens them in the browser, and posts E2E acceptance summaries with screenshots to the PR. Use this skill whenever the user wants to test their changes, run E2E acceptance tests on recent work, validate what they've been working on, or check if their code changes broke anything. Triggers on: 'test my changes', 'run tests on my changes', 'acceptance test my work', 'check my changes', 'validate my changes', 'test before I push', 'make sure my changes work', 'regression test my changes', 'test on preview', 'test on staging'. This is the go-to skill for change-driven E2E acceptance testing — it handles everything from change detection to test execution to result reporting."
 ---
 
 # Muggle Test — Change-Driven E2E Acceptance Router
@@ -21,7 +21,7 @@ A router skill that detects code changes, resolves impacted test cases, executes
 
 Every test case verifies exactly **one** user-observable behavior. Never bundle multiple concerns, sequential flows, or bootstrap/setup into a single test case — even if you think it would be "cleaner" or "more efficient."
 
-**Ordering, dependencies, and bootstrap are Muggle's service responsibility, not yours.** Muggle's cloud handles test case dependencies, prerequisite state, and execution ordering. Your job is to describe the *atomic behavior to verify* — never the flow that gets there.
+**Ordering, dependencies, and bootstrap are Muggle Test's service responsibility, not yours.** Muggle Test's cloud handles test case dependencies, prerequisite state, and execution ordering. Your job is to describe the *atomic behavior to verify* — never the flow that gets there.
 
 - ❌ Wrong: one test case that "signs up, logs in, navigates to the detail modal, verifies icon stacking, verifies tab order, verifies history format, and verifies reference layout."
 - ✅ Right: four separate test cases — one per verifiable behavior — each with instruction text like "Verify the detail modal shows stacked pair of icons per card" with **no** signup / login / navigation / setup language.
@@ -39,11 +39,11 @@ Gates run per `preference-gates/README.md`.
 | Preference | Step | Decision it gates |
 |------------|------|-------------------|
 | `autoLogin` | 3 | Reuse saved credentials when auth is required |
-| `autoSelectProject` | 4 | Reuse last-used Muggle project for this repo |
+| `autoSelectProject` | 4 | Reuse last-used Muggle Test project for this repo |
 | `localDevHost` | 7A | Reuse last-used local dev server URL for this repo |
 | `autoDetectChanges` | 2 | Scan local git changes and map to affected test cases |
 | `defaultExecutionMode` | 1 | Default to local or remote test execution |
-| `autoPublishLocalResults` | 7A | Upload local results to Muggle cloud after run |
+| `autoPublishLocalResults` | 7A | Upload local results to Muggle Test cloud after run |
 | `showElectronBrowser` | 7A | Show the Electron browser window during local test execution (vs. run headless) |
 | `postPRVisualWalkthrough` | 9 | Post visual walkthrough to PR after results are available |
 
@@ -59,7 +59,7 @@ Parse the user's query and explicitly confirm their expectation. There are exact
 Signs the user wants this: mentions "localhost", "local", "my machine", "dev server", "my changes locally", or just "test my changes" in a repo context.
 
 ### Mode B: Remote Test Generation
-> Ask Muggle's cloud to generate test scripts against a **preview/staging URL**.
+> Ask Muggle Test's cloud to generate test scripts against a **preview/staging URL**.
 >
 > Execution tool: `muggle-remote-workflow-start-test-script-generation`
 
@@ -113,9 +113,9 @@ If auth fails repeatedly, suggest: `muggle logout && muggle login` from terminal
 
 A **project** is where all your test results, use cases, and test scripts are grouped on the Muggle AI dashboard. Pick the project that matches what you're working on.
 
-The per-repo cache lives at `<cwd>/.muggle-ai/last-project.json` (managed via the `muggle-local-last-project-get` / `muggle-local-last-project-set` MCP tools). Look for the `Muggle Last Project: id=… url=… name="…"` line in session context — if present, that's this repo's cached pick.
+The per-repo cache lives at `<cwd>/.muggle-ai/last-project.json` (managed via the `muggle-local-last-project-get` / `muggle-local-last-project-set` MCP tools). Look for the `Muggle Test Last Project: id=… url=… name="…"` line in session context — if present, that's this repo's cached pick.
 
-Gate `autoSelectProject` (per `preference-gates/README.md`). Cache: `Muggle Last Project` session line.
+Gate `autoSelectProject` (per `preference-gates/README.md`). Cache: `Muggle Test Last Project` session line.
 - `always` + cache → use cached `projectId`, skip to Step 5. No cache → fall through to `ask`.
 - `never` → full project list; skip Picker 2.
 - `ask` → project list picker (see gate file for spec + Picker 2 override). Skip Picker 2 if "Create new project".
@@ -206,9 +206,9 @@ Wait for user confirmation before moving to execution.
 
 ### Pre-flight question — Local URL (gated by `localDevHost`)
 
-Cache lookup: `muggle-local-last-host-get` (or read the `Muggle Last Host: <url>` line from session context). Auto-detect a suggested URL by checking common ports (e.g., `lsof -iTCP -sTCP:LISTEN -nP | grep -E ':(3000|3001|4200|5173|8080)'`).
+Cache lookup: `muggle-local-last-host-get` (or read the `Muggle Test Last Host: <url>` line from session context). Auto-detect a suggested URL by checking common ports (e.g., `lsof -iTCP -sTCP:LISTEN -nP | grep -E ':(3000|3001|4200|5173|8080)'`).
 
-Gate `localDevHost` (per `preference-gates/README.md` + `preference-gates/localDevHost.md`). Cache: `Muggle Last Host:` session line.
+Gate `localDevHost` (per `preference-gates/README.md` + `preference-gates/localDevHost.md`). Cache: `Muggle Test Last Host:` session line.
 - `always` + cache → use cached `{lastHost}` silently. No cache → fall through to `ask`.
 - `never` → always run Picker 1; skip Picker 2.
 - `ask` → run Picker 1 from the gate file (options: `Use {lastHost}` if cached / `Use {suggestedHost}` if detected / `Type a URL`). After the user picks, run Picker 2 from the gate file.
@@ -437,7 +437,7 @@ This skill always uses **Mode A** (post to an existing PR); `muggle-do` is the o
 - **Use `AskQuestion` for every selection** — never ask the user to type a number; always present clickable options
 - **Auto-detect localhost URL when possible**; only fall back to free-text when nothing is listening on a common port
 - **Parallelize independent cloud jobs** — when creating N use cases, generating/creating N test cases, fetching N test case details, starting N remote workflows, polling N workflow runtimes, publishing N local runs, or fetching N per-step test scripts, issue all N calls in a single message so they fan out in parallel. The only tolerated sequential loop is local Electron execution (one browser, one test at a time). For use case creation specifically, use the native batch form of `muggle-remote-use-case-create-from-prompts` (all descriptions in one `instructions` array) instead of parallel calls.
-- **One atomic behavior per test case** — every test case verifies exactly one user-observable behavior. Never bundle signup/login/navigation/bootstrap/teardown into a test case body. Ordering and dependencies are Muggle's service responsibility, not the skill's.
+- **One atomic behavior per test case** — every test case verifies exactly one user-observable behavior. Never bundle signup/login/navigation/bootstrap/teardown into a test case body. Ordering and dependencies are Muggle Test's service responsibility, not the skill's.
 - **Never consolidate the generator's output** — if `muggle-remote-test-case-generate-from-prompt` returns N micro-tests, accept all N; never merge them into fewer test cases, even if "the plan" says 4 UC / 4 TC.
 - **Never skip the generate→review cycle** — always present generated test cases to the user before calling `muggle-remote-test-case-create`, even when you're confident. "I'll skip the review and create directly" is always wrong.
 - **Never silently drop test cases** — log failures and continue, then report them

--- a/plugin/skills/muggle-test/SKILL.md
+++ b/plugin/skills/muggle-test/SKILL.md
@@ -206,14 +206,12 @@ Wait for user confirmation before moving to execution.
 
 ### Pre-flight question — Local URL (gated by `localDevHost`)
 
-Cache lookup: `muggle-local-last-host-get` (or read the `Muggle Test Last Host: <url>` line from session context). Auto-detect a suggested URL by checking common ports (e.g., `lsof -iTCP -sTCP:LISTEN -nP | grep -E ':(3000|3001|4200|5173|8080)'`).
+Skill responsibilities (the rest is in `preference-gates/localDevHost.md`):
+- **Read the cache**: `Muggle Test Last Host: <url>` session-context line, or `muggle-local-last-host-get`. Pass as `{lastHost}` substitution.
+- **Auto-detect a suggested URL**: `lsof -iTCP -sTCP:LISTEN -nP | grep -E ':(3000|3001|4200|5173|8080)'`. Pass as `{suggestedHost}`.
+- **Save the cache**: call `muggle-local-last-host-set` after the user picks (the gate file requires this on every pick).
 
-Gate `localDevHost` (per `preference-gates/README.md` + `preference-gates/localDevHost.md`). Cache: `Muggle Test Last Host:` session line.
-- `always` + cache → use cached `{lastHost}` silently. No cache → fall through to `ask`.
-- `never` → always run Picker 1; skip Picker 2.
-- `ask` → run Picker 1 from the gate file (options: `Use {lastHost}` if cached / `Use {suggestedHost}` if detected / `Type a URL`). After the user picks, run Picker 2 from the gate file.
-
-Always call `muggle-local-last-host-set` with the resolved URL — independent of Picker 2 — so future runs can offer `Use {lastHost}`.
+Gate `localDevHost` per `preference-gates/README.md` + `preference-gates/localDevHost.md`.
 
 ### Pre-flight visibility (gated by `showElectronBrowser`)
 

--- a/plugin/skills/muggle-test/SKILL.md
+++ b/plugin/skills/muggle-test/SKILL.md
@@ -40,6 +40,7 @@ Gates run per `preference-gates/README.md`.
 |------------|------|-------------------|
 | `autoLogin` | 3 | Reuse saved credentials when auth is required |
 | `autoSelectProject` | 4 | Reuse last-used Muggle project for this repo |
+| `localDevHost` | 7A | Reuse last-used local dev server URL for this repo |
 | `autoDetectChanges` | 2 | Scan local git changes and map to affected test cases |
 | `defaultExecutionMode` | 1 | Default to local or remote test execution |
 | `autoPublishLocalResults` | 7A | Upload local results to Muggle cloud after run |
@@ -203,13 +204,16 @@ Wait for user confirmation before moving to execution.
 
 ## Step 7A: Execute — Local Mode
 
-### Pre-flight question — Local URL
+### Pre-flight question — Local URL (gated by `localDevHost`)
 
-Try to auto-detect the dev server URL by checking running terminals or common ports (e.g., `lsof -iTCP -sTCP:LISTEN -nP | grep -E ':(3000|3001|4200|5173|8080)'`). If a likely URL is found, present it as a clickable default via `AskQuestion`:
-- Option 1: "http://localhost:3000" (or whatever was detected)
-- Option 2: "Other — let me type a URL"
+Cache lookup: `muggle-local-last-host-get` (or read the `Muggle Last Host: <url>` line from session context). Auto-detect a suggested URL by checking common ports (e.g., `lsof -iTCP -sTCP:LISTEN -nP | grep -E ':(3000|3001|4200|5173|8080)'`).
 
-If nothing detected, ask as free text: "Your local app should be running. What's the URL? (e.g., http://localhost:3000)"
+Gate `localDevHost` (per `preference-gates/README.md` + `preference-gates/localDevHost.md`). Cache: `Muggle Last Host:` session line.
+- `always` + cache → use cached `{lastHost}` silently. No cache → fall through to `ask`.
+- `never` → always run Picker 1; skip Picker 2.
+- `ask` → run Picker 1 from the gate file (options: `Use {lastHost}` if cached / `Use {suggestedHost}` if detected / `Type a URL`). After the user picks, run Picker 2 from the gate file.
+
+Always call `muggle-local-last-host-set` with the resolved URL — independent of Picker 2 — so future runs can offer `Use {lastHost}`.
 
 ### Pre-flight visibility (gated by `showElectronBrowser`)
 

--- a/plugin/skills/muggle-upgrade/SKILL.md
+++ b/plugin/skills/muggle-upgrade/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: muggle-upgrade
-description: Update Muggle AI to latest version. Use when user types muggle upgrade or asks to update Muggle tools.
+description: Update Muggle AI to latest version. Use when user types muggle upgrade or asks to update Muggle Test tools.
 ---
 
-# Muggle Upgrade
+# Muggle Test Upgrade
 
 Update all Muggle AI components to the latest published version. This means **both** the `@muggleai/works` CLI on npm **and** the Electron runner the CLI manages.
 

--- a/plugin/skills/muggle-works-npm-release/SKILL.md
+++ b/plugin/skills/muggle-works-npm-release/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   dispatch publish-works-to-npm.yml—no local npm publish.
 ---
 
-# Muggle Works — npm release (single playbook)
+# Muggle Test Works — npm release (single playbook)
 
 Repo: **`multiplex-ai/muggle-ai-works`**. Workflow: **`.github/workflows/publish-works-to-npm.yml`** (“Publish Works to npm”). **Never** run local **`npm publish`** (OIDC trusted publishing in CI).
 

--- a/plugin/skills/muggle/SKILL.md
+++ b/plugin/skills/muggle/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: muggle
-description: Muggle AI command router and menu. Use when user types "muggle" or asks for available Muggle commands.
+description: Muggle AI command router and menu. Use when user types "muggle" or asks for available Muggle Test commands.
 ---
 
-# Muggle
+# Muggle Test
 
-Use this as the top-level Muggle command router.
+Use this as the top-level Muggle Test command router.
 
 ## Preferences
 
-User preferences are injected by the SessionStart hook into a `Muggle Preferences` line in session context (key=value pairs). Resolution: defaults → `~/.muggle-ai/preferences.json` (global) → `<repo>/.muggle-ai/preferences.json` (project). Treat absent prefs as `ask`.
+User preferences are injected by the SessionStart hook into a `Muggle Test Preferences` line in session context (key=value pairs). Resolution: defaults → `~/.muggle-ai/preferences.json` (global) → `<repo>/.muggle-ai/preferences.json` (project). Treat absent prefs as `ask`.
 
 This router skill itself does not gate any decision on a preference — it just routes user intent to a downstream skill. Each downstream skill consults its own preferences. For example, `checkForUpdates` is consulted by `muggle-status` (Check 4), not here.
 


### PR DESCRIPTION
## Summary

Implements the cache infrastructure for the `localDevHost` gate (added in #112) and wires it into the two skills that ask for a local URL. Mirrors the existing last-project pattern.

### MCP plumbing

- `packages/mcps/src/shared/last-host.ts` — `read`/`write`/`clear`/`format` for `<cwd>/.muggle-ai/last-host.json` (versioned JSON, same shape as `last-project.json`)
- `last-host-schemas.ts` — Zod input schemas for the 3 tools
- 3 new MCP tools registered: `muggle-local-last-host-get`, `muggle-local-last-host-set`, `muggle-local-last-host-clear`
- `last-host.test.ts` — unit + schema tests

### Session context injection

- `ensure-electron-app.sh` injects a `Muggle Last Host: <url>` line, so skills read the cached URL with zero token cost — same trick the last-project cache uses.

### Skill wiring

- `muggle-test-feature-local` Step 4 (Local URL): gate `localDevHost` with three-way branch (`always` + cache → silent reuse / `never` → always picker / `ask` → Picker 1 + Picker 2). Always calls `last-host-set` after the pick so future runs see the latest URL.
- `muggle-test` Step 7A (pre-flight URL): same wiring.

### Effect

After the user opts to remember a URL once, subsequent runs in the same repo skip the URL prompt entirely and go straight to execution.

## Test plan

- [ ] `muggle-local-last-host-get` returns null on a fresh repo, returns the cached URL after `set`
- [ ] `muggle-local-last-host-set` creates `.muggle-ai/last-host.json` with the right shape
- [ ] `Muggle Last Host: <url>` line shows in session context after a write (verify in next session)
- [ ] `muggle-test-feature-local` with `localDevHost=ask`: Picker 1 shows last/suggested/type options
- [ ] `muggle-test-feature-local` with `localDevHost=always` + cache: URL reused silently with the silent-mode footer
- [ ] `muggle-test` Step 7A: same as above

🤖 Generated with [Claude Code](https://claude.ai/claude-code)