### PR TITLE
fix(skills): publish failed local runs so PR walkthrough shows screenshots

### DIFF
--- a/plugin/skills/muggle-pr-visual-walkthrough/e2e-report-assembly.md
+++ b/plugin/skills/muggle-pr-visual-walkthrough/e2e-report-assembly.md
@@ -2,7 +2,9 @@
 
 Include **all** runs — passed and failed. Never drop a run.
 
-## Published run (returned by `muggle-local-publish-test-script`)
+## Published run (passed or failed — anything with action steps)
+
+Most runs end up here, including failures. Any run with at least one action step should be uploaded via `muggle-local-publish-test-script` — pass-or-fail. The `status: "failed"` payload tells the backend to record the run without promoting its action script as the test case's canonical replay script, so screenshots become cloud-accessible without clobbering a previously working script.
 
 Issue all `muggle-remote-test-script-get` calls in parallel — one per `testScriptId`. For each response:
 
@@ -11,9 +13,11 @@ Issue all `muggle-remote-test-script-get` calls in parallel — one per `testScr
 3. `status` — from `muggle-local-run-result-get`.
 4. If failed: also capture `failureStepIndex`, `error`, `artifactsDir` from the run result.
 
-## Failed/unpublished run (timeout, `goal_not_achievable`, or any run never passed to `muggle-local-publish-test-script`)
+## True unpublishable (no steps recorded)
 
-1. `steps: []` — no cloud screenshots available.
+Reserved for runs Electron rejected before producing any action — orchestration timeout before launch, hard crash, `goal_not_achievable` halt at step 0. Recognizable because `muggle-local-publish-test-script` rejects with `has no generated actionScript steps to publish`.
+
+1. `steps: []` — nothing to render.
 2. `viewUrl`: `https://www.muggle-ai.com/muggleTestV0/dashboard/projects/{projectId}/runs`
 3. `status: "failed"`, `failureStepIndex: 0`, `error` from run result.
 4. `testCaseId` — from execution step selection. `runId` — from `muggle-local-execute-test-generation` (always present even on failure).

--- a/plugin/skills/muggle-pr-visual-walkthrough/e2e-report-assembly.md
+++ b/plugin/skills/muggle-pr-visual-walkthrough/e2e-report-assembly.md
@@ -1,24 +1,29 @@
 # E2eReport Assembly Guide
 
-Include **all** runs — passed and failed. Never drop a run.
+Include **all** runs — passed and failed. Never drop a run. Always best-effort to upload so the dashboard has a record reviewers can open from the PR — even when the local run produced zero action steps.
 
-## Published run (passed or failed — anything with action steps)
+## Uploaded run (passed or failed; the common path)
 
-Most runs end up here, including failures. Any run with at least one action step should be uploaded via `muggle-local-publish-test-script` — pass-or-fail. The `status: "failed"` payload tells the backend to record the run without promoting its action script as the test case's canonical replay script, so screenshots become cloud-accessible without clobbering a previously working script.
+Every run that completed locally — pass or fail, with or without action steps — should reach the cloud via Step 8 of the caller skill. The upload response carries `actionScriptId` and `viewUrl`; `testScriptId` is **only present for passing runs and replays** (failed generations skip the test script wrapper to avoid clobbering the canonical replay target).
 
-Issue all `muggle-remote-test-script-get` calls in parallel — one per `testScriptId`. For each response:
+Fetch step screenshots in parallel — pick the right tool per upload:
 
-1. Build `steps[]`: `[{ stepIndex: <index>, action: steps[i].operation.action, screenshotUrl: steps[i].operation.screenshotUrl }, ...]`
-2. `viewUrl` — from publish response.
+- **`testScriptId` present** → `muggle-remote-test-script-get` with that id.
+- **`testScriptId` missing** (failed generation, or zero-step fallback via `muggle-remote-local-run-upload`) → `muggle-remote-action-script-get` with `actionScriptId` from the upload response. Same `steps[]` + `summaryStep` shape; just one less hop.
+
+For each result:
+
+1. Build `steps[]`: `[{ stepIndex: <index>, action: steps[i].operation.action, screenshotUrl: steps[i].operation.screenshotUrl }, ...]`. Empty array is fine — zero-step runs still render the failure summary header in the walkthrough.
+2. `viewUrl` — from upload response (deep-links to the specific run via `actionScriptId`).
 3. `status` — from `muggle-local-run-result-get`.
 4. If failed: also capture `failureStepIndex`, `error`, `artifactsDir` from the run result.
 
-## True unpublishable (no steps recorded)
+## Last-resort: upload genuinely failed
 
-Reserved for runs Electron rejected before producing any action — orchestration timeout before launch, hard crash, `goal_not_achievable` halt at step 0. Recognizable because `muggle-local-publish-test-script` rejects with `has no generated actionScript steps to publish`.
+Reach this branch only when **both** `muggle-local-publish-test-script` AND the `muggle-remote-local-run-upload` fallback errored (network failure, auth issue, etc.) — not for ordinary zero-step runs, which the fallback handles. Don't drop the run; render a stub entry so reviewers still see something happened.
 
-1. `steps: []` — nothing to render.
-2. `viewUrl`: `https://www.muggle-ai.com/muggleTestV0/dashboard/projects/{projectId}/runs`
+1. `steps: []`.
+2. `viewUrl`: `https://www.muggle-ai.com/muggleTestV0/dashboard/projects/{projectId}/runs` (generic dashboard).
 3. `status: "failed"`, `failureStepIndex: 0`, `error` from run result.
 4. `testCaseId` — from execution step selection. `runId` — from `muggle-local-execute-test-generation` (always present even on failure).
 
@@ -49,7 +54,7 @@ If called from `muggle-do`: `e2e-acceptance.md` already produces this shape — 
       "useCaseName": "<parent use case title (recommended)>",
       "testCaseId": "<testCaseId from execution step>",
       "runId": "<runId from muggle-local-execute-test-generation>",
-      "viewUrl": "https://www.muggle-ai.com/muggleTestV0/dashboard/projects/<projectId>/runs",
+      "viewUrl": "<viewUrl from upload response, deep-linked via actionScriptId>",
       "status": "failed",
       "steps": [],
       "failureStepIndex": 0,

--- a/plugin/skills/muggle-test-feature-local/SKILL.md
+++ b/plugin/skills/muggle-test-feature-local/SKILL.md
@@ -171,7 +171,7 @@ Upload pass-or-fail. Failed runs still need cloud-hosted screenshots and per-ste
   - Pro-action: open `viewUrl` automatically (`open "<viewUrl>"` on macOS or OS equivalent).
   - Skip-action: print the URL only.
 
-If publish rejects with `has no generated actionScript steps to publish` (true zero-step runs — Electron never produced an action), skip publish and fall through; step 10's report assembly handles the no-steps branch.
+If publish rejects with `has no generated actionScript steps to publish` (true zero-step runs — Electron never produced an action), fall back to `muggle-remote-local-run-upload` directly with whatever data exists (`summaryStep`, `errorMessage`, empty `actionScript`). This still gets the failure summary and any goal-not-achievable verdict onto the dashboard so reviewers can see why the run failed. Capture the returned `actionScriptId` and `viewUrl` from this fallback path the same way you would from publish.
 
 ### 9. Report
 


### PR DESCRIPTION
## Summary

Failed local generation runs were skipped at publish time, so the PR visual walkthrough had only a generic \"failed\" link — no per-step screenshots, no failure step pointer. Reviewers on PRs like multiplex-ai/muggle-ai-ui#282 had no visual context for why the run failed.

This change makes the local-feature flow upload pass-or-fail so cloud-hosted screenshots are available to the walkthrough renderer.

## Changes

- `plugin/skills/muggle-test-feature-local/SKILL.md` Step 8 — upload every completed run, not just successful ones. Document that the backend uses the `status` field to decide whether to promote the run's action script as the test case's canonical replay target.
- `plugin/skills/muggle-pr-visual-walkthrough/e2e-report-assembly.md` — rename the \"Failed/unpublished\" section to \"True unpublishable (no steps recorded)\" and clarify that any run with ≥1 action step (pass or fail) flows through the published-run path.

## Required pairing

The skill change assumes the backend honors `status: \"failed\"` by recording the run without clobbering the canonical action script. Backend pair: muggle-ai-prompt-service PR (linked).

## Test plan

- [ ] Run a failing local generation against a test case with a previously-passing canonical script.
- [ ] Verify `muggle-local-publish-test-script` is called and returns a `viewUrl`.
- [ ] Verify the PR comment shows per-step screenshots and a failure step indicator.
- [ ] Verify a subsequent replay still uses the previous-passing canonical action script (no clobber).

🤖 Generated with [Claude Code](https://claude.com/claude-code)