### PR TITLE
fix: bump @muggleai/telemetry to 0.3.2 (runtime init fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "zod": "^4.3.6"
     },
     "devDependencies": {
-        "@muggleai/telemetry": "0.3.1",
+        "@muggleai/telemetry": "0.3.2",
         "@eslint/js": "^10.0.1",
         "@types/node": "^25.5.2",
         "@types/uuid": "^11.0.0",

--- a/packages/mcps/package.json
+++ b/packages/mcps/package.json
@@ -20,7 +20,7 @@
     "test:watch": "vitest"
   },
   "devDependencies": {
-    "@muggleai/telemetry": "0.3.1",
+    "@muggleai/telemetry": "0.3.2",
     "vitest": "*",
     "typescript": "*"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.2.1)
       '@muggleai/telemetry':
-        specifier: 0.3.1
-        version: 0.3.1
+        specifier: 0.3.2
+        version: 0.3.2
       '@types/node':
         specifier: ^25.5.2
         version: 25.6.0
@@ -90,8 +90,8 @@ importers:
   packages/mcps:
     devDependencies:
       '@muggleai/telemetry':
-        specifier: 0.3.1
-        version: 0.3.1
+        specifier: 0.3.2
+        version: 0.3.2
       typescript:
         specifier: '*'
         version: 6.0.3
@@ -452,8 +452,8 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
-  '@muggleai/telemetry@0.3.1':
-    resolution: {integrity: sha512-WmDk0pgt0clxmeNfCXqmRB6WhYc+iH4ByyLyEhGMQxC8BhGvU2LHeCNMiT5uGhZuXwCyLrlAQGCHQZ02RwRWJA==}
+  '@muggleai/telemetry@0.3.2':
+    resolution: {integrity: sha512-/8habXnsrK4soj7tyco2/6l/HwY/+OxBeNIv3RT6Dd1kzTu1y0jh0+aZJmImiHtOIFdJDIZq5obkAKHZ9WOlKw==}
     engines: {node: '>=20'}
 
   '@napi-rs/wasm-runtime@1.1.4':
@@ -2940,7 +2940,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@muggleai/telemetry@0.3.1':
+  '@muggleai/telemetry@0.3.2':
     dependencies:
       applicationinsights: 3.14.0
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

Bumps `@muggleai/telemetry` from `0.3.1` → `0.3.2`.

## Why

`v0.3.1` (shipped in #118) had a runtime bug: every call to `track()` was a silent no-op because `initTelemetry()` failed at startup with `Cannot read properties of undefined (reading 'context')`.

**Root cause**: `applicationinsights@^3.14` is CJS and exposes `defaultClient` as a runtime-mutable property (it's set by `start()`). The package used `import * as AppInsights from "applicationinsights"`, but under Node's CJS→ESM interop, ESM star-imports return a snapshot that doesn't reflect post-import mutations. So `AppInsights.defaultClient` stayed `undefined` even after `AppInsights.start()`, the catch block swallowed the error, and the package set its internal client to `null`.

**Why tests didn't catch it**: the package mocks `applicationinsights` with a static object. The mock never exercises the runtime-mutation behavior, so initialization always "succeeded" in tests.

`v0.3.2` switches to a default import (`import AppInsights from "applicationinsights"`), which holds a live reference to the module object and sees the mutation. Verified locally with a real `APPLICATIONINSIGHTS_CONNECTION_STRING` — events now reach the App Insights `customEvents` table.

## Test plan

- [x] `pnpm run typecheck` clean
- [x] `pnpm test` 97/97 passing
- [x] `pnpm run build` clean; bundled chunk still has telemetry inlined, no `@muggleai/telemetry` reference leaks (verified via grep)
- [x] Smoke test: imported the bundled package, called `initTelemetry()` + `track(EventName.McpToolInvoked)` with a unique correlationId, confirmed event landed in App Insights

🤖 Generated with [Claude Code](https://claude.com/claude-code)