### PR TITLE
feat(skills): add autoCreatePR gate + silent PR-create on postPRVisualWalkthrough

### DIFF
--- a/packages/mcps/src/shared/preferences-constants.ts
+++ b/packages/mcps/src/shared/preferences-constants.ts
@@ -31,6 +31,7 @@ export const DEFAULT_PREFERENCES: IPreferences = {
   [PreferenceKey.SuggestRelatedTestCases]: PreferenceValue.Ask,
   [PreferenceKey.AutoDetectChanges]: PreferenceValue.Ask,
   [PreferenceKey.PostPRVisualWalkthrough]: PreferenceValue.Ask,
+  [PreferenceKey.AutoCreatePR]: PreferenceValue.Ask,
   [PreferenceKey.CheckForUpdates]: PreferenceValue.Ask,
   [PreferenceKey.VerboseOutput]: PreferenceValue.Ask,
   [PreferenceKey.AutoUseWorktree]: PreferenceValue.Ask,
@@ -67,6 +68,7 @@ export const PREFERENCE_ALLOWED_VALUES: Record<PreferenceKey, readonly Preferenc
   [PreferenceKey.SuggestRelatedTestCases]: ALWAYS_ASK_NEVER,
   [PreferenceKey.AutoDetectChanges]: ALWAYS_ASK_NEVER,
   [PreferenceKey.PostPRVisualWalkthrough]: ALWAYS_ASK_NEVER,
+  [PreferenceKey.AutoCreatePR]: ALWAYS_ASK_NEVER,
   [PreferenceKey.CheckForUpdates]: ALWAYS_ASK_NEVER,
   [PreferenceKey.VerboseOutput]: ALWAYS_ASK_NEVER,
   [PreferenceKey.AutoUseWorktree]: ALWAYS_ASK_NEVER,
@@ -108,6 +110,9 @@ export const PREFERENCES_SCHEMA: Record<PreferenceKey, IPreferenceSchemaEntry> =
   },
   [PreferenceKey.PostPRVisualWalkthrough]: {
     description: "After test results are available, post visual walkthrough comment with screenshots to the PR",
+  },
+  [PreferenceKey.AutoCreatePR]: {
+    description: "At the end of the muggle-do dev cycle (or when a test needs an open PR to post results to), push the branch and open a PR without prompting",
   },
   [PreferenceKey.CheckForUpdates]: {
     description: "At session start, check if a newer Muggle Test version is available and notify",

--- a/packages/mcps/src/shared/preferences-types.ts
+++ b/packages/mcps/src/shared/preferences-types.ts
@@ -28,6 +28,8 @@ export enum PreferenceKey {
   AutoDetectChanges = "autoDetectChanges",
   /** Post visual walkthrough comment with screenshots to the PR. */
   PostPRVisualWalkthrough = "postPRVisualWalkthrough",
+  /** Push the branch and open a PR at the end of the dev cycle. */
+  AutoCreatePR = "autoCreatePR",
   /** Check for newer Muggle Test versions at session start. */
   CheckForUpdates = "checkForUpdates",
   /** Show detailed progress logs during execution. */

--- a/packages/mcps/src/test/preferences.test.ts
+++ b/packages/mcps/src/test/preferences.test.ts
@@ -32,9 +32,9 @@ import {
 } from "../shared/preferences.js";
 
 describe("PreferenceKey enum", () => {
-  it("has exactly 16 keys", () => {
+  it("has exactly 17 keys", () => {
     const keys = Object.values(PreferenceKey);
-    expect(keys).toHaveLength(16);
+    expect(keys).toHaveLength(17);
   });
 
   it("contains all expected keys", () => {
@@ -49,6 +49,7 @@ describe("PreferenceKey enum", () => {
     expect(PreferenceKey.SuggestRelatedTestCases).toBe("suggestRelatedTestCases");
     expect(PreferenceKey.AutoDetectChanges).toBe("autoDetectChanges");
     expect(PreferenceKey.PostPRVisualWalkthrough).toBe("postPRVisualWalkthrough");
+    expect(PreferenceKey.AutoCreatePR).toBe("autoCreatePR");
     expect(PreferenceKey.CheckForUpdates).toBe("checkForUpdates");
     expect(PreferenceKey.VerboseOutput).toBe("verboseOutput");
     expect(PreferenceKey.AutoUseWorktree).toBe("autoUseWorktree");

--- a/plugin/scripts/ensure-electron-app.sh
+++ b/plugin/scripts/ensure-electron-app.sh
@@ -81,7 +81,8 @@ if [ -f "$prefs_global_file" ]; then
         showElectronBrowser:'ask', openTestResultsAfterRun:'ask',
         defaultExecutionMode:'ask', autoPublishLocalResults:'ask',
         suggestRelatedUseCases:'ask', suggestRelatedTestCases:'ask', autoDetectChanges:'ask',
-        postPRVisualWalkthrough:'ask', checkForUpdates:'ask', verboseOutput:'ask',
+        postPRVisualWalkthrough:'ask', autoCreatePR:'ask',
+        checkForUpdates:'ask', verboseOutput:'ask',
         autoUseWorktree:'ask', autoRebase:'ask', autoCleanup:'ask'
       };
       const cwd = process.env.CLAUDE_CWD || process.env.CURSOR_CWD || process.cwd();

--- a/plugin/skills/do/open-prs.md
+++ b/plugin/skills/do/open-prs.md
@@ -41,6 +41,8 @@ You receive:
 
 For each repo with changes:
 
+0. **Apply the `autoCreatePR` gate** per [`../muggle-preferences/preference-gates/README.md`](../muggle-preferences/preference-gates/README.md) + [`autoCreatePR.md`](../muggle-preferences/preference-gates/autoCreatePR.md). On the skip path, record the reason in `result.md` and move to the next repo.
+
 1. **Push the branch** to origin: `git push -u origin <branch-name>` in the repo directory.
 2. **Build the PR title:**
    - If E2E acceptance tests have failures: `[E2E FAILING] <goal>`

--- a/plugin/skills/muggle-preferences/ops/configure.md
+++ b/plugin/skills/muggle-preferences/ops/configure.md
@@ -28,7 +28,7 @@ For each option: label = key name, description = first paragraph of `preference-
 - `multiSelect: true`, `header: "Auth & session"` — `autoLogin`, `autoSelectProject`, `checkForUpdates`, `verboseOutput`
 - `multiSelect: true`, `header: "Test setup"` — `autoSelectLocalHost`, `autoDetectChanges`
 - `multiSelect: true`, `header: "Test run"` — `showElectronBrowser`, `openTestResultsAfterRun`, `autoPublishLocalResults`
-- `multiSelect: true`, `header: "Suggestions & PR"` — `suggestRelatedUseCases`, `suggestRelatedTestCases`, `postPRVisualWalkthrough`
+- `multiSelect: true`, `header: "Suggestions & PR"` — `suggestRelatedUseCases`, `suggestRelatedTestCases`, `postPRVisualWalkthrough`, `autoCreatePR`
 - `multiSelect: true`, `header: "Branch hygiene"` — `autoUseWorktree`, `autoRebase`, `autoCleanup`
 - `multiSelect: false`, `header: "Default mode"` — `defaultExecutionMode`. Options: `Local — run on my computer` (`local`), `Remote — run in the Muggle Test cloud` (`remote`), `Ask each time` (don't change).
 - `multiSelect: false`, `header: "Scope"` — final scope question. Options: `Global (all repos)` (~/.muggle-ai/), `This project only` (.muggle-ai/ in repo).

--- a/plugin/skills/muggle-preferences/preference-gates/autoCreatePR.md
+++ b/plugin/skills/muggle-preferences/preference-gates/autoCreatePR.md
@@ -1,0 +1,13 @@
+# `autoCreatePR`
+
+Push the branch and open a pull request after the dev cycle finishes, or stop short and let the user open it manually.
+
+Used at the end of `muggle-do` (stage 7, `do/open-prs.md`). Substitute `{branch}`.
+
+**Picker 1** — header `Open PR?`, question `"Push '{branch}' and open a pull request for these changes?"`
+- `Open the PR` — `Push the branch and run gh pr create with the rendered walkthrough body.` → `always`
+- `Skip — I'll open it myself` — `Stop after the local commits. You can push and open the PR manually later.` → `never`
+
+**Silent action**
+- `always` → `Opening PR for {branch}`
+- `never` → `Skipping PR creation — push manually when ready`

--- a/plugin/skills/muggle-preferences/preference-gates/postPRVisualWalkthrough.md
+++ b/plugin/skills/muggle-preferences/preference-gates/postPRVisualWalkthrough.md
@@ -17,14 +17,14 @@ Substitute `{prNumber}`, `{prTitle}` into prompts.
 
 ## Case B — no open PR
 
-Situational fork — saved value is *not* updated from this picker.
+Saved value covers this case — if the user previously set `always`, that includes auto-creating the PR. Picker 1 only runs when the gate is `ask`.
 
 **Picker 1** — header `No PR yet`, question `"This branch has no open PR. Create one and post the walkthrough, or skip?"`
-- `Create a PR and post` — `I'll open a PR for this branch, then attach the walkthrough.` → run PR-creation flow (calling skill's responsibility), then post.
-- `Skip` — `Skip the walkthrough this time — you can post later from the dashboard.` → continue.
+- `Create a PR and post` — `I'll open a PR for this branch, then attach the walkthrough.` → run PR-creation flow (calling skill's responsibility), then post. → `always`
+- `Skip` — `Skip the walkthrough this time — you can post later from the dashboard.` → continue. → `never`
 
-**Picker 2** — skipped entirely.
+**Picker 2** — standard `Remember this choice?` template (`Always create a PR and post the walkthrough from now on, without asking?`).
 
 **Silent action (Case B)** — when saved gate is `always` or `never` but no PR exists:
-- `always` → fall through to Case B Picker 1 (don't auto-create silently). Print: `(Your saved choice says always, but this branch has no PR — asking what to do.)`
+- `always` → `Creating PR for {branch} and posting walkthrough`. Run PR-creation flow, then post — no prompt.
 - `never` → `Skipping PR walkthrough — no open PR for this branch`

--- a/plugin/skills/muggle-test-feature-local/SKILL.md
+++ b/plugin/skills/muggle-test-feature-local/SKILL.md
@@ -220,7 +220,10 @@ Read `plugin/skills/muggle-pr-visual-walkthrough/e2e-report-assembly.md` for the
 
 Run `gh pr view --json number,title,url 2>/dev/null` first (mandatory). Then gate `postPRVisualWalkthrough` (per `preference-gates/README.md` + gate file):
 - **Case A (PR found)** — `always` → proceed to 10c; `never`/skip → stop.
-- **Case B (no PR)** — always run Picker 1 regardless of saved value; "Create a PR and post" → create PR then proceed to 10c; "Skip" → stop.
+- **Case B (no PR)** — saved value applies:
+  - `always` → silently create the PR (push branch + `gh pr create`) then proceed to 10c. Print silent footer (`Creating PR for {branch} and posting walkthrough` + the standard `Skipped the prompt` line).
+  - `never` → silently skip; print `Skipping PR walkthrough — no open PR for this branch` plus the standard footer.
+  - `ask` → run Picker 1; on "Create a PR and post" follow with Picker 2 to save, then create + proceed to 10c. On "Skip" do not save.
 
 #### 10c: Invoke the shared skill in Mode A
 

--- a/plugin/skills/muggle-test/SKILL.md
+++ b/plugin/skills/muggle-test/SKILL.md
@@ -409,7 +409,10 @@ Read `plugin/skills/muggle-pr-visual-walkthrough/e2e-report-assembly.md` for the
 
 Run `gh pr view --json number,title,url 2>/dev/null` first (mandatory — gate uses the result). Then gate `postPRVisualWalkthrough` (per `preference-gates/README.md` + gate file for two-case Picker 1):
 - **Case A (PR found)** — `always` → proceed to 9c; `never`/skip → stop.
-- **Case B (no PR)** — always run Picker 1 regardless of saved value; "Create a PR and post" → create PR then proceed to 9c; "Skip" → stop.
+- **Case B (no PR)** — saved value applies:
+  - `always` → silently create the PR (push branch + `gh pr create`) then proceed to 9c. Print silent footer (`Creating PR for {branch} and posting walkthrough` + the standard `Skipped the prompt` line).
+  - `never` → silently skip; print `Skipping PR walkthrough — no open PR for this branch` plus the standard footer.
+  - `ask` → run Picker 1; on "Create a PR and post" follow with Picker 2 to save, then create + proceed to 9c. On "Skip" do not save.
 
 ### 9c: Invoke the shared skill in Mode A
 


### PR DESCRIPTION
## Summary

- New `autoCreatePR` preference gate — at the end of the `muggle-do` dev cycle (stage 7, `do/open-prs.md`), the user can have the PR opened automatically without being prompted each run.
- `postPRVisualWalkthrough` Case B (no PR on the branch) now silently creates the PR *and* posts the walkthrough when the saved value is `always`. Previously the gate fell through and asked anyway, which made `always` a half-measure.
- `muggle-test` step 9b and `muggle-test-feature-local` step 10b now honour the same three-branch behaviour (always / never / ask) — `always` silently creates the PR, `never` silently skips, `ask` runs the picker.
- Wired the new key into defaults (`ensure-electron-app.sh`) and the `Suggestions & PR` group of the configure picker.

## Test plan

- [ ] `/muggle-preferences` — verify `autoCreatePR` shows up in the `Suggestions & PR` multi-select with the description from its gate file.
- [ ] `/muggle-preferences autoCreatePR` — Picker 1 fires with the "Open the PR" / "Skip — I'll open it myself" choices and saves correctly.
- [ ] Set `autoCreatePR=always` globally, run a `/muggle-do` cycle to completion, confirm stage 7 prints the silent footer and proceeds to push + `gh pr create` without prompting.
- [ ] Set `autoCreatePR=never`, run a `/muggle-do` cycle, confirm stage 7 stops after commits and records the skip.
- [ ] On a branch with no open PR, set `postPRVisualWalkthrough=always`, run `/muggle-test`, confirm step 9b silently creates the PR and posts the walkthrough.
- [ ] On a branch with no open PR, set `postPRVisualWalkthrough=ask`, run `/muggle-test`, confirm Picker 1 + Picker 2 fire and the saved value matches the choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)