### PR TITLE
fix(pr-section): add inconclusive status and strict verdict line

### DIFF
--- a/plugin/agents/acceptance-tester.md
+++ b/plugin/agents/acceptance-tester.md
@@ -36,20 +36,27 @@ The orchestrator provides a dispatch prompt with:
 
 ### When Running Tests
 
-Always return two sections:
+Always return two sections. **This is the agent's text report back to the orchestrator — it is NOT the PR comment.** The PR comment is rendered separately by `muggle build-pr-section` via the `muggle-pr-visual-walkthrough` skill, and it has its own formatting (don't paste this template into a PR comment, don't add a "Verdict" line to a hand-written PR comment, don't add a "Project:" footer or `Tested on:` line — the CLI emits none of those).
 
 **Section 1 — Test Summary**
 
 ```
 ## Test Summary
-- **Tests:** {total} total — {passed} passed, {failed} failed
-- **Verdict:** PASS | FAIL
+- **Tests:** {total} total — {passed} passed, {failed} failed, {inconclusive} inconclusive
+- **Verdict:** PASS | FAIL | INCONCLUSIVE
 - **Dashboard:** {link to Muggle Test dashboard, if results were published}
 ```
 
+Verdict policy (matches the CLI's `computeVerdict`):
+- Any failed → **FAIL**.
+- No failures but any inconclusive → **INCONCLUSIVE**.
+- All passed → **PASS**.
+
+A test is **inconclusive** when the run could not yield a pass/fail signal for reasons outside the product itself: no replayable script, environment precondition unmet, infra error blocked execution, agent stalled before reaching the assertion (auth/cookie banner, missing secret). The product is not implicated. If you are tempted to call a run "passed except for one that didn't really run," that one is inconclusive.
+
 **Section 2 — Per-Test Highlights**
 
-Order failures first, then passes.
+Order failures first, then inconclusives, then passes.
 
 For each **failed** test:
 
@@ -57,6 +64,13 @@ For each **failed** test:
 ### {Test Name} — FAIL
 - **Blocking issue:** {What went wrong from the user's perspective. Describe the observable symptom — what the user sees or doesn't see.}
 - **Suggested fix:** {What the coding agent should investigate. Reference UI flows and components, not specific file paths — the acceptance tester operates at the UI layer.}
+```
+
+For each **inconclusive** test:
+
+```
+### {Test Name} — INCONCLUSIVE
+- **Reason:** {Why the run could not yield a pass/fail signal — one short sentence.}
 ```
 
 For each **passed** test, list the name only:

--- a/plugin/skills/do/e2e-acceptance.md
+++ b/plugin/skills/do/e2e-acceptance.md
@@ -160,10 +160,18 @@ For each test case:
   - steps: `[{ stepIndex, action, screenshotUrl }, ...]`
   - artifactsDir: `<path>` (for local debugging)
 
+**Inconclusive:** (count) — use for runs that couldn't yield a pass/fail signal: no replayable script, environment precondition unmet, infra error, agent stalled on auth/cookie banner before reaching the assertion, missing secrets. The product is **not** implicated — that's `failed`, not `inconclusive`.
+- (test case name):
+  - testCaseId: `<id>`
+  - runId: `<id>` (synthesize a UUID if no run started)
+  - viewUrl: `<url>` (project-level dashboard fallback when no specific run URL exists)
+  - reason: `<one short sentence>`
+  - steps: `[{ stepIndex, action, screenshotUrl }, ...]` (may be empty)
+
 **Metadata:**
 - projectId: `<projectId>`
 
-**Overall:** ALL PASSED | FAILURES DETECTED
+**Overall:** ALL PASSED | FAILURES DETECTED | INCONCLUSIVE
 
 ## Non-negotiables
 
@@ -173,3 +181,4 @@ For each test case:
 - No hiding failures: surface errors, exit codes, and artifact paths.
 - Every test case must be executed — generate a new script if none exists (no skips).
 - Always publish after execution to ensure screenshots are cloud-accessible for PR comments.
+- **Never drop a test case from the report because it "couldn't run cleanly."** A test that didn't reach its assertion is `inconclusive`, not absent. Dropping it produces misleading verdicts and pushes downstream PR-comment renderers to hand-write the comment — which is the failure mode this stage exists to prevent.

--- a/plugin/skills/muggle-pr-visual-walkthrough/SKILL.md
+++ b/plugin/skills/muggle-pr-visual-walkthrough/SKILL.md
@@ -66,12 +66,37 @@ Every caller must build an `E2eReport` JSON object and have it in conversation c
       "failureStepIndex": 2,
       "error": "Element not found: Click checkout button",
       "artifactsDir": "/Users/.../~/.muggle-ai/sessions/<runId>"
+    },
+    {
+      "name": "Clear search input restores full list",
+      "description": "Verify clearing the search input restores all options.",
+      "useCaseName": "Filter Dropdowns",
+      "testCaseId": "<UUID>",
+      "runId": "<UUID>",
+      "viewUrl": "https://www.muggle-ai.com/...",
+      "status": "inconclusive",
+      "steps": [],
+      "reason": "No replayable script exists yet — needs first generation run."
     }
   ]
 }
 ```
 
-Required fields per test: `name`, `testCaseId`, `runId`, `viewUrl`, `status`, `steps[]` with `{stepIndex, action, screenshotUrl}`. Failed tests additionally require `failureStepIndex` and `error`.
+Required fields per test: `name`, `testCaseId`, `runId`, `viewUrl`, `status`, `steps[]` with `{stepIndex, action, screenshotUrl}`.
+
+- **Failed** tests additionally require `failureStepIndex` and `error`.
+- **Inconclusive** tests additionally require `reason` (one short sentence on why the result is neither pass nor fail). `steps[]` may be empty — that's fine. Inconclusive is for runs that couldn't be classified pass/fail (no replayable script, environment precondition unmet, infra error blocked execution, agent stalled before reaching the assertion). **Never silently drop these — always emit them as `inconclusive`.** The CLI counts them in the overview and renders an `⚠️` row with the dashboard link so reviewers can click through. If you find yourself wanting to skip a test or hand-write a comment because the schema "doesn't fit," that is the schema fitting — use `inconclusive`.
+
+### Verdict
+
+The renderer computes a verdict from the tests and emits a `**Verdict:** ✅ PASS | ❌ FAIL | ⚠️ INCONCLUSIVE` line at the top of the overview. The policy is strict:
+
+- Any failed test → **FAIL** (regardless of how many passed or are inconclusive).
+- No failures but any inconclusive → **INCONCLUSIVE**.
+- All passed → **PASS**.
+- Empty report → no verdict line.
+
+You do not compute or render the verdict yourself — the CLI does. Never write a "Verdict: PASS" line into a hand-edited summary; it will conflict with the CLI's computed verdict.
 
 **Optional but recommended** per test:
 - `description` — a one-line summary of what the test case verifies. Shown in the collapsible header for each test and helps reviewers understand the test without expanding it. Pull from the test case's `title`/`description` via `muggle-remote-test-case-get`.
@@ -168,7 +193,7 @@ In Mode B, this skill does not call `gh pr comment` or `gh pr create` itself —
 
 ## Guardrails
 
-- **Never hand-write the walkthrough markdown** — always call `muggle build-pr-section`. The CLI is the single source of truth for formatting.
+- **Never hand-write the walkthrough markdown** — always call `muggle build-pr-section`. The CLI is the single source of truth for formatting. If a test outcome doesn't fit `passed | failed`, that's what `inconclusive` is for — never fall back to a hand-written summary, a custom table, a "Verdict: PASS" header, a `Tested on:`/`Project:` footer, or any other freeform text. The CLI already emits per-test-case dashboard links (no project-level link), uses `https://www.muggle-ai.com/...` URLs (never the test target's `localhost` URL), and computes the verdict — anything you would manually add is wrong by construction.
 - **Never modify the CLI's output** — post `body` and (if present) `comment` verbatim. Any reformatting defeats the fit-vs-overflow budget math.
 - **Never invent report fields** — if `projectId`, a per-test `viewUrl`, or per-step `screenshotUrl` is missing, stop and report what's missing. Do not fabricate URLs or fill in placeholders.
 - **Never post the overflow comment when `comment` is `null`** — the CLI decides fit-vs-overflow.

--- a/plugin/skills/muggle-pr-visual-walkthrough/e2e-report-assembly.md
+++ b/plugin/skills/muggle-pr-visual-walkthrough/e2e-report-assembly.md
@@ -1,6 +1,16 @@
 # E2eReport Assembly Guide
 
-Include **all** runs — passed and failed. Never drop a run. Always best-effort to upload so the dashboard has a record reviewers can open from the PR — even when the local run produced zero action steps.
+Include **all** runs — passed, failed, **and inconclusive**. Never drop a run. Always best-effort to upload so the dashboard has a record reviewers can open from the PR — even when the local run produced zero action steps.
+
+## Picking a status
+
+| Status | Use when | Required extras |
+|---|---|---|
+| `passed` | Run completed and the assertion held. | — |
+| `failed` | Run completed and the assertion failed, or the product itself broke before the assertion could be made (server error, 500, broken page). | `failureStepIndex`, `error` |
+| `inconclusive` | Run could not yield a pass/fail signal for reasons **outside the product**: no replayable script existed, environment precondition unmet, infra/Electron error, agent stalled on a cookie banner or login wall, missing secrets, agent went off-course. | `reason` (one short sentence; `steps[]` may be empty) |
+
+If a test should be inconclusive but you don't have a real `runId` / `viewUrl` (e.g., generation never ran), use the same project-level dashboard fallback as the "last-resort" failed branch below: emit a stub run via `muggle-remote-local-run-upload` if at all possible; otherwise synthesize a UUID-shaped runId and use `https://www.muggle-ai.com/muggleTestV0/dashboard/projects/{projectId}/runs` as `viewUrl`. The schema requires both fields — but a working dashboard link is better than nothing.
 
 ## Uploaded run (passed or failed; the common path)
 
@@ -59,6 +69,17 @@ If called from `muggle-do`: `e2e-acceptance.md` already produces this shape — 
       "steps": [],
       "failureStepIndex": 0,
       "error": "<error message from run result>"
+    },
+    {
+      "name": "<inconclusive test case title>",
+      "description": "<one-line description (recommended)>",
+      "useCaseName": "<parent use case title (recommended)>",
+      "testCaseId": "<testCaseId from execution step>",
+      "runId": "<runId from execute, or synthesized UUID if no run started>",
+      "viewUrl": "<viewUrl from upload response, or project-level fallback URL>",
+      "status": "inconclusive",
+      "steps": [],
+      "reason": "<one short sentence: why neither pass nor fail applies>"
     }
   ]
 }

--- a/src/cli/pr-section/index.ts
+++ b/src/cli/pr-section/index.ts
@@ -9,7 +9,7 @@ import { splitWithOverflow, type ISplitOptions, type ISplitResult } from "./over
 import type { E2eReport } from "./types.js";
 
 export { E2eReportSchema } from "./types.js";
-export type { E2eReport, TestResult, PassedTest, FailedTest, Step } from "./types.js";
+export type { E2eReport, TestResult, PassedTest, FailedTest, InconclusiveTest, Step } from "./types.js";
 export type { ISplitOptions, ISplitResult } from "./overflow.js";
 
 /**

--- a/src/cli/pr-section/render.ts
+++ b/src/cli/pr-section/render.ts
@@ -30,20 +30,50 @@ interface ICounts {
   total: number;
   passed: number;
   failed: number;
+  inconclusive: number;
 }
 
 function countTests (report: E2eReport): ICounts {
   const total = report.tests.length;
   const passed = report.tests.filter((t) => t.status === "passed").length;
   const failed = report.tests.filter((t) => t.status === "failed").length;
-  return { total, passed, failed };
+  const inconclusive = report.tests.filter((t) => t.status === "inconclusive").length;
+  return { total, passed, failed, inconclusive };
 }
 
 function statusEmoji (test: TestResult): string {
-  return test.status === "passed" ? "✅" : "❌";
+  if (test.status === "passed") return "✅";
+  if (test.status === "failed") return "❌";
+  return "⚠️";
 }
 
-/** The "ending screenshot" step for a test: failure-step for failed, last step for passed. */
+/** Overall verdict for a report. `none` when there are no tests at all. */
+export type Verdict = "pass" | "fail" | "inconclusive" | "none";
+
+/**
+ * Strict verdict policy:
+ * - Any failed test → FAIL (overrides everything else)
+ * - Any inconclusive test (with no failures) → INCONCLUSIVE
+ * - All passed and at least one test → PASS
+ * - Empty report → NONE
+ */
+export function computeVerdict (report: E2eReport): Verdict {
+  if (report.tests.length === 0) return "none";
+  if (report.tests.some((t) => t.status === "failed")) return "fail";
+  if (report.tests.some((t) => t.status === "inconclusive")) return "inconclusive";
+  return "pass";
+}
+
+function renderVerdictLine (verdict: Verdict): string | null {
+  switch (verdict) {
+    case "pass": return "**Verdict: ✅ PASS**";
+    case "fail": return "**Verdict: ❌ FAIL**";
+    case "inconclusive": return "**Verdict: ⚠️ INCONCLUSIVE**";
+    case "none": return null;
+  }
+}
+
+/** The "ending screenshot" step for a test: failure-step for failed, last step for passed/inconclusive. */
 function endingScreenshot (test: TestResult): Step | null {
   if (test.steps.length === 0) {
     return null;
@@ -63,6 +93,9 @@ function endingScreenshot (test: TestResult): Step | null {
 function defaultEndingCaption (test: TestResult): string {
   if (test.status === "failed") {
     return `Failure at step ${test.failureStepIndex}`;
+  }
+  if (test.status === "inconclusive") {
+    return "Last frame before run was cut short";
   }
   return "Final page after the test completed";
 }
@@ -122,12 +155,14 @@ function buildTestNumbering (report: E2eReport): Map<string, number> {
  * Numbering is global across groups so it matches the details block headings.
  */
 export function renderOverview (report: E2eReport): string {
-  const { total, passed, failed } = countTests(report);
-  const lines: string[] = [
-    "## E2E Acceptance Results",
-    "",
-    `**${total} tests ran — ${passed} passed / ${failed} failed**`,
-  ];
+  const { total, passed, failed, inconclusive } = countTests(report);
+  const verdict = computeVerdict(report);
+  const verdictLine = renderVerdictLine(verdict);
+  const lines: string[] = ["## E2E Acceptance Results", ""];
+  if (verdictLine) {
+    lines.push(verdictLine, "");
+  }
+  lines.push(`**${total} tests ran — ${passed} passed / ${failed} failed / ${inconclusive} inconclusive**`);
   if (total === 0) {
     lines.push("", "_No tests were executed._");
     return lines.join("\n");
@@ -225,9 +260,12 @@ function renderResultSummary (test: TestResult, projectId: string): string[] {
   const lines: string[] = [];
   if (test.status === "passed") {
     lines.push(`**Result:** ✅ PASSED`);
-  } else {
+  } else if (test.status === "failed") {
     lines.push(`**Result:** ❌ FAILED at step ${test.failureStepIndex}`);
     lines.push(`**Error:** \`${safeInlineCode(test.error)}\``);
+  } else {
+    lines.push(`**Result:** ⚠️ INCONCLUSIVE`);
+    lines.push(`**Reason:** \`${safeInlineCode(test.reason)}\``);
   }
   lines.push(`**Steps:** ${test.steps.length}`);
   lines.push(`<a href="${dashboardUrl}" target="_blank" rel="noopener noreferrer">View steps on Muggle AI →</a>`);

--- a/src/cli/pr-section/types.ts
+++ b/src/cli/pr-section/types.ts
@@ -42,9 +42,32 @@ const FailedTestSchema = z.object({
   endingScreenshotCaption: z.string().min(1).optional(),
 });
 
+// A test whose outcome cannot be classified as pass/fail: the test couldn't
+// run cleanly (no replayable script existed, environment precondition was
+// unmet, infra error blocked execution, etc.). The product is not implicated.
+// Carries the same run identifiers as passed/failed so the dashboard link
+// still works; `reason` explains why the result is inconclusive instead of
+// pass/fail. `steps[]` may be empty when the run never produced action steps.
+const InconclusiveTestSchema = z.object({
+  name: z.string().min(1),
+  testCaseId: z.string().min(1),
+  testScriptId: z.string().min(1).optional(),
+  runId: z.string().min(1),
+  viewUrl: z.string().url(),
+  status: z.literal("inconclusive"),
+  steps: z.array(StepSchema),
+  reason: z.string().min(1),
+  artifactsDir: z.string().min(1).optional(),
+  useCaseName: z.string().min(1).optional(),
+  description: z.string().min(1).optional(),
+  endingScreenshotUrl: z.string().url().optional(),
+  endingScreenshotCaption: z.string().min(1).optional(),
+});
+
 const TestResultSchema = z.discriminatedUnion("status", [
   PassedTestSchema,
   FailedTestSchema,
+  InconclusiveTestSchema,
 ]);
 
 export const E2eReportSchema = z.object({
@@ -56,4 +79,5 @@ export type E2eReport = z.infer<typeof E2eReportSchema>;
 export type TestResult = z.infer<typeof TestResultSchema>;
 export type PassedTest = z.infer<typeof PassedTestSchema>;
 export type FailedTest = z.infer<typeof FailedTestSchema>;
+export type InconclusiveTest = z.infer<typeof InconclusiveTestSchema>;
 export type Step = z.infer<typeof StepSchema>;

--- a/src/test/cli/pr-section/index.test.ts
+++ b/src/test/cli/pr-section/index.test.ts
@@ -29,7 +29,7 @@ describe("buildPrSection", () => {
   it("keeps the overview section in the body even when details are spilled", () => {
     const result = buildPrSection(load("grouped-by-use-case.json"), { maxBodyBytes: 500 });
     expect(result.body).toContain("## E2E Acceptance Results");
-    expect(result.body).toContain("**3 tests ran — 2 passed / 1 failed**");
+    expect(result.body).toContain("**3 tests ran — 2 passed / 1 failed / 0 inconclusive**");
     expect(result.body).toContain("- **Create a New Project**");
     expect(result.body).not.toContain("<details>");
     expect(result.comment).toContain("<details>");

--- a/src/test/cli/pr-section/render.test.ts
+++ b/src/test/cli/pr-section/render.test.ts
@@ -2,12 +2,13 @@ import { describe, it, expect } from "vitest";
 
 import {
   DASHBOARD_URL_BASE,
+  computeVerdict,
   renderOverview,
   renderTestDetails,
   renderBody,
   renderComment,
 } from "../../../cli/pr-section/render.js";
-import type { E2eReport, FailedTest, PassedTest } from "../../../cli/pr-section/types.js";
+import type { E2eReport, FailedTest, InconclusiveTest, PassedTest } from "../../../cli/pr-section/types.js";
 
 const PROJECT_ID = "p1";
 
@@ -84,9 +85,39 @@ const failedNoMeta: FailedTest = {
   ],
 };
 
+const inconclusiveWithDesc: InconclusiveTest = {
+  name: "Clear search input restores full list",
+  description: "Verify clearing the search input restores all options.",
+  useCaseName: "Filter Dropdowns",
+  testCaseId: "tc-6",
+  runId: "run-6",
+  viewUrl: "https://www.muggle-ai.com/x/run-6",
+  status: "inconclusive",
+  reason: "No replayable script exists yet — needs first generation run.",
+  steps: [],
+};
+
+const inconclusiveWithSteps: InconclusiveTest = {
+  name: "Pre-checkout banner inconclusive",
+  testCaseId: "tc-7",
+  runId: "run-7",
+  viewUrl: "https://www.muggle-ai.com/x/run-7",
+  status: "inconclusive",
+  reason: "Environment precondition unmet: cookie banner stale on this branch.",
+  steps: [
+    { stepIndex: 0, action: "Open cart", screenshotUrl: "https://cdn/7-0.png" },
+    { stepIndex: 1, action: "Hit cookie banner", screenshotUrl: "https://cdn/7-1.png" },
+  ],
+};
+
 const groupedReport: E2eReport = {
   projectId: PROJECT_ID,
   tests: [passedWithDesc, failedWithDesc, passedAuthGroup],
+};
+
+const mixedWithInconclusiveReport: E2eReport = {
+  projectId: PROJECT_ID,
+  tests: [passedWithDesc, passedAuthGroup, inconclusiveWithDesc],
 };
 
 const flatReport: E2eReport = {
@@ -106,11 +137,35 @@ const allPassedNoMeta: E2eReport = {
 
 const emptyReport: E2eReport = { projectId: PROJECT_ID, tests: [] };
 
+describe("computeVerdict", () => {
+  it("returns 'none' for an empty report", () => {
+    expect(computeVerdict({ projectId: PROJECT_ID, tests: [] })).toBe("none");
+  });
+
+  it("returns 'pass' when every test passed", () => {
+    expect(computeVerdict({ projectId: PROJECT_ID, tests: [passedWithDesc, passedAuthGroup] })).toBe("pass");
+  });
+
+  it("returns 'fail' when any test failed (even with inconclusives)", () => {
+    expect(
+      computeVerdict({
+        projectId: PROJECT_ID,
+        tests: [passedWithDesc, failedWithDesc, inconclusiveWithDesc],
+      }),
+    ).toBe("fail");
+  });
+
+  it("returns 'inconclusive' when there are no failures but at least one inconclusive", () => {
+    expect(computeVerdict(mixedWithInconclusiveReport)).toBe("inconclusive");
+  });
+});
+
 describe("renderOverview", () => {
   it("renders counts and a flat numbered list when no test has a useCaseName", () => {
     const md = renderOverview(flatReport);
     expect(md).toContain("## E2E Acceptance Results");
-    expect(md).toContain("**2 tests ran — 1 passed / 1 failed**");
+    expect(md).toContain("**Verdict: ❌ FAIL**");
+    expect(md).toContain("**2 tests ran — 1 passed / 1 failed / 0 inconclusive**");
     expect(md).toContain("**Tests run:**");
     expect(md).toContain("- **1.** ✅ Logout flow");
     expect(md).toContain("- **2.** ❌ Checkout breaks");
@@ -121,7 +176,8 @@ describe("renderOverview", () => {
 
   it("groups tests by useCaseName with global numbering across groups", () => {
     const md = renderOverview(groupedReport);
-    expect(md).toContain("**3 tests ran — 2 passed / 1 failed**");
+    expect(md).toContain("**Verdict: ❌ FAIL**");
+    expect(md).toContain("**3 tests ran — 2 passed / 1 failed / 0 inconclusive**");
     expect(md).toContain("- **Create a New Project**");
     expect(md).toContain("  - **1.** ✅ User creates a new project with valid URL");
     expect(md).toContain("  - **2.** ❌ User receives error for invalid URL format");
@@ -129,12 +185,27 @@ describe("renderOverview", () => {
     expect(md).toContain("  - **3.** ✅ Login with valid credentials");
   });
 
+  it("renders the verdict line as INCONCLUSIVE when no failures but any inconclusive test exists", () => {
+    const md = renderOverview(mixedWithInconclusiveReport);
+    expect(md).toContain("**Verdict: ⚠️ INCONCLUSIVE**");
+    expect(md).toContain("**3 tests ran — 2 passed / 0 failed / 1 inconclusive**");
+    expect(md).toContain("⚠️ Clear search input restores full list");
+  });
+
+  it("renders the verdict line as PASS when all tests passed", () => {
+    const md = renderOverview({ projectId: PROJECT_ID, tests: [passedWithDesc, passedAuthGroup] });
+    expect(md).toContain("**Verdict: ✅ PASS**");
+    expect(md).toContain("**2 tests ran — 2 passed / 0 failed / 0 inconclusive**");
+  });
+
   it("handles an empty report with a friendly placeholder", () => {
     const md = renderOverview(emptyReport);
     expect(md).toContain("## E2E Acceptance Results");
-    expect(md).toContain("**0 tests ran — 0 passed / 0 failed**");
+    expect(md).toContain("**0 tests ran — 0 passed / 0 failed / 0 inconclusive**");
     expect(md).toContain("_No tests were executed._");
     expect(md).not.toContain("**Tests run:**");
+    // No verdict line on an empty report — there's nothing to rule on.
+    expect(md).not.toContain("**Verdict:");
   });
 });
 
@@ -203,6 +274,26 @@ describe("renderTestDetails", () => {
     expect(md).toContain("target=\"_blank\"");
     expect(md).toContain("rel=\"noopener noreferrer\"");
   });
+
+  it("renders an inconclusive test with the warning emoji, reason line, and no error", () => {
+    const md = renderTestDetails(inconclusiveWithDesc, PROJECT_ID, 3);
+    expect(md).toContain("<b>3. </b><i>▶ click to expand</i> <b>Clear search input restores full list</b> ⚠️");
+    expect(md).toContain("**Result:** ⚠️ INCONCLUSIVE");
+    expect(md).toContain("**Reason:** `No replayable script exists yet — needs first generation run.`");
+    expect(md).not.toContain("**Error:**");
+    expect(md).toContain("**Steps:** 0");
+    // No ending-screen block when there are zero steps.
+    expect(md).not.toContain("**📸 Ending screen");
+    // Dashboard link still works — that's what makes per-TC navigation possible.
+    expect(md).toContain(`${DASHBOARD_URL_BASE}/p1/scripts?modal=script-details&testCaseId=tc-6`);
+  });
+
+  it("renders an inconclusive test with steps using a 'cut short' caption", () => {
+    const md = renderTestDetails(inconclusiveWithSteps, PROJECT_ID, 4);
+    expect(md).toContain("**📸 Ending screen — Last frame before run was cut short**");
+    expect(md).toContain('<img src="https://cdn/7-1.png"');
+    expect(md).toContain("**Result:** ⚠️ INCONCLUSIVE");
+  });
 });
 
 describe("renderBody", () => {
@@ -239,7 +330,7 @@ describe("renderBody", () => {
 
   it("empty report: no details, no horizontal rule", () => {
     const body = renderBody(emptyReport, { inlineDetails: true });
-    expect(body).toContain("**0 tests ran — 0 passed / 0 failed**");
+    expect(body).toContain("**0 tests ran — 0 passed / 0 failed / 0 inconclusive**");
     expect(body).toContain("_No tests were executed._");
     expect(body).not.toContain("---");
     expect(body).not.toContain("<details>");

--- a/src/test/cli/pr-section/types.test.ts
+++ b/src/test/cli/pr-section/types.test.ts
@@ -148,6 +148,62 @@ describe("E2eReportSchema", () => {
     expect(() => E2eReportSchema.parse(bad)).toThrow();
   });
 
+  it("accepts an inconclusive test with reason + same identifiers as passed/failed", () => {
+    const parsed = E2eReportSchema.parse({
+      projectId: "p1",
+      tests: [
+        {
+          name: "Clear search input restores full list",
+          testCaseId: "tc1",
+          runId: "r1",
+          viewUrl: "https://example.com/run-1",
+          status: "inconclusive",
+          steps: [],
+          reason: "No replayable script exists yet — needs first generation run.",
+        },
+      ],
+    });
+    const t = parsed.tests[0];
+    expect(t.status).toBe("inconclusive");
+    if (t.status === "inconclusive") {
+      expect(t.reason).toContain("No replayable script");
+      expect(t.steps).toHaveLength(0);
+    }
+  });
+
+  it("rejects an inconclusive test that has no reason field", () => {
+    const bad = {
+      projectId: "p1",
+      tests: [
+        {
+          name: "x",
+          testCaseId: "tc1",
+          runId: "r1",
+          viewUrl: "https://example.com/x",
+          status: "inconclusive",
+          steps: [],
+        },
+      ],
+    };
+    expect(() => E2eReportSchema.parse(bad)).toThrow();
+  });
+
+  it("rejects an inconclusive test that omits required runId/viewUrl", () => {
+    const bad = {
+      projectId: "p1",
+      tests: [
+        {
+          name: "x",
+          testCaseId: "tc1",
+          status: "inconclusive",
+          steps: [],
+          reason: "prereq unmet",
+        },
+      ],
+    };
+    expect(() => E2eReportSchema.parse(bad)).toThrow();
+  });
+
   it("parses the grouped-by-use-case fixture", () => {
     const parsed = E2eReportSchema.parse(loadFixture("grouped-by-use-case.json"));
     expect(parsed.tests).toHaveLength(3);


### PR DESCRIPTION
## Summary

Fixes the broken PR comment seen on [multiplex-ai/muggle-ai-ui#275](https://github.com/multiplex-ai/muggle-ai-ui/pull/275): inconsistent formatting, localhost dashboard URLs, an unhelpful project-level link, and a `Verdict: PASS` line even when 1 test was inconclusive.

All four symptoms shared one root cause: the renderer's schema only accepted `passed | failed`. When a test couldn't yield a clean pass/fail signal (no replayable script, env precondition unmet, infra error, agent stalled on auth/cookie banner), the LLM had no schema-valid way to model it and fell back to hand-writing the comment — picking up the wrong URLs, freeform "Verdict: PASS" header, "Tested on:" / "Project:" footers, and a fabricated counts line.

### What changed

- `src/cli/pr-section/types.ts` — new `InconclusiveTestSchema` (status + required `reason`, same identifiers as passed/failed so the dashboard link always works).
- `src/cli/pr-section/render.ts` — new `computeVerdict()`; overview now emits an explicit `**Verdict:** ✅ PASS | ❌ FAIL | ⚠️ INCONCLUSIVE` line above the counts; counts include inconclusive; per-test detail renders `**Result:** ⚠️ INCONCLUSIVE` + `**Reason:** ...` with no fake error or screenshot.
- Tests extended in `render.test.ts`, `types.test.ts`, `index.test.ts` — 57/57 pr-section tests pass.
- `plugin/skills/muggle-pr-visual-walkthrough/{SKILL.md,e2e-report-assembly.md}` — schema docs include inconclusive; guardrails now explicitly forbid the freeform anti-patterns we saw.
- `plugin/skills/do/e2e-acceptance.md` — output template adds the inconclusive bucket; non-negotiable "never drop a test case because it 'couldn't run cleanly'".
- `plugin/agents/acceptance-tester.md` — adds INCONCLUSIVE to verdict choices and explicitly marks the agent template as orchestrator-only (NOT the PR comment) to stop the leak that produced the broken comment.

### Verdict policy

Strict (single source of truth in `computeVerdict`):

| Counts | Verdict |
|---|---|
| Any failed | FAIL |
| No failed, any inconclusive | INCONCLUSIVE |
| All passed | PASS |
| Empty | none (no verdict line) |

## Test plan

- [ ] `pnpm vitest run src/test/cli/pr-section/` — 57 passing
- [ ] `tsc --noEmit` — clean
- [ ] `eslint src/cli/pr-section/ src/test/cli/pr-section/` — clean
- [ ] Spot-check: pipe a mixed report (2 passed / 0 failed / 1 inconclusive) through `muggle build-pr-section` and confirm the verdict renders as ⚠️ INCONCLUSIVE
- [ ] Spot-check: confirm dashboard URLs use `https://www.muggle-ai.com/...` (never the test target's localhost URL) and there is no project-level link in the rendered output

🤖 Generated with [Claude Code](https://claude.com/claude-code)