### PR TITLE
chore(skills): gate-first ordering for walkthrough post

### DIFF
--- a/plugin/skills/muggle-test-feature-local/SKILL.md
+++ b/plugin/skills/muggle-test-feature-local/SKILL.md
@@ -50,7 +50,7 @@ Gates run per `preference-gates/README.md`.
 | `showElectronBrowser` | 7 | Show Electron browser window during local E2E tests |
 | `openTestResultsAfterRun` | 8 | Open results page on Muggle Test dashboard after run |
 | `postPRVisualWalkthrough` | 10 | Post visual walkthrough to PR after results |
-| `autoCreatePR` | 10b | Auto-create the PR when posting the walkthrough has no PR to target |
+| `autoCreatePR` | 10 | Auto-create the PR when posting the walkthrough has no PR to target |
 | `autoCleanup` | post-merge | Run cleanup after the PR for this work is merged (see [`_shared/post-merge-cleanup.md`](../_shared/post-merge-cleanup.md)) |
 
 ## Workflow
@@ -217,26 +217,13 @@ Skip silently when the run passed cleanly — failure-mode events are by definit
 
 ### 10. Offer to post a visual walkthrough to the PR
 
-After reporting results, gather the required input and hand off to the shared **`muggle:muggle-pr-visual-walkthrough`** skill, which renders the walkthrough via `muggle build-pr-section` and posts it to the current branch's open PR.
+After reporting results:
 
-#### 10a: Assemble the `E2eReport`
-
-Read `plugin/skills/muggle-pr-visual-walkthrough/e2e-report-assembly.md` for the full assembly guide.
-
-#### 10b: Detect the PR, then apply the `postPRVisualWalkthrough` gate
-
-Run `gh pr view --json number,title,url 2>/dev/null` first (mandatory). Then gate `postPRVisualWalkthrough` (per `preference-gates/README.md` + gate file):
-- **Case A (PR found)** — `always` → proceed to 10c; `never`/skip → stop.
-- **Case B (no PR)** — saved value applies:
-  - `always` → silently create the PR (push branch + `gh pr create`) then proceed to 10c. Print silent footer (`Creating PR for {branch} and posting walkthrough` + the standard `Skipped the prompt` line).
-  - `never` → silently skip; print `Skipping PR walkthrough — no open PR for this branch` plus the standard footer.
-  - `ask` → run Picker 1; on "Create a PR and post" follow with Picker 2 to save, then create + proceed to 10c. On "Skip" do not save.
-
-#### 10c: Invoke the shared skill in Mode A
-
-Invoke the `muggle:muggle-pr-visual-walkthrough` skill via the `Skill` tool. With the `E2eReport` in context, the skill renders the markdown block via the CLI, posts `body` as a comment to the PR, posts the overflow `comment` only if the CLI emitted one, and confirms the PR URL to the user.
-
-Always use **Mode A** (post to existing PR) from this skill. Never hand-write the walkthrough markdown or call `gh pr comment` directly — delegate to `muggle:muggle-pr-visual-walkthrough`.
+1. Fire [`postPRVisualWalkthrough`](../muggle-preferences/preference-gates/postPRVisualWalkthrough.md). On skip → end.
+2. `gh pr view --json number,title,url 2>/dev/null` — find the PR.
+3. If no PR: fire [`autoCreatePR`](../muggle-preferences/preference-gates/autoCreatePR.md). On skip → end.
+4. Assemble the `E2eReport` — see [`../muggle-pr-visual-walkthrough/e2e-report-assembly.md`](../muggle-pr-visual-walkthrough/e2e-report-assembly.md).
+5. Invoke [`../muggle-pr-visual-walkthrough/SKILL.md`](../muggle-pr-visual-walkthrough/SKILL.md) Mode A with the `E2eReport`.
 
 ## Non-negotiables
 

--- a/plugin/skills/muggle-test-feature-local/SKILL.md
+++ b/plugin/skills/muggle-test-feature-local/SKILL.md
@@ -50,7 +50,7 @@ Gates run per `preference-gates/README.md`.
 | `showElectronBrowser` | 7 | Show Electron browser window during local E2E tests |
 | `openTestResultsAfterRun` | 8 | Open results page on Muggle Test dashboard after run |
 | `postPRVisualWalkthrough` | 10 | Post visual walkthrough to PR after results |
-| `autoCreatePR` | 10 | Auto-create the PR when posting the walkthrough has no PR to target |
+| `autoCreatePR` | 10 (if no PR) | Auto-create the PR when posting the walkthrough has no PR to target |
 | `autoCleanup` | post-merge | Run cleanup after the PR for this work is merged (see [`_shared/post-merge-cleanup.md`](../_shared/post-merge-cleanup.md)) |
 
 ## Workflow

--- a/plugin/skills/muggle-test/SKILL.md
+++ b/plugin/skills/muggle-test/SKILL.md
@@ -48,7 +48,7 @@ Gates run per `preference-gates/README.md`.
 | `autoPublishLocalResults` | 7A | Upload local results to Muggle Test cloud after run |
 | `showElectronBrowser` | 7A | Show the Electron browser window during local test execution (vs. run headless) |
 | `postPRVisualWalkthrough` | 9 | Post visual walkthrough to PR after results are available |
-| `autoCreatePR` | 9 | Auto-create the PR when posting the walkthrough has no PR to target |
+| `autoCreatePR` | 9 (if no PR) | Auto-create the PR when posting the walkthrough has no PR to target |
 
 ## Step 1: Confirm Scope of Work (Always First)
 

--- a/plugin/skills/muggle-test/SKILL.md
+++ b/plugin/skills/muggle-test/SKILL.md
@@ -48,7 +48,7 @@ Gates run per `preference-gates/README.md`.
 | `autoPublishLocalResults` | 7A | Upload local results to Muggle Test cloud after run |
 | `showElectronBrowser` | 7A | Show the Electron browser window during local test execution (vs. run headless) |
 | `postPRVisualWalkthrough` | 9 | Post visual walkthrough to PR after results are available |
-| `autoCreatePR` | 9b | Auto-create the PR when posting the walkthrough has no PR to target |
+| `autoCreatePR` | 9 | Auto-create the PR when posting the walkthrough has no PR to target |
 
 ## Step 1: Confirm Scope of Work (Always First)
 
@@ -400,32 +400,13 @@ Tell the user:
 
 ## Step 9: Offer to Post Visual Walkthrough to PR
 
-After reporting results, ask the user if they want to attach a **visual walkthrough** — a markdown block with per-test-case dashboard links and step-by-step screenshots — to the current branch's open PR. The rendering and posting workflow lives in the shared `muggle-pr-visual-walkthrough` skill; this step gathers the required input and hands off.
+After reporting results:
 
-### 9a: Assemble the `E2eReport`
-
-Read `plugin/skills/muggle-pr-visual-walkthrough/e2e-report-assembly.md` for the full assembly guide. All runs from Step 7A must be included (passed and failed).
-
-### 9b: Detect the PR, then apply the `postPRVisualWalkthrough` gate
-
-Run `gh pr view --json number,title,url 2>/dev/null` first (mandatory — gate uses the result). Then gate `postPRVisualWalkthrough` (per `preference-gates/README.md` + gate file for two-case Picker 1):
-- **Case A (PR found)** — `always` → proceed to 9c; `never`/skip → stop.
-- **Case B (no PR)** — saved value applies:
-  - `always` → silently create the PR (push branch + `gh pr create`) then proceed to 9c. Print silent footer (`Creating PR for {branch} and posting walkthrough` + the standard `Skipped the prompt` line).
-  - `never` → silently skip; print `Skipping PR walkthrough — no open PR for this branch` plus the standard footer.
-  - `ask` → run Picker 1; on "Create a PR and post" follow with Picker 2 to save, then create + proceed to 9c. On "Skip" do not save.
-
-### 9c: Invoke the shared skill in Mode A
-
-If 9b resolved to "post" (either via `postPRVisualWalkthrough = always` or the user picking "Yes, post to PR"), invoke the `muggle-pr-visual-walkthrough` skill via the `Skill` tool. With the `E2eReport` already in context, the skill will:
-
-1. Call `muggle build-pr-section` to render the markdown block (fit-vs-overflow automatic)
-2. Find the PR via `gh pr view`
-3. Post `body` as a `gh pr comment`
-4. Post the overflow `comment` as a second comment (only if the CLI emitted one)
-5. Confirm the PR URL to the user
-
-This skill always uses **Mode A** (post to an existing PR); `muggle-do` is the only caller that uses Mode B. Do not attempt to render the walkthrough markdown yourself — delegate to the shared skill.
+1. Fire [`postPRVisualWalkthrough`](../muggle-preferences/preference-gates/postPRVisualWalkthrough.md). On skip → Step 10.
+2. `gh pr view --json number,title,url 2>/dev/null` — find the PR.
+3. If no PR: fire [`autoCreatePR`](../muggle-preferences/preference-gates/autoCreatePR.md). On skip → Step 10.
+4. Assemble the `E2eReport` — see [`../muggle-pr-visual-walkthrough/e2e-report-assembly.md`](../muggle-pr-visual-walkthrough/e2e-report-assembly.md). Include all runs from Step 7A (passed and failed).
+5. Invoke [`../muggle-pr-visual-walkthrough/SKILL.md`](../muggle-pr-visual-walkthrough/SKILL.md) Mode A with the `E2eReport`.
 
 ## Step 10: Offer feedback on failures
 


### PR DESCRIPTION
## Summary

Replaces the verbose Case A / Case B narration in `muggle-test` Step 9 and `muggle-test-feature-local` Step 10 with a single 5-step gate-first list. (Picked up from the closed #141, which had this cleanup but is no longer mergeable after master diverged.)

**New shape — same in both files:**

1. Fire `postPRVisualWalkthrough` — on skip, stop.
2. Look up the PR.
3. If no PR, fire `autoCreatePR` — on skip, stop.
4. Assemble the `E2eReport`.
5. Hand off to `muggle-pr-visual-walkthrough` Mode A.

**Why this is better:**

- **Gate fires first** — skipping at the gate also skips the assembly work. The old order assembled the report speculatively and then discarded it on skip.
- **No more 9a/9b/9c (or 10a/10b/10c) sub-sections** — the Case A/B logic now lives in the gate files (`postPRVisualWalkthrough.md`, `autoCreatePR.md`), not duplicated in every caller's procedure.
- **Diff is net `-32` lines.**

## Test plan

- [ ] Confirm no other docs reference `Step 9a`/`9b`/`9c` or `Step 10a`/`10b`/`10c` (grep clean in `plugin/`).
- [ ] Confirm the Preferences tables in both files point `autoCreatePR` at the parent step (`9` / `10`) since the sub-step `9b`/`10b` no longer exists.
- [ ] Spot-check that the Step 9/10 procedure still reads correctly end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)