### PR TITLE
feat(skills): short m* aliases for muggle-* skills and slash commands

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -15,7 +15,7 @@ For npm installs:
 npm install -g @muggleai/works
 ```
 
-This updates the CLI, configures Cursor MCP (`~/.cursor/mcp.json`), and syncs `muggle-*` skills into `~/.cursor/skills/`. Claude slash commands remain plugin-managed, so use `/plugin update muggleai@muggle-works` to refresh them.
+This updates the CLI, configures Cursor MCP (`~/.cursor/mcp.json`), and syncs `muggle-*` skills (plus their short `m*` aliases) into `~/.cursor/skills/`. Claude slash commands remain plugin-managed, so use `/plugin update muggleai@muggle-works` to refresh them.
 
 ## Skills
 
@@ -32,6 +32,8 @@ Type `muggle` to discover the full command family.
 | `/muggle:muggle-status` | Health check for Electron browser test runner, MCP server, and authentication. |
 | `/muggle:muggle-repair` | Diagnose and fix broken installation automatically. |
 | `/muggle:muggle-upgrade` | Update Electron browser test runner and MCP server to latest version. |
+
+Each skill above also ships a short alias to save typing — `m` (router), `mtest`, `mdo`, `mpr`, `mprefs`, `mstatus`, `mrepair`, `mupgrade`, `mfeedback`, `mimport`, `mtestlocal`, `mtestprep`, `mregen`, `mrelease`. Type `/m` (Claude Code) or `m` (Cursor) to open the menu, or jump straight to one (e.g. `/mtest`).
 
 ## MCP Tools
 

--- a/plugin/commands/m.md
+++ b/plugin/commands/m.md
@@ -1,0 +1,7 @@
+---
+description: Muggle AI command router and menu (alias for /muggle)
+argument-hint: [optional sub-request]
+allowed-tools: [Skill]
+---
+
+Invoke the `muggle` skill via the Skill tool. Forward `$ARGUMENTS` as the skill's `args`.

--- a/plugin/commands/mdo.md
+++ b/plugin/commands/mdo.md
@@ -1,0 +1,7 @@
+---
+description: Run a browser automation task on a website in natural language (alias for /muggle-do-task)
+argument-hint: [task description and target site]
+allowed-tools: [Skill]
+---
+
+Invoke the `muggle-do-task` skill via the Skill tool. Forward `$ARGUMENTS` as the skill's `args`.

--- a/plugin/commands/mfeedback.md
+++ b/plugin/commands/mfeedback.md
@@ -1,0 +1,7 @@
+---
+description: Submit, list, or delete Muggle Test feedback (alias for /muggle-feedback)
+argument-hint: [optional feedback text or action]
+allowed-tools: [Skill]
+---
+
+Invoke the `muggle-feedback` skill via the Skill tool. Forward `$ARGUMENTS` as the skill's `args`.

--- a/plugin/commands/mimport.md
+++ b/plugin/commands/mimport.md
@@ -1,0 +1,7 @@
+---
+description: Import existing tests/PRDs/specs INTO Muggle Test (alias for /muggle-test-import)
+argument-hint: [path or source of tests to import]
+allowed-tools: [Skill]
+---
+
+Invoke the `muggle-test-import` skill via the Skill tool. Forward `$ARGUMENTS` as the skill's `args`.

--- a/plugin/commands/mpr.md
+++ b/plugin/commands/mpr.md
@@ -1,0 +1,7 @@
+---
+description: Post the Muggle E2E visual walkthrough to a PR (alias for /muggle-pr-visual-walkthrough)
+argument-hint: [optional PR number]
+allowed-tools: [Skill]
+---
+
+Invoke the `muggle-pr-visual-walkthrough` skill via the Skill tool. Forward `$ARGUMENTS` as the skill's `args`.

--- a/plugin/commands/mprefs.md
+++ b/plugin/commands/mprefs.md
@@ -1,0 +1,7 @@
+---
+description: View, set, or reset Muggle AI preferences (alias for /muggle-preferences)
+argument-hint: [optional preference key or action]
+allowed-tools: [Skill]
+---
+
+Invoke the `muggle-preferences` skill via the Skill tool. Forward `$ARGUMENTS` as the skill's `args`.

--- a/plugin/commands/mregen.md
+++ b/plugin/commands/mregen.md
@@ -1,0 +1,7 @@
+---
+description: Bulk-regenerate test scripts for test cases missing one (alias for /muggle-test-regenerate-missing)
+argument-hint: [optional project hint]
+allowed-tools: [Skill]
+---
+
+Invoke the `muggle-test-regenerate-missing` skill via the Skill tool. Forward `$ARGUMENTS` as the skill's `args`.

--- a/plugin/commands/mrelease.md
+++ b/plugin/commands/mrelease.md
@@ -1,0 +1,7 @@
+---
+description: Cut a @muggleai/works npm release (alias for /muggle-works-npm-release)
+argument-hint: [major|minor|patch]
+allowed-tools: [Skill]
+---
+
+Invoke the `muggle-works-npm-release` skill via the Skill tool. Forward `$ARGUMENTS` as the skill's `args`.

--- a/plugin/commands/mrepair.md
+++ b/plugin/commands/mrepair.md
@@ -1,0 +1,7 @@
+---
+description: Diagnose and fix a broken Muggle AI installation (alias for /muggle-repair)
+argument-hint: [no args]
+allowed-tools: [Skill]
+---
+
+Invoke the `muggle-repair` skill via the Skill tool. Forward `$ARGUMENTS` as the skill's `args`.

--- a/plugin/commands/mstatus.md
+++ b/plugin/commands/mstatus.md
@@ -1,0 +1,7 @@
+---
+description: Check Muggle AI installation health (alias for /muggle-status)
+argument-hint: [no args]
+allowed-tools: [Skill]
+---
+
+Invoke the `muggle-status` skill via the Skill tool. Forward `$ARGUMENTS` as the skill's `args`.

--- a/plugin/commands/mtest.md
+++ b/plugin/commands/mtest.md
@@ -1,0 +1,7 @@
+---
+description: Run change-driven E2E acceptance tests on your changes (alias for /muggle-test)
+argument-hint: [optional context, e.g. "on staging"]
+allowed-tools: [Skill]
+---
+
+Invoke the `muggle-test` skill via the Skill tool. Forward `$ARGUMENTS` as the skill's `args`.

--- a/plugin/commands/mtestlocal.md
+++ b/plugin/commands/mtestlocal.md
@@ -1,0 +1,7 @@
+---
+description: Run a real-browser E2E acceptance test against localhost (alias for /muggle-test-feature-local)
+argument-hint: [feature or flow to test]
+allowed-tools: [Skill]
+---
+
+Invoke the `muggle-test-feature-local` skill via the Skill tool. Forward `$ARGUMENTS` as the skill's `args`.

--- a/plugin/commands/mtestprep.md
+++ b/plugin/commands/mtestprep.md
@@ -1,0 +1,7 @@
+---
+description: Prepare local dev servers and sibling services for E2E testing (alias for /muggle-test-prepare)
+argument-hint: [no args]
+allowed-tools: [Skill]
+---
+
+Invoke the `muggle-test-prepare` skill via the Skill tool. Forward `$ARGUMENTS` as the skill's `args`.

--- a/plugin/commands/mupgrade.md
+++ b/plugin/commands/mupgrade.md
@@ -1,0 +1,7 @@
+---
+description: Update Muggle AI to the latest version (alias for /muggle-upgrade)
+argument-hint: [no args]
+allowed-tools: [Skill]
+---
+
+Invoke the `muggle-upgrade` skill via the Skill tool. Forward `$ARGUMENTS` as the skill's `args`.

--- a/plugin/skills/_aliases.json
+++ b/plugin/skills/_aliases.json
@@ -1,0 +1,18 @@
+{
+    "aliases": [
+        "m",
+        "mtest",
+        "mdo",
+        "mpr",
+        "mprefs",
+        "mstatus",
+        "mrepair",
+        "mupgrade",
+        "mfeedback",
+        "mimport",
+        "mtestlocal",
+        "mtestprep",
+        "mregen",
+        "mrelease"
+    ]
+}

--- a/plugin/skills/m/SKILL.md
+++ b/plugin/skills/m/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: m
+description: Explicit short alias for the `muggle` skill (router/menu). ONLY invoke when the user explicitly types `m` or `/m` — never auto-trigger from any other phrasing.
+---
+
+# m — alias for muggle
+
+Invoke the `muggle` skill via the Skill tool. Forward any user-provided arguments unchanged.

--- a/plugin/skills/mdo/SKILL.md
+++ b/plugin/skills/mdo/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: mdo
+description: Explicit short alias for the `muggle-do-task` skill. ONLY invoke when the user explicitly types `mdo` or `/mdo` — never auto-trigger from any other phrasing.
+---
+
+# mdo — alias for muggle-do-task
+
+Invoke the `muggle-do-task` skill via the Skill tool. Forward any user-provided arguments unchanged.

--- a/plugin/skills/mfeedback/SKILL.md
+++ b/plugin/skills/mfeedback/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: mfeedback
+description: Explicit short alias for the `muggle-feedback` skill. ONLY invoke when the user explicitly types `mfeedback` or `/mfeedback` — never auto-trigger from any other phrasing.
+---
+
+# mfeedback — alias for muggle-feedback
+
+Invoke the `muggle-feedback` skill via the Skill tool. Forward any user-provided arguments unchanged.

--- a/plugin/skills/mimport/SKILL.md
+++ b/plugin/skills/mimport/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: mimport
+description: Explicit short alias for the `muggle-test-import` skill. ONLY invoke when the user explicitly types `mimport` or `/mimport` — never auto-trigger from any other phrasing.
+---
+
+# mimport — alias for muggle-test-import
+
+Invoke the `muggle-test-import` skill via the Skill tool. Forward any user-provided arguments unchanged.

--- a/plugin/skills/mpr/SKILL.md
+++ b/plugin/skills/mpr/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: mpr
+description: Explicit short alias for the `muggle-pr-visual-walkthrough` skill. ONLY invoke when the user explicitly types `mpr` or `/mpr` — never auto-trigger from any other phrasing.
+---
+
+# mpr — alias for muggle-pr-visual-walkthrough
+
+Invoke the `muggle-pr-visual-walkthrough` skill via the Skill tool. Forward any user-provided arguments unchanged.

--- a/plugin/skills/mprefs/SKILL.md
+++ b/plugin/skills/mprefs/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: mprefs
+description: Explicit short alias for the `muggle-preferences` skill. ONLY invoke when the user explicitly types `mprefs` or `/mprefs` — never auto-trigger from any other phrasing.
+---
+
+# mprefs — alias for muggle-preferences
+
+Invoke the `muggle-preferences` skill via the Skill tool. Forward any user-provided arguments unchanged.

--- a/plugin/skills/mregen/SKILL.md
+++ b/plugin/skills/mregen/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: mregen
+description: Explicit short alias for the `muggle-test-regenerate-missing` skill. ONLY invoke when the user explicitly types `mregen` or `/mregen` — never auto-trigger from any other phrasing.
+---
+
+# mregen — alias for muggle-test-regenerate-missing
+
+Invoke the `muggle-test-regenerate-missing` skill via the Skill tool. Forward any user-provided arguments unchanged.

--- a/plugin/skills/mrelease/SKILL.md
+++ b/plugin/skills/mrelease/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: mrelease
+description: Explicit short alias for the `muggle-works-npm-release` skill. ONLY invoke when the user explicitly types `mrelease` or `/mrelease` — never auto-trigger from any other phrasing.
+---
+
+# mrelease — alias for muggle-works-npm-release
+
+Invoke the `muggle-works-npm-release` skill via the Skill tool. Forward any user-provided arguments unchanged.

--- a/plugin/skills/mrepair/SKILL.md
+++ b/plugin/skills/mrepair/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: mrepair
+description: Explicit short alias for the `muggle-repair` skill. ONLY invoke when the user explicitly types `mrepair` or `/mrepair` — never auto-trigger from any other phrasing.
+---
+
+# mrepair — alias for muggle-repair
+
+Invoke the `muggle-repair` skill via the Skill tool. Forward any user-provided arguments unchanged.

--- a/plugin/skills/mstatus/SKILL.md
+++ b/plugin/skills/mstatus/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: mstatus
+description: Explicit short alias for the `muggle-status` skill. ONLY invoke when the user explicitly types `mstatus` or `/mstatus` — never auto-trigger from any other phrasing.
+---
+
+# mstatus — alias for muggle-status
+
+Invoke the `muggle-status` skill via the Skill tool. Forward any user-provided arguments unchanged.

--- a/plugin/skills/mtest/SKILL.md
+++ b/plugin/skills/mtest/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: mtest
+description: Explicit short alias for the `muggle-test` skill. ONLY invoke when the user explicitly types `mtest` or `/mtest` — never auto-trigger from any other phrasing.
+---
+
+# mtest — alias for muggle-test
+
+Invoke the `muggle-test` skill via the Skill tool. Forward any user-provided arguments unchanged.

--- a/plugin/skills/mtestlocal/SKILL.md
+++ b/plugin/skills/mtestlocal/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: mtestlocal
+description: Explicit short alias for the `muggle-test-feature-local` skill. ONLY invoke when the user explicitly types `mtestlocal` or `/mtestlocal` — never auto-trigger from any other phrasing.
+---
+
+# mtestlocal — alias for muggle-test-feature-local
+
+Invoke the `muggle-test-feature-local` skill via the Skill tool. Forward any user-provided arguments unchanged.

--- a/plugin/skills/mtestprep/SKILL.md
+++ b/plugin/skills/mtestprep/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: mtestprep
+description: Explicit short alias for the `muggle-test-prepare` skill. ONLY invoke when the user explicitly types `mtestprep` or `/mtestprep` — never auto-trigger from any other phrasing.
+---
+
+# mtestprep — alias for muggle-test-prepare
+
+Invoke the `muggle-test-prepare` skill via the Skill tool. Forward any user-provided arguments unchanged.

--- a/plugin/skills/mupgrade/SKILL.md
+++ b/plugin/skills/mupgrade/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: mupgrade
+description: Explicit short alias for the `muggle-upgrade` skill. ONLY invoke when the user explicitly types `mupgrade` or `/mupgrade` — never auto-trigger from any other phrasing.
+---
+
+# mupgrade — alias for muggle-upgrade
+
+Invoke the `muggle-upgrade` skill via the Skill tool. Forward any user-provided arguments unchanged.

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -34,6 +34,22 @@ const VERSION_OVERRIDE_FILE_NAME = "electron-app-version-override.json";
 const CURSOR_SKILLS_DIRECTORY_NAME = ".cursor";
 const CURSOR_SKILLS_SUBDIRECTORY_NAME = "skills";
 const MUGGLE_SKILL_PREFIX = "muggle";
+const MUGGLE_ALIAS_SKILLS = new Set([
+    "m",
+    "mtest",
+    "mdo",
+    "mpr",
+    "mprefs",
+    "mstatus",
+    "mrepair",
+    "mupgrade",
+    "mfeedback",
+    "mimport",
+    "mtestlocal",
+    "mtestprep",
+    "mregen",
+    "mrelease",
+]);
 
 /**
  * Get the path to the postinstall log file.
@@ -241,7 +257,7 @@ function syncCursorSkills() {
             continue;
         }
 
-        if (!skillEntry.name.startsWith(MUGGLE_SKILL_PREFIX)) {
+        if (!skillEntry.name.startsWith(MUGGLE_SKILL_PREFIX) && !MUGGLE_ALIAS_SKILLS.has(skillEntry.name)) {
             continue;
         }
 

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -34,22 +34,16 @@ const VERSION_OVERRIDE_FILE_NAME = "electron-app-version-override.json";
 const CURSOR_SKILLS_DIRECTORY_NAME = ".cursor";
 const CURSOR_SKILLS_SUBDIRECTORY_NAME = "skills";
 const MUGGLE_SKILL_PREFIX = "muggle";
-const MUGGLE_ALIAS_SKILLS = new Set([
-    "m",
-    "mtest",
-    "mdo",
-    "mpr",
-    "mprefs",
-    "mstatus",
-    "mrepair",
-    "mupgrade",
-    "mfeedback",
-    "mimport",
-    "mtestlocal",
-    "mtestprep",
-    "mregen",
-    "mrelease",
-]);
+const ALIAS_SKILLS_MANIFEST_PATH = join(
+    dirname(fileURLToPath(import.meta.url)),
+    "..",
+    "plugin",
+    "skills",
+    "_aliases.json",
+);
+const MUGGLE_ALIAS_SKILLS = new Set(
+    JSON.parse(readFileSync(ALIAS_SKILLS_MANIFEST_PATH, "utf-8")).aliases,
+);
 
 /**
  * Get the path to the postinstall log file.

--- a/src/cli/cleanup.ts
+++ b/src/cli/cleanup.ts
@@ -20,6 +20,24 @@ const CURSOR_SKILLS_SUBDIR = "skills";
 /** Prefix for muggle skills. */
 const MUGGLE_SKILL_PREFIX = "muggle";
 
+/** Short-name alias skills that ship alongside the muggle-* skills (kept in sync with scripts/postinstall.mjs). */
+const MUGGLE_ALIAS_SKILLS = new Set<string>([
+  "m",
+  "mtest",
+  "mdo",
+  "mpr",
+  "mprefs",
+  "mstatus",
+  "mrepair",
+  "mupgrade",
+  "mfeedback",
+  "mimport",
+  "mtestlocal",
+  "mtestprep",
+  "mregen",
+  "mrelease",
+]);
+
 /** Install manifest filename. */
 const INSTALL_MANIFEST_FILE = "install-manifest.json";
 
@@ -145,7 +163,7 @@ export function listObsoleteSkills (): IObsoleteSkill[] {
         continue;
       }
 
-      if (!entry.name.startsWith(MUGGLE_SKILL_PREFIX)) {
+      if (!entry.name.startsWith(MUGGLE_SKILL_PREFIX) && !MUGGLE_ALIAS_SKILLS.has(entry.name)) {
         continue;
       }
 

--- a/src/cli/cleanup.ts
+++ b/src/cli/cleanup.ts
@@ -5,6 +5,7 @@
 import { existsSync, readFileSync, readdirSync, rmSync, statSync } from "fs";
 import { homedir } from "os";
 import * as path from "path";
+import { fileURLToPath } from "url";
 
 import { getDataDir, getElectronAppVersion, getLogger } from "../../packages/mcps/src/index.js";
 
@@ -20,23 +21,26 @@ const CURSOR_SKILLS_SUBDIR = "skills";
 /** Prefix for muggle skills. */
 const MUGGLE_SKILL_PREFIX = "muggle";
 
-/** Short-name alias skills that ship alongside the muggle-* skills (kept in sync with scripts/postinstall.mjs). */
-const MUGGLE_ALIAS_SKILLS = new Set<string>([
-  "m",
-  "mtest",
-  "mdo",
-  "mpr",
-  "mprefs",
-  "mstatus",
-  "mrepair",
-  "mupgrade",
-  "mfeedback",
-  "mimport",
-  "mtestlocal",
-  "mtestprep",
-  "mregen",
-  "mrelease",
-]);
+/**
+ * Resolve the muggle alias-skill manifest. The file ships under `plugin/skills/` so it
+ * is reachable from both this source location (`src/cli/`) and the bundled output (`dist/`)
+ * by walking up to the package root. Single source of truth shared with
+ * scripts/postinstall.mjs.
+ */
+function loadMuggleAliasSkills (): Set<string> {
+  let dir = path.dirname(fileURLToPath(import.meta.url));
+  while (dir !== path.dirname(dir)) {
+    const manifestPath = path.join(dir, "plugin", "skills", "_aliases.json");
+    if (existsSync(manifestPath)) {
+      const parsed = JSON.parse(readFileSync(manifestPath, "utf-8")) as { aliases: string[] };
+      return new Set<string>(parsed.aliases);
+    }
+    dir = path.dirname(dir);
+  }
+  throw new Error("Could not locate plugin/skills/_aliases.json relative to cleanup module");
+}
+
+const MUGGLE_ALIAS_SKILLS = loadMuggleAliasSkills();
 
 /** Install manifest filename. */
 const INSTALL_MANIFEST_FILE = "install-manifest.json";


### PR DESCRIPTION
## Summary

- Adds 14 short-name aliases for the muggle-* skills (router + 13 leaf skills) so users can invoke them with far fewer keystrokes — e.g. `/mtest` instead of `/muggle-test`, `/mdo` instead of `/muggle-do-task`.
- Each alias ships in two forms for cross-IDE coverage:
  - **`plugin/commands/<alias>.md`** — Claude Code slash commands (thin wrappers that invoke the underlying skill via the `Skill` tool).
  - **`plugin/skills/<alias>/SKILL.md`** — alias skills with deliberately minimal descriptions so they only trigger on explicit name match (no auto-fire), picked up by Cursor via the existing skill sync.
- Updates the Cursor sync allowlist (`scripts/postinstall.mjs`) and the cleanup filter (`src/cli/cleanup.ts`) so the new `m*` names sync alongside the existing `muggle-*` prefix match. The two allowlists must stay in sync — flagged in code comments.

## Alias map

| Alias | Underlying skill |
|---|---|
| `m` | `muggle` (router) |
| `mtest` | `muggle-test` |
| `mdo` | `muggle-do-task` |
| `mpr` | `muggle-pr-visual-walkthrough` |
| `mprefs` | `muggle-preferences` |
| `mstatus` | `muggle-status` |
| `mrepair` | `muggle-repair` |
| `mupgrade` | `muggle-upgrade` |
| `mfeedback` | `muggle-feedback` |
| `mimport` | `muggle-test-import` |
| `mtestlocal` | `muggle-test-feature-local` |
| `mtestprep` | `muggle-test-prepare` |
| `mregen` | `muggle-test-regenerate-missing` |
| `mrelease` | `muggle-works-npm-release` |

## Test plan

- [x] `npx vitest run` — 98 tests pass (incl. `preference-gates-lint.test.ts`, which walks every skill dir and tolerates aliases with no Preferences table)
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: `/mstatus` in Claude Code invokes `muggle-status`
- [ ] Manual: `/mtest` invokes `muggle-test` and forwards `\$ARGUMENTS`
- [ ] Manual: after `npm install -g @muggleai/works`, the m* alias dirs land in `~/.cursor/skills/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)