### PR TITLE
fix(skills): centralize E2eReport assembly and fix PR comment formatting

### DIFF
--- a/plugin/skills/do/open-prs.md
+++ b/plugin/skills/do/open-prs.md
@@ -57,10 +57,7 @@ For each repo with changes:
 7. **Post the overflow `comment` only if it is non-null.** In the common case, `comment` is `null` and nothing is posted. Never post speculatively.
 
    ```bash
-   gh pr comment <PR#> --body "$(cat <<'EOF'
-   <comment field contents>
-   EOF
-   )"
+   jq -r '.comment' /tmp/muggle-pr-section.json | gh pr comment <PR#> --body-file -
    ```
 
 ## Rendering the E2E acceptance block via the shared skill

--- a/plugin/skills/muggle-pr-visual-walkthrough/SKILL.md
+++ b/plugin/skills/muggle-pr-visual-walkthrough/SKILL.md
@@ -78,77 +78,9 @@ Required fields per test: `name`, `testCaseId`, `runId`, `viewUrl`, `status`, `s
 
 If any required field is missing, stop and tell the caller exactly what's missing. Never fabricate data.
 
-## Step 1: Assemble the `E2eReport` (canonical guide)
+## Step 1: Assemble the `E2eReport`
 
-This step is the **single source of truth** for building the `E2eReport`. Callers (`muggle-test`, `muggle-test-feature-local`) point here instead of duplicating the logic.
-
-### From `muggle-test` / `muggle-test-feature-local` (local mode)
-
-**Include ALL runs — passed and failed.** Never drop a run from the report. Reviewers need the full picture.
-
-#### For each published run (returned by `muggle-local-publish-test-script`)
-
-Issue all `muggle-remote-test-script-get` calls in parallel — one per `testScriptId`. For each response:
-
-1. Extract `steps[]`: build `[{ stepIndex: <index>, action: steps[i].operation.action, screenshotUrl: steps[i].operation.screenshotUrl }, ...]`.
-2. Use the `viewUrl` returned by `muggle-local-publish-test-script`.
-3. Set `status` from the local run result (`muggle-local-run-result-get`).
-4. For a published-but-failed run, also capture `failureStepIndex`, `error`, and `artifactsDir` from the run result.
-
-#### For each failed/unpublished run (timeout, `goal_not_achievable`, or any run never passed to `muggle-local-publish-test-script`)
-
-1. Set `steps: []` — no cloud screenshots available.
-2. Set `viewUrl` to the project runs page: `https://www.muggle-ai.com/muggleTestV0/dashboard/projects/{projectId}/runs`
-3. Set `status: "failed"`, `failureStepIndex: 0`, and `error` from the run result.
-4. `testCaseId` comes from the test case selected in the execution step. `runId` comes from the `runId` returned by `muggle-local-execute-test-generation` — it is always present even when the execution failed.
-
-#### Populate metadata on every entry
-
-- `description` — the test case's title/description. Drives the collapsible header.
-- `useCaseName` — the parent use case title. When present on any entry, the overview groups by use case.
-
-Prefer values already in context; only call `muggle-remote-test-case-get` / `muggle-remote-use-case-get` for anything not already known.
-
-#### Assembled E2eReport shape
-
-```json
-{
-  "projectId": "<projectId>",
-  "tests": [
-    {
-      "name": "<test case title>",
-      "description": "<one-line description (recommended)>",
-      "useCaseName": "<parent use case title (recommended)>",
-      "testCaseId": "<testCaseId from execution step>",
-      "testScriptId": "<testScriptId from publish>",
-      "runId": "<runId from muggle-local-execute-test-generation>",
-      "viewUrl": "<viewUrl from publish>",
-      "status": "passed",
-      "steps": [{ "stepIndex": 0, "action": "...", "screenshotUrl": "..." }]
-    },
-    {
-      "name": "<failed test case title>",
-      "description": "<description>",
-      "useCaseName": "<use case title>",
-      "testCaseId": "<testCaseId from execution step>",
-      "runId": "<runId from muggle-local-execute-test-generation>",
-      "viewUrl": "https://www.muggle-ai.com/muggleTestV0/dashboard/projects/<projectId>/runs",
-      "status": "failed",
-      "steps": [],
-      "failureStepIndex": 0,
-      "error": "<error message from run result>"
-    }
-  ]
-}
-```
-
-### From `muggle-do` (`open-prs.md`)
-
-The `e2e-acceptance.md` stage already produces an `E2eReport` with the exact shape above — pass it through unchanged.
-
-### Direct invocation (user asked to post existing results)
-
-The caller must have already executed tests and published them. If the `E2eReport` is not in context, stop and tell the user to run `muggle-test` or `muggle-test-feature-local` first.
+Read `plugin/skills/muggle-pr-visual-walkthrough/e2e-report-assembly.md` for the full assembly guide.
 
 ## Step 2: Render via `muggle build-pr-section`
 

--- a/plugin/skills/muggle-pr-visual-walkthrough/SKILL.md
+++ b/plugin/skills/muggle-pr-visual-walkthrough/SKILL.md
@@ -78,24 +78,73 @@ Required fields per test: `name`, `testCaseId`, `runId`, `viewUrl`, `status`, `s
 
 If any required field is missing, stop and tell the caller exactly what's missing. Never fabricate data.
 
-## Step 1: Gather the `E2eReport`
+## Step 1: Assemble the `E2eReport` (canonical guide)
 
-How to assemble the JSON depends on which caller you are:
+This step is the **single source of truth** for building the `E2eReport`. Callers (`muggle-test`, `muggle-test-feature-local`) point here instead of duplicating the logic.
 
 ### From `muggle-test` / `muggle-test-feature-local` (local mode)
 
-After `muggle-local-publish-test-script` returns `{testScriptId, viewUrl, ...}` for each run:
+**Include ALL runs — passed and failed.** Never drop a run from the report. Reviewers need the full picture.
 
-1. Call `muggle-remote-test-script-get` with `testScriptId` to fetch the published script.
-2. Extract `steps[]` — for each step, build `{stepIndex: <index>, action: operation.action, screenshotUrl: operation.screenshotUrl}`.
-3. Determine `status` from the local run result (`muggle-local-run-result-get`).
-4. For failures, read `failureStepIndex`, `error`, and `artifactsDir` from the run result.
-5. Assemble the `E2eReport` with `projectId` from the test run.
-6. Populate `description` (test case title/description) and `useCaseName` (parent use case title) on each report entry — optional but strongly recommended; they drive the grouped overview and the per-test collapsible headers. Prefer values already in your conversation context from earlier steps (e.g. a test case you just created or selected, or a use case you confirmed); only call `muggle-remote-test-case-get` / `muggle-remote-use-case-get` for anything you don't already have.
+#### For each published run (returned by `muggle-local-publish-test-script`)
+
+Issue all `muggle-remote-test-script-get` calls in parallel — one per `testScriptId`. For each response:
+
+1. Extract `steps[]`: build `[{ stepIndex: <index>, action: steps[i].operation.action, screenshotUrl: steps[i].operation.screenshotUrl }, ...]`.
+2. Use the `viewUrl` returned by `muggle-local-publish-test-script`.
+3. Set `status` from the local run result (`muggle-local-run-result-get`).
+4. For a published-but-failed run, also capture `failureStepIndex`, `error`, and `artifactsDir` from the run result.
+
+#### For each failed/unpublished run (timeout, `goal_not_achievable`, or any run never passed to `muggle-local-publish-test-script`)
+
+1. Set `steps: []` — no cloud screenshots available.
+2. Set `viewUrl` to the project runs page: `https://www.muggle-ai.com/muggleTestV0/dashboard/projects/{projectId}/runs`
+3. Set `status: "failed"`, `failureStepIndex: 0`, and `error` from the run result.
+4. `testCaseId` comes from the test case selected in the execution step. `runId` comes from the `runId` returned by `muggle-local-execute-test-generation` — it is always present even when the execution failed.
+
+#### Populate metadata on every entry
+
+- `description` — the test case's title/description. Drives the collapsible header.
+- `useCaseName` — the parent use case title. When present on any entry, the overview groups by use case.
+
+Prefer values already in context; only call `muggle-remote-test-case-get` / `muggle-remote-use-case-get` for anything not already known.
+
+#### Assembled E2eReport shape
+
+```json
+{
+  "projectId": "<projectId>",
+  "tests": [
+    {
+      "name": "<test case title>",
+      "description": "<one-line description (recommended)>",
+      "useCaseName": "<parent use case title (recommended)>",
+      "testCaseId": "<testCaseId from execution step>",
+      "testScriptId": "<testScriptId from publish>",
+      "runId": "<runId from muggle-local-execute-test-generation>",
+      "viewUrl": "<viewUrl from publish>",
+      "status": "passed",
+      "steps": [{ "stepIndex": 0, "action": "...", "screenshotUrl": "..." }]
+    },
+    {
+      "name": "<failed test case title>",
+      "description": "<description>",
+      "useCaseName": "<use case title>",
+      "testCaseId": "<testCaseId from execution step>",
+      "runId": "<runId from muggle-local-execute-test-generation>",
+      "viewUrl": "https://www.muggle-ai.com/muggleTestV0/dashboard/projects/<projectId>/runs",
+      "status": "failed",
+      "steps": [],
+      "failureStepIndex": 0,
+      "error": "<error message from run result>"
+    }
+  ]
+}
+```
 
 ### From `muggle-do` (`open-prs.md`)
 
-The `e2e-acceptance.md` stage already produces an `E2eReport` with the exact shape above — that is the report's native output format. Pass it through unchanged.
+The `e2e-acceptance.md` stage already produces an `E2eReport` with the exact shape above — pass it through unchanged.
 
 ### Direct invocation (user asked to post existing results)
 

--- a/plugin/skills/muggle-pr-visual-walkthrough/e2e-report-assembly.md
+++ b/plugin/skills/muggle-pr-visual-walkthrough/e2e-report-assembly.md
@@ -2,37 +2,39 @@
 
 Include **all** runs — passed and failed. Never drop a run.
 
-## Published run (returned by `muggle-local-publish-test-script`)
+## From `muggle-test` / `muggle-test-feature-local` (local mode)
 
-Issue all `muggle-remote-test-script-get` calls in parallel — one per `testScriptId`:
+### Published run (returned by `muggle-local-publish-test-script`)
 
-1. Build `steps[]`: `[{ stepIndex, action: steps[i].operation.action, screenshotUrl: steps[i].operation.screenshotUrl }, ...]`
+Issue all `muggle-remote-test-script-get` calls in parallel — one per `testScriptId`. For each response:
+
+1. Build `steps[]`: `[{ stepIndex: <index>, action: steps[i].operation.action, screenshotUrl: steps[i].operation.screenshotUrl }, ...]`
 2. `viewUrl` — from publish response.
 3. `status` — from `muggle-local-run-result-get`.
 4. If failed: also capture `failureStepIndex`, `error`, `artifactsDir` from the run result.
 
-## Failed/unpublished run (timeout, `goal_not_achievable`, never published)
+### Failed/unpublished run (timeout, `goal_not_achievable`, or any run never passed to `muggle-local-publish-test-script`)
 
-1. `steps: []`
+1. `steps: []` — no cloud screenshots available.
 2. `viewUrl`: `https://www.muggle-ai.com/muggleTestV0/dashboard/projects/{projectId}/runs`
 3. `status: "failed"`, `failureStepIndex: 0`, `error` from run result.
 4. `testCaseId` — from execution step selection. `runId` — from `muggle-local-execute-test-generation` (always present even on failure).
 
-## Metadata (every entry)
+### Metadata (every entry)
 
-- `description` — test case title/description. Prefer context; call `muggle-remote-test-case-get` only if missing.
-- `useCaseName` — parent use case title. Prefer context; call `muggle-remote-use-case-get` only if missing.
+- `description` — test case title/description. Drives the collapsible header. Prefer context; call `muggle-remote-test-case-get` only if missing.
+- `useCaseName` — parent use case title. When present on any entry, the overview groups by use case. Prefer context; call `muggle-remote-use-case-get` only if missing.
 
-## Shape
+### Shape
 
 ```json
 {
   "projectId": "<projectId>",
   "tests": [
     {
-      "name": "<title>",
-      "description": "<one-line description>",
-      "useCaseName": "<use case title>",
+      "name": "<test case title>",
+      "description": "<one-line description (recommended)>",
+      "useCaseName": "<parent use case title (recommended)>",
       "testCaseId": "<testCaseId from execution step>",
       "testScriptId": "<testScriptId from publish>",
       "runId": "<runId from muggle-local-execute-test-generation>",
@@ -41,21 +43,25 @@ Issue all `muggle-remote-test-script-get` calls in parallel — one per `testScr
       "steps": [{ "stepIndex": 0, "action": "...", "screenshotUrl": "..." }]
     },
     {
-      "name": "<title>",
-      "description": "<one-line description>",
-      "useCaseName": "<use case title>",
+      "name": "<failed test case title>",
+      "description": "<one-line description (recommended)>",
+      "useCaseName": "<parent use case title (recommended)>",
       "testCaseId": "<testCaseId from execution step>",
       "runId": "<runId from muggle-local-execute-test-generation>",
       "viewUrl": "https://www.muggle-ai.com/muggleTestV0/dashboard/projects/<projectId>/runs",
       "status": "failed",
       "steps": [],
       "failureStepIndex": 0,
-      "error": "<error from run result>"
+      "error": "<error message from run result>"
     }
   ]
 }
 ```
 
-## From `muggle-do`
+## From `muggle-do` (`open-prs.md`)
 
 `e2e-acceptance.md` already produces this shape — pass it through unchanged.
+
+## Direct invocation (user asked to post existing results)
+
+The caller must have already executed tests and published them. If the `E2eReport` is not in context, stop and tell the user to run `muggle-test` or `muggle-test-feature-local` first.

--- a/plugin/skills/muggle-pr-visual-walkthrough/e2e-report-assembly.md
+++ b/plugin/skills/muggle-pr-visual-walkthrough/e2e-report-assembly.md
@@ -2,9 +2,7 @@
 
 Include **all** runs — passed and failed. Never drop a run.
 
-## From `muggle-test` / `muggle-test-feature-local` (local mode)
-
-### Published run (returned by `muggle-local-publish-test-script`)
+## Published run (returned by `muggle-local-publish-test-script`)
 
 Issue all `muggle-remote-test-script-get` calls in parallel — one per `testScriptId`. For each response:
 
@@ -13,19 +11,18 @@ Issue all `muggle-remote-test-script-get` calls in parallel — one per `testScr
 3. `status` — from `muggle-local-run-result-get`.
 4. If failed: also capture `failureStepIndex`, `error`, `artifactsDir` from the run result.
 
-### Failed/unpublished run (timeout, `goal_not_achievable`, or any run never passed to `muggle-local-publish-test-script`)
+## Failed/unpublished run (timeout, `goal_not_achievable`, or any run never passed to `muggle-local-publish-test-script`)
 
 1. `steps: []` — no cloud screenshots available.
 2. `viewUrl`: `https://www.muggle-ai.com/muggleTestV0/dashboard/projects/{projectId}/runs`
 3. `status: "failed"`, `failureStepIndex: 0`, `error` from run result.
 4. `testCaseId` — from execution step selection. `runId` — from `muggle-local-execute-test-generation` (always present even on failure).
 
-### Metadata (every entry)
+On every entry: `description` (test case title/description — drives the collapsible header) and `useCaseName` (parent use case title — when present, the overview groups by use case) are optional but recommended. Prefer values already in context; only call `muggle-remote-test-case-get` / `muggle-remote-use-case-get` if missing.
 
-- `description` — test case title/description. Drives the collapsible header. Prefer context; call `muggle-remote-test-case-get` only if missing.
-- `useCaseName` — parent use case title. When present on any entry, the overview groups by use case. Prefer context; call `muggle-remote-use-case-get` only if missing.
+If called from `muggle-do`: `e2e-acceptance.md` already produces this shape — pass it through unchanged.
 
-### Shape
+## Shape
 
 ```json
 {
@@ -57,11 +54,3 @@ Issue all `muggle-remote-test-script-get` calls in parallel — one per `testScr
   ]
 }
 ```
-
-## From `muggle-do` (`open-prs.md`)
-
-`e2e-acceptance.md` already produces this shape — pass it through unchanged.
-
-## Direct invocation (user asked to post existing results)
-
-The caller must have already executed tests and published them. If the `E2eReport` is not in context, stop and tell the user to run `muggle-test` or `muggle-test-feature-local` first.

--- a/plugin/skills/muggle-pr-visual-walkthrough/e2e-report-assembly.md
+++ b/plugin/skills/muggle-pr-visual-walkthrough/e2e-report-assembly.md
@@ -1,0 +1,71 @@
+# E2eReport Assembly Guide
+
+This is the **single source of truth** for building the `E2eReport` JSON required by `muggle-pr-visual-walkthrough`. Load this file when assembling the report.
+
+## From `muggle-test` / `muggle-test-feature-local` (local mode)
+
+**Include ALL runs — passed and failed.** Never drop a run from the report. Reviewers need the full picture.
+
+### For each published run (returned by `muggle-local-publish-test-script`)
+
+Issue all `muggle-remote-test-script-get` calls in parallel — one per `testScriptId`. For each response:
+
+1. Extract `steps[]`: build `[{ stepIndex: <index>, action: steps[i].operation.action, screenshotUrl: steps[i].operation.screenshotUrl }, ...]`.
+2. Use the `viewUrl` returned by `muggle-local-publish-test-script`.
+3. Set `status` from the local run result (`muggle-local-run-result-get`).
+4. For a published-but-failed run, also capture `failureStepIndex`, `error`, and `artifactsDir` from the run result.
+
+### For each failed/unpublished run (timeout, `goal_not_achievable`, or any run never passed to `muggle-local-publish-test-script`)
+
+1. Set `steps: []` — no cloud screenshots available.
+2. Set `viewUrl` to the project runs page: `https://www.muggle-ai.com/muggleTestV0/dashboard/projects/{projectId}/runs`
+3. Set `status: "failed"`, `failureStepIndex: 0`, and `error` from the run result.
+4. `testCaseId` comes from the test case selected in the execution step. `runId` comes from the `runId` returned by `muggle-local-execute-test-generation` — it is always present even when the execution failed.
+
+### Populate metadata on every entry
+
+- `description` — the test case's title/description. Drives the collapsible header.
+- `useCaseName` — the parent use case title. When present on any entry, the overview groups by use case.
+
+Prefer values already in context; only call `muggle-remote-test-case-get` / `muggle-remote-use-case-get` for anything not already known.
+
+### Assembled E2eReport shape
+
+```json
+{
+  "projectId": "<projectId>",
+  "tests": [
+    {
+      "name": "<test case title>",
+      "description": "<one-line description (recommended)>",
+      "useCaseName": "<parent use case title (recommended)>",
+      "testCaseId": "<testCaseId from execution step>",
+      "testScriptId": "<testScriptId from publish>",
+      "runId": "<runId from muggle-local-execute-test-generation>",
+      "viewUrl": "<viewUrl from publish>",
+      "status": "passed",
+      "steps": [{ "stepIndex": 0, "action": "...", "screenshotUrl": "..." }]
+    },
+    {
+      "name": "<failed test case title>",
+      "description": "<description>",
+      "useCaseName": "<use case title>",
+      "testCaseId": "<testCaseId from execution step>",
+      "runId": "<runId from muggle-local-execute-test-generation>",
+      "viewUrl": "https://www.muggle-ai.com/muggleTestV0/dashboard/projects/<projectId>/runs",
+      "status": "failed",
+      "steps": [],
+      "failureStepIndex": 0,
+      "error": "<error message from run result>"
+    }
+  ]
+}
+```
+
+## From `muggle-do` (`open-prs.md`)
+
+The `e2e-acceptance.md` stage already produces an `E2eReport` with the exact shape above — pass it through unchanged.
+
+## Direct invocation (user asked to post existing results)
+
+The caller must have already executed tests and published them. If the `E2eReport` is not in context, stop and tell the user to run `muggle-test` or `muggle-test-feature-local` first.

--- a/plugin/skills/muggle-pr-visual-walkthrough/e2e-report-assembly.md
+++ b/plugin/skills/muggle-pr-visual-walkthrough/e2e-report-assembly.md
@@ -1,44 +1,38 @@
 # E2eReport Assembly Guide
 
-This is the **single source of truth** for building the `E2eReport` JSON required by `muggle-pr-visual-walkthrough`. Load this file when assembling the report.
+Include **all** runs — passed and failed. Never drop a run.
 
-## From `muggle-test` / `muggle-test-feature-local` (local mode)
+## Published run (returned by `muggle-local-publish-test-script`)
 
-**Include ALL runs — passed and failed.** Never drop a run from the report. Reviewers need the full picture.
+Issue all `muggle-remote-test-script-get` calls in parallel — one per `testScriptId`:
 
-### For each published run (returned by `muggle-local-publish-test-script`)
+1. Build `steps[]`: `[{ stepIndex, action: steps[i].operation.action, screenshotUrl: steps[i].operation.screenshotUrl }, ...]`
+2. `viewUrl` — from publish response.
+3. `status` — from `muggle-local-run-result-get`.
+4. If failed: also capture `failureStepIndex`, `error`, `artifactsDir` from the run result.
 
-Issue all `muggle-remote-test-script-get` calls in parallel — one per `testScriptId`. For each response:
+## Failed/unpublished run (timeout, `goal_not_achievable`, never published)
 
-1. Extract `steps[]`: build `[{ stepIndex: <index>, action: steps[i].operation.action, screenshotUrl: steps[i].operation.screenshotUrl }, ...]`.
-2. Use the `viewUrl` returned by `muggle-local-publish-test-script`.
-3. Set `status` from the local run result (`muggle-local-run-result-get`).
-4. For a published-but-failed run, also capture `failureStepIndex`, `error`, and `artifactsDir` from the run result.
+1. `steps: []`
+2. `viewUrl`: `https://www.muggle-ai.com/muggleTestV0/dashboard/projects/{projectId}/runs`
+3. `status: "failed"`, `failureStepIndex: 0`, `error` from run result.
+4. `testCaseId` — from execution step selection. `runId` — from `muggle-local-execute-test-generation` (always present even on failure).
 
-### For each failed/unpublished run (timeout, `goal_not_achievable`, or any run never passed to `muggle-local-publish-test-script`)
+## Metadata (every entry)
 
-1. Set `steps: []` — no cloud screenshots available.
-2. Set `viewUrl` to the project runs page: `https://www.muggle-ai.com/muggleTestV0/dashboard/projects/{projectId}/runs`
-3. Set `status: "failed"`, `failureStepIndex: 0`, and `error` from the run result.
-4. `testCaseId` comes from the test case selected in the execution step. `runId` comes from the `runId` returned by `muggle-local-execute-test-generation` — it is always present even when the execution failed.
+- `description` — test case title/description. Prefer context; call `muggle-remote-test-case-get` only if missing.
+- `useCaseName` — parent use case title. Prefer context; call `muggle-remote-use-case-get` only if missing.
 
-### Populate metadata on every entry
-
-- `description` — the test case's title/description. Drives the collapsible header.
-- `useCaseName` — the parent use case title. When present on any entry, the overview groups by use case.
-
-Prefer values already in context; only call `muggle-remote-test-case-get` / `muggle-remote-use-case-get` for anything not already known.
-
-### Assembled E2eReport shape
+## Shape
 
 ```json
 {
   "projectId": "<projectId>",
   "tests": [
     {
-      "name": "<test case title>",
-      "description": "<one-line description (recommended)>",
-      "useCaseName": "<parent use case title (recommended)>",
+      "name": "<title>",
+      "description": "<one-line description>",
+      "useCaseName": "<use case title>",
       "testCaseId": "<testCaseId from execution step>",
       "testScriptId": "<testScriptId from publish>",
       "runId": "<runId from muggle-local-execute-test-generation>",
@@ -47,8 +41,8 @@ Prefer values already in context; only call `muggle-remote-test-case-get` / `mug
       "steps": [{ "stepIndex": 0, "action": "...", "screenshotUrl": "..." }]
     },
     {
-      "name": "<failed test case title>",
-      "description": "<description>",
+      "name": "<title>",
+      "description": "<one-line description>",
       "useCaseName": "<use case title>",
       "testCaseId": "<testCaseId from execution step>",
       "runId": "<runId from muggle-local-execute-test-generation>",
@@ -56,16 +50,12 @@ Prefer values already in context; only call `muggle-remote-test-case-get` / `mug
       "status": "failed",
       "steps": [],
       "failureStepIndex": 0,
-      "error": "<error message from run result>"
+      "error": "<error from run result>"
     }
   ]
 }
 ```
 
-## From `muggle-do` (`open-prs.md`)
+## From `muggle-do`
 
-The `e2e-acceptance.md` stage already produces an `E2eReport` with the exact shape above — pass it through unchanged.
-
-## Direct invocation (user asked to post existing results)
-
-The caller must have already executed tests and published them. If the `E2eReport` is not in context, stop and tell the user to run `muggle-test` or `muggle-test-feature-local` first.
+`e2e-acceptance.md` already produces this shape — pass it through unchanged.

--- a/plugin/skills/muggle-test-feature-local/SKILL.md
+++ b/plugin/skills/muggle-test-feature-local/SKILL.md
@@ -177,7 +177,7 @@ After reporting results, gather the required input and hand off to the shared **
 
 #### 10a: Assemble the `E2eReport`
 
-Build the `E2eReport` JSON by following **Step 1 of `muggle-pr-visual-walkthrough`** — that skill is the single source of truth for assembly logic, including how to handle failed/unpublished runs.
+Read `plugin/skills/muggle-pr-visual-walkthrough/e2e-report-assembly.md` for the full assembly guide.
 
 #### 10b: Detect the PR, then apply the `postPRVisualWalkthrough` gate
 

--- a/plugin/skills/muggle-test-feature-local/SKILL.md
+++ b/plugin/skills/muggle-test-feature-local/SKILL.md
@@ -175,38 +175,9 @@ Gate `showElectronBrowser` (per `preference-gates/README.md`). Reuse choice with
 
 After reporting results, gather the required input and hand off to the shared **`muggle:muggle-pr-visual-walkthrough`** skill, which renders the walkthrough via `muggle build-pr-section` and posts it to the current branch's open PR.
 
-#### 10a: Gather per-step screenshots
+#### 10a: Assemble the `E2eReport`
 
-The shared skill takes an **`E2eReport` JSON** that includes per-step screenshot URLs. After step 8 has called `muggle-local-publish-test-script` and you have the `testScriptId`:
-
-1. Call `muggle-remote-test-script-get` with the `testScriptId`.
-2. Extract per step: `steps[].operation.action` and `steps[].operation.screenshotUrl`.
-3. Build the `steps` array: `[{ stepIndex: 0, action: "...", screenshotUrl: "..." }, ...]`.
-4. If the run failed, capture `failureStepIndex`, `error`, and the local `artifactsDir` from the run result in step 9.
-5. Populate `description` (test case title/description) and `useCaseName` (parent use case title) on the report entry — optional but strongly recommended; they drive the grouped overview and the per-test collapsible headers. Prefer values already in your conversation context from earlier steps (e.g. the test case you just created or selected, or the use case you confirmed); only call `muggle-remote-test-case-get` / `muggle-remote-use-case-get` for anything you don't already have.
-
-Assemble the `E2eReport`:
-
-```json
-{
-  "projectId": "<projectId from step 2 (Targets)>",
-  "tests": [
-    {
-      "name": "<test case title>",
-      "description": "<one-line description of what this test verifies (optional but recommended)>",
-      "useCaseName": "<parent use case title (optional but recommended)>",
-      "testCaseId": "<id>",
-      "testScriptId": "<id from publish>",
-      "runId": "<runId from execute>",
-      "viewUrl": "<viewUrl from publish>",
-      "status": "passed",
-      "steps": [{ "stepIndex": 0, "action": "...", "screenshotUrl": "..." }]
-    }
-  ]
-}
-```
-
-See the `muggle:muggle-pr-visual-walkthrough` skill for the full schema including the failed-test shape.
+Build the `E2eReport` JSON by following **Step 1 of `muggle-pr-visual-walkthrough`** — that skill is the single source of truth for assembly logic, including how to handle failed/unpublished runs.
 
 #### 10b: Detect the PR, then apply the `postPRVisualWalkthrough` gate
 

--- a/plugin/skills/muggle-test/SKILL.md
+++ b/plugin/skills/muggle-test/SKILL.md
@@ -350,39 +350,9 @@ Tell the user:
 
 After reporting results, ask the user if they want to attach a **visual walkthrough** — a markdown block with per-test-case dashboard links and step-by-step screenshots — to the current branch's open PR. The rendering and posting workflow lives in the shared `muggle-pr-visual-walkthrough` skill; this step gathers the required input and hands off.
 
-### 9a: Gather per-step screenshots (required input for the shared skill)
+### 9a: Assemble the `E2eReport`
 
-The shared skill takes an **`E2eReport` JSON** that includes per-step screenshot URLs. You already have `projectId`, `testCaseId`, `runId`, `viewUrl`, and `status` from earlier steps — you still need the step-level data.
-
-For the published runs from Step 7A, issue **all** `muggle-remote-test-script-get` calls in parallel (single message, multiple tool calls) — one per `testScriptId` returned by `muggle-local-publish-test-script`. Then, for each response:
-
-1. Extract `steps[].operation.action` (description) and `steps[].operation.screenshotUrl` (cloud URL).
-2. Build a `steps` array: `[{ stepIndex: 0, action: "...", screenshotUrl: "..." }, ...]`.
-3. If the run failed, also capture `failureStepIndex`, `error`, and the local `artifactsDir` from `muggle-local-run-result-get`.
-4. Populate `description` (test case title/description) and `useCaseName` (parent use case title) on each report entry — optional but strongly recommended; they drive the grouped overview and the per-test collapsible headers. Prefer values already in your conversation context from earlier steps (e.g. the test case you just created or selected, or the use case you confirmed); only call `muggle-remote-test-case-get` / `muggle-remote-use-case-get` for anything you don't already have.
-
-Assemble the report:
-
-```json
-{
-  "projectId": "<projectId>",
-  "tests": [
-    {
-      "name": "<test case title>",
-      "description": "<one-line description of what this test verifies (optional but recommended)>",
-      "useCaseName": "<parent use case title (optional but recommended)>",
-      "testCaseId": "<id>",
-      "testScriptId": "<id>",
-      "runId": "<id>",
-      "viewUrl": "<publish response viewUrl>",
-      "status": "passed",
-      "steps": [{ "stepIndex": 0, "action": "...", "screenshotUrl": "..." }]
-    }
-  ]
-}
-```
-
-See the shared skill for the full schema (including the failed-test shape with `failureStepIndex` and `error`).
+Build the `E2eReport` JSON by following **Step 1 of `muggle-pr-visual-walkthrough`** — that skill is the single source of truth for assembly logic, including how to handle failed/unpublished runs. All runs from Step 7A must be included (passed and failed).
 
 ### 9b: Detect the PR, then apply the `postPRVisualWalkthrough` gate
 

--- a/plugin/skills/muggle-test/SKILL.md
+++ b/plugin/skills/muggle-test/SKILL.md
@@ -352,7 +352,7 @@ After reporting results, ask the user if they want to attach a **visual walkthro
 
 ### 9a: Assemble the `E2eReport`
 
-Build the `E2eReport` JSON by following **Step 1 of `muggle-pr-visual-walkthrough`** — that skill is the single source of truth for assembly logic, including how to handle failed/unpublished runs. All runs from Step 7A must be included (passed and failed).
+Read `plugin/skills/muggle-pr-visual-walkthrough/e2e-report-assembly.md` for the full assembly guide. All runs from Step 7A must be included (passed and failed).
 
 ### 9b: Detect the PR, then apply the `postPRVisualWalkthrough` gate
 


### PR DESCRIPTION
## Summary
- **Centralize E2eReport assembly**: `muggle-pr-visual-walkthrough` Step 1 is now the single source of truth. `muggle-test` Step 9a and `muggle-test-feature-local` Step 10a reference it instead of duplicating the logic — eliminates drift.
- **Include all runs in the report**: The canonical guide requires all runs (passed and failed/unpublished). Failed/unpublished runs get `steps: []` and a fallback `viewUrl` to the project runs page. Clarifies that `testCaseId` comes from the execution step selection and `runId` always comes from `muggle-local-execute-test-generation` even on failure.
- **Fix literal `\n` in PR comments**: Replace heredoc body extraction with `jq -r '.body' | gh pr comment --body-file -` in `muggle-pr-visual-walkthrough` Steps 3A.2, 3A.3, Mode B, and `open-prs.md`. The old heredoc pattern left JSON escape sequences unresolved.

## Test Plan
- [ ] Run `/muggle:muggle-test` on a branch with mixed pass/fail runs — verify all tests appear in the PR comment
- [ ] Verify the PR comment renders with proper markdown formatting (no literal `\n`)
- [ ] Verify `muggle-do` overflow comment posts correctly via `open-prs.md`