### PR TITLE
Three-branch enumeration on every gate stanza

### DIFF
--- a/plugin/skills/muggle-status/SKILL.md
+++ b/plugin/skills/muggle-status/SKILL.md
@@ -26,8 +26,9 @@ Gates run per `preference-gates/README.md`.
 3. **Authentication** — call `muggle-remote-auth-status`. Report whether credentials are valid and when they expire.
 
 4. **CLI version** — gate `checkForUpdates` (per `preference-gates/README.md`):
-   - Pro-action: run the check below.
-   - Skip-action: render the row as `[skip]  check disabled by preference`.
+   - `always` → run the check below.
+   - `never` → render the row as `[skip]  check disabled by preference`.
+   - `ask` → run Picker 1 from `preference-gates/checkForUpdates.md` via `AskUserQuestion`; map the answer back to one of the actions above.
 
    When the check runs: capture installed (`muggle --version`) and latest (`npm view @muggleai/works version`). Compare with `sort -V`; flag as out-of-date only when latest is strictly greater.
 

--- a/plugin/skills/muggle-test-feature-local/SKILL.md
+++ b/plugin/skills/muggle-test-feature-local/SKILL.md
@@ -43,8 +43,9 @@ Gates run per `preference-gates/README.md`.
 
 - `muggle-remote-auth-status`
 - If **authenticated**: gate `autoLogin` (per `preference-gates/README.md`):
-  - Pro-action: proceed with saved session.
-  - Skip-action: `muggle-remote-auth-login` with `forceNewSession: true`, then `muggle-remote-auth-poll`.
+  - `always` → proceed with saved session.
+  - `never` → `muggle-remote-auth-login` with `forceNewSession: true`, then `muggle-remote-auth-poll`.
+  - `ask` → run Picker 1 from `preference-gates/autoLogin.md` via `AskUserQuestion`; map the answer back to one of the actions above.
 - If **not signed in or expired**: call `muggle-remote-auth-login` then `muggle-remote-auth-poll`. Do not skip or assume auth.
 
 ### 2. Targets (user must confirm)
@@ -166,8 +167,9 @@ Gate `showElectronBrowser` (per `preference-gates/README.md`). Reuse choice with
 
 - `muggle-local-publish-test-script`
 - Gate `openTestResultsAfterRun` (per `preference-gates/README.md`):
-  - Pro-action: open `viewUrl` automatically (`open "<viewUrl>"` on macOS or OS equivalent).
-  - Skip-action: print the URL only.
+  - `always` → open `viewUrl` automatically (`open "<viewUrl>"` on macOS or OS equivalent).
+  - `never` → print the URL only.
+  - `ask` → run Picker 1 from `preference-gates/openTestResultsAfterRun.md` via `AskUserQuestion`; map the answer back to one of the actions above.
 
 ### 9. Report
 

--- a/plugin/skills/muggle-test-import/SKILL.md
+++ b/plugin/skills/muggle-test-import/SKILL.md
@@ -144,8 +144,9 @@ If the user wants changes, incorporate feedback, then ask again. Only proceed af
 Call `muggle-remote-auth-status` first.
 
 If **already authenticated** → gate `autoLogin` (per `preference-gates/README.md`):
-- Pro-action: skip to Step 5.
-- Skip-action: `muggle-remote-auth-login` with `forceNewSession: true`, then `muggle-remote-auth-poll`.
+- `always` → skip to Step 5.
+- `never` → `muggle-remote-auth-login` with `forceNewSession: true`, then `muggle-remote-auth-poll`.
+- `ask` → run Picker 1 from `preference-gates/autoLogin.md` via `AskUserQuestion`; map the answer back to one of the actions above.
 
 If **not authenticated**:
 1. Tell the user a browser window is about to open.
@@ -403,8 +404,9 @@ Two preferences gate optional follow-ups: `suggestRelatedUseCases` and `suggestR
 The query is: "from the use cases already in this project, which ones are *not* in the import set but look related to it?" — surface them so the user can decide whether their import missed something the project already tracks.
 
 Gate `suggestRelatedUseCases` (per `preference-gates/README.md`):
-- Pro-action: run the query below.
-- Skip-action: skip.
+- `always` → run the query below.
+- `never` → skip.
+- `ask` → run Picker 1 from `preference-gates/suggestRelatedUseCases.md` via `AskUserQuestion`; map the answer back to one of the actions above.
 
 When running the query:
 1. Call `muggle-remote-use-case-list` for the project.
@@ -419,8 +421,9 @@ When running the query:
 For each use case the user just created, surface other test cases already attached that the import didn't add — same idea, scoped to a single use case.
 
 Gate `suggestRelatedTestCases` (per `preference-gates/README.md`):
-- Pro-action: run the query below.
-- Skip-action: skip.
+- `always` → run the query below.
+- `never` → skip.
+- `ask` → run Picker 1 from `preference-gates/suggestRelatedTestCases.md` via `AskUserQuestion`; map the answer back to one of the actions above.
 
 When running the query, for each use case in the import:
 1. Call `muggle-remote-test-case-list-by-use-case` with that `useCaseId`.

--- a/plugin/skills/muggle-test-regenerate-missing/SKILL.md
+++ b/plugin/skills/muggle-test-regenerate-missing/SKILL.md
@@ -52,8 +52,9 @@ Treat this filter as a default, not a law. If the user explicitly says "include 
 
 1. Call `muggle-remote-auth-status`.
 2. If **authenticated and not expired** → gate `autoLogin` (per `preference-gates/README.md`):
-   - Pro-action: proceed with saved session.
-   - Skip-action: `muggle-remote-auth-login` with `forceNewSession: true`, then `muggle-remote-auth-poll`.
+   - `always` → proceed with saved session.
+   - `never` → `muggle-remote-auth-login` with `forceNewSession: true`, then `muggle-remote-auth-poll`.
+   - `ask` → run Picker 1 from `preference-gates/autoLogin.md` via `AskUserQuestion`; map the answer back to one of the actions above.
 3. If **not authenticated or expired** → call `muggle-remote-auth-login`, then poll with `muggle-remote-auth-poll`.
 4. Do not skip auth and do not assume a stale token still works.
 

--- a/plugin/skills/muggle-test/SKILL.md
+++ b/plugin/skills/muggle-test/SKILL.md
@@ -80,8 +80,9 @@ Only proceed after selection.
 ## Step 2: Detect Local Changes (gated by `autoDetectChanges`)
 
 Gate `autoDetectChanges` (per `preference-gates/README.md`):
-- Pro-action: run the scan and proceed to analysis below.
-- Skip-action: ask "What would you like to test?" then jump to Step 3.
+- `always` → run the scan and proceed to analysis below.
+- `never` → ask "What would you like to test?" then jump to Step 3.
+- `ask` → run Picker 1 from `preference-gates/autoDetectChanges.md` via `AskUserQuestion`; map the answer back to one of the actions above.
 
 ### Analysis (when scan is enabled)
 
@@ -104,8 +105,9 @@ If no changes detected (clean tree), tell the user and ask what they want to tes
 
 1. Call `muggle-remote-auth-status`
 2. If **authenticated and not expired** → gate `autoLogin` (per `preference-gates/README.md`):
-   - Pro-action: reuse saved session.
-   - Skip-action: `muggle-remote-auth-login` with `forceNewSession: true`, then `muggle-remote-auth-poll`.
+   - `always` → reuse saved session.
+   - `never` → `muggle-remote-auth-login` with `forceNewSession: true`, then `muggle-remote-auth-poll`.
+   - `ask` → run Picker 1 from `preference-gates/autoLogin.md` via `AskUserQuestion`; map the answer back to one of the actions above.
 3. If **not authenticated or expired** → call `muggle-remote-auth-login`
 4. If login pending → call `muggle-remote-auth-poll`
 
@@ -218,8 +220,9 @@ Gate `autoSelectLocalHost` per `preference-gates/README.md` + `preference-gates/
 ### Pre-flight visibility (gated by `showElectronBrowser`)
 
 Gate `showElectronBrowser` (per `preference-gates/README.md`). Resolve once; apply same `showUi` to every test case.
-- Pro-action: omit `showUi` (defaults visible).
-- Skip-action: pass `showUi: false`.
+- `always` → omit `showUi` (defaults visible).
+- `never` → pass `showUi: false`.
+- `ask` → run Picker 1 from `preference-gates/showElectronBrowser.md` via `AskUserQuestion`; map the answer back to one of the actions above.
 
 ### Fetch test case details (in parallel)
 
@@ -256,8 +259,9 @@ For every `runId`, issue all `muggle-local-run-result-get` calls in parallel. Ex
 ### Publish each run to cloud (gated by `autoPublishLocalResults`)
 
 Gate `autoPublishLocalResults` (per `preference-gates/README.md`):
-- Pro-action: proceed to publish logic below.
-- Skip-action: skip to report summary; tell user Steps 8/9 and per-step screenshots are unavailable without publishing.
+- `always` → proceed to publish logic below.
+- `never` → skip to report summary; tell user Steps 8/9 and per-step screenshots are unavailable without publishing.
+- `ask` → run Picker 1 from `preference-gates/autoPublishLocalResults.md` via `AskUserQuestion`; map the answer back to one of the actions above.
 
 ### Publish logic (when publishing is enabled)
 


### PR DESCRIPTION
## Summary

Follow-up to #125 — the trim commits that addressed your "keep it clean" review feedback (`5ae6c4c`, `2de50eb`) were pushed AFTER the merge and never made it to master. This PR is just those two commits squashed into a single clean change.

Replaces the previous two-branch "Pro-action / Skip-action" stanzas with explicit three-branch enumeration:

- `always` → pro-action
- `never` → skip-action
- `ask` → run Picker 1 from `preference-gates/<key>.md` via `AskUserQuestion`; map the answer back to one of the actions above.

The eval in #123 showed the LLM doesn't reliably consult the README's "absent → ask" rule from a two-branch stanza — when the resolved value was `ask` the agent skipped the gate. Spelling out the third branch with the tool name named at the call site pins the behavior.

## Touched gates

`autoLogin` (×4 sites), `autoDetectChanges`, `showElectronBrowser` (×2), `openTestResultsAfterRun`, `autoPublishLocalResults`, `checkForUpdates`, `suggestRelatedUseCases`, `suggestRelatedTestCases`.

## Test plan

- [x] `pnpm vitest run src/test/skills/preference-gates-lint.test.ts` — 98/98 (Layer 1 contract lint)
- [x] No `Pro-action` / `Skip-action` strings remain anywhere in `plugin/skills/`
- [x] Behavioral eval on #123 branch showed 3/3 PASS at 3 reps each on Sonnet 4.6 with this same stanza shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)