### PR TITLE
fix(render): update test summary line formatting for improved clarity

### DIFF
--- a/src/cli/pr-section/render.ts
+++ b/src/cli/pr-section/render.ts
@@ -194,12 +194,12 @@ export function renderTestDetails (test: TestResult, projectId: string, testNumb
 }
 
 function renderSummaryLine (test: TestResult, testNumber: number): string {
-  const base = `<b>${testNumber}. ${test.name}</b> ${statusEmoji(test)}`;
+  const base = `<b>${test.name}</b> ${statusEmoji(test)}`;
   const head = "<i>▶ click to expand</i> ";
   if (test.description) {
-    return `${head}${base} — ${test.description}`;
+    return `<b>${testNumber}. </b>${head}${base} — ${test.description}`;
   }
-  return `${head}${base}`;
+  return `<b>${testNumber}. </b>${head}${base}`;
 }
 
 /**


### PR DESCRIPTION
Adjusted the rendering of test summary lines to include the test number before the test name, enhancing the visual structure and clarity of test details displayed. This change ensures that the test number is consistently presented alongside the test name and description.