### PR TITLE
feat: /muggle-feedback skill + MCP user-feedback tools

### DIFF
--- a/packages/mcps/src/mcp/e2e/contracts/index.ts
+++ b/packages/mcps/src/mcp/e2e/contracts/index.ts
@@ -581,10 +581,20 @@ export const UserFeedbackCreateInputSchema = z.object({
 });
 
 export const UserFeedbackListInputSchema = z.object({
-  projectId: IdSchema.describe("Project ID (UUID) to list feedback for"),
+  projectId: IdSchema.describe("Project ID (UUID) to list feedback for. Always required — defines the auth boundary."),
+  actionScriptId: IdSchema.optional().describe("Narrow to feedback whose target resolves to this action script. Mutually exclusive with the other narrowing filters."),
+  testScriptId: IdSchema.optional().describe("Narrow to feedback on the action script of this test script. Mutually exclusive with the other narrowing filters."),
+  testCaseId: IdSchema.optional().describe("Narrow to feedback on any action script ever generated for this test case. Mutually exclusive with the other narrowing filters."),
+  useCaseId: IdSchema.optional().describe("Narrow to feedback on any action script ever generated under this use case. Mutually exclusive with the other narrowing filters."),
   limit: z.number().int().positive().max(1000).optional().describe("Max entries to return (default 100)"),
   offset: z.number().int().min(0).optional().describe("Offset for pagination (default 0)"),
-});
+}).refine(
+  (data) => {
+    const set = [data.actionScriptId, data.testScriptId, data.testCaseId, data.useCaseId].filter(Boolean);
+    return set.length <= 1;
+  },
+  { message: "At most one of actionScriptId / testScriptId / testCaseId / useCaseId may be set" },
+);
 
 export const UserFeedbackDeleteInputSchema = z.object({
   feedbackId: IdSchema.describe("User feedback ID (UUID) to soft-delete"),

--- a/packages/mcps/src/mcp/e2e/contracts/index.ts
+++ b/packages/mcps/src/mcp/e2e/contracts/index.ts
@@ -553,6 +553,44 @@ export const ApiKeyRevokeInputSchema = z.object({
 });
 
 // =============================================================================
+// User Feedback Schemas
+// =============================================================================
+
+/**
+ * Target type values mirror the server's UserFeedbackTargetTypeEnum:
+ *  - actionScript: feedback about a script's overall outcome (targetId = actionScriptId)
+ *  - step: feedback about a specific step within a script (targetId = `${actionScriptId}:${stepIndex}`)
+ */
+export const UserFeedbackTargetTypeSchema = z.enum(["actionScript", "step"]);
+
+export const UserFeedbackTargetSchema = z.object({
+  targetType: UserFeedbackTargetTypeSchema.describe("Target entity kind: 'actionScript' for whole-script feedback, 'step' for a specific step"),
+  targetId: z
+    .string()
+    .min(1)
+    .describe("Target identifier. For 'actionScript' use the actionScriptId; for 'step' use `${actionScriptId}:${stepIndex}` (0-based stepIndex)"),
+});
+
+export const UserFeedbackCreateInputSchema = z.object({
+  projectId: IdSchema.describe("Project ID (UUID) the feedback belongs to"),
+  target: UserFeedbackTargetSchema.describe("What entity this feedback is about (action script or a specific step)"),
+  feedbackText: z
+    .string()
+    .min(1)
+    .describe("Free-form paragraph describing what went wrong and what the expected behavior should be"),
+});
+
+export const UserFeedbackListInputSchema = z.object({
+  projectId: IdSchema.describe("Project ID (UUID) to list feedback for"),
+  limit: z.number().int().positive().max(1000).optional().describe("Max entries to return (default 100)"),
+  offset: z.number().int().min(0).optional().describe("Offset for pagination (default 0)"),
+});
+
+export const UserFeedbackDeleteInputSchema = z.object({
+  feedbackId: IdSchema.describe("User feedback ID (UUID) to soft-delete"),
+});
+
+// =============================================================================
 // Auth Schemas (Device Code Flow)
 // =============================================================================
 

--- a/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
+++ b/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
@@ -1424,7 +1424,7 @@ const userFeedbackTools: IQaToolDefinition[] = [
   {
     name: "muggle-remote-user-feedback-list",
     description:
-      "List active user feedback entries for a project. Supports limit/offset pagination. Response: { feedback: IUserFeedback[], total: number, hasMore: boolean }.",
+      "List active user feedback entries for a project. Optionally narrow by exactly one of actionScriptId / testScriptId / testCaseId / useCaseId — the typical query is 'show me feedback on this test case (or test script, or use case).' Supports limit/offset pagination. Response: { feedback: IUserFeedback[], total: number, hasMore: boolean }.",
     inputSchema: schemas.UserFeedbackListInputSchema,
     mapToUpstream: (input) => {
       const data = input as z.infer<typeof schemas.UserFeedbackListInputSchema>;
@@ -1433,6 +1433,10 @@ const userFeedbackTools: IQaToolDefinition[] = [
         path: `${MUGGLE_TEST_PREFIX}/user-feedback`,
         queryParams: {
           projectId: data.projectId,
+          actionScriptId: data.actionScriptId,
+          testScriptId: data.testScriptId,
+          testCaseId: data.testCaseId,
+          useCaseId: data.useCaseId,
           limit: data.limit,
           offset: data.offset,
         },

--- a/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
+++ b/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
@@ -1399,6 +1399,61 @@ const apiKeyTools: IQaToolDefinition[] = [
 ];
 
 // =============================================================================
+// User Feedback Tools
+// =============================================================================
+
+const userFeedbackTools: IQaToolDefinition[] = [
+  {
+    name: "muggle-remote-user-feedback-create",
+    description:
+      "Submit user feedback on a generated action script — either the whole script (targetType='actionScript', targetId=actionScriptId) or a specific step (targetType='step', targetId=`${actionScriptId}:${stepIndex}` with 0-based stepIndex). Persists the feedback and triggers an async feedback-analysis workflow that may regenerate the script. The response includes the saved feedback and, when the analysis workflow was started, a feedbackAnalysisWorkflowRuntimeId for polling.",
+    inputSchema: schemas.UserFeedbackCreateInputSchema,
+    mapToUpstream: (input) => {
+      const data = input as z.infer<typeof schemas.UserFeedbackCreateInputSchema>;
+      return {
+        method: "POST",
+        path: `${MUGGLE_TEST_PREFIX}/user-feedback`,
+        body: {
+          projectId: data.projectId,
+          target: data.target,
+          feedbackText: data.feedbackText,
+        },
+      };
+    },
+  },
+  {
+    name: "muggle-remote-user-feedback-list",
+    description:
+      "List active user feedback entries for a project. Supports limit/offset pagination. Response: { feedback: IUserFeedback[], total: number, hasMore: boolean }.",
+    inputSchema: schemas.UserFeedbackListInputSchema,
+    mapToUpstream: (input) => {
+      const data = input as z.infer<typeof schemas.UserFeedbackListInputSchema>;
+      return {
+        method: "GET",
+        path: `${MUGGLE_TEST_PREFIX}/user-feedback`,
+        queryParams: {
+          projectId: data.projectId,
+          limit: data.limit,
+          offset: data.offset,
+        },
+      };
+    },
+  },
+  {
+    name: "muggle-remote-user-feedback-delete",
+    description: "Soft-delete a user feedback entry by ID. Returns 204 on success.",
+    inputSchema: schemas.UserFeedbackDeleteInputSchema,
+    mapToUpstream: (input) => {
+      const data = input as z.infer<typeof schemas.UserFeedbackDeleteInputSchema>;
+      return {
+        method: "DELETE",
+        path: `${MUGGLE_TEST_PREFIX}/user-feedback/${data.feedbackId}`,
+      };
+    },
+  },
+];
+
+// =============================================================================
 // Auth Tools (Device Code Flow)
 // =============================================================================
 
@@ -1558,6 +1613,7 @@ export const allQaToolDefinitions: IQaToolDefinition[] = [
   ...walletTools,
   ...recommendationTools,
   ...apiKeyTools,
+  ...userFeedbackTools,
   ...authTools,
 ];
 

--- a/plugin/skills/muggle-feedback/SKILL.md
+++ b/plugin/skills/muggle-feedback/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: muggle-feedback
+description: Capture feedback on a generated Muggle Test action script — either step-level or whole-script — and submit it so the system can analyze it and regenerate affected scripts. Use when the user has just run a Muggle Test (local or remote) and wants to flag what went wrong, when they paste a Muggle dashboard URL with a test script or run, or when they want to view or delete previously submitted feedback. Triggers on: '/muggle-feedback', 'give feedback on this run', 'the test was wrong', 'step N didn't work', 'the script clicked the wrong button', 'flag this run', 'the summary is wrong', 'show my feedback', 'list feedback', 'delete that feedback'. Skill auto-detects the run context from a recent local run, a remote run, or a Muggle dashboard URL in the prompt.
+---
+
+# Muggle Test Feedback
+
+> Telemetry first step: see [`_shared/telemetry-emit.md`](../_shared/telemetry-emit.md). Use `skillName: "muggle-feedback"`.
+
+Capture user feedback on what a generated Muggle Test action script did wrong. The server uses each feedback row to find similar test cases via LLM and regenerate their scripts in the background.
+
+## Routing
+
+Pick the operation, then read its op file for the procedure.
+
+| Intent | Op file |
+|---|---|
+| "give feedback on this run" / "the test was wrong" / "step N didn't work" / a Muggle dashboard URL in the prompt / chained from another skill | [`ops/submit.md`](ops/submit.md) |
+| "show my feedback" / "list feedback for this project" / "what feedback have I filed" | [`ops/list.md`](ops/list.md) |
+| "delete that feedback" / "remove feedback for X" | [`ops/delete.md`](ops/delete.md) |
+
+If intent is ambiguous, use `AskUserQuestion` once with options **Submit / List / Delete** — never ask the user to type a clarification in plain text.
+
+## Constraints (all ops)
+
+- **Feedback attaches to a cloud action-script id.** A local run that has not yet been uploaded to the cloud has no such id. Submit must upload the run first if needed.
+- **Feedback target is one of two shapes:**
+  - **Whole script** — `target.targetType = "actionScript"`, `target.targetId = <actionScriptId>`.
+  - **One specific step** — `target.targetType = "step"`, `target.targetId = "<actionScriptId>:<stepIndex>"` where `stepIndex` is **0-based** on the wire even though steps are shown to the user 1-based.
+- **Project scope.** All ops scope to the user's last-used project (`muggle-local-last-project-get`). If unset, ask once and persist via `muggle-local-last-project-set` so subsequent ops in this session reuse it.
+- **`feedbackText` must be non-empty.** Re-prompt the user if they leave it blank.
+
+## Non-negotiables (all ops)
+
+- Use `AskUserQuestion` for every selection (project, test case, run, target type, confirm). Never ask the user to "reply with a number" in plain text.
+- Convert step numbers between 1-based (rendered to user) and 0-based (wire format) at the boundary. Never expose 0-based indices to the user.
+- One MCP submit/delete call per feedback piece — never batch into a single call.
+- Surface the `feedbackAnalysisWorkflowRuntimeId` returned by submit so the user knows regeneration is running. Do not poll it from this skill.

--- a/plugin/skills/muggle-feedback/ops/delete.md
+++ b/plugin/skills/muggle-feedback/ops/delete.md
@@ -1,0 +1,49 @@
+# Delete feedback
+
+Soft-delete a feedback entry. Always confirm with the user before deleting — this is a write the user cannot undo from this skill.
+
+## 1. Identify the feedback
+
+Three paths:
+
+- **Explicit id** — user named the feedback id (e.g. "delete feedback `abcd-1234-...`"). Use it.
+- **Recently shown id** — the user is referring to a row from a list rendered earlier in the conversation. Resolve from that context.
+- **No id given** — run [`list.md`](list.md) first to surface entries; offer "Delete one" as the next-action; the user picks.
+
+## 2. Show what will be deleted
+
+Print:
+
+```
+Feedback: <id>
+Target:   <Whole script | Step N>
+Test case: <title>
+Created:  <human-readable>
+Text:
+  <full feedbackText, indented>
+```
+
+## 3. Confirm
+
+`AskUserQuestion`:
+
+> "Delete this feedback?"
+> - **Delete** — proceed
+> - **Cancel** — abort
+
+If the user cancels, print "Cancelled — feedback kept." and stop.
+
+## 4. Soft-delete
+
+`muggle-remote-user-feedback-delete` with the feedback id.
+
+## 5. Report
+
+On success: `✓ Deleted feedback <id>.`
+
+On failure: print the error verbatim. If the error is "not found", inform the user the entry was likely already deleted and continue gracefully.
+
+## Non-negotiables
+
+- Never delete without an explicit confirm step, even if the user said "delete X" in their original prompt — the confirm shows what they're actually deleting.
+- One delete call per invocation. No bulk delete in v1.

--- a/plugin/skills/muggle-feedback/ops/list.md
+++ b/plugin/skills/muggle-feedback/ops/list.md
@@ -1,6 +1,6 @@
 # List feedback
 
-Show feedback the user has filed in the current project. Optionally drill down by test case to keep noisy projects readable.
+Show feedback the user has filed. The user usually wants feedback on a specific test case (or test script, or use case) — not the whole project — so the skill picks a scope first.
 
 ## 1. Scope to a project
 
@@ -8,27 +8,34 @@ Read `muggle-local-last-project-get`. If set, use it.
 
 If unset: `muggle-remote-project-list` and pick via `AskUserQuestion` (top 5 by recency, plus "Show full list"). Persist with `muggle-local-last-project-set`.
 
-## 2. Fetch
+## 2. Pick a narrowing scope
 
-`muggle-remote-user-feedback-list` with `projectId`.
+Ask once via `AskUserQuestion` — the list tool accepts at most one narrowing filter:
 
-If the response has zero entries, print "No feedback filed yet for `<projectName>`." and offer `AskUserQuestion` with **Submit new feedback / Done**.
+> "What feedback do you want to see?"
+> - **A specific test case** (most common)
+> - **A specific test script**
+> - **A specific use case**
+> - **All in this project**
 
-## 3. Drill-down (only when noisy)
+If the user came from a chained skill or from a recent run, default to the matching narrowing scope and skip this question.
 
-If the response has more than 10 entries, ask via `AskUserQuestion`:
+## 3. Resolve the filter id
 
-> "<N> feedback entries in this project. Filter to a specific test case?"
-> - **Show all**
-> - **Filter by test case**
+- **Test case** → `muggle-remote-test-case-list` with `projectId`, `AskUserQuestion`. Pass picked id as `testCaseId`.
+- **Test script** → first pick a test case (as above), then `muggle-remote-test-script-list` with `testCaseId`, `AskUserQuestion`. Pass as `testScriptId`.
+- **Use case** → `muggle-remote-use-case-list` with `projectId`, `AskUserQuestion`. Pass as `useCaseId`.
+- **All in project** → no narrowing param.
 
-If filter chosen:
+Use relevance-first filtering on each picker: top 3-5 most relevant to the user's stated goal, plus "Show full list".
 
-1. `muggle-remote-test-case-list` with `projectId`. Pick one via `AskUserQuestion`.
-2. `muggle-remote-test-script-list` with `testCaseId`. Collect the set of `actionScriptId` values across the returned scripts.
-3. Client-side filter the feedback list: keep entries where `feedback.target.targetId` either equals one of those `actionScriptId` values (whole-script feedback) or starts with `<actionScriptId>:` (step feedback).
+## 4. Fetch
 
-## 4. Render
+`muggle-remote-user-feedback-list` with `projectId` and at most one of `actionScriptId` / `testScriptId` / `testCaseId` / `useCaseId`.
+
+If the response has zero entries, print "No feedback yet for `<scope description>`." and offer `AskUserQuestion` with **Submit new feedback / Done**.
+
+## 5. Render
 
 Markdown table sorted by `createdAt` (newest first):
 
@@ -36,24 +43,23 @@ Markdown table sorted by `createdAt` (newest first):
 |---|---|---|---|---|---|
 
 - **Target** — "Whole script" or "Step N" (convert wire 0-based index to 1-based for display).
-- **Test case** — resolve from the action-script id if not in the filter step. Use a small in-memory cache: for each unique `actionScriptId`, fetch via `muggle-remote-test-script-list` (or the per-script lookup) once.
+- **Test case** — when the scope is `testCaseId` or `testScriptId`, all rows share the same test case (use the title from the picker). When the scope is `useCaseId` or project-wide, resolve per row by fetching `muggle-remote-test-script-list` once for each unique `actionScriptId` (cache in-memory) — or skip and show "Test case: …" if there are >20 unique scripts.
 - **Excerpt** — first 80 chars of `feedbackText`, single line.
 - **Created** — human-readable, e.g. `2 days ago`.
-- **Id** — the feedback id (truncated to first 8 chars in the table; full id available in detail view).
+- **Id** — feedback id, truncated to first 8 chars in the table; full id shown in the detail view.
 
-If the action-script lookup is expensive (many distinct ids), show "Test case: …" and offer "Resolve test case names" as an opt-in via `AskUserQuestion`.
-
-## 5. Offer next action
+## 6. Offer next action
 
 `AskUserQuestion`:
 
 > "What next?"
-> - **View detail** — pick an entry, print full `feedbackText`, full ids, target, dashboard link if remote.
+> - **View detail** — pick an entry, print full `feedbackText`, full ids, target, dashboard link if available.
 > - **Delete one** — hand off to [`delete.md`](delete.md).
 > - **Submit new feedback** — hand off to [`submit.md`](submit.md).
 > - **Done**
 
 ## Non-negotiables
 
+- One narrowing filter only — never set more than one of `actionScriptId` / `testScriptId` / `testCaseId` / `useCaseId` in the same call.
 - Convert wire 0-based step indices to 1-based when rendering to the user.
-- Don't fetch test-case names for every row eagerly when the list is huge — make it opt-in past ~20 entries.
+- Don't fetch test-case names per row eagerly past ~20 unique action scripts — make it opt-in.

--- a/plugin/skills/muggle-feedback/ops/list.md
+++ b/plugin/skills/muggle-feedback/ops/list.md
@@ -1,0 +1,59 @@
+# List feedback
+
+Show feedback the user has filed in the current project. Optionally drill down by test case to keep noisy projects readable.
+
+## 1. Scope to a project
+
+Read `muggle-local-last-project-get`. If set, use it.
+
+If unset: `muggle-remote-project-list` and pick via `AskUserQuestion` (top 5 by recency, plus "Show full list"). Persist with `muggle-local-last-project-set`.
+
+## 2. Fetch
+
+`muggle-remote-user-feedback-list` with `projectId`.
+
+If the response has zero entries, print "No feedback filed yet for `<projectName>`." and offer `AskUserQuestion` with **Submit new feedback / Done**.
+
+## 3. Drill-down (only when noisy)
+
+If the response has more than 10 entries, ask via `AskUserQuestion`:
+
+> "<N> feedback entries in this project. Filter to a specific test case?"
+> - **Show all**
+> - **Filter by test case**
+
+If filter chosen:
+
+1. `muggle-remote-test-case-list` with `projectId`. Pick one via `AskUserQuestion`.
+2. `muggle-remote-test-script-list` with `testCaseId`. Collect the set of `actionScriptId` values across the returned scripts.
+3. Client-side filter the feedback list: keep entries where `feedback.target.targetId` either equals one of those `actionScriptId` values (whole-script feedback) or starts with `<actionScriptId>:` (step feedback).
+
+## 4. Render
+
+Markdown table sorted by `createdAt` (newest first):
+
+| # | Target | Test case | Excerpt | Created | Id |
+|---|---|---|---|---|---|
+
+- **Target** — "Whole script" or "Step N" (convert wire 0-based index to 1-based for display).
+- **Test case** — resolve from the action-script id if not in the filter step. Use a small in-memory cache: for each unique `actionScriptId`, fetch via `muggle-remote-test-script-list` (or the per-script lookup) once.
+- **Excerpt** — first 80 chars of `feedbackText`, single line.
+- **Created** — human-readable, e.g. `2 days ago`.
+- **Id** — the feedback id (truncated to first 8 chars in the table; full id available in detail view).
+
+If the action-script lookup is expensive (many distinct ids), show "Test case: …" and offer "Resolve test case names" as an opt-in via `AskUserQuestion`.
+
+## 5. Offer next action
+
+`AskUserQuestion`:
+
+> "What next?"
+> - **View detail** — pick an entry, print full `feedbackText`, full ids, target, dashboard link if remote.
+> - **Delete one** — hand off to [`delete.md`](delete.md).
+> - **Submit new feedback** — hand off to [`submit.md`](submit.md).
+> - **Done**
+
+## Non-negotiables
+
+- Convert wire 0-based step indices to 1-based when rendering to the user.
+- Don't fetch test-case names for every row eagerly when the list is huge — make it opt-in past ~20 entries.

--- a/plugin/skills/muggle-feedback/ops/submit.md
+++ b/plugin/skills/muggle-feedback/ops/submit.md
@@ -1,0 +1,117 @@
+# Submit feedback
+
+Resolve the action script being commented on, render it for review, collect feedback against one or more steps and/or the whole script, then submit each piece as its own server-side row.
+
+## 1. Resolve the action script (the "anchor")
+
+Pick the first applicable path. Stop at the first that yields an `actionScriptId`.
+
+### 1a. Dashboard URL in user's prompt
+
+A Muggle dashboard URL looks like `https://app.muggle-ai.com/muggleTestV0/dashboard/projects/<projectId>/...`. Scan the user's recent message for any `https://app.muggle-ai.com/...` URL.
+
+- Extract any UUID-shaped path segments. If `/projects/<uuid>` is present, capture as `projectId`. If `/test-scripts/<uuid>` is present, capture as `testScriptId`.
+- If a `testScriptId` was captured: call `muggle-remote-test-script-get` to get the script and read `actionScriptId` off it. Done — proceed to step 2.
+- If only a `projectId` was captured: use it as the project for path 1c and continue to picker.
+- If parsing yields nothing actionable: fall through to 1b.
+
+### 1b. Recent local run (chained or just-finished)
+
+If this skill was invoked by another skill (`muggle-test`, `muggle-test-feature-local`) the caller MUST pass the just-finished `runId` as context. If you have a `runId`:
+
+1. `muggle-local-run-result-get` with the `runId`.
+2. The result includes the test case context. If the run was already published (`muggle-local-publish-test-script` was called), the resulting `testScriptId` gives you the cloud `actionScriptId` via `muggle-remote-test-script-get`.
+3. **If the run was NOT published**, upload it first via `muggle-remote-local-run-upload` (passing the `runId`'s test case context and `actionScript` payload). Use the returned cloud `actionScriptId`.
+
+If no `runId` was passed but the user is plausibly continuing from a recent test:
+
+1. `muggle-local-list-sessions` and pick sessions completed in the last 10 minutes for the current project.
+2. If exactly one fresh session exists, offer it as the default via `AskUserQuestion` ("Feedback on the run from <X> minutes ago?" with **Yes / Pick a different run**).
+3. If multiple, present the top 3 via `AskUserQuestion` (most recent first).
+4. Once picked, follow the publish-or-upload path above.
+
+If neither chained nor recent fits, fall through to 1c.
+
+### 1c. Picker (project → test case → run)
+
+1. **Project.** Read `muggle-local-last-project-get`. If set, use it. Else `muggle-remote-project-list` with `AskUserQuestion` (top 5 by recency, plus "Show full list"). Persist the pick with `muggle-local-last-project-set`.
+2. **Test case.** `muggle-remote-test-case-list` with `projectId`, then `AskUserQuestion`. Top 5 by recency plus "Show full list". Rank by relevance if the user mentioned anything specific.
+3. **Run / script.** `muggle-remote-test-script-list` with `testCaseId`. Show via `AskUserQuestion` with: name + status + updatedAt. Top 5 by recency.
+4. `muggle-remote-test-script-get` on the picked one → note `actionScriptId`.
+
+## 2. Render the script for review
+
+Always render before asking for feedback — the user must see the steps to reference them by index.
+
+`muggle-remote-action-script-get` with the resolved `actionScriptId`.
+
+Print:
+
+- **Header** — project name, test case title, script name, status, run url (if available). For remote, include the dashboard link.
+- **Steps** — numbered list, **1-based**, in order:
+  - `Step <n>: <action label> on <element text or id> — <briefExplanation>`
+  - If `screenshotPath` is present (local) or `screenshotUrl` (remote), append `[screenshot: <path>]` so the user can open it manually.
+- **Summary** — print `summary` from the action script if present, else "No summary recorded".
+
+## 3. Collect feedback (batch)
+
+Use `AskUserQuestion` to scope which targets:
+
+> "Where is the problem?"
+> - One specific step
+> - Multiple steps
+> - The whole script's outcome / summary
+> - Multiple steps **and** the whole outcome
+
+For each chosen target, prompt for the feedback paragraph in plain text. Keep prompts specific:
+
+- For a step: "What should step `<n>` have done instead?"
+- For the whole script: "What's wrong with the overall outcome?"
+
+Validate each paragraph is non-empty (re-prompt if blank). Build an in-memory list of feedback pieces:
+
+```
+[
+  { kind: "step", stepNumber: 3, text: "..." },
+  { kind: "step", stepNumber: 7, text: "..." },
+  { kind: "actionScript",            text: "..." },
+]
+```
+
+Before submitting, re-confirm the full set with the user via `AskUserQuestion`:
+
+> "Submit these <N> feedback entries?" — **Submit / Edit / Cancel**.
+
+## 4. Submit
+
+For each piece, call `muggle-remote-user-feedback-create` once. Map fields:
+
+| Piece kind | `target.targetType` | `target.targetId` |
+|---|---|---|
+| Step `n` (1-based) | `"step"` | `` `${actionScriptId}:${n - 1}` `` (convert to 0-based) |
+| Whole script | `"actionScript"` | `actionScriptId` |
+
+Always pass `projectId` and `feedbackText`. Capture each response — note `feedback.id` and `feedbackAnalysisWorkflowRuntimeId` (may be undefined).
+
+If a single create call fails, log the error, continue with the rest, and report the failure at the end. Do not abort the batch.
+
+## 5. Report
+
+Print one line per submitted feedback in this shape:
+
+```
+✓ feedback <id> — <target description> [analysis runtime: <id>]
+```
+
+End with a one-line note:
+
+> "Regeneration runs in the background. Re-run this test case later to use the updated script."
+
+If any pieces failed, list them under a `Failed:` header with the error.
+
+## Non-negotiables
+
+- Always render the script (step 2) before collecting feedback.
+- One create call per feedback piece — never concatenate paragraphs across targets.
+- Convert step numbers from 1-based (UI) to 0-based (wire) at submit time.
+- If the user came from a non-uploaded local run, do the upload silently before submit; do not ask for permission for the upload itself.

--- a/plugin/skills/muggle-test-feature-local/SKILL.md
+++ b/plugin/skills/muggle-test-feature-local/SKILL.md
@@ -173,6 +173,16 @@ Gate `showElectronBrowser` (per `preference-gates/README.md`). Reuse choice with
 - `muggle-local-run-result-get` with the run id from execute.
 - Include: status, duration, pass/fail summary, per-step summary, artifact/screenshot paths, errors if failed, and script view URL when publishing ran.
 
+### 9a. Offer feedback when something looked wrong
+
+If the run's status is `failed`, the per-step summary shows an error, or the user verbally flags that the script did the wrong thing, suggest the feedback skill via `AskUserQuestion`:
+
+> "Want to leave feedback on what should've happened? It triggers regeneration of the affected script."
+> - **Yes — give feedback** → invoke the `muggle-feedback` skill via the `Skill` tool, passing the just-finished `runId` so the submit flow opens with this run preloaded.
+> - **No — skip**
+
+Skip silently if the run passed cleanly and the user did not flag anything.
+
 ### 10. Offer to post a visual walkthrough to the PR
 
 After reporting results, gather the required input and hand off to the shared **`muggle:muggle-pr-visual-walkthrough`** skill, which renders the walkthrough via `muggle build-pr-section` and posts it to the current branch's open PR.

--- a/plugin/skills/muggle-test/SKILL.md
+++ b/plugin/skills/muggle-test/SKILL.md
@@ -374,6 +374,18 @@ If 9b resolved to "post" (either via `postPRVisualWalkthrough = always` or the u
 
 This skill always uses **Mode A** (post to an existing PR); `muggle-do` is the only caller that uses Mode B. Do not attempt to render the walkthrough markdown yourself — delegate to the shared skill.
 
+## Step 10: Offer feedback on failures
+
+After the report is complete, if **any** test in the run had a `failed` or unexpected status (or the user verbally flags something looked off), suggest the feedback skill:
+
+> "Looks like `<N>` test(s) didn't go as expected. Want to leave feedback on what should've happened? It triggers regeneration on the affected scripts."
+
+Use `AskUserQuestion`:
+- **Yes — give feedback** → invoke the `muggle-feedback` skill via the `Skill` tool. Pass the failed run's `runId` (local) or `testScriptId` (remote) as anchor context so the submit flow opens with the correct script already loaded.
+- **No — skip**
+
+This is a suggestion, not automatic invocation. Skip silently if every test passed cleanly.
+
 ## Tool Reference
 
 | Phase | Tool | Mode |

--- a/plugin/skills/muggle/SKILL.md
+++ b/plugin/skills/muggle/SKILL.md
@@ -37,5 +37,6 @@ If the user intent clearly matches one command, route directly — no menu neede
 - test localhost/validate single feature/test a feature → `muggle-test-feature-local`
 - build/implement from request/end-to-end → `muggle-do`
 - post results to PR/attach walkthrough/visual evidence on PR → `muggle-pr-visual-walkthrough`
+- give feedback on a run/the test was wrong/step N didn't work/show my feedback/delete feedback → `muggle-feedback`
 
 If intent is ambiguous, use `AskQuestion` with the most likely options rather than asking the user to type a clarification.


### PR DESCRIPTION
## Summary
- New `/muggle-feedback` skill: routes submit / list / delete operations on user feedback against generated action scripts. Auto-detects the run anchor from a recent local run, a remote run, or a Muggle dashboard URL pasted in the prompt; renders the script for review and collects step-level + whole-script feedback in one batch.
- Three new MCP tools backing the skill: `muggle-remote-user-feedback-{create,list,delete}` mapped to `/v1/protected/muggle-test/user-feedback`.
- Chain hooks in `/muggle-test` and `/muggle-test-feature-local` that suggest feedback when a run fails or looks wrong, passing the run id as anchor.

## Design
Spec: `muggle-ai-brain/product/2026-05-08-muggle-feedback-skill-design.md` (Status: Pending).

## Notes
- `studioAuthInfo` is intentionally absent from the MCP create schema — the controller reads it from request headers and the feedback-analysis workflow falls through gracefully when it's missing (feedback is still saved).
- List uses `limit`/`offset` to match the existing controller signature (not `page`/`pageSize`).
- **Open issue worth tracking server-side:** the regeneration prompt does not currently consume the feedback text — only similarity matching does. So submitting feedback may regenerate the same script. Worth fixing before the skill is widely advertised.

## Test plan
- [x] `pnpm exec tsc --noEmit` clean for `packages/mcps`
- [ ] CI green
- [ ] Smoke-test from a Claude Code session: `/muggle-feedback` after a local run → submit → confirm feedback row + analysis runtime id surfaced
- [ ] Smoke-test list/delete paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)