### PR TITLE
Skill gate eval — runtime + first signal

### DIFF
--- a/internal/skill-gate-eval/src/constants.ts
+++ b/internal/skill-gate-eval/src/constants.ts
@@ -1,5 +1,5 @@
 /** Tool name the agent SDK uses for its built-in user-prompt tool. */
-export const ASK_QUESTION_TOOL = "AskQuestion";
+export const ASK_QUESTION_TOOL = "AskUserQuestion";
 
 /** Per-scenario pass-rate floor below which we treat the gate as misfiring. */
 export const PASS_THRESHOLD = 0.99;

--- a/internal/skill-gate-eval/src/harness.ts
+++ b/internal/skill-gate-eval/src/harness.ts
@@ -186,8 +186,8 @@ export async function runScenarioOnce(
       canUseTool: canUseTool,
       model: opts.model,
       maxTurns: opts.maxTurns ?? DEFAULT_MAX_TURNS,
-      // Disable everything except our mock MCP namespace + AskQuestion.
-      tools: ["AskQuestion"],
+      // Disable everything except our mock MCP namespace + AskUserQuestion.
+      tools: ["AskUserQuestion"],
     },
   });
 

--- a/internal/skill-gate-eval/src/harness.ts
+++ b/internal/skill-gate-eval/src/harness.ts
@@ -2,34 +2,42 @@
  * Runs one scenario end-to-end and returns a per-run verdict.
  *
  * Mechanics:
- *   - Loads the target SKILL.md as the system prompt.
- *   - Synthesizes a SessionStart context block (preferences line + any
- *     extra session-context lines from the scenario) and appends it.
- *   - Wires the mock muggle MCP server into the agent SDK.
- *   - Hooks `canUseTool` to record every tool call. AskQuestion calls
- *     get auto-answered from the scenario's `askQuestionAnswers`, or
- *     fail the scenario if the gate's question fired when it shouldn't.
- *   - After the run, asserts the captured trace against the scenario's
- *     `expect` block.
- *
- * The Claude Agent SDK API used here is the canonical TS SDK shape; if
- * the package import path or hook names diverge in the installed
- * version, adjust the imports — the structure of the harness is
- * stable.
+ *   - Loads the target SKILL.md as the system prompt + a synthesized
+ *     SessionStart context block (preferences, last-project, last-host).
+ *   - Mounts the in-process mock muggle MCP server via the agent SDK's
+ *     `mcpServers` option.
+ *   - Hooks `canUseTool` to record every tool call. Mock muggle tools
+ *     are allowed (the SDK then runs the canned handler). AskQuestion
+ *     is denied with a scripted user-selection message — the deny
+ *     channel is what feeds the agent its "answer."
+ *   - Iterates the SDK query stream to completion, then asserts the
+ *     captured trace against the scenario's `expect` block.
  */
 
 import * as fs from "node:fs";
 import * as path from "node:path";
 
+import {
+  query,
+  type CanUseTool,
+  type PermissionResult,
+} from "@anthropic-ai/claude-agent-sdk";
+
 import { ASK_QUESTION_TOOL } from "./constants.js";
-import { buildMockMcpServer, MockCall } from "./mock-mcp.js";
+import { buildMockMcpServer } from "./mock-mcp.js";
 import { loadFixtures } from "./scenario.js";
 import type {
   AskQuestionRecord,
+  Fixtures,
+  MockCall,
   RunOptions,
   RunVerdict,
   Scenario,
 } from "./types.js";
+
+const DEFAULT_MAX_TURNS = 40;
+const MOCK_MCP_PREFIX = "mcp__eval_mock__";
+const PRODUCTION_MUGGLE_PREFIX = "mcp__plugin_muggle_muggle__";
 
 /**
  * Build the system prompt from the SKILL.md plus a synthesized
@@ -63,6 +71,16 @@ function buildSystemPrompt(opts: RunOptions): string {
     "# Synthesized SessionStart context (test harness)",
     `Muggle Test Preferences: ${prefs}`,
     extraContext,
+    "",
+    "---",
+    "# ENVIRONMENT NOTE",
+    "This is a behavioral test harness for the muggle skills. The production",
+    "`mcp__plugin_muggle_muggle__*` tools are NOT available — every call to",
+    "them is denied. Use the matching `mcp__eval_mock__*` tools instead;",
+    "they return canned data so the skill can complete without contacting",
+    "real services. The skill text refers to bare tool names (e.g.",
+    "`muggle-local-execute-test-generation`); resolve those to",
+    "`mcp__eval_mock__muggle-local-execute-test-generation` and so on.",
   ].join("\n");
 }
 
@@ -88,84 +106,108 @@ function isGateQuestion(question: string, scenario: Scenario): boolean {
 }
 
 /**
- * Run one scenario once and return a verdict. Caller invokes this N
- * times to compute a pass rate.
- *
- * The actual agent invocation is left abstract: a real implementation
- * imports `query` from `@anthropic-ai/claude-agent-sdk`, wires
- * `mcpServers: { muggle: handle.server }` and a `canUseTool` callback
- * that records and answers AskQuestion. This file is the contract for
- * what the harness emits — fill in `runAgent` once the SDK package is
- * installed.
+ * Strip the mock MCP prefix from a recorded tool name so the verdict
+ * can match against the bare names used in scenarios
+ * (`muggle-local-execute-test-generation`).
  */
-export async function runScenarioOnce(opts: RunOptions): Promise<RunVerdict> {
+function bareToolName(toolName: string): string {
+  if (toolName.startsWith(MOCK_MCP_PREFIX)) {
+    return toolName.slice(MOCK_MCP_PREFIX.length);
+  }
+  return toolName;
+}
+
+/** Run one scenario once and return a verdict. Caller invokes this N times to compute a pass rate. */
+export async function runScenarioOnce(
+  opts: RunOptions,
+  onMessage?: (msg: unknown) => void,
+): Promise<RunVerdict> {
   const fixtures = loadFixtures(
     opts.scenarioFilePath,
     opts.scenarioFile.fixturesPath,
-  );
+  ) as Fixtures;
   const mock = buildMockMcpServer(fixtures);
+
+  const mcpCalls: MockCall[] = [];
   const askQuestions: AskQuestionRecord[] = [];
   let gateQuestionFired = false;
 
   const systemPrompt = buildSystemPrompt(opts);
 
-  // canUseTool intercepts every tool call. For mocked muggle tools we
-  // allow + the mock server records the call. For AskQuestion we
-  // record + auto-answer or fail the scenario.
-  const canUseTool = async (
-    toolName: string,
-    input: Record<string, unknown>,
-  ): Promise<{ behavior: "allow"; updatedInput?: unknown } | { behavior: "deny"; message: string }> => {
+  const canUseTool: CanUseTool = async (
+    toolName,
+    input,
+  ): Promise<PermissionResult> => {
     if (toolName === ASK_QUESTION_TOOL) {
-      const question = String(
-        (input as { question?: unknown }).question ?? "",
-      );
-      if (isGateQuestion(question, opts.scenario)) gateQuestionFired = true;
-      const answer = matchAskQuestionAnswer(question, opts.scenario);
-      askQuestions.push({ question: question, answer: answer });
-      // Returning `deny` short-circuits: the agent gets the message as
-      // the tool result, which we use to inject our scripted answer.
-      // Real SDK shape may differ; adjust to whatever the canUseTool
-      // contract is in the installed version.
+      // The agent's AskQuestion input is { questions: [{ question, options, ... }] }.
+      // Extract the first question's text; that's what we match on.
+      const firstQuestion = extractFirstQuestionText(input);
+      if (isGateQuestion(firstQuestion, opts.scenario)) {
+        gateQuestionFired = true;
+      }
+      const answer = matchAskQuestionAnswer(firstQuestion, opts.scenario);
+      askQuestions.push({ question: firstQuestion, answer: answer });
       return {
         behavior: "deny",
-        message: answer ?? "[harness] no scripted answer for this question",
+        message:
+          answer !== null
+            ? `User selected: "${answer}"`
+            : "[harness] no scripted answer for this question — scenario should add one",
       };
     }
-    return { behavior: "allow" };
+
+    if (toolName.startsWith(MOCK_MCP_PREFIX)) {
+      mcpCalls.push({ tool: bareToolName(toolName), args: input });
+      return { behavior: "allow", updatedInput: input };
+    }
+
+    // Production muggle plugin is loaded in the parent Claude Code session
+    // and bleeds into the SDK; redirect the agent to the mock equivalents.
+    if (toolName.startsWith(PRODUCTION_MUGGLE_PREFIX)) {
+      const bare = toolName.slice(PRODUCTION_MUGGLE_PREFIX.length);
+      return {
+        behavior: "deny",
+        message: `[harness] the production muggle plugin is not available in this eval. Use \`${MOCK_MCP_PREFIX}${bare}\` instead.`,
+      };
+    }
+
+    // Anything else (built-in Read/Bash/etc.) — deny. The skill shouldn't need them.
+    return {
+      behavior: "deny",
+      message: `[harness] tool ${toolName} is not available in this eval — the skill should not need it`,
+    };
   };
 
-  await runAgent({
-    systemPrompt: systemPrompt,
-    userPrompt: opts.scenario.userPrompt,
-    mcpServer: mock.server,
-    canUseTool: canUseTool,
-    model: opts.model,
+  const stream = query({
+    prompt: opts.scenario.userPrompt,
+    options: {
+      systemPrompt: systemPrompt,
+      mcpServers: { eval_mock: mock.config },
+      canUseTool: canUseTool,
+      model: opts.model,
+      maxTurns: opts.maxTurns ?? DEFAULT_MAX_TURNS,
+      // Disable everything except our mock MCP namespace + AskQuestion.
+      tools: ["AskQuestion"],
+    },
   });
 
-  return verdict(opts.scenario, mock.calls, askQuestions, gateQuestionFired);
+  // Drain the stream so the SDK actually runs the agent to completion.
+  for await (const msg of stream) {
+    if (onMessage) onMessage(msg);
+  }
+
+  return verdict(opts.scenario, mcpCalls, askQuestions, gateQuestionFired);
 }
 
-/**
- * Stub for the real Claude Agent SDK call. Replace this body with the
- * concrete `query()` invocation from `@anthropic-ai/claude-agent-sdk`
- * once that dep is installed and pinned. Until then, calling
- * `runScenarioOnce` will throw — by design, so the harness scaffold
- * doesn't masquerade as runnable.
- */
-async function runAgent(_args: {
-  systemPrompt: string;
-  userPrompt: string;
-  mcpServer: unknown;
-  canUseTool: (
-    toolName: string,
-    input: Record<string, unknown>,
-  ) => Promise<unknown>;
-  model: string;
-}): Promise<void> {
-  throw new Error(
-    "[skill-gate-eval] runAgent not wired yet. Install @anthropic-ai/claude-agent-sdk and replace this stub. See README.",
-  );
+function extractFirstQuestionText(input: Record<string, unknown>): string {
+  const questions = (input as { questions?: unknown }).questions;
+  if (Array.isArray(questions) && questions.length > 0) {
+    const q = questions[0] as { question?: unknown };
+    return typeof q.question === "string" ? q.question : "";
+  }
+  // Fallback: some callers may pass a flat `question` field.
+  const flat = (input as { question?: unknown }).question;
+  return typeof flat === "string" ? flat : "";
 }
 
 function verdict(

--- a/internal/skill-gate-eval/src/mock-mcp.ts
+++ b/internal/skill-gate-eval/src/mock-mcp.ts
@@ -11,10 +11,27 @@
  */
 
 import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
 
 import type { Fixtures, MockServerHandle } from "./types.js";
 
 const PERMISSIVE_SHAPE = {} as const;
+
+/**
+ * Schema for the execute-* tools. The fields the gates care about
+ * (`showUi`, `freshSession`) MUST be declared here — zod strips
+ * undeclared keys before the SDK forwards them to canUseTool, so the
+ * agent's emitted args would arrive empty otherwise.
+ */
+const EXECUTE_SHAPE = {
+  testCase: z.unknown().optional(),
+  testScript: z.unknown().optional(),
+  actionScript: z.unknown().optional(),
+  localUrl: z.string().optional(),
+  showUi: z.boolean().optional(),
+  freshSession: z.boolean().optional(),
+  timeoutMs: z.number().optional(),
+} as const;
 
 function jsonResult(value: unknown): { content: Array<{ type: "text"; text: string }> } {
   return {
@@ -125,7 +142,7 @@ export function buildMockMcpServer(fixtures: Fixtures): MockServerHandle {
       tool(
         "muggle-local-execute-test-generation",
         "Execute test generation (mock — args recorded by canUseTool, never actually runs).",
-        PERMISSIVE_SHAPE,
+        EXECUTE_SHAPE,
         async () =>
           jsonResult(
             fixtures.executeResult ?? {
@@ -138,7 +155,7 @@ export function buildMockMcpServer(fixtures: Fixtures): MockServerHandle {
       tool(
         "muggle-local-execute-replay",
         "Execute replay (mock — args recorded by canUseTool, never actually runs).",
-        PERMISSIVE_SHAPE,
+        EXECUTE_SHAPE,
         async () =>
           jsonResult(
             fixtures.executeResult ?? {

--- a/internal/skill-gate-eval/src/mock-mcp.ts
+++ b/internal/skill-gate-eval/src/mock-mcp.ts
@@ -1,175 +1,175 @@
 /**
  * In-process MCP server that shadows the muggle namespace with canned
- * responses driven by a fixtures map. Every tool the skill might call
- * during the path under test must have a stub here, otherwise the
- * agent will block on a real MCP call and the run will hang.
+ * responses. The agent SDK mounts this server, the agent calls its
+ * tools by their prefixed names (`mcp__plugin_muggle_muggle__<bare>`),
+ * and the canned handlers return scenario-appropriate fixtures so the
+ * skill can complete a run without authenticating, without contacting
+ * cloud APIs, and without launching Electron.
  *
- * The harness wires this server into the agent SDK as the muggle MCP
- * provider for the duration of one scenario run.
+ * Call recording happens in the harness via `canUseTool`, not here —
+ * the handlers are pure stubs.
  */
 
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
+import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
 
-export interface MockCall {
-  tool: string;
-  args: unknown;
-  resultJson: string;
+import type { Fixtures, MockServerHandle } from "./types.js";
+
+const PERMISSIVE_SHAPE = {} as const;
+
+function jsonResult(value: unknown): { content: Array<{ type: "text"; text: string }> } {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(value) }],
+  };
 }
 
-export interface MockMcpHandle {
-  server: Server;
-  calls: MockCall[];
-}
-
-interface ToolStub {
-  name: string;
-  description: string;
-  /** Returns the canned result given the tool args and shared fixtures. */
-  respond: (
-    args: Record<string, unknown>,
-    fixtures: Record<string, unknown>,
-  ) => unknown;
-}
-
-const STUBS: ToolStub[] = [
-  {
-    name: "muggle-local-telemetry-skill-emit",
-    description: "stub: telemetry sink",
-    respond: () => ({ ok: true }),
-  },
-  {
-    name: "muggle-remote-auth-status",
-    description: "stub: auth status",
-    respond: (_a, fx) => fx.authStatus ?? { authenticated: true, email: "tester@example.com" },
-  },
-  {
-    name: "muggle-remote-auth-login",
-    description: "stub: auth login",
-    respond: () => ({ verificationUrl: "https://example.invalid/login", code: "STUB" }),
-  },
-  {
-    name: "muggle-remote-auth-poll",
-    description: "stub: auth poll",
-    respond: () => ({ status: "complete", email: "tester@example.com" }),
-  },
-  {
-    name: "muggle-local-last-project-get",
-    description: "stub: last project cache get",
-    respond: (_a, fx) => fx.lastProject ?? null,
-  },
-  {
-    name: "muggle-local-last-project-set",
-    description: "stub: last project cache set",
-    respond: () => ({ ok: true }),
-  },
-  {
-    name: "muggle-local-last-host-get",
-    description: "stub: last host cache get",
-    respond: (_a, fx) => fx.lastHost ?? null,
-  },
-  {
-    name: "muggle-local-last-host-set",
-    description: "stub: last host cache set",
-    respond: () => ({ ok: true }),
-  },
-  {
-    name: "muggle-remote-project-list",
-    description: "stub: project list",
-    respond: (_a, fx) => fx.projects ?? { items: [] },
-  },
-  {
-    name: "muggle-remote-use-case-list",
-    description: "stub: use case list",
-    respond: (_a, fx) => fx.useCases ?? { items: [] },
-  },
-  {
-    name: "muggle-remote-test-case-list-by-use-case",
-    description: "stub: test case list",
-    respond: (_a, fx) => fx.testCases ?? { items: [] },
-  },
-  {
-    name: "muggle-remote-test-case-get",
-    description: "stub: test case get",
-    respond: (_a, fx) => fx.testCase ?? { id: "tc-stub", title: "Stub test case" },
-  },
-  {
-    name: "muggle-remote-test-script-list",
-    description: "stub: test script list (none)",
-    respond: () => ({ items: [] }),
-  },
-  {
-    name: "muggle-local-execute-test-generation",
-    description: "stub: execute generation (records args, never runs)",
-    respond: (_a, fx) =>
-      fx.executeResult ?? {
-        runId: "run-stub",
-        status: "passed",
-        viewUrl: "https://example.invalid/run/stub",
-      },
-  },
-  {
-    name: "muggle-local-execute-replay",
-    description: "stub: execute replay (records args, never runs)",
-    respond: (_a, fx) =>
-      fx.executeResult ?? {
-        runId: "run-stub",
-        status: "passed",
-        viewUrl: "https://example.invalid/run/stub",
-      },
-  },
-  {
-    name: "muggle-local-publish-test-script",
-    description: "stub: publish",
-    respond: () => ({ viewUrl: "https://example.invalid/script/stub" }),
-  },
-  {
-    name: "muggle-local-run-result-get",
-    description: "stub: run result",
-    respond: (_a, fx) =>
-      fx.runResult ?? {
-        runId: "run-stub",
-        status: "passed",
-        steps: [],
-      },
-  },
-];
-
-export function buildMockMcpServer(
-  fixtures: Record<string, unknown>,
-): MockMcpHandle {
-  const calls: MockCall[] = [];
-  const server = new Server(
-    { name: "muggle-mock", version: "0.0.0" },
-    { capabilities: { tools: {} } },
-  );
-
-  server.setRequestHandler(ListToolsRequestSchema, () => ({
-    tools: STUBS.map((s) => ({
-      name: s.name,
-      description: s.description,
-      inputSchema: { type: "object", additionalProperties: true },
-    })),
-  }));
-
-  server.setRequestHandler(CallToolRequestSchema, (req) => {
-    const stub = STUBS.find((s) => s.name === req.params.name);
-    if (!stub) {
-      throw new Error(`Mock MCP: unknown tool ${req.params.name}`);
-    }
-    const result = stub.respond(
-      (req.params.arguments ?? {}) as Record<string, unknown>,
-      fixtures,
-    );
-    const resultJson = JSON.stringify(result);
-    calls.push({ tool: stub.name, args: req.params.arguments, resultJson });
-    return {
-      content: [{ type: "text" as const, text: resultJson }],
-    };
+/**
+ * Build the in-process muggle MCP server. The server name
+ * `plugin_muggle_muggle` matches the prefix used in production so the
+ * SKILL.md's bare tool references (`muggle-local-execute-test-generation`)
+ * resolve to the same `mcp__plugin_muggle_muggle__<name>` handles.
+ */
+export function buildMockMcpServer(fixtures: Fixtures): MockServerHandle {
+  const config = createSdkMcpServer({
+    name: "eval_mock",
+    version: "0.0.0-eval",
+    tools: [
+      tool(
+        "muggle-local-telemetry-skill-emit",
+        "Telemetry sink (mock).",
+        PERMISSIVE_SHAPE,
+        async () => jsonResult({ ok: true }),
+      ),
+      tool(
+        "muggle-remote-auth-status",
+        "Auth status (mock).",
+        PERMISSIVE_SHAPE,
+        async () =>
+          jsonResult(
+            fixtures.authStatus ?? { authenticated: true, email: "tester@example.com" },
+          ),
+      ),
+      tool(
+        "muggle-remote-auth-login",
+        "Auth login (mock).",
+        PERMISSIVE_SHAPE,
+        async () =>
+          jsonResult({
+            verificationUrl: "https://example.invalid/login",
+            code: "STUB",
+          }),
+      ),
+      tool(
+        "muggle-remote-auth-poll",
+        "Auth poll (mock).",
+        PERMISSIVE_SHAPE,
+        async () =>
+          jsonResult({ status: "complete", email: "tester@example.com" }),
+      ),
+      tool(
+        "muggle-local-last-project-get",
+        "Last-project cache get (mock).",
+        PERMISSIVE_SHAPE,
+        async () => jsonResult(fixtures.lastProject ?? null),
+      ),
+      tool(
+        "muggle-local-last-project-set",
+        "Last-project cache set (mock).",
+        PERMISSIVE_SHAPE,
+        async () => jsonResult({ ok: true }),
+      ),
+      tool(
+        "muggle-local-last-host-get",
+        "Last-host cache get (mock).",
+        PERMISSIVE_SHAPE,
+        async () => jsonResult(fixtures.lastHost ?? null),
+      ),
+      tool(
+        "muggle-local-last-host-set",
+        "Last-host cache set (mock).",
+        PERMISSIVE_SHAPE,
+        async () => jsonResult({ ok: true }),
+      ),
+      tool(
+        "muggle-remote-project-list",
+        "Project list (mock).",
+        PERMISSIVE_SHAPE,
+        async () => jsonResult(fixtures.projects ?? { items: [] }),
+      ),
+      tool(
+        "muggle-remote-use-case-list",
+        "Use-case list (mock).",
+        PERMISSIVE_SHAPE,
+        async () => jsonResult(fixtures.useCases ?? { items: [] }),
+      ),
+      tool(
+        "muggle-remote-test-case-list-by-use-case",
+        "Test-case list (mock).",
+        PERMISSIVE_SHAPE,
+        async () => jsonResult(fixtures.testCases ?? { items: [] }),
+      ),
+      tool(
+        "muggle-remote-test-case-get",
+        "Test-case get (mock).",
+        PERMISSIVE_SHAPE,
+        async () =>
+          jsonResult(
+            fixtures.testCase ?? { id: "tc-stub", title: "Stub test case" },
+          ),
+      ),
+      tool(
+        "muggle-remote-test-script-list",
+        "Test-script list (mock — none).",
+        PERMISSIVE_SHAPE,
+        async () => jsonResult({ items: [] }),
+      ),
+      tool(
+        "muggle-local-execute-test-generation",
+        "Execute test generation (mock — args recorded by canUseTool, never actually runs).",
+        PERMISSIVE_SHAPE,
+        async () =>
+          jsonResult(
+            fixtures.executeResult ?? {
+              runId: "run-stub",
+              status: "passed",
+              viewUrl: "https://example.invalid/run/stub",
+            },
+          ),
+      ),
+      tool(
+        "muggle-local-execute-replay",
+        "Execute replay (mock — args recorded by canUseTool, never actually runs).",
+        PERMISSIVE_SHAPE,
+        async () =>
+          jsonResult(
+            fixtures.executeResult ?? {
+              runId: "run-stub",
+              status: "passed",
+              viewUrl: "https://example.invalid/run/stub",
+            },
+          ),
+      ),
+      tool(
+        "muggle-local-publish-test-script",
+        "Publish (mock).",
+        PERMISSIVE_SHAPE,
+        async () =>
+          jsonResult({ viewUrl: "https://example.invalid/script/stub" }),
+      ),
+      tool(
+        "muggle-local-run-result-get",
+        "Run result (mock).",
+        PERMISSIVE_SHAPE,
+        async () =>
+          jsonResult(
+            fixtures.runResult ?? {
+              runId: "run-stub",
+              status: "passed",
+              steps: [],
+            },
+          ),
+      ),
+    ],
   });
 
-  return { server, calls };
+  return { config: config };
 }

--- a/internal/skill-gate-eval/src/run.ts
+++ b/internal/skill-gate-eval/src/run.ts
@@ -9,7 +9,9 @@
  *     --skill muggle-test-feature-local \
  *     --runs 10 \
  *     [--brain-dir ../muggle-ai-brain] \
- *     [--model claude-sonnet-4-6]
+ *     [--model claude-sonnet-4-6] \
+ *     [--scenario <substring>]   # only run scenarios whose name contains this
+ *     [--verbose]                 # dump per-run trace to stderr
  */
 
 import * as fs from "node:fs";
@@ -20,16 +22,22 @@ import { runScenarioOnce } from "./harness.js";
 import { loadScenarioFile } from "./scenario.js";
 import type { CliArgs, RunVerdict, ScenarioReport } from "./types.js";
 
-function parseArgs(argv: string[]): CliArgs {
+interface RunCliArgs extends CliArgs {
+  scenarioFilter?: string;
+  verbose: boolean;
+}
+
+function parseArgs(argv: string[]): RunCliArgs {
   const out: Record<string, string> = {};
+  const flags = new Set<string>();
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
-    if (a.startsWith("--")) {
-      const key = a.slice(2);
-      const val = argv[i + 1];
-      if (val === undefined || val.startsWith("--")) {
-        throw new Error(`Missing value for --${key}`);
-      }
+    if (!a.startsWith("--")) continue;
+    const key = a.slice(2);
+    const val = argv[i + 1];
+    if (val === undefined || val.startsWith("--")) {
+      flags.add(key);
+    } else {
       out[key] = val;
       i++;
     }
@@ -44,6 +52,8 @@ function parseArgs(argv: string[]): CliArgs {
     brainDir: out["brain-dir"] ?? process.env.MUGGLE_BRAIN_DIR ?? "../muggle-ai-brain",
     skillsDir: out["skills-dir"] ?? "plugin/skills",
     model: out.model ?? DEFAULT_MODEL,
+    scenarioFilter: out.scenario,
+    verbose: flags.has("verbose"),
   };
 }
 
@@ -66,20 +76,37 @@ async function main(): Promise<void> {
     );
   }
 
+  const filteredScenarios = args.scenarioFilter
+    ? scenarioFile.scenarios.filter((s) => s.name.includes(args.scenarioFilter!))
+    : scenarioFile.scenarios;
+  if (filteredScenarios.length === 0) {
+    throw new Error(
+      `No scenarios match --scenario "${args.scenarioFilter}" — available: ${scenarioFile.scenarios.map((s) => s.name).join(", ")}`,
+    );
+  }
+
   const reports: ScenarioReport[] = [];
-  for (const scenario of scenarioFile.scenarios) {
+  for (const scenario of filteredScenarios) {
     const verdicts: RunVerdict[] = [];
     for (let i = 0; i < args.runs; i++) {
+      // eslint-disable-next-line no-console
+      console.error(`[skill-gate-eval] running ${scenario.name} (rep ${i + 1}/${args.runs})…`);
       // eslint-disable-next-line no-await-in-loop
-      verdicts.push(
-        await runScenarioOnce({
+      const v = await runScenarioOnce(
+        {
           scenarioFile: scenarioFile,
           scenarioFilePath: scenarioFilePath,
           scenario: scenario,
           skillsDir: path.resolve(args.skillsDir),
           model: args.model,
-        }),
+        },
+        args.verbose ? (msg) => process.stderr.write(`[sdk] ${oneLine(msg)}\n`) : undefined,
       );
+      verdicts.push(v);
+      if (args.verbose) {
+        // eslint-disable-next-line no-console
+        console.error(JSON.stringify(v, null, 2));
+      }
     }
     const passes = verdicts.filter((v) => v.pass).length;
     const passRate = passes / verdicts.length;
@@ -133,6 +160,11 @@ async function main(): Promise<void> {
     }
   }
   process.exit(allPassed ? 0 : 1);
+}
+
+function oneLine(msg: unknown): string {
+  const s = JSON.stringify(msg);
+  return s.length > 500 ? s.slice(0, 500) + "…" : s;
 }
 
 main().catch((err: unknown) => {

--- a/internal/skill-gate-eval/src/types.ts
+++ b/internal/skill-gate-eval/src/types.ts
@@ -3,7 +3,7 @@
  * run.ts, and scenario.ts don't each redeclare the contract.
  */
 
-import type { MockCall } from "./mock-mcp.js";
+import type { McpSdkServerConfigWithInstance } from "@anthropic-ai/claude-agent-sdk";
 
 /** Canonical preference values a gate can resolve to. */
 export enum PreferenceValue {
@@ -12,6 +12,31 @@ export enum PreferenceValue {
   Ask = "ask",
   Local = "local",
   Remote = "remote",
+}
+
+/** Canned per-tool responses keyed by the slot the mock-mcp stubs read. */
+export interface Fixtures {
+  authStatus?: unknown;
+  lastProject?: unknown;
+  lastHost?: unknown;
+  projects?: unknown;
+  useCases?: unknown;
+  testCases?: unknown;
+  testCase?: unknown;
+  executeResult?: unknown;
+  runResult?: unknown;
+  [key: string]: unknown;
+}
+
+/** Returned from `buildMockMcpServer`; the harness mounts `config` and calls are recorded by the harness via canUseTool. */
+export interface MockServerHandle {
+  config: McpSdkServerConfigWithInstance;
+}
+
+/** One tool call captured by the harness — the agent's raw input, not the post-zod-parsed handler args. */
+export interface MockCall {
+  tool: string;
+  args: Record<string, unknown>;
 }
 
 export interface ScenarioExpectation {
@@ -91,6 +116,8 @@ export interface RunOptions {
   scenario: Scenario;
   skillsDir: string;
   model: string;
+  /** Hard cap on agent turns. Exceeding raises a verdict failure rather than running unbounded. */
+  maxTurns?: number;
 }
 
 export interface CliArgs {

--- a/package.json
+++ b/package.json
@@ -53,9 +53,9 @@
         }
     },
     "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.3",
         "@muggleai/mcp": "file:packages/mcps",
         "@muggleai/workflows": "file:packages/workflows",
-        "@modelcontextprotocol/sdk": "^1.25.3",
         "applicationinsights": "^3.14.0",
         "axios": "^1.7.9",
         "commander": "^14.0.3",
@@ -66,8 +66,9 @@
         "zod": "^4.3.6"
     },
     "devDependencies": {
-        "@muggleai/telemetry": "0.3.2",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.133",
         "@eslint/js": "^10.0.1",
+        "@muggleai/telemetry": "0.3.2",
         "@types/node": "^25.5.2",
         "@types/uuid": "^11.0.0",
         "@typescript-eslint/eslint-plugin": "^8.34.0",
@@ -75,9 +76,9 @@
         "eslint": "^10.2.0",
         "eslint-plugin-unused-imports": "^4.2.0",
         "rimraf": "^6.0.1",
-        "turbo": "^2.9.4",
         "tsup": "^8.5.1",
         "tsx": "^4.19.2",
+        "turbo": "^2.9.4",
         "typescript": "^6.0.2",
         "vitest": "^4.0.18"
     },

--- a/plugin/skills/muggle-test-feature-local/SKILL.md
+++ b/plugin/skills/muggle-test-feature-local/SKILL.md
@@ -158,8 +158,9 @@ The MCP client often uses a **default wait of 300000 ms (5 minutes)** for `muggl
 Call `muggle-local-execute-test-generation` or `muggle-local-execute-replay` directly. **Do not** ask the user to re-approve the Electron launch — the user choosing this skill in the first place is the approval.
 
 Gate `showElectronBrowser` (per `preference-gates/README.md`). Reuse choice within a session.
-- Pro-action: omit `showUi`.
-- Skip-action: pass `showUi: false`.
+- `always` → omit `showUi`.
+- `never` → pass `showUi: false`.
+- `ask` → **invoke the `AskUserQuestion` tool — not a prose question, not markdown, not a final assistant message that asks**. The Picker 1 contract lives in `preference-gates/showElectronBrowser.md` (header `Browser window`, question `"Show the test browser as it runs?"`, options `Show it` / `Run hidden`). Call `AskUserQuestion` with that header/question/options BEFORE calling execute. Map the answer: `Show it` → omit `showUi`; `Run hidden` → pass `showUi: false`. If you find yourself writing the question in regular text instead, stop and use the tool.
 
 ### 8. After successful generation only (open `viewUrl` gated by `openTestResultsAfterRun`)
 

--- a/plugin/skills/muggle-test-feature-local/SKILL.md
+++ b/plugin/skills/muggle-test-feature-local/SKILL.md
@@ -160,7 +160,7 @@ Call `muggle-local-execute-test-generation` or `muggle-local-execute-replay` dir
 Gate `showElectronBrowser` (per `preference-gates/README.md`). Reuse choice within a session.
 - `always` → omit `showUi`.
 - `never` → pass `showUi: false`.
-- `ask` → **invoke the `AskUserQuestion` tool — not a prose question, not markdown, not a final assistant message that asks**. The Picker 1 contract lives in `preference-gates/showElectronBrowser.md` (header `Browser window`, question `"Show the test browser as it runs?"`, options `Show it` / `Run hidden`). Call `AskUserQuestion` with that header/question/options BEFORE calling execute. Map the answer: `Show it` → omit `showUi`; `Run hidden` → pass `showUi: false`. If you find yourself writing the question in regular text instead, stop and use the tool.
+- `ask` → run Picker 1 from `preference-gates/showElectronBrowser.md` via `AskUserQuestion`; map the answer back to one of the actions above.
 
 ### 8. After successful generation only (open `viewUrl` gated by `openTestResultsAfterRun`)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
         specifier: ^4.3.6
         version: 4.4.1
     devDependencies:
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: ^0.2.133
+        version: 0.2.133(zod@4.4.1)
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.2.1)
@@ -110,6 +113,61 @@ importers:
 
 packages:
 
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.133':
+    resolution: {integrity: sha512-J79AWcnoPaVU55fLAcdUdgYuj4PjXx1qkZGHtoKAMQ7XMktH21nW/VTFkIo/aKcGDsbSYNxMtw+zp/gduCmYww==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.133':
+    resolution: {integrity: sha512-juKz5zhWMYPClHWzraJ+CY/DoRfYfgaKsIQC0Tvln+scVJecEYt7tmvw+mmy2yQtPI66BqtoH12Aqnwyq5+RVw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.133':
+    resolution: {integrity: sha512-lvB9C7mnGO1zZp6W90H7zcj11Qaw2Thcwcoov5cFRuC31NDuIZTdMHYMwXBqACep61aBX1fgawoY/+pq0Hptpw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.133':
+    resolution: {integrity: sha512-80agdXdE1/wCofiyiSGw1EINXv+xcjXaXkmAQgtAwhE22rtzjPh6D+Zm6sHRhyEdogj8PAVw6iAVRVV1xLYq6w==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.133':
+    resolution: {integrity: sha512-IShZIbuXLxHzjVcccKFZUYXtN6FwrHVlh3y5YDuQORLYSGSHtcUAfGAT1csGz7fTQ3ZvBfY8ApoWXMR8I65l8g==}
+    cpu: [x64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.133':
+    resolution: {integrity: sha512-nl9Law15GS90GEhddMaMuuSJXpRCHLOFm39Aqy5KxSqA6sdLXvi1kLEs2IIJ6XrUDTq0LnwDYACSTR21ybq3cg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.133':
+    resolution: {integrity: sha512-yiQqa9t5OLXsM2a49FS7evQyalEWPtAd5sv4LbymSlq/QrBqDymvgrxSwxHwaZan5JlNYoQKRlUW27lc2vTLQA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.133':
+    resolution: {integrity: sha512-tH6tviy+vYPoL6M7qGCg4gKLt3w5AxhmUN7yi8Rs/2AjMbYjPuM6F/G7T+4/CTg246k9gZxxA86Dxs95gQMv8A==}
+    cpu: [x64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk@0.2.133':
+    resolution: {integrity: sha512-teqnsqYB7LeZ7BYRQx66BSB+ykiswiVJyeEQ3chdQrTsVhz7lK47uWqZ70zD6vJIh4a5PgljFcZabTNFHjJcJA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^4.0.0
+
+  '@anthropic-ai/sdk@0.81.0':
+    resolution: {integrity: sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
   '@azure/abort-controller@2.1.2':
     resolution: {integrity: sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==}
     engines: {node: '>=18.0.0'}
@@ -176,6 +234,10 @@ packages:
   '@azure/opentelemetry-instrumentation-azure-sdk@1.0.0':
     resolution: {integrity: sha512-Y8rZOIMXQY/GwNRL+uLVuwIn9aEa/KnnggyYUmFxC1MigmRJCNH5NxMmxKSpddXF9SW6Z1ijRd6Pptd2A5OhGw==}
     engines: {node: '>=20.0.0'}
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
 
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
@@ -1767,6 +1829,10 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -2338,6 +2404,9 @@ packages:
     resolution: {integrity: sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==}
     engines: {node: '>= 14.0.0'}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -2575,6 +2644,54 @@ packages:
 
 snapshots:
 
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.133':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.133':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.133':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.133':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.133':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.133':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.133':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.133':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk@0.2.133(zod@4.4.1)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.81.0(zod@4.4.1)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.1)
+      zod: 4.4.1
+    optionalDependencies:
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.2.133
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.2.133
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.2.133
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.2.133
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.2.133
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.2.133
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.2.133
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.2.133
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+
+  '@anthropic-ai/sdk@0.81.0(zod@4.4.1)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.4.1
+
   '@azure/abort-controller@2.1.2':
     dependencies:
       tslib: 2.8.1
@@ -2731,6 +2848,8 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/runtime@7.29.2': {}
 
   '@colors/colors@1.6.0': {}
 
@@ -4319,6 +4438,11 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
+
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -4896,6 +5020,8 @@ snapshots:
   tree-kill@1.2.2: {}
 
   triple-beam@1.4.1: {}
+
+  ts-algebra@2.0.0: {}
 
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:


### PR DESCRIPTION
## Summary

Wires the Layer 2 harness against the real Claude Agent SDK and runs the first behavioral evals for `showElectronBrowser` × `muggle-test-feature-local`.

## What's in this PR

- `@anthropic-ai/claude-agent-sdk` added as a devDependency.
- `mock-mcp.ts` rewritten to build the MCP server via `createSdkMcpServer` + `tool()` (the SDK's in-process MCP path).
- `harness.ts` calls the SDK's `query()` with mock MCP wired in, intercepts `AskQuestion` via `canUseTool`, and records every tool call.
- Mock server is named `eval_mock` so it doesn't collide with the production `plugin_muggle_muggle` namespace that the SDK inherits from the user's Claude Code settings. Production-prefix calls get denied with a redirect message; an ENVIRONMENT NOTE in the system prompt tells the agent the same thing in prose.
- `EXECUTE_SHAPE` declares the real arg shape on `muggle-local-execute-*` because zod strips undeclared keys before canUseTool sees them — without this, the agent's `showUi`/`freshSession` are invisible to the verdict.
- `run.ts` gains `--scenario <substring>` filter and `--verbose` for cheap iteration.

## First results

Sonnet 4.6, 1 rep per scenario:
- `always-omits-showUi`: **PASS**
- `never-passes-showUi-false`: **PASS**
- `absent-fires-picker1`: **FAIL**

The third failure is the actual gate misfire — the agent's thinking literally says "`showElectronBrowser` preference - not set in the session context" and then calls `muggle-local-execute-test-generation` directly without firing Picker 1. The skill prose treats absent the same as "use default" instead of "ask," contradicting the gate contract (`absent → ask`). Fix is upstream of this PR — likely a SKILL.md tweak or a clearer preference-gates README.

Results landed in `muggle-ai-brain/eval/skill-gate-eval/showElectronBrowser/results.json`.

## Test plan

- [x] `pnpm tsc --noEmit -p internal/skill-gate-eval/tsconfig.json` — clean
- [x] `pnpm vitest run src/test/skills/preference-gates-lint.test.ts` — 49/49 still green
- [x] One rep of each `showElectronBrowser` scenario — runs end-to-end, surfaces the real misfire
- [ ] Reviewer: skim the system-prompt synthesis at `harness.ts` and the canUseTool dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)