### PR TITLE
Skill preference-gate eval — Layer 1 lint + Layer 2 harness scaffold

### DIFF
--- a/internal/skill-gate-eval/README.md
+++ b/internal/skill-gate-eval/README.md
@@ -5,7 +5,7 @@ session against a skill, with all Muggle MCP tools stubbed and
 `AskQuestion` intercepted, then asserts the recorded tool-call trace
 honors the gate contract for each preference value.
 
-See: `muggle-ai-brain/architecture/2026-05-07-skill-gate-eval-design.md`
+Design: `muggle-ai-brain/architecture/` — grep for "skill preference-gate eval".
 
 ## Layout
 
@@ -14,7 +14,9 @@ internal/skill-gate-eval/
   src/
     harness.ts      # runs one scenario: spawns agent, captures trace, asserts
     mock-mcp.ts     # in-process stub for the muggle MCP namespace
-    scenario.ts     # scenario file shape + loader
+    scenario.ts     # scenario file loader (types live in types.ts)
+    types.ts        # shared types + PreferenceValue enum
+    constants.ts    # ASK_QUESTION_TOOL, PASS_THRESHOLD, DEFAULT_MODEL
     run.ts          # CLI entrypoint
 ```
 

--- a/internal/skill-gate-eval/README.md
+++ b/internal/skill-gate-eval/README.md
@@ -1,0 +1,51 @@
+# Skill Gate Eval — Layer 2 (behavioral)
+
+Behavioral test harness for skill preference gates. Spawns a real agent
+session against a skill, with all Muggle MCP tools stubbed and
+`AskQuestion` intercepted, then asserts the recorded tool-call trace
+honors the gate contract for each preference value.
+
+See: `muggle-ai-brain/architecture/2026-05-07-skill-gate-eval-design.md`
+
+## Layout
+
+```
+internal/skill-gate-eval/
+  src/
+    harness.ts      # runs one scenario: spawns agent, captures trace, asserts
+    mock-mcp.ts     # in-process stub for the muggle MCP namespace
+    scenario.ts     # scenario file shape + loader
+    run.ts          # CLI entrypoint
+```
+
+Scenario data lives in `muggle-ai-brain/eval/skill-gate-eval/<gate>/`,
+not here. The harness reads scenarios from there and writes results
+back to the same place.
+
+## Running
+
+Layer 2 is run **manually** until the suite is stable. From the
+muggle-ai-works repo root:
+
+```bash
+ANTHROPIC_API_KEY=... \
+  MUGGLE_BRAIN_DIR=../muggle-ai-brain \
+  pnpm tsx internal/skill-gate-eval/src/run.ts \
+    --gate showElectronBrowser \
+    --skill muggle-test-feature-local \
+    --runs 10
+```
+
+The harness loads
+`$MUGGLE_BRAIN_DIR/eval/skill-gate-eval/showElectronBrowser/scenarios.json`,
+runs each scenario `--runs` times, and writes results to
+`$MUGGLE_BRAIN_DIR/eval/skill-gate-eval/showElectronBrowser/results.json`.
+
+A scenario passes if it succeeds on ≥ 99% of runs (per the design doc).
+
+## Why not vitest
+
+Layer 1 lives in `src/test/skills/` and runs via vitest on every
+commit. Layer 2 is multi-turn agent sessions — slow, costs API
+tokens, nondeterministic. Keeping it out of the vitest tree avoids
+accidental CI runs. Promote to CI only after the suite stabilizes.

--- a/internal/skill-gate-eval/src/constants.ts
+++ b/internal/skill-gate-eval/src/constants.ts
@@ -1,0 +1,8 @@
+/** Tool name the agent SDK uses for its built-in user-prompt tool. */
+export const ASK_QUESTION_TOOL = "AskQuestion";
+
+/** Per-scenario pass-rate floor below which we treat the gate as misfiring. */
+export const PASS_THRESHOLD = 0.99;
+
+/** Default eval target until the suite is stable enough to add others. */
+export const DEFAULT_MODEL = "claude-sonnet-4-6";

--- a/internal/skill-gate-eval/src/harness.ts
+++ b/internal/skill-gate-eval/src/harness.ts
@@ -21,29 +21,30 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 
+import { ASK_QUESTION_TOOL } from "./constants.js";
 import { buildMockMcpServer, MockCall } from "./mock-mcp.js";
-import { Scenario, ScenarioFile, loadFixtures } from "./scenario.js";
+import { loadFixtures } from "./scenario.js";
+import type {
+  AskQuestionRecord,
+  RunOptions,
+  RunVerdict,
+  Scenario,
+} from "./types.js";
 
-export interface RunVerdict {
-  scenario: string;
-  pass: boolean;
-  reasons: string[];
-  trace: {
-    mcpCalls: MockCall[];
-    askQuestions: { question: string; answer: string | null }[];
-  };
-}
-
-export interface RunOptions {
-  scenarioFile: ScenarioFile;
-  scenarioFilePath: string;
-  scenario: Scenario;
-  skillsDir: string;
-  model: string;
-}
-
-const ASK_QUESTION_TOOL = "AskQuestion";
-
+/**
+ * Build the system prompt from the SKILL.md plus a synthesized
+ * SessionStart context block.
+ *
+ * Output shape (one string, lines joined with `\n`):
+ *
+ *     <full SKILL.md body>
+ *
+ *     ---
+ *     # Synthesized SessionStart context (test harness)
+ *     Muggle Test Preferences: showElectronBrowser=always autoLogin=always ...
+ *     Muggle Test Last Project: id=proj-stub-1 url=http://localhost:3000 ...
+ *     Muggle Test Last Host: http://localhost:3000
+ */
 function buildSystemPrompt(opts: RunOptions): string {
   const skillMdPath = path.join(
     opts.skillsDir,
@@ -103,7 +104,7 @@ export async function runScenarioOnce(opts: RunOptions): Promise<RunVerdict> {
     opts.scenarioFile.fixturesPath,
   );
   const mock = buildMockMcpServer(fixtures);
-  const askQuestions: { question: string; answer: string | null }[] = [];
+  const askQuestions: AskQuestionRecord[] = [];
   let gateQuestionFired = false;
 
   const systemPrompt = buildSystemPrompt(opts);
@@ -121,7 +122,7 @@ export async function runScenarioOnce(opts: RunOptions): Promise<RunVerdict> {
       );
       if (isGateQuestion(question, opts.scenario)) gateQuestionFired = true;
       const answer = matchAskQuestionAnswer(question, opts.scenario);
-      askQuestions.push({ question, answer });
+      askQuestions.push({ question: question, answer: answer });
       // Returning `deny` short-circuits: the agent gets the message as
       // the tool result, which we use to inject our scripted answer.
       // Real SDK shape may differ; adjust to whatever the canUseTool
@@ -135,10 +136,10 @@ export async function runScenarioOnce(opts: RunOptions): Promise<RunVerdict> {
   };
 
   await runAgent({
-    systemPrompt,
+    systemPrompt: systemPrompt,
     userPrompt: opts.scenario.userPrompt,
     mcpServer: mock.server,
-    canUseTool,
+    canUseTool: canUseTool,
     model: opts.model,
   });
 
@@ -170,7 +171,7 @@ async function runAgent(_args: {
 function verdict(
   scenario: Scenario,
   mcpCalls: MockCall[],
-  askQuestions: { question: string; answer: string | null }[],
+  askQuestions: AskQuestionRecord[],
   gateQuestionFired: boolean,
 ): RunVerdict {
   const reasons: string[] = [];
@@ -212,7 +213,10 @@ function verdict(
   return {
     scenario: scenario.name,
     pass: reasons.length === 0,
-    reasons,
-    trace: { mcpCalls, askQuestions },
+    reasons: reasons,
+    trace: {
+      mcpCalls: mcpCalls,
+      askQuestions: askQuestions,
+    },
   };
 }

--- a/internal/skill-gate-eval/src/harness.ts
+++ b/internal/skill-gate-eval/src/harness.ts
@@ -1,0 +1,218 @@
+/**
+ * Runs one scenario end-to-end and returns a per-run verdict.
+ *
+ * Mechanics:
+ *   - Loads the target SKILL.md as the system prompt.
+ *   - Synthesizes a SessionStart context block (preferences line + any
+ *     extra session-context lines from the scenario) and appends it.
+ *   - Wires the mock muggle MCP server into the agent SDK.
+ *   - Hooks `canUseTool` to record every tool call. AskQuestion calls
+ *     get auto-answered from the scenario's `askQuestionAnswers`, or
+ *     fail the scenario if the gate's question fired when it shouldn't.
+ *   - After the run, asserts the captured trace against the scenario's
+ *     `expect` block.
+ *
+ * The Claude Agent SDK API used here is the canonical TS SDK shape; if
+ * the package import path or hook names diverge in the installed
+ * version, adjust the imports — the structure of the harness is
+ * stable.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { buildMockMcpServer, MockCall } from "./mock-mcp.js";
+import { Scenario, ScenarioFile, loadFixtures } from "./scenario.js";
+
+export interface RunVerdict {
+  scenario: string;
+  pass: boolean;
+  reasons: string[];
+  trace: {
+    mcpCalls: MockCall[];
+    askQuestions: { question: string; answer: string | null }[];
+  };
+}
+
+export interface RunOptions {
+  scenarioFile: ScenarioFile;
+  scenarioFilePath: string;
+  scenario: Scenario;
+  skillsDir: string;
+  model: string;
+}
+
+const ASK_QUESTION_TOOL = "AskQuestion";
+
+function buildSystemPrompt(opts: RunOptions): string {
+  const skillMdPath = path.join(
+    opts.skillsDir,
+    opts.scenarioFile.skill,
+    "SKILL.md",
+  );
+  const skillBody = fs.readFileSync(skillMdPath, "utf8");
+  const prefs = Object.entries(opts.scenario.preferences)
+    .map(([k, v]) => `${k}=${v}`)
+    .join(" ");
+  const extraContext = (opts.scenario.sessionContext ?? []).join("\n");
+  return [
+    skillBody,
+    "",
+    "---",
+    "# Synthesized SessionStart context (test harness)",
+    `Muggle Test Preferences: ${prefs}`,
+    extraContext,
+  ].join("\n");
+}
+
+function matchAskQuestionAnswer(
+  question: string,
+  scenario: Scenario,
+): string | null {
+  for (const a of scenario.askQuestionAnswers ?? []) {
+    if (question.includes(a.questionContains)) return a.answer;
+  }
+  return null;
+}
+
+/**
+ * Decide whether an AskQuestion call relates to the gate under test.
+ * The simplest signal is `gateQuestionSubstring` — when present, an
+ * AskQuestion whose text contains the substring is "the gate firing".
+ */
+function isGateQuestion(question: string, scenario: Scenario): boolean {
+  const sub = scenario.expect.gateQuestionSubstring;
+  if (!sub) return false;
+  return question.includes(sub);
+}
+
+/**
+ * Run one scenario once and return a verdict. Caller invokes this N
+ * times to compute a pass rate.
+ *
+ * The actual agent invocation is left abstract: a real implementation
+ * imports `query` from `@anthropic-ai/claude-agent-sdk`, wires
+ * `mcpServers: { muggle: handle.server }` and a `canUseTool` callback
+ * that records and answers AskQuestion. This file is the contract for
+ * what the harness emits — fill in `runAgent` once the SDK package is
+ * installed.
+ */
+export async function runScenarioOnce(opts: RunOptions): Promise<RunVerdict> {
+  const fixtures = loadFixtures(
+    opts.scenarioFilePath,
+    opts.scenarioFile.fixturesPath,
+  );
+  const mock = buildMockMcpServer(fixtures);
+  const askQuestions: { question: string; answer: string | null }[] = [];
+  let gateQuestionFired = false;
+
+  const systemPrompt = buildSystemPrompt(opts);
+
+  // canUseTool intercepts every tool call. For mocked muggle tools we
+  // allow + the mock server records the call. For AskQuestion we
+  // record + auto-answer or fail the scenario.
+  const canUseTool = async (
+    toolName: string,
+    input: Record<string, unknown>,
+  ): Promise<{ behavior: "allow"; updatedInput?: unknown } | { behavior: "deny"; message: string }> => {
+    if (toolName === ASK_QUESTION_TOOL) {
+      const question = String(
+        (input as { question?: unknown }).question ?? "",
+      );
+      if (isGateQuestion(question, opts.scenario)) gateQuestionFired = true;
+      const answer = matchAskQuestionAnswer(question, opts.scenario);
+      askQuestions.push({ question, answer });
+      // Returning `deny` short-circuits: the agent gets the message as
+      // the tool result, which we use to inject our scripted answer.
+      // Real SDK shape may differ; adjust to whatever the canUseTool
+      // contract is in the installed version.
+      return {
+        behavior: "deny",
+        message: answer ?? "[harness] no scripted answer for this question",
+      };
+    }
+    return { behavior: "allow" };
+  };
+
+  await runAgent({
+    systemPrompt,
+    userPrompt: opts.scenario.userPrompt,
+    mcpServer: mock.server,
+    canUseTool,
+    model: opts.model,
+  });
+
+  return verdict(opts.scenario, mock.calls, askQuestions, gateQuestionFired);
+}
+
+/**
+ * Stub for the real Claude Agent SDK call. Replace this body with the
+ * concrete `query()` invocation from `@anthropic-ai/claude-agent-sdk`
+ * once that dep is installed and pinned. Until then, calling
+ * `runScenarioOnce` will throw — by design, so the harness scaffold
+ * doesn't masquerade as runnable.
+ */
+async function runAgent(_args: {
+  systemPrompt: string;
+  userPrompt: string;
+  mcpServer: unknown;
+  canUseTool: (
+    toolName: string,
+    input: Record<string, unknown>,
+  ) => Promise<unknown>;
+  model: string;
+}): Promise<void> {
+  throw new Error(
+    "[skill-gate-eval] runAgent not wired yet. Install @anthropic-ai/claude-agent-sdk and replace this stub. See README.",
+  );
+}
+
+function verdict(
+  scenario: Scenario,
+  mcpCalls: MockCall[],
+  askQuestions: { question: string; answer: string | null }[],
+  gateQuestionFired: boolean,
+): RunVerdict {
+  const reasons: string[] = [];
+
+  if (scenario.expect.askQuestionForGate && !gateQuestionFired) {
+    reasons.push(
+      `expected gate to ask Picker 1 (substring="${scenario.expect.gateQuestionSubstring}") but it never fired`,
+    );
+  }
+  if (!scenario.expect.askQuestionForGate && gateQuestionFired) {
+    reasons.push(
+      `expected gate to be silent but Picker 1 fired (substring matched: "${scenario.expect.gateQuestionSubstring}")`,
+    );
+  }
+
+  if (scenario.expect.executeTool) {
+    const exec = mcpCalls.find((c) => c.tool === scenario.expect.executeTool);
+    if (!exec) {
+      reasons.push(`expected ${scenario.expect.executeTool} to be called but it was not`);
+    } else if (scenario.expect.executeArgs) {
+      const args = (exec.args ?? {}) as Record<string, unknown>;
+      for (const [k, expected] of Object.entries(scenario.expect.executeArgs)) {
+        const actualPresent = Object.prototype.hasOwnProperty.call(args, k);
+        if (expected === "OMITTED") {
+          if (actualPresent) {
+            reasons.push(`expected ${k} to be omitted from ${exec.tool} but it was ${JSON.stringify(args[k])}`);
+          }
+        } else {
+          if (!actualPresent) {
+            reasons.push(`expected ${k}=${JSON.stringify(expected)} on ${exec.tool} but it was omitted`);
+          } else if (args[k] !== expected) {
+            reasons.push(`expected ${k}=${JSON.stringify(expected)} on ${exec.tool} but got ${JSON.stringify(args[k])}`);
+          }
+        }
+      }
+    }
+  }
+
+  return {
+    scenario: scenario.name,
+    pass: reasons.length === 0,
+    reasons,
+    trace: { mcpCalls, askQuestions },
+  };
+}

--- a/internal/skill-gate-eval/src/mock-mcp.ts
+++ b/internal/skill-gate-eval/src/mock-mcp.ts
@@ -1,0 +1,175 @@
+/**
+ * In-process MCP server that shadows the muggle namespace with canned
+ * responses driven by a fixtures map. Every tool the skill might call
+ * during the path under test must have a stub here, otherwise the
+ * agent will block on a real MCP call and the run will hang.
+ *
+ * The harness wires this server into the agent SDK as the muggle MCP
+ * provider for the duration of one scenario run.
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+
+export interface MockCall {
+  tool: string;
+  args: unknown;
+  resultJson: string;
+}
+
+export interface MockMcpHandle {
+  server: Server;
+  calls: MockCall[];
+}
+
+interface ToolStub {
+  name: string;
+  description: string;
+  /** Returns the canned result given the tool args and shared fixtures. */
+  respond: (
+    args: Record<string, unknown>,
+    fixtures: Record<string, unknown>,
+  ) => unknown;
+}
+
+const STUBS: ToolStub[] = [
+  {
+    name: "muggle-local-telemetry-skill-emit",
+    description: "stub: telemetry sink",
+    respond: () => ({ ok: true }),
+  },
+  {
+    name: "muggle-remote-auth-status",
+    description: "stub: auth status",
+    respond: (_a, fx) => fx.authStatus ?? { authenticated: true, email: "tester@example.com" },
+  },
+  {
+    name: "muggle-remote-auth-login",
+    description: "stub: auth login",
+    respond: () => ({ verificationUrl: "https://example.invalid/login", code: "STUB" }),
+  },
+  {
+    name: "muggle-remote-auth-poll",
+    description: "stub: auth poll",
+    respond: () => ({ status: "complete", email: "tester@example.com" }),
+  },
+  {
+    name: "muggle-local-last-project-get",
+    description: "stub: last project cache get",
+    respond: (_a, fx) => fx.lastProject ?? null,
+  },
+  {
+    name: "muggle-local-last-project-set",
+    description: "stub: last project cache set",
+    respond: () => ({ ok: true }),
+  },
+  {
+    name: "muggle-local-last-host-get",
+    description: "stub: last host cache get",
+    respond: (_a, fx) => fx.lastHost ?? null,
+  },
+  {
+    name: "muggle-local-last-host-set",
+    description: "stub: last host cache set",
+    respond: () => ({ ok: true }),
+  },
+  {
+    name: "muggle-remote-project-list",
+    description: "stub: project list",
+    respond: (_a, fx) => fx.projects ?? { items: [] },
+  },
+  {
+    name: "muggle-remote-use-case-list",
+    description: "stub: use case list",
+    respond: (_a, fx) => fx.useCases ?? { items: [] },
+  },
+  {
+    name: "muggle-remote-test-case-list-by-use-case",
+    description: "stub: test case list",
+    respond: (_a, fx) => fx.testCases ?? { items: [] },
+  },
+  {
+    name: "muggle-remote-test-case-get",
+    description: "stub: test case get",
+    respond: (_a, fx) => fx.testCase ?? { id: "tc-stub", title: "Stub test case" },
+  },
+  {
+    name: "muggle-remote-test-script-list",
+    description: "stub: test script list (none)",
+    respond: () => ({ items: [] }),
+  },
+  {
+    name: "muggle-local-execute-test-generation",
+    description: "stub: execute generation (records args, never runs)",
+    respond: (_a, fx) =>
+      fx.executeResult ?? {
+        runId: "run-stub",
+        status: "passed",
+        viewUrl: "https://example.invalid/run/stub",
+      },
+  },
+  {
+    name: "muggle-local-execute-replay",
+    description: "stub: execute replay (records args, never runs)",
+    respond: (_a, fx) =>
+      fx.executeResult ?? {
+        runId: "run-stub",
+        status: "passed",
+        viewUrl: "https://example.invalid/run/stub",
+      },
+  },
+  {
+    name: "muggle-local-publish-test-script",
+    description: "stub: publish",
+    respond: () => ({ viewUrl: "https://example.invalid/script/stub" }),
+  },
+  {
+    name: "muggle-local-run-result-get",
+    description: "stub: run result",
+    respond: (_a, fx) =>
+      fx.runResult ?? {
+        runId: "run-stub",
+        status: "passed",
+        steps: [],
+      },
+  },
+];
+
+export function buildMockMcpServer(
+  fixtures: Record<string, unknown>,
+): MockMcpHandle {
+  const calls: MockCall[] = [];
+  const server = new Server(
+    { name: "muggle-mock", version: "0.0.0" },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, () => ({
+    tools: STUBS.map((s) => ({
+      name: s.name,
+      description: s.description,
+      inputSchema: { type: "object", additionalProperties: true },
+    })),
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, (req) => {
+    const stub = STUBS.find((s) => s.name === req.params.name);
+    if (!stub) {
+      throw new Error(`Mock MCP: unknown tool ${req.params.name}`);
+    }
+    const result = stub.respond(
+      (req.params.arguments ?? {}) as Record<string, unknown>,
+      fixtures,
+    );
+    const resultJson = JSON.stringify(result);
+    calls.push({ tool: stub.name, args: req.params.arguments, resultJson });
+    return {
+      content: [{ type: "text" as const, text: resultJson }],
+    };
+  });
+
+  return { server, calls };
+}

--- a/internal/skill-gate-eval/src/run.ts
+++ b/internal/skill-gate-eval/src/run.ts
@@ -1,0 +1,163 @@
+/**
+ * CLI entrypoint: run the scenarios for one (gate, skill) pair N times,
+ * aggregate per-scenario pass rates, write results.json next to the
+ * scenarios.json in muggle-ai-brain/eval/skill-gate-eval/.
+ *
+ * Usage:
+ *   tsx internal/skill-gate-eval/src/run.ts \
+ *     --gate showElectronBrowser \
+ *     --skill muggle-test-feature-local \
+ *     --runs 10 \
+ *     [--brain-dir ../muggle-ai-brain] \
+ *     [--model claude-sonnet-4-6]
+ *
+ * Pass threshold: 99% (per design doc).
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { loadScenarioFile } from "./scenario.js";
+import { runScenarioOnce, RunVerdict } from "./harness.js";
+
+const PASS_THRESHOLD = 0.99;
+const DEFAULT_MODEL = "claude-sonnet-4-6";
+
+interface CliArgs {
+  gate: string;
+  skill: string;
+  runs: number;
+  brainDir: string;
+  skillsDir: string;
+  model: string;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const out: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const val = argv[i + 1];
+      if (val === undefined || val.startsWith("--")) {
+        throw new Error(`Missing value for --${key}`);
+      }
+      out[key] = val;
+      i++;
+    }
+  }
+  if (!out.gate || !out.skill) {
+    throw new Error("Required: --gate <key> --skill <name>");
+  }
+  return {
+    gate: out.gate,
+    skill: out.skill,
+    runs: parseInt(out.runs ?? "10", 10),
+    brainDir: out["brain-dir"] ?? process.env.MUGGLE_BRAIN_DIR ?? "../muggle-ai-brain",
+    skillsDir: out["skills-dir"] ?? "plugin/skills",
+    model: out.model ?? DEFAULT_MODEL,
+  };
+}
+
+interface ScenarioReport {
+  name: string;
+  runs: number;
+  passes: number;
+  passRate: number;
+  passed: boolean;
+  failureReasons: string[];
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const scenarioFilePath = path.resolve(
+    args.brainDir,
+    "eval",
+    "skill-gate-eval",
+    args.gate,
+    "scenarios.json",
+  );
+  if (!fs.existsSync(scenarioFilePath)) {
+    throw new Error(`No scenario file at ${scenarioFilePath}`);
+  }
+  const scenarioFile = loadScenarioFile(scenarioFilePath);
+  if (scenarioFile.skill !== args.skill) {
+    throw new Error(
+      `Scenario file is for skill ${scenarioFile.skill}, not ${args.skill}`,
+    );
+  }
+
+  const reports: ScenarioReport[] = [];
+  for (const scenario of scenarioFile.scenarios) {
+    const verdicts: RunVerdict[] = [];
+    for (let i = 0; i < args.runs; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      verdicts.push(
+        await runScenarioOnce({
+          scenarioFile,
+          scenarioFilePath,
+          scenario,
+          skillsDir: path.resolve(args.skillsDir),
+          model: args.model,
+        }),
+      );
+    }
+    const passes = verdicts.filter((v) => v.pass).length;
+    const passRate = passes / verdicts.length;
+    const failureReasons = Array.from(
+      new Set(verdicts.flatMap((v) => v.reasons)),
+    );
+    reports.push({
+      name: scenario.name,
+      runs: verdicts.length,
+      passes,
+      passRate,
+      passed: passRate >= PASS_THRESHOLD,
+      failureReasons,
+    });
+  }
+
+  const resultsPath = path.resolve(
+    path.dirname(scenarioFilePath),
+    "results.json",
+  );
+  fs.writeFileSync(
+    resultsPath,
+    JSON.stringify(
+      {
+        gate: args.gate,
+        skill: args.skill,
+        model: args.model,
+        runsPerScenario: args.runs,
+        passThreshold: PASS_THRESHOLD,
+        recordedAt: new Date().toISOString(),
+        scenarios: reports,
+      },
+      null,
+      2,
+    ),
+  );
+
+  const allPassed = reports.every((r) => r.passed);
+  // eslint-disable-next-line no-console
+  console.log(
+    `[skill-gate-eval] ${args.gate} on ${args.skill}: ${reports.filter((r) => r.passed).length}/${reports.length} scenarios passed @ ≥${(PASS_THRESHOLD * 100).toFixed(0)}%`,
+  );
+  for (const r of reports) {
+    // eslint-disable-next-line no-console
+    console.log(
+      `  ${r.passed ? "PASS" : "FAIL"}  ${r.name}  (${r.passes}/${r.runs} = ${(r.passRate * 100).toFixed(1)}%)`,
+    );
+    for (const reason of r.failureReasons) {
+      // eslint-disable-next-line no-console
+      console.log(`    - ${reason}`);
+    }
+  }
+  process.exit(allPassed ? 0 : 1);
+}
+
+main().catch((err: unknown) => {
+  // eslint-disable-next-line no-console
+  console.error(err);
+  process.exit(2);
+});

--- a/internal/skill-gate-eval/src/run.ts
+++ b/internal/skill-gate-eval/src/run.ts
@@ -10,27 +10,15 @@
  *     --runs 10 \
  *     [--brain-dir ../muggle-ai-brain] \
  *     [--model claude-sonnet-4-6]
- *
- * Pass threshold: 99% (per design doc).
  */
 
 import * as fs from "node:fs";
 import * as path from "node:path";
 
+import { DEFAULT_MODEL, PASS_THRESHOLD } from "./constants.js";
+import { runScenarioOnce } from "./harness.js";
 import { loadScenarioFile } from "./scenario.js";
-import { runScenarioOnce, RunVerdict } from "./harness.js";
-
-const PASS_THRESHOLD = 0.99;
-const DEFAULT_MODEL = "claude-sonnet-4-6";
-
-interface CliArgs {
-  gate: string;
-  skill: string;
-  runs: number;
-  brainDir: string;
-  skillsDir: string;
-  model: string;
-}
+import type { CliArgs, RunVerdict, ScenarioReport } from "./types.js";
 
 function parseArgs(argv: string[]): CliArgs {
   const out: Record<string, string> = {};
@@ -59,15 +47,6 @@ function parseArgs(argv: string[]): CliArgs {
   };
 }
 
-interface ScenarioReport {
-  name: string;
-  runs: number;
-  passes: number;
-  passRate: number;
-  passed: boolean;
-  failureReasons: string[];
-}
-
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
   const scenarioFilePath = path.resolve(
@@ -94,9 +73,9 @@ async function main(): Promise<void> {
       // eslint-disable-next-line no-await-in-loop
       verdicts.push(
         await runScenarioOnce({
-          scenarioFile,
-          scenarioFilePath,
-          scenario,
+          scenarioFile: scenarioFile,
+          scenarioFilePath: scenarioFilePath,
+          scenario: scenario,
           skillsDir: path.resolve(args.skillsDir),
           model: args.model,
         }),
@@ -110,10 +89,10 @@ async function main(): Promise<void> {
     reports.push({
       name: scenario.name,
       runs: verdicts.length,
-      passes,
-      passRate,
+      passes: passes,
+      passRate: passRate,
       passed: passRate >= PASS_THRESHOLD,
-      failureReasons,
+      failureReasons: failureReasons,
     });
   }
 

--- a/internal/skill-gate-eval/src/scenario.ts
+++ b/internal/skill-gate-eval/src/scenario.ts
@@ -1,73 +1,17 @@
-/**
- * Scenario file shape. Scenarios live in muggle-ai-brain/eval/, this
- * file just describes what the harness consumes.
- */
+/** Loads scenario files and the fixtures they reference. Types live in `./types`. */
 
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-export type PreferenceValue =
-  | "always"
-  | "never"
-  | "ask"
-  | "local"
-  | "remote";
+import type { ScenarioFile } from "./types.js";
 
-export interface ScenarioExpectation {
-  /**
-   * Whether the agent should call AskQuestion specifically for the gate
-   * being tested. `false` for `always`/`never` (silent path); `true`
-   * for absent / `ask`. Other AskQuestion calls (project picker, etc.)
-   * are unrelated and do not violate this expectation.
-   */
-  askQuestionForGate: boolean;
-
-  /**
-   * Substring that must appear in the AskQuestion text when the gate
-   * fires (only checked when askQuestionForGate=true). Lets the
-   * scenario assert "the question that was asked is the gate's
-   * canonical Picker 1 question, not some other AskQuestion call."
-   */
-  gateQuestionSubstring?: string;
-
-  /**
-   * Which Muggle execute tool the agent must end up calling, and the
-   * arg shape that proves the gate's effect was applied. Use the
-   * literal string "OMITTED" as a value to assert the key was not
-   * present in the call (e.g., showUi must be omitted for `always`).
-   */
-  executeTool?:
-    | "muggle-local-execute-test-generation"
-    | "muggle-local-execute-replay";
-  executeArgs?: Record<string, unknown | "OMITTED">;
-}
-
-export interface Scenario {
-  name: string;
-  preferences: Record<string, PreferenceValue>;
-  /**
-   * Extra session-context lines beyond the preferences line — e.g. the
-   * `Muggle Test Last Project: ...` cache. Each entry becomes a line
-   * under the SessionStart context.
-   */
-  sessionContext?: string[];
-  userPrompt: string;
-  /**
-   * Canned answers for AskQuestion calls the harness must auto-respond
-   * to in order to keep the agent flowing (e.g., project picker). Map
-   * by a substring of the question; first match wins.
-   */
-  askQuestionAnswers?: Array<{ questionContains: string; answer: string }>;
-  expect: ScenarioExpectation;
-}
-
-export interface ScenarioFile {
-  skill: string;
-  gate: string;
-  fixturesPath: string; // relative to scenario file
-  scenarios: Scenario[];
-}
-
+/**
+ * Read and parse a scenarios.json file.
+ *
+ * Output shape: `ScenarioFile` — { skill, gate, fixturesPath, scenarios[] }.
+ * Throws on missing required fields rather than silently returning a
+ * malformed object.
+ */
 export function loadScenarioFile(filePath: string): ScenarioFile {
   const raw = fs.readFileSync(filePath, "utf8");
   const parsed = JSON.parse(raw) as ScenarioFile;
@@ -77,6 +21,13 @@ export function loadScenarioFile(filePath: string): ScenarioFile {
   return parsed;
 }
 
+/**
+ * Load a fixtures.json sitting next to (or relative to) the scenario file.
+ *
+ * Output shape: arbitrary record consumed by `mock-mcp.ts` stubs — keys
+ * map to per-tool canned responses (e.g. `projects`, `useCases`,
+ * `executeResult`).
+ */
 export function loadFixtures(
   scenarioFile: string,
   fixturesPath: string,

--- a/internal/skill-gate-eval/src/scenario.ts
+++ b/internal/skill-gate-eval/src/scenario.ts
@@ -1,0 +1,89 @@
+/**
+ * Scenario file shape. Scenarios live in muggle-ai-brain/eval/, this
+ * file just describes what the harness consumes.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export type PreferenceValue =
+  | "always"
+  | "never"
+  | "ask"
+  | "local"
+  | "remote";
+
+export interface ScenarioExpectation {
+  /**
+   * Whether the agent should call AskQuestion specifically for the gate
+   * being tested. `false` for `always`/`never` (silent path); `true`
+   * for absent / `ask`. Other AskQuestion calls (project picker, etc.)
+   * are unrelated and do not violate this expectation.
+   */
+  askQuestionForGate: boolean;
+
+  /**
+   * Substring that must appear in the AskQuestion text when the gate
+   * fires (only checked when askQuestionForGate=true). Lets the
+   * scenario assert "the question that was asked is the gate's
+   * canonical Picker 1 question, not some other AskQuestion call."
+   */
+  gateQuestionSubstring?: string;
+
+  /**
+   * Which Muggle execute tool the agent must end up calling, and the
+   * arg shape that proves the gate's effect was applied. Use the
+   * literal string "OMITTED" as a value to assert the key was not
+   * present in the call (e.g., showUi must be omitted for `always`).
+   */
+  executeTool?:
+    | "muggle-local-execute-test-generation"
+    | "muggle-local-execute-replay";
+  executeArgs?: Record<string, unknown | "OMITTED">;
+}
+
+export interface Scenario {
+  name: string;
+  preferences: Record<string, PreferenceValue>;
+  /**
+   * Extra session-context lines beyond the preferences line — e.g. the
+   * `Muggle Test Last Project: ...` cache. Each entry becomes a line
+   * under the SessionStart context.
+   */
+  sessionContext?: string[];
+  userPrompt: string;
+  /**
+   * Canned answers for AskQuestion calls the harness must auto-respond
+   * to in order to keep the agent flowing (e.g., project picker). Map
+   * by a substring of the question; first match wins.
+   */
+  askQuestionAnswers?: Array<{ questionContains: string; answer: string }>;
+  expect: ScenarioExpectation;
+}
+
+export interface ScenarioFile {
+  skill: string;
+  gate: string;
+  fixturesPath: string; // relative to scenario file
+  scenarios: Scenario[];
+}
+
+export function loadScenarioFile(filePath: string): ScenarioFile {
+  const raw = fs.readFileSync(filePath, "utf8");
+  const parsed = JSON.parse(raw) as ScenarioFile;
+  if (!parsed.skill || !parsed.gate || !Array.isArray(parsed.scenarios)) {
+    throw new Error(`Invalid scenario file at ${filePath}`);
+  }
+  return parsed;
+}
+
+export function loadFixtures(
+  scenarioFile: string,
+  fixturesPath: string,
+): Record<string, unknown> {
+  const resolved = path.resolve(path.dirname(scenarioFile), fixturesPath);
+  return JSON.parse(fs.readFileSync(resolved, "utf8")) as Record<
+    string,
+    unknown
+  >;
+}

--- a/internal/skill-gate-eval/src/types.ts
+++ b/internal/skill-gate-eval/src/types.ts
@@ -1,0 +1,112 @@
+/**
+ * Shared types for the skill-gate eval. Kept here so harness.ts,
+ * run.ts, and scenario.ts don't each redeclare the contract.
+ */
+
+import type { MockCall } from "./mock-mcp.js";
+
+/** Canonical preference values a gate can resolve to. */
+export enum PreferenceValue {
+  Always = "always",
+  Never = "never",
+  Ask = "ask",
+  Local = "local",
+  Remote = "remote",
+}
+
+export interface ScenarioExpectation {
+  /**
+   * Whether the agent should call AskQuestion specifically for the gate
+   * being tested. `false` for `always`/`never` (silent path); `true`
+   * for absent / `ask`. Other AskQuestion calls (project picker, etc.)
+   * are unrelated and do not violate this expectation.
+   */
+  askQuestionForGate: boolean;
+
+  /**
+   * Substring that must appear in the AskQuestion text when the gate
+   * fires (only checked when askQuestionForGate=true). Lets the
+   * scenario assert "the question that was asked is the gate's
+   * canonical Picker 1 question, not some other AskQuestion call."
+   */
+  gateQuestionSubstring?: string;
+
+  /**
+   * Which Muggle execute tool the agent must end up calling, and the
+   * arg shape that proves the gate's effect was applied. Use the
+   * literal string "OMITTED" as a value to assert the key was not
+   * present in the call (e.g., showUi must be omitted for `always`).
+   */
+  executeTool?:
+    | "muggle-local-execute-test-generation"
+    | "muggle-local-execute-replay";
+  executeArgs?: Record<string, unknown | "OMITTED">;
+}
+
+export interface Scenario {
+  name: string;
+  preferences: Record<string, PreferenceValue>;
+  /**
+   * Extra session-context lines beyond the preferences line — e.g. the
+   * `Muggle Test Last Project: ...` cache. Each entry becomes a line
+   * under the SessionStart context.
+   */
+  sessionContext?: string[];
+  userPrompt: string;
+  /**
+   * Canned answers for AskQuestion calls the harness must auto-respond
+   * to in order to keep the agent flowing (e.g., project picker). Map
+   * by a substring of the question; first match wins.
+   */
+  askQuestionAnswers?: Array<{ questionContains: string; answer: string }>;
+  expect: ScenarioExpectation;
+}
+
+export interface ScenarioFile {
+  skill: string;
+  gate: string;
+  fixturesPath: string; // relative to scenario file
+  scenarios: Scenario[];
+}
+
+/** One AskQuestion call captured by the harness during a run. */
+export interface AskQuestionRecord {
+  question: string;
+  answer: string | null;
+}
+
+export interface RunVerdict {
+  scenario: string;
+  pass: boolean;
+  reasons: string[];
+  trace: {
+    mcpCalls: MockCall[];
+    askQuestions: AskQuestionRecord[];
+  };
+}
+
+export interface RunOptions {
+  scenarioFile: ScenarioFile;
+  scenarioFilePath: string;
+  scenario: Scenario;
+  skillsDir: string;
+  model: string;
+}
+
+export interface CliArgs {
+  gate: string;
+  skill: string;
+  runs: number;
+  brainDir: string;
+  skillsDir: string;
+  model: string;
+}
+
+export interface ScenarioReport {
+  name: string;
+  runs: number;
+  passes: number;
+  passRate: number;
+  passed: boolean;
+  failureReasons: string[];
+}

--- a/internal/skill-gate-eval/tsconfig.json
+++ b/internal/skill-gate-eval/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src/**/*"]
+}

--- a/src/test/skills/preference-gates-lint.test.ts
+++ b/src/test/skills/preference-gates-lint.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Layer 1 of the skill-gate eval: static contract lint.
+ *
+ * Verifies wiring between SKILL.md preference tables and the
+ * preference-gates/<key>.md contract files. Catches drift; does NOT
+ * catch "the LLM forgot to fire the gate" — that is Layer 2.
+ *
+ * See: muggle-ai-brain/architecture/2026-05-07-skill-gate-eval-design.md
+ */
+
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "../../..");
+const SKILLS_DIR = path.join(REPO_ROOT, "plugin", "skills");
+const GATES_DIR = path.join(
+  SKILLS_DIR,
+  "muggle-preferences",
+  "preference-gates",
+);
+
+const CANONICAL_VALUES = new Set([
+  "always",
+  "never",
+  "ask",
+  "local",
+  "remote",
+]);
+
+interface SkillGateRefs {
+  skill: string;
+  gates: string[];
+}
+
+interface GateContract {
+  key: string;
+  ungated: boolean;
+  picker1Values: Set<string>;
+  silentActionValues: Set<string>;
+}
+
+function listSkills(): string[] {
+  return fs
+    .readdirSync(SKILLS_DIR, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)
+    .filter((n) => fs.existsSync(path.join(SKILLS_DIR, n, "SKILL.md")));
+}
+
+/**
+ * Parse the `## Preferences` table out of a SKILL.md and return the
+ * preference keys it claims to fire. Returns [] if no table is present
+ * (e.g., the router skill has a Preferences section but no table).
+ */
+function parseSkillGates(skillName: string): SkillGateRefs {
+  const md = fs.readFileSync(
+    path.join(SKILLS_DIR, skillName, "SKILL.md"),
+    "utf8",
+  );
+  const lines = md.split("\n");
+  const prefHeader = lines.findIndex((l) => /^##\s+Preferences\b/i.test(l));
+  if (prefHeader === -1) return { skill: skillName, gates: [] };
+
+  // Find the first markdown table after the heading whose first column is "Preference".
+  let i = prefHeader + 1;
+  while (i < lines.length && !/^##\s/.test(lines[i])) {
+    if (/^\|\s*Preference\s*\|/i.test(lines[i])) {
+      i += 2; // skip header + separator
+      const gates: string[] = [];
+      while (i < lines.length && lines[i].startsWith("|")) {
+        const firstCell = lines[i].split("|")[1] ?? "";
+        const m = firstCell.match(/`([^`]+)`/);
+        if (m) gates.push(m[1]);
+        i++;
+      }
+      return { skill: skillName, gates };
+    }
+    i++;
+  }
+  return { skill: skillName, gates: [] };
+}
+
+/**
+ * Parse a preference-gate contract file. Picker 1 values come from
+ * `→ \`<value>\`` mappings on bullet lines. Silent-action values come
+ * from `- \`<value>\` →` lines under the **Silent action** heading.
+ */
+function parseGateFile(key: string): GateContract {
+  const md = fs.readFileSync(path.join(GATES_DIR, `${key}.md`), "utf8");
+  if (/Not gated\./.test(md)) {
+    return {
+      key,
+      ungated: true,
+      picker1Values: new Set(),
+      silentActionValues: new Set(),
+    };
+  }
+
+  const picker1Values = new Set<string>();
+  for (const line of md.split("\n")) {
+    if (!line.trimStart().startsWith("-")) continue;
+    // Match the trailing `→ \`<value>\`` segment of a Picker 1 bullet.
+    const m = line.match(/→\s*`([a-z]+)`\s*$/);
+    if (m && CANONICAL_VALUES.has(m[1])) picker1Values.add(m[1]);
+  }
+
+  const silentActionValues = new Set<string>();
+  const lines = md.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    if (/\*\*Silent action[^*]*\*\*/.test(lines[i])) {
+      let j = i + 1;
+      while (j < lines.length && !/^\*\*/.test(lines[j].trim())) {
+        const m = lines[j].match(/^-\s*`([a-z]+)`/);
+        if (m && CANONICAL_VALUES.has(m[1])) silentActionValues.add(m[1]);
+        j++;
+      }
+    }
+  }
+
+  return { key, ungated: false, picker1Values, silentActionValues };
+}
+
+function listGateFiles(): string[] {
+  return fs
+    .readdirSync(GATES_DIR)
+    .filter((f) => f.endsWith(".md") && f !== "README.md")
+    .map((f) => f.replace(/\.md$/, ""));
+}
+
+describe("preference-gate contract lint", () => {
+  const skillRefs = listSkills().map(parseSkillGates);
+  const allReferencedGates = new Set(skillRefs.flatMap((r) => r.gates));
+  const gateFiles = listGateFiles();
+  const gateContracts = new Map(
+    gateFiles.map((k) => [k, parseGateFile(k)] as const),
+  );
+
+  describe("parser sanity: refuse to pass vacuously", () => {
+    it("found at least one skill with gate references", () => {
+      expect(
+        skillRefs.some((r) => r.gates.length > 0),
+        "no skill's Preferences table parsed any gate keys — parser likely broken",
+      ).toBe(true);
+    });
+    it("found at least 10 gate contract files", () => {
+      expect(gateFiles.length).toBeGreaterThanOrEqual(10);
+    });
+  });
+
+  describe("existence: every gate referenced by a skill has a contract file", () => {
+    for (const ref of skillRefs) {
+      for (const gate of ref.gates) {
+        it(`${ref.skill} → ${gate}.md exists`, () => {
+          expect(
+            gateContracts.has(gate),
+            `Skill ${ref.skill} references preference \`${gate}\` but no preference-gates/${gate}.md exists`,
+          ).toBe(true);
+        });
+      }
+    }
+  });
+
+  describe("no orphans: every gate file is referenced or explicitly ungated", () => {
+    for (const [key, contract] of gateContracts) {
+      it(`${key}.md is referenced or ungated`, () => {
+        if (contract.ungated) return; // ungated knobs (e.g. verboseOutput) are exempt
+        expect(
+          allReferencedGates.has(key),
+          `preference-gates/${key}.md is gated but no skill's Preferences table references it`,
+        ).toBe(true);
+      });
+    }
+  });
+
+  describe("internal consistency: Picker 1 values match Silent-action values", () => {
+    for (const [key, contract] of gateContracts) {
+      if (contract.ungated) continue;
+      // Some gate files (autoSelectProject, autoSelectLocalHost) render
+      // Picker 1 via the calling skill rather than mapping bullets
+      // directly — they have no Picker 1 `→ value` arrows. Skip the
+      // bidirectional check for those, but still require their Silent
+      // action set to be non-empty and canonical.
+      if (contract.picker1Values.size === 0) {
+        it(`${key}.md silent-action set is non-empty (Picker 1 is skill-rendered)`, () => {
+          expect(
+            contract.silentActionValues.size,
+            `${key}.md has no Silent action values declared`,
+          ).toBeGreaterThan(0);
+          for (const v of contract.silentActionValues) {
+            expect(CANONICAL_VALUES.has(v), `${key}.md silent action references unknown value \`${v}\``).toBe(true);
+          }
+        });
+        continue;
+      }
+      it(`${key}.md Picker 1 values === Silent action values`, () => {
+        const p = [...contract.picker1Values].sort();
+        const s = [...contract.silentActionValues].sort();
+        expect(
+          p,
+          `${key}.md mismatch — Picker 1 maps to {${p.join(",")}} but Silent action covers {${s.join(",")}}`,
+        ).toEqual(s);
+      });
+    }
+  });
+});

--- a/src/test/skills/preference-gates-lint.test.ts
+++ b/src/test/skills/preference-gates-lint.test.ts
@@ -4,8 +4,6 @@
  * Verifies wiring between SKILL.md preference tables and the
  * preference-gates/<key>.md contract files. Catches drift; does NOT
  * catch "the LLM forgot to fire the gate" — that is Layer 2.
- *
- * See: muggle-ai-brain/architecture/2026-05-07-skill-gate-eval-design.md
  */
 
 import { describe, it, expect } from "vitest";


### PR DESCRIPTION
## Summary

Two-layer test strategy for skill preference gates. Design lives at [`muggle-ai-brain/architecture/2026-05-07-skill-gate-eval-design.md`](https://github.com/multiplex-ai/muggle-ai-brain/blob/main/architecture/2026-05-07-skill-gate-eval-design.md).

- **Layer 1 — static contract lint** (`src/test/skills/preference-gates-lint.test.ts`). Walks every SKILL.md preferences table and every `preference-gates/<key>.md` contract; asserts gate references exist, no orphan files, and Picker 1 mappings stay consistent with Silent action values. Runs under existing vitest. **49 assertions green.**
- **Layer 2 — behavioral harness scaffold** (`internal/skill-gate-eval/`). Mock muggle MCP server (in-process), scenario schema, single-run harness with `canUseTool` interception of `AskQuestion` + `executeArgs` assertions, CLI runner with 99% pass threshold per design.

Scenario data + the design doc live in `muggle-ai-brain/eval/skill-gate-eval/` and `muggle-ai-brain/architecture/`, not in this repo. First scenarios target `showElectronBrowser` × `muggle-test-feature-local` (the gate the user reported misfiring).

## What's NOT in this PR

Two intentional gaps in Layer 2 before it can run:
1. `@anthropic-ai/claude-agent-sdk` is not installed — held off so the dep version can be pinned in a follow-up.
2. `runAgent()` in `harness.ts` is a stub; needs to be replaced with the real SDK `query()` call.

Layer 2 stays manual until stable; not running in CI yet.

## Test plan

- [x] `pnpm vitest run src/test/skills/preference-gates-lint.test.ts` — 49/49 green
- [x] `pnpm tsc --noEmit` — clean
- [ ] Reviewer skim: `internal/skill-gate-eval/README.md` for usage; `harness.ts:130` for the stub gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)