### PR TITLE
feat(skills): replay/regen classifier + failure-mode router

### DIFF
--- a/internal/skill-gate-eval/src/mock-mcp.ts
+++ b/internal/skill-gate-eval/src/mock-mcp.ts
@@ -57,6 +57,12 @@ export function buildMockMcpServer(fixtures: Fixtures): MockServerHandle {
         async () => jsonResult({ ok: true }),
       ),
       tool(
+        "muggle-local-telemetry-event-emit",
+        "Failure-mode telemetry sink (mock).",
+        PERMISSIVE_SHAPE,
+        async () => jsonResult({ ok: true }),
+      ),
+      tool(
         "muggle-remote-auth-status",
         "Auth status (mock).",
         PERMISSIVE_SHAPE,

--- a/packages/mcps/src/mcp/local/contracts/telemetry-schemas.ts
+++ b/packages/mcps/src/mcp/local/contracts/telemetry-schemas.ts
@@ -14,3 +14,63 @@ export const SkillTelemetryEmitInputSchema = z.object({
 });
 
 export type SkillTelemetryEmitInput = z.infer<typeof SkillTelemetryEmitInputSchema>;
+
+export enum FailureEventType {
+    PreExecutionClassification = "pre-execution-classification",
+    ReplayFailureClassified = "replay-failure-classified",
+    ReplayFailureResolved = "replay-failure-resolved",
+    RegenFailureClassified = "regen-failure-classified",
+    RegenFailureResolved = "regen-failure-resolved",
+}
+
+export const EventTelemetryEmitInputSchema = z.object({
+    eventType: z
+        .nativeEnum(FailureEventType)
+        .describe(
+            "Which decision point this event records. Five values cover the AI's pre-execution " +
+            "replay-vs-regen choice and the four post-failure classify→resolve pairs.",
+        ),
+    skillName: z
+        .string()
+        .min(1)
+        .describe("Skill that emitted this event (e.g. 'muggle-test', 'muggle-test-feature-local')."),
+    aiClassification: z
+        .string()
+        .optional()
+        .describe(
+            "What the AI classified the situation as. " +
+            "pre-execution: 'replay' or 'regen'. " +
+            "replay-failure: 'infra' | 'stale-script' | 'product-defect'. " +
+            "regen-failure: 'transient' | 'infra' | 'agent-course' | 'product-uxux'.",
+        ),
+    aiSuggestion: z
+        .string()
+        .optional()
+        .describe(
+            "What the AI suggested the user do. Examples: 'regenerate', 'report-bug', " +
+            "'muggle-feedback', 'retry', 'wait-and-share'.",
+        ),
+    userAction: z
+        .string()
+        .optional()
+        .describe(
+            "What the user actually picked (only set on *-resolved events). " +
+            "Compare against aiSuggestion to measure classification accuracy.",
+        ),
+    runId: z.string().optional().describe("Anchor: local run ID for the affected execution."),
+    testCaseId: z.string().optional().describe("Anchor: cloud test case ID."),
+    projectId: z.string().optional().describe("Anchor: cloud project ID."),
+    signals: z
+        .array(z.string())
+        .optional()
+        .describe(
+            "Signals that drove the classification, e.g. ['element-not-found', 'selector-timeout', " +
+            "'electron-exit-26', 'goal-not-achievable']. Used to refine the rules later.",
+        ),
+    metadata: z
+        .record(z.string(), z.unknown())
+        .optional()
+        .describe("Free-form additional context (e.g. error excerpt, last step name)."),
+});
+
+export type EventTelemetryEmitInput = z.infer<typeof EventTelemetryEmitInputSchema>;

--- a/packages/mcps/src/mcp/local/index.ts
+++ b/packages/mcps/src/mcp/local/index.ts
@@ -74,6 +74,7 @@ function isLocalOnlyTool(toolName: string): boolean {
     "muggle_test_script_get",
     // Client telemetry — purely local, no backend call
     "muggle-local-telemetry-skill-emit",
+    "muggle-local-telemetry-event-emit",
   ];
 
   return localOnlyTools.includes(toolName);

--- a/packages/mcps/src/mcp/tools/local/tool-registry.ts
+++ b/packages/mcps/src/mcp/tools/local/tool-registry.ts
@@ -33,7 +33,9 @@ import {
   LastHostSetInputSchema,
   LastHostClearInputSchema,
   SkillTelemetryEmitInputSchema,
+  EventTelemetryEmitInputSchema,
 } from "../../local/contracts/index.js";
+import { appendFailureEvent } from "../../../shared/failure-events.js";
 import { writePreferences } from "../../../shared/preferences.js";
 import {
   readLastProject,
@@ -822,6 +824,36 @@ const telemetrySkillEmitTool: ILocalMcpTool = {
   },
 };
 
+// Records structured failure-mode events (AI classification + suggested action +
+// user's actual choice) so we can later measure classification accuracy and
+// refine guidance. See plugin/skills/_shared/failure-mode-handling.md.
+const telemetryEventEmitTool: ILocalMcpTool = {
+  name: "muggle-local-telemetry-event-emit",
+  description:
+    "Emit a structured failure-mode telemetry event recording how a Muggle Test skill " +
+    "classified a situation and what action the user took. Used at five decision points: " +
+    "'pre-execution-classification' (replay vs regen), 'replay-failure-classified', " +
+    "'replay-failure-resolved', 'regen-failure-classified', 'regen-failure-resolved'. " +
+    "Records to ~/.muggle-ai/telemetry/failure-events.jsonl. Never fails the skill on telemetry errors.",
+  inputSchema: EventTelemetryEmitInputSchema,
+  execute: async (ctx) => {
+    const input = EventTelemetryEmitInputSchema.parse(ctx.input);
+    appendFailureEvent({
+      eventType: input.eventType,
+      skillName: input.skillName,
+      aiClassification: input.aiClassification,
+      aiSuggestion: input.aiSuggestion,
+      userAction: input.userAction,
+      runId: input.runId,
+      testCaseId: input.testCaseId,
+      projectId: input.projectId,
+      signals: input.signals,
+      metadata: input.metadata,
+    });
+    return { content: "ok", isError: false, data: { recorded: true } };
+  },
+};
+
 // ========================================
 // All Tools Registry
 // ========================================
@@ -858,6 +890,7 @@ export const allLocalQaTools: ILocalMcpTool[] = [
   lastHostClearTool,
   // Client telemetry: skills emit invocation events through this tool
   telemetrySkillEmitTool,
+  telemetryEventEmitTool,
 ];
 
 /**

--- a/packages/mcps/src/shared/failure-events.ts
+++ b/packages/mcps/src/shared/failure-events.ts
@@ -1,0 +1,54 @@
+/**
+ * Append-only JSONL log for structured failure-mode telemetry events.
+ *
+ * Skills classify replay/regen failures and record their classification + the
+ * user's chosen action here. The file is later analyzed (grep/jq/CLI) to
+ * measure AI classification accuracy and refine guidance — see
+ * `plugin/skills/_shared/failure-mode-handling.md`.
+ *
+ * Lives under the global Muggle data dir (`~/.muggle-ai/telemetry/`),
+ * not per-repo, because failure-mode signal is cross-project by design.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { getDataDir } from "./data-dir.js";
+import { getLogger } from "./logger.js";
+
+const TELEMETRY_DIR_NAME = "telemetry";
+const FAILURE_EVENTS_FILE_NAME = "failure-events.jsonl";
+
+export interface IFailureEventRecord {
+  ts: string;
+  eventType: string;
+  skillName: string;
+  aiClassification?: string;
+  aiSuggestion?: string;
+  userAction?: string;
+  runId?: string;
+  testCaseId?: string;
+  projectId?: string;
+  signals?: string[];
+  metadata?: Record<string, unknown>;
+}
+
+/** Absolute path to the failure-events JSONL log. */
+export function getFailureEventsFilePath(): string {
+  return path.join(getDataDir(), TELEMETRY_DIR_NAME, FAILURE_EVENTS_FILE_NAME);
+}
+
+/** Append one event line. Swallows all errors — telemetry must never fail the skill. */
+export function appendFailureEvent(record: Omit<IFailureEventRecord, "ts">): void {
+  try {
+    const dir = path.join(getDataDir(), TELEMETRY_DIR_NAME);
+    fs.mkdirSync(dir, { recursive: true });
+    const filePath = path.join(dir, FAILURE_EVENTS_FILE_NAME);
+    const full: IFailureEventRecord = { ts: new Date().toISOString(), ...record };
+    fs.appendFileSync(filePath, `${JSON.stringify(full)}\n`, "utf-8");
+  } catch (error) {
+    getLogger().warn("Failed to append failure event", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/plugin/skills/_shared/failure-mode-handling.md
+++ b/plugin/skills/_shared/failure-mode-handling.md
@@ -1,0 +1,206 @@
+# Failure-Mode Handling — Shared Reference
+
+> Source of truth for **(a)** the pre-execution replay-vs-regen choice and **(b)** the post-execution failure router used by `muggle-test`, `muggle-test-feature-local`, `muggle-do-task`, and `muggle-test-regenerate-missing`. Skills MUST link here rather than restate the rules.
+
+## The contract
+
+Every decision in this doc follows the same shape:
+
+1. **Classify** — pick a bucket from a fixed taxonomy based on the available signals.
+2. **Suggest** — present the bucket-specific suggestion to the user via `AskUserQuestion`.
+3. **User decides** — the user always makes the final call. Never auto-act.
+4. **Emit telemetry** — record `(aiClassification, aiSuggestion, userAction, signals)` via `muggle-local-telemetry-event-emit` so the rules can be refined later from real data.
+
+The classification rules below are **starting heuristics**. Trust the AI's bucket only enough to phrase a default suggestion — let the user override freely.
+
+---
+
+## A. Pre-execution: replay vs regen (used by `muggle-test`)
+
+Run during change analysis, **per impacted test case**. Picks the initial execution mode before Step 7. Other skills with a single user-picked target (`muggle-test-feature-local`, `muggle-do-task`) skip this section — the user already chose.
+
+### Inputs
+
+- The change summary from `git diff` (file paths + diff content).
+- The test case (title, description, instructions, last passing run timestamp).
+- Existing test scripts for that test case from `muggle-remote-test-script-list`.
+
+### Rules (fire in order; first match wins)
+
+| # | Condition | Mode | Reason |
+|---|---|---|---|
+| 1 | No replayable/succeeded script exists for the test case | `regen` | Nothing to replay. |
+| 2 | A changed file looks like UI/markup mapped to this test case (component, page, route, template, JSX/TSX/Vue/Svelte/HTML, CSS that changes layout or selectors) | `regen` | Selectors likely broken — replay would fail on staleness. |
+| 3 | Last successful run was > **30 days** ago | `regen` | Drift accumulates; the saved script is stale even without a flagged change. |
+| 4 | Otherwise — changes are logic-only / backend / styling-without-DOM-impact | `replay` | Selectors should still work; replay catches real regressions. |
+
+### Mapping "changed file → test case"
+
+Use the test case's `instructions` and `goal` text plus filenames in the diff. Match heuristically — a test case titled "Submit signup form" plus a diff in `app/auth/signup/page.tsx` is a clear match. When in doubt, prefer `regen` (rule 2 wins) — a needless regen wastes budget; a stale replay fails the test for the wrong reason.
+
+### Telemetry
+
+Emit **`pre-execution-classification`** for every test case in the batch, before execution starts:
+
+```json
+{
+  "eventType": "pre-execution-classification",
+  "skillName": "muggle-test",
+  "aiClassification": "replay" | "regen",
+  "aiSuggestion": "<same as classification>",
+  "testCaseId": "<id>",
+  "projectId": "<id>",
+  "signals": ["rule-1-no-script" | "rule-2-ui-changed" | "rule-3-stale-30d" | "rule-4-default-replay"],
+  "metadata": { "lastPassedAgeDays": <n>, "changedFilesMatched": ["..."] }
+}
+```
+
+Skill MAY surface the per-test-case decision in the report (e.g., "regenerating 3, replaying 5") so the user can override before execution. If the user overrides, emit a follow-up event with `userAction` set to the overriding mode.
+
+---
+
+## B. Post-replay failure (used by all four skills with replays)
+
+Triggered when `muggle-local-execute-replay` returns `status: "failed"` (or non-zero Electron exit) **and** the run is not an orchestration timeout already covered in `muggle-test-feature-local/SKILL.md` Step 6.
+
+### Buckets
+
+| Bucket | Meaning |
+|---|---|
+| **infra** | Something is wrong inside Muggle Test itself (e.g., click didn't register on a clearly-clickable element, Electron crash, browser engine quirk). Not the user's fault and not a stale script. |
+| **stale-script** | The test script no longer matches the live UI (selectors moved, label paths changed, page renamed). The product still works; the script is out of date. |
+| **product-defect** | The script and infra are fine; the user's app actually misbehaved (assertion failure on previously-passing step, unexpected error, wrong page after action). This is the failure mode acceptance testing exists to catch. |
+
+### Initial signal heuristics
+
+Derive signals from the run's per-step results, error messages, and step screenshots (`muggle-local-run-result-get`):
+
+- **infra** signals: `electron-crash`, `chromium-error`, `click-no-effect-on-clickable-element`, `timeout-on-trivial-wait`, `internal-error-in-mcp-output`.
+- **stale-script** signals: `element-not-found`, `selector-timeout`, `label-path-mismatch`, `nav-target-404`, `aria-label-changed`.
+- **product-defect** signals: `assertion-failed-on-passing-step`, `unexpected-error-toast`, `wrong-page-after-action`, `network-500-from-app`, `form-validation-rejected-valid-input`.
+
+If signals span multiple buckets, pick the most specific one and list all signals in telemetry — the user can override.
+
+### Suggestions per bucket
+
+Present via `AskUserQuestion`. The first option is the AI's recommendation (label it `(Recommended)`); always include the others so the user can redirect. **Always include "Skip — just report" so the user can opt out without committing to anything.**
+
+| Bucket | Recommended suggestion | Other options |
+|---|---|---|
+| **infra** | Report bug to Muggle AI → invoke `muggle-feedback` skill with `category: "muggle-infra"` (and run id / signals). | Retry; muggle-feedback (different category); Skip. |
+| **stale-script** | Regenerate the script → call `muggle-local-execute-test-generation` (or remote equivalent) for this test case, then re-replay. | Retry as-is; muggle-feedback; Skip. |
+| **product-defect** | Surface as a real defect — show the failing step + screenshot + one-line summary; offer to share via email/SMS/file ticket (see "Sharing real defects" below). | muggle-feedback (if the script's *expectation* was wrong); Retry; Skip. |
+
+### Sharing real defects
+
+When the user picks "share / file ticket" on a `product-defect`:
+
+1. Build a one-paragraph summary: test case title, failing step, expected-vs-actual, screenshot path, run id.
+2. Ask `AskUserQuestion`: where to share?
+   - Email — open `mailto:` with the summary pre-filled.
+   - SMS — copy the summary to clipboard, instruct user to paste.
+   - File ticket — if `gh` is available and there's a repo, offer `gh issue create` with the summary as the body; otherwise copy summary and instruct user.
+   - Skip — just keep the report.
+3. Record the choice in telemetry (`userAction: "share-email" | "share-sms" | "share-ticket" | "skip"`).
+
+### Telemetry
+
+Emit **two events per failure**: one when the AI classifies (before asking the user) and one when the user picks an action.
+
+```json
+{
+  "eventType": "replay-failure-classified",
+  "skillName": "<this skill>",
+  "aiClassification": "infra" | "stale-script" | "product-defect",
+  "aiSuggestion": "report-bug" | "regenerate" | "share-defect",
+  "runId": "<local run id>",
+  "testCaseId": "<id>",
+  "projectId": "<id>",
+  "signals": ["element-not-found", "selector-timeout"],
+  "metadata": { "failingStep": "<step name>", "errorExcerpt": "<first 200 chars>" }
+}
+```
+
+```json
+{
+  "eventType": "replay-failure-resolved",
+  "skillName": "<this skill>",
+  "aiClassification": "<same as above>",
+  "aiSuggestion": "<same as above>",
+  "userAction": "regenerate" | "report-bug" | "share-email" | "retry" | "muggle-feedback" | "skip",
+  "runId": "<local run id>",
+  "testCaseId": "<id>",
+  "projectId": "<id>"
+}
+```
+
+The `(aiSuggestion, userAction)` pair is the metric we tune from — when they diverge, the classifier needs work.
+
+---
+
+## C. Post-regen failure (used by all four skills with generation)
+
+Triggered when `muggle-local-execute-test-generation` (or the remote equivalent) returns `failed`, exit 26, `goal_not_achievable`, or any other non-passing terminal state.
+
+### Buckets
+
+| Bucket | Meaning |
+|---|---|
+| **transient** | Network blip, single LLM call failed, intermittent flake. Likely succeeds on retry without changing anything. |
+| **infra** | A Muggle Test bug stopped generation from progressing (handler crash, schema validation in our code, deterministic LLM-pipeline failure). |
+| **agent-course** | The generation agent went down a wrong path (chose the wrong button, misread the goal, looped on a blocking modal). The product is fine and the test case is fine — the agent's *course* needs steering. |
+| **product-uxux** | The product itself blocks the test (broken page, missing element, server error). Agent can't proceed because the feature doesn't actually work. |
+
+### Initial signal heuristics
+
+From `muggle-local-run-result-get` (summary, structured summary, last steps, error):
+
+- **transient**: `network-error`, `llm-rate-limit`, `single-tool-call-error`, run had partial progress then died.
+- **infra**: `electron-mcp-handler-crash`, `internal-validation-error`, `pipeline-stuck`, identical failure repeated more than twice.
+- **agent-course**: `goal_not_achievable` with summary mentioning the agent picked a different element, looped on a modal, kept trying the same wrong action; many steps but no real progress.
+- **product-uxux**: server 5xx in step screenshots, "page not found" reached repeatedly, expected element provably absent (visible in screenshot), product clearly broken in the artifact log.
+
+### Suggestions per bucket
+
+Present via `AskUserQuestion`. **Always show the run summary first** so the user has context, then offer the bucket's recommended action plus alternatives.
+
+| Bucket | Recommended suggestion | Other options |
+|---|---|---|
+| **transient** | Retry as-is. | muggle-feedback; Edit test case; Skip. |
+| **infra** | Report bug to Muggle AI → `muggle-feedback` with `category: "muggle-infra"` (run id, signals, summary excerpt). | Retry; Skip. |
+| **agent-course** | Steer the agent → invoke `muggle-feedback` skill so the user describes what should have happened; the workflow re-runs with the corrected course. | Retry; Edit test case; Skip. |
+| **product-uxux** | Wait for fix — share the run summary + screenshot to the dev. Offer email / SMS / file ticket (see "Sharing real defects" in section B). | Retry once the fix lands; muggle-feedback; Skip. |
+
+### Telemetry
+
+Same two-event pattern as section B, with `eventType` values `regen-failure-classified` and `regen-failure-resolved`. `aiClassification` is one of the four bucket strings; `userAction` is the user's pick.
+
+```json
+{
+  "eventType": "regen-failure-classified",
+  "skillName": "<this skill>",
+  "aiClassification": "transient" | "infra" | "agent-course" | "product-uxux",
+  "aiSuggestion": "retry" | "report-bug" | "muggle-feedback" | "wait-and-share",
+  "runId": "<local run id>",
+  "testCaseId": "<id>",
+  "projectId": "<id>",
+  "signals": ["goal_not_achievable", "loop-on-modal"],
+  "metadata": { "summary": "<excerpt>", "stepsCompleted": <n> }
+}
+```
+
+---
+
+## D. Emitting telemetry — implementation notes
+
+- Tool: `muggle-local-telemetry-event-emit` (local-only, fire-and-forget).
+- Sink: `~/.muggle-ai/telemetry/failure-events.jsonl` (one JSON record per line, append-only).
+- Never block the skill on a telemetry call. If the tool errors, log and continue.
+- Always emit the **classified** event before asking the user, and the **resolved** event immediately after the user picks. Don't merge them into one event after the fact — the *latency* between AI suggestion and user choice is also data.
+- For the pre-execution classifier (section A), the event has no separate "resolved" pair unless the user actively overrides; if they do, emit a single follow-up `pre-execution-classification` event with `userAction` set.
+
+## E. What this doc deliberately does not bake in
+
+- **Quantitative thresholds** beyond rule A.3 (30-day drift). Bucket signal lists above are an initial best guess; once telemetry has data, the user will refine which signals reliably indicate which bucket.
+- **Auto-retry**. There is no "if X then automatically rerun" path anywhere. The user decides every time — that's the whole point of the contract.
+- **Cross-bucket fallbacks**. If the AI mis-classifies, the user picks a different option from the AskUserQuestion list; the AI does not retry classification.

--- a/plugin/skills/_shared/telemetry-emit.md
+++ b/plugin/skills/_shared/telemetry-emit.md
@@ -9,3 +9,7 @@ At the start of every `muggle-*` skill, call `muggle-local-telemetry-skill-emit`
   - `"user-slash"` — user typed `/<skill-name>` (the common case; default this)
   - `"claude-proactive"` — Claude matched on the skill's description, not a slash command
   - `"nested-skill"` — invoked from another skill via the `Skill` tool
+
+## Failure-mode events
+
+Skills that run replays or generations also emit structured failure-mode events through a separate tool — `muggle-local-telemetry-event-emit`. Don't reinvent the schema or sink in the skill; follow [`failure-mode-handling.md`](./failure-mode-handling.md), which defines the bucket taxonomies, the AI-classify → user-pick contract, and the exact event shape.

--- a/plugin/skills/muggle-do-task/SKILL.md
+++ b/plugin/skills/muggle-do-task/SKILL.md
@@ -117,3 +117,18 @@ Load and call `muggle-local-execute-replay` with:
 
 Tell the user:
 > Running **[useCaseName]** on [domain]. Watch the Muggle Test window — it will execute the task with your parameters applied.
+
+## Step 8 — Route failures through the failure-mode handler
+
+If Phase 1 generation or Phase 2 replay returns `failed` or any non-passing terminal state, follow [`_shared/failure-mode-handling.md`](../_shared/failure-mode-handling.md):
+
+- **Phase 1 (generation) failure** → section C (buckets: `transient` / `infra` / `agent-course` / `product-uxux`).
+- **Phase 2 (replay) failure** → section B (buckets: `infra` / `stale-script` / `product-defect`).
+
+Steps:
+1. Read the run via `muggle-local-run-result-get` and extract signals per the heuristics in the shared doc.
+2. Emit `regen-failure-classified` or `replay-failure-classified` via `muggle-local-telemetry-event-emit` **before** asking the user.
+3. Present the recommended action via `AskUserQuestion` with the alternatives the shared doc lists for that bucket.
+4. After the user picks, emit the matching `*-resolved` event with `userAction`.
+
+If the user picks `muggle-feedback` from any bucket's options, invoke the `muggle-feedback` skill via the `Skill` tool with the `runId`. Skip silently on clean success.

--- a/plugin/skills/muggle-test-feature-local/SKILL.md
+++ b/plugin/skills/muggle-test-feature-local/SKILL.md
@@ -162,27 +162,38 @@ Gate `showElectronBrowser` (per `preference-gates/README.md`). Reuse choice with
 - `never` → pass `showUi: false`.
 - `ask` → run Picker 1 from `preference-gates/showElectronBrowser.md` via `AskUserQuestion`; map the answer back to one of the actions above.
 
-### 8. After successful generation only (open `viewUrl` gated by `openTestResultsAfterRun`)
+### 8. Upload run to cloud (every completed run; open `viewUrl` gated by `openTestResultsAfterRun`)
+
+Upload pass-or-fail. Failed runs still need cloud-hosted screenshots and per-step actions for the PR walkthrough — without them reviewers see only a generic "failed" link. The `status` field in the upload payload tells the backend whether to promote the run's action script as the test case's canonical replay script (passed → promote; failed → record only).
 
 - `muggle-local-publish-test-script`
 - Gate `openTestResultsAfterRun` (per `preference-gates/README.md`):
   - Pro-action: open `viewUrl` automatically (`open "<viewUrl>"` on macOS or OS equivalent).
   - Skip-action: print the URL only.
 
+If publish rejects with `has no generated actionScript steps to publish` (true zero-step runs — Electron never produced an action), skip publish and fall through; step 10's report assembly handles the no-steps branch.
+
 ### 9. Report
 
 - `muggle-local-run-result-get` with the run id from execute.
 - Include: status, duration, pass/fail summary, per-step summary, artifact/screenshot paths, errors if failed, and script view URL when publishing ran.
 
-### 9a. Offer feedback when something looked wrong
+### 9a. Route failures through the failure-mode handler
 
-If the run's status is `failed`, the per-step summary shows an error, or the user verbally flags that the script did the wrong thing, suggest the feedback skill via `AskUserQuestion`:
+If the run's status is `failed` or any non-passing terminal state, follow [`_shared/failure-mode-handling.md`](../_shared/failure-mode-handling.md):
 
-> "Want to leave feedback on what should've happened? It triggers regeneration of the affected script."
-> - **Yes — give feedback** → invoke the `muggle-feedback` skill via the `Skill` tool, passing the just-finished `runId` so the submit flow opens with this run preloaded.
-> - **No — skip**
+- **Replay-mode run failed** (the user picked an existing script in Step 5) → section B (buckets: `infra` / `stale-script` / `product-defect`).
+- **Regen-mode run failed** (the user picked "Generate new script" or no script existed) → section C (buckets: `transient` / `infra` / `agent-course` / `product-uxux`).
 
-Skip silently if the run passed cleanly and the user did not flag anything.
+Steps:
+1. Read the run via `muggle-local-run-result-get` and extract signals per the heuristics in the shared doc.
+2. Emit `replay-failure-classified` or `regen-failure-classified` via `muggle-local-telemetry-event-emit` **before** asking the user.
+3. Present the recommended action via `AskUserQuestion` with the alternatives the shared doc lists for that bucket.
+4. After the user picks, emit the matching `*-resolved` event with `userAction`.
+
+If the user picks `muggle-feedback` from any bucket's options, invoke the `muggle-feedback` skill via the `Skill` tool, passing the just-finished `runId` so the submit flow opens with this run preloaded.
+
+Skip silently when the run passed cleanly — failure-mode events are by definition about failures.
 
 ### 10. Offer to post a visual walkthrough to the PR
 

--- a/plugin/skills/muggle-test-regenerate-missing/SKILL.md
+++ b/plugin/skills/muggle-test-regenerate-missing/SKILL.md
@@ -164,6 +164,19 @@ Total: 17 dispatched | 16 started | 1 failed
 
 For failures: include a one-line error excerpt from the item's error field and (where possible) a hint at the cause (e.g., "missing instructions field — edit the test case in the dashboard, then re-run this skill").
 
+### Per-item failure routing (regen)
+
+For every item with a non-success dispatch status, follow [`_shared/failure-mode-handling.md`](../_shared/failure-mode-handling.md) section C (regen failure buckets: `transient` / `infra` / `agent-course` / `product-uxux`).
+
+Because this skill is bulk-dispatch (no live user attention per item), batch the routing — don't ask the user per item:
+
+1. Group failed items by AI-classified bucket using the signal heuristics in the shared doc (most failures here will be `transient` or `infra` since dispatch failures rarely surface product-uxux signals).
+2. Emit one `regen-failure-classified` event per failed item via `muggle-local-telemetry-event-emit`.
+3. Present the buckets to the user via a single `AskUserQuestion` summarizing counts: e.g., "12 transient (recommend retry), 3 infra (recommend report-bug). What do you want to do?" Options: "Retry transient items", "Report all to Muggle AI", "muggle-feedback for selected items", "Skip — leave them as-is".
+4. Emit one `regen-failure-resolved` event per item with the user's batch decision applied.
+
+Bulk regen does not run replays, so the section B (replay) router does not apply here.
+
 ### Step 8 — Open the Dashboard
 
 Open the Muggle AI dashboard so the user can watch progress visually:

--- a/plugin/skills/muggle-test/SKILL.md
+++ b/plugin/skills/muggle-test/SKILL.md
@@ -204,6 +204,23 @@ Use `AskUserQuestion` to confirm: "You selected [N] test case(s): [list titles].
 
 Wait for user confirmation before moving to execution.
 
+### 6f: Classify execution mode per test case (replay vs regen)
+
+For each selected test case, decide whether the run should be a **replay** of an existing script or a fresh **regen**, using the rules in [`_shared/failure-mode-handling.md`](../_shared/failure-mode-handling.md) section A. Inputs: the change summary from Step 2, the test case body, and the result of `muggle-remote-test-script-list` for that test case (last passing timestamp + whether any replayable script exists).
+
+Per test case, fire one `muggle-local-telemetry-event-emit` with `eventType: "pre-execution-classification"` capturing the picked mode, the rule that fired, and the matched changed-file paths.
+
+Then show the per-case decision in one `AskUserQuestion`:
+
+> "Here's how I plan to run each test case — replay reuses the saved script, regen rebuilds it from scratch:
+> - [REPLAY] Login with valid creds — selectors look unchanged
+> - [REGEN] Sign up with valid email — last passed > 30 days ago
+> - [REGEN] Add to cart — `app/cart/page.tsx` changed (UI/markup)"
+>
+> Options: "Looks good — proceed", "Override one or more", "Cancel"
+
+If the user picks "Override one or more", let them flip the mode for any test case via a second multi-select `AskUserQuestion`. Emit a follow-up `pre-execution-classification` event with `userAction` set whenever the user overrides.
+
 ## Step 7A: Execute — Local Mode
 
 ### Pre-flight question — Local URL (gated by `autoSelectLocalHost`)
@@ -238,16 +255,25 @@ If none of the above apply, omit `freshSession` (defaults to `false`, preserving
 
 ### Run sequentially (Electron constraint)
 
-Execution itself **must** be sequential because there is only one local Electron browser. For each test case, in order:
+Execution itself **must** be sequential because there is only one local Electron browser. For each test case, in the order chosen, branch on the mode picked in Step 6f:
 
+**Regen-mode test case:**
 1. Call `muggle-local-execute-test-generation`:
    - `testCase`: Full test case object from the parallel fetch above
    - `localUrl`: User's local URL from the pre-flight question
    - `showUi`: from the `showElectronBrowser` resolution — omit (default visible) for `always`, pass `false` for `never`
    - `freshSession`: `true` if the test case requires a clean browser state (see above), omit otherwise
-2. Store the returned `runId`
+2. Store the returned `runId` and tag the result `mode: "regen"`.
 
-If a generation fails, log it and continue to the next. Do not abort the batch.
+**Replay-mode test case:**
+1. Fetch the action script: `muggle-remote-test-script-get` (latest replayable script id) → `muggle-remote-action-script-get` (full `actionScript` — use as-is, never edit). For batches, fan these calls out in parallel before the sequential execution loop begins.
+2. Call `muggle-local-execute-replay`:
+   - `testScript`: from `muggle-remote-test-script-get`
+   - `actionScript`: from `muggle-remote-action-script-get`
+   - `localUrl`, `showUi`, `freshSession`: same resolution as regen
+3. Store the returned `runId` and tag the result `mode: "replay"`.
+
+If a run fails, log it and continue to the next — do not abort the batch. Failures are routed through Step 7C's post-failure handler after the batch completes.
 
 ### Collect results (in parallel)
 
@@ -297,7 +323,9 @@ Issue all `muggle-remote-test-case-get` calls in parallel (single message, multi
 
 ### Trigger remote workflows (in parallel)
 
-Once details are in hand, issue all `muggle-remote-workflow-start-test-script-generation` calls in parallel — never loop them sequentially. For each test case:
+Branch each test case on the mode chosen in Step 6f, then issue **all** workflow-start calls in parallel — never loop them sequentially. Mix regen and replay starts in the same parallel batch.
+
+**Regen-mode test case** — `muggle-remote-workflow-start-test-script-generation`:
 
 - `projectId`: The project ID
 - `useCaseId`: The use case ID
@@ -309,7 +337,9 @@ Once details are in hand, issue all `muggle-remote-workflow-start-test-script-ge
 - `instructions`: From the test case
 - `expectedResult`: From the test case
 
-Store each returned workflow runtime ID.
+**Replay-mode test case** — `muggle-remote-workflow-start-test-script-replay` against the latest replayable script for that test case (resolve via `muggle-remote-test-script-list` if not already in hand from Step 6f). Tag results with `mode: "replay"` so Step 7C can route failures correctly.
+
+Store each returned workflow runtime ID along with its mode tag.
 
 ### Monitor and report (in parallel)
 
@@ -322,6 +352,21 @@ Login with valid creds     RUNNING           rt-abc123
 Login with invalid creds   COMPLETED         rt-def456
 Checkout flow              QUEUED            rt-ghi789
 ```
+
+## Step 7C: Route failures through the failure-mode handler
+
+For every run with `status: "failed"` (or any non-passing terminal state) from 7A or 7B, follow [`_shared/failure-mode-handling.md`](../_shared/failure-mode-handling.md):
+
+- **Replay-mode failures** — section B (buckets: `infra` / `stale-script` / `product-defect`).
+- **Regen-mode failures** — section C (buckets: `transient` / `infra` / `agent-course` / `product-uxux`).
+
+For each failed run:
+1. Read the run with `muggle-local-run-result-get` (local) or `muggle-remote-wf-get-ts-gen-latest-run` / `muggle-remote-wf-get-ts-replay-latest-run` (remote) and extract signals per the heuristics in the shared doc.
+2. Emit `replay-failure-classified` or `regen-failure-classified` via `muggle-local-telemetry-event-emit` **before** asking the user.
+3. Present the recommended action via `AskUserQuestion` along with the alternatives the shared doc lists for that bucket.
+4. After the user picks, emit the matching `*-resolved` event with `userAction` set to what they chose.
+
+Process failures one at a time so the user isn't drowning in pickers — but emit telemetry per failure regardless.
 
 ## Step 8: Open Results in Browser
 
@@ -401,10 +446,14 @@ This is a suggestion, not automatic invocation. Skip silently if every test pass
 | Test Case | `muggle-remote-test-case-generate-from-prompt` | Both |
 | Test Case | `muggle-remote-test-case-create` | Both |
 | Test Case | `muggle-remote-test-case-get` | Both |
-| Execute | `muggle-local-execute-test-generation` | Local |
-| Execute | `muggle-remote-workflow-start-test-script-generation` | Remote |
+| Execute (regen) | `muggle-local-execute-test-generation` | Local |
+| Execute (replay) | `muggle-local-execute-replay` | Local |
+| Replay action script fetch | `muggle-remote-test-script-get`, `muggle-remote-action-script-get` | Local replay |
+| Execute (regen) | `muggle-remote-workflow-start-test-script-generation` | Remote |
+| Execute (replay) | `muggle-remote-workflow-start-test-script-replay` | Remote |
+| Failure-mode telemetry | `muggle-local-telemetry-event-emit` | Both |
 | Results | `muggle-local-run-result-get` | Local |
-| Results | `muggle-remote-wf-get-ts-gen-latest-run` | Remote |
+| Results | `muggle-remote-wf-get-ts-gen-latest-run`, `muggle-remote-wf-get-ts-replay-latest-run` | Remote |
 | Publish | `muggle-local-publish-test-script` | Local |
 | Per-step screenshots (for walkthrough) | `muggle-remote-test-script-get` | Both |
 | Browser | `open` (shell command) | Both |


### PR DESCRIPTION
## Summary
- Per-test-case replay-vs-regen classifier in `muggle-test` (no script → regen; UI/markup changed → regen; last passed > 30 days → regen; else replay), with explicit user override before execution
- Shared `_shared/failure-mode-handling.md` defines bucket taxonomies and the AI-classify → user-pick contract for replay failures (`infra` / `stale-script` / `product-defect`) and regen failures (`transient` / `infra` / `agent-course` / `product-uxux`) — wired into `muggle-test`, `muggle-test-feature-local`, `muggle-do-task`, `muggle-test-regenerate-missing`
- New `muggle-local-telemetry-event-emit` MCP tool records `(aiClassification, aiSuggestion, userAction, signals)` per decision to `~/.muggle-ai/telemetry/failure-events.jsonl` so heuristics can be refined from real data later

## Test plan
- [x] `pnpm --filter @muggleai/mcp typecheck` clean
- [x] `pnpm --filter @muggleai/mcp test` — 118 passed
- [x] root `pnpm typecheck` clean
- [x] root `pnpm test` — 97 passed
- [ ] Run a real failed replay through `/muggle-test-feature-local` and confirm an event appears in `~/.muggle-ai/telemetry/failure-events.jsonl`
- [ ] Confirm the per-case replay/regen picker renders correctly in `/muggle-test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)