### PR TITLE
feat(skills): stage 8 helpers — CODEOWNERS, reply routing, classify examples (5/N)

### DIFF
--- a/plugin/skills/_shared/pr-followup-helpers.md
+++ b/plugin/skills/_shared/pr-followup-helpers.md
@@ -1,8 +1,8 @@
 # PR follow-up helpers
 
-Operational detail for [`pr-followup.md`](pr-followup.md). The main file describes the per-tick contract; this file fills in the procedures it calls out by name (reviewer allow-list, reply routing, comment classification).
+Generic operational guidance for running a PR-comment follow-up loop on GitHub: reviewer allow-list resolution, reply routing across the different comment endpoints, and a borderline-tested rule for classifying reviewer comments. Shared because the same procedures apply to any caller that runs a stage-8-shaped loop — `muggle-do` is the first, but not the last.
 
-Keep both files in lockstep — when the contract changes, update both.
+The per-tick contract that consumes these procedures lives in [`../do/pr-followup.md`](../do/pr-followup.md). Keep both files in lockstep — when the contract changes, update both.
 
 ## Resolving the reviewer allow-list
 
@@ -101,7 +101,7 @@ fix(ci): lint — remove unused import
 
 ## Classify
 
-The decision table in `pr-followup.md` is the rule. This section is worked examples — read them when classifying a borderline case.
+The decision table in [`../do/pr-followup.md`](../do/pr-followup.md) is the rule. This section is worked examples — read them when classifying a borderline case.
 
 ### Directive (comply silently)
 
@@ -153,7 +153,7 @@ Default. When the comment doesn't cleanly fit directive or question, escalate.
 | "this is wrong" | Asserts a problem but doesn't propose a fix |
 | "we discussed this offline — please address" | References context the loop doesn't have |
 
-For each, escalate per `pr-followup.md` Step 7. Don't guess.
+For each, escalate per [`../do/pr-followup.md`](../do/pr-followup.md) Step 7. Don't guess.
 
 ### Borderline rule
 

--- a/plugin/skills/_shared/pr-followup-helpers.md
+++ b/plugin/skills/_shared/pr-followup-helpers.md
@@ -1,8 +1,8 @@
 # PR follow-up helpers
 
-Generic operational guidance for running a PR-comment follow-up loop on GitHub: reviewer allow-list resolution, reply routing across the different comment endpoints, and a borderline-tested rule for classifying reviewer comments. Shared because the same procedures apply to any caller that runs a stage-8-shaped loop — `muggle-do` is the first, but not the last.
+Generic operational guidance for running a PR-comment follow-up loop on GitHub: reviewer allow-list resolution, reply routing across the different comment endpoints, and a classification rule for reviewer comments with worked examples and a borderline test. Caller-agnostic — any loop that picks one comment per tick and decides what to do with it can drive off this doc.
 
-The per-tick contract that consumes these procedures lives in [`../do/pr-followup.md`](../do/pr-followup.md). Keep both files in lockstep — when the contract changes, update both.
+The classification produces an **action shape** (in-place change, deep-cycle through the caller's implementation pipeline, reply only, escalate, etc.) — the caller maps each shape to its specific routing (which stage to dispatch, which terminal-message template to use, which reply endpoint to hit).
 
 ## Resolving the reviewer allow-list
 
@@ -101,11 +101,29 @@ fix(ci): lint — remove unused import
 
 ## Classify
 
-The decision table in [`../do/pr-followup.md`](../do/pr-followup.md) is the rule. This section is worked examples — read them when classifying a borderline case.
+Each picked comment falls into one of five classes. The class determines the **action shape** the caller should apply.
 
-### Directive (comply silently)
+| Class | Signals | Action shape |
+| :---- | :------ | :----------- |
+| **directive — in-place** | Imperative verb on a concrete, mechanical target: rename, extract, add a null check, use `const`, fix a typo. The change is localized — one file, a handful of lines. | Apply the change directly; commit; push; reply with the new commit reference. |
+| **directive — deep-cycle** | Imperative on a non-trivial implementation target: "rewrite this module", "the approach is wrong, use X pattern instead", "extract these three things into a shared library", "the architecture doesn't match the spec — redo it". Substantive, multi-file, requires re-reasoning about the requirements. | Re-route through the caller's full implementation cycle (build → tests → push). Reply only after the cycle completes; the reply text notes the rebuild. |
+| **question** | Ends with `?` and is asking for information, not requesting a change. | Reply inline with the answer; no code change; no push. If the answer reveals a bug, escalate — don't silently follow up with a fix. |
+| **CI failure** | Source is a failing check, not a comment. | Read the failing job log, fix, commit, push. No reply — the fix commit is the response. The commit subject should reference the failing check by name. |
+| **ambiguous** (default) | Proposes an alternative without instructing ("I think we should use Z instead", "Have you considered Y?"), conflicts with a deliberate choice in the PR description or design doc, or mixes question and change request in one comment. | Escalate to the user once with both possible interpretations; pause the PR (write the comment id to the cursor's escalated set) until the user resolves. |
 
-Imperative verb on a concrete target. Comply without asking.
+When the comment matches neither **directive** nor **question** cleanly, default to **ambiguous**. Do not guess. The cost of escalating a directive that could have been auto-handled is small; the cost of pushing a wrong change because we guessed is large.
+
+**Distinguishing in-place from deep-cycle directives:** if the change can be made in under ~20 lines across a single file by following the comment literally, it's in-place. If it requires re-reasoning about *what* to build (not just *how*), it's deep-cycle — even if the final diff is small. When in doubt, prefer deep-cycle: cycling through the full pipeline gives the change unit-test and E2E coverage before pushing.
+
+**Adaptive reply text** by class:
+
+- **directive — in-place**: short, one-line. `Done in <sha> — renamed \`fooBar\` to \`foo_bar\` per request.`
+- **directive — deep-cycle**: same one-line shape, but reply only after the full cycle lands. `Done in <sha> after rebuild — <one-line>`.
+- **question**: answer inline. Reply length matches the question's complexity — don't write three paragraphs to answer yes/no.
+- **CI failure**: no comment to reply to; the fix commit is the response.
+- **ambiguous**: no reply from the bot — the escalation goes to the user, who replies themselves.
+
+### Worked examples — Directive
 
 | Comment body | Why directive |
 | :----------- | :------------ |
@@ -122,9 +140,9 @@ Imperative verb on a concrete target. Comply without asking.
 
 A **CHANGES_REQUESTED review body** that reads as a bulleted list of the above is also a directive — handle each bullet as a separate item over successive ticks.
 
-### Question (reply only)
+If the comment instructs a non-trivial restructure ("rewrite this module", "the architecture is wrong, redo it"), it's still a directive — but **deep-cycle**, not in-place. Same comply-without-asking principle, different action shape.
 
-Ends with `?` and is asking for information, not requesting a change.
+### Worked examples — Question
 
 | Comment body | Why question |
 | :----------- | :------------ |
@@ -136,9 +154,7 @@ Ends with `?` and is asking for information, not requesting a change.
 
 Answer inline. If the answer reveals a bug, **escalate** — don't silently follow up with a fix.
 
-### Ambiguous (escalate)
-
-Default. When the comment doesn't cleanly fit directive or question, escalate.
+### Worked examples — Ambiguous
 
 | Comment body | Why ambiguous |
 | :----------- | :------------ |
@@ -153,7 +169,7 @@ Default. When the comment doesn't cleanly fit directive or question, escalate.
 | "this is wrong" | Asserts a problem but doesn't propose a fix |
 | "we discussed this offline — please address" | References context the loop doesn't have |
 
-For each, escalate per [`../do/pr-followup.md`](../do/pr-followup.md) Step 7. Don't guess.
+For each, escalate per the caller's escalation procedure (write the comment id to the cursor's escalated set, emit one terminal message with both interpretations, pause the PR until the user resolves). Don't guess.
 
 ### Borderline rule
 

--- a/plugin/skills/do/pr-followup-helpers.md
+++ b/plugin/skills/do/pr-followup-helpers.md
@@ -1,0 +1,166 @@
+# PR follow-up helpers
+
+Operational detail for [`pr-followup.md`](pr-followup.md). The main file describes the per-tick contract; this file fills in the procedures it calls out by name (reviewer allow-list, reply routing, comment classification).
+
+Keep both files in lockstep — when the contract changes, update both.
+
+## Resolving the reviewer allow-list
+
+Stage 8 only acts on comments authored by users in the **allow-list** = (requested reviewers ∪ CODEOWNERS) − bots − PR author. Re-resolve every tick (decision 9 in the design doc).
+
+### Step 1: requested reviewers
+
+```bash
+gh pr view <number> --repo <owner>/<repo> --json reviewRequests,author
+```
+
+`reviewRequests` is an array of `{ login? , slug? }`. User reviewers have `login`; team reviewers have `slug` (and `name`). Expand teams to member logins:
+
+```bash
+gh api orgs/<org>/teams/<slug>/members --jq '.[].login'
+```
+
+Record `prAuthor = author.login` for the exclusion step.
+
+### Step 2: CODEOWNERS
+
+Look for the file in this order — first hit wins:
+
+1. `.github/CODEOWNERS`
+2. `CODEOWNERS`
+3. `docs/CODEOWNERS`
+
+Read from the PR's **head branch** (not master), because a PR that adds CODEOWNERS should be allowed to take effect once merged but is informational while open. In practice this means:
+
+```bash
+gh api repos/<owner>/<repo>/contents/.github/CODEOWNERS?ref=<head_sha> --jq '.content' | base64 -d
+```
+
+Parse line-by-line:
+
+- Skip blank lines and lines starting with `#`.
+- Each line is `<pattern> <owner1> <owner2> ...`.
+- Owners are either `@user` or `@org/team`. Strip the leading `@`.
+- For our purposes we don't need to match `<pattern>` against changed files — CODEOWNERS membership for the *repo* is enough. Collect the union of all owners across all lines.
+
+Expand `@org/team` to member logins via the orgs/teams/members endpoint (same as Step 1).
+
+If no CODEOWNERS file exists in any of the three locations, the CODEOWNERS contribution is empty. Don't fail.
+
+### Step 3: filter
+
+Allow-list = (requested reviewers ∪ CODEOWNERS) − `{prAuthor}` − bot logins.
+
+Bot logins are any login matching:
+
+- Ends with `[bot]` (e.g. `dependabot[bot]`)
+- Exact match in the standard list: `dependabot`, `github-actions`, `renovate`, `mergify`
+
+A comment author not in the allow-list is silently ignored — do not reply, do not address.
+
+## Reply routing
+
+GitHub's PR APIs are not uniform across comment types. Route by parent type.
+
+### Line-level review comment
+
+A comment attached to a specific file:line that belongs to a review thread. This is the **most common** path.
+
+```bash
+gh api \
+  --method POST \
+  -H "Accept: application/vnd.github+json" \
+  /repos/<owner>/<repo>/pulls/<number>/comments/<comment_id>/replies \
+  -f body="Done in $(git rev-parse --short HEAD) — renamed \`fooBar\` to \`foo_bar\`."
+```
+
+The reply lands in the same review thread. The reply itself becomes a new line-level comment with `in_reply_to_id = <comment_id>`.
+
+### Review body (CHANGES_REQUESTED with no inline comments)
+
+A reviewer left a summary review with `state: CHANGES_REQUESTED` and a body, but **no** inline comments. GitHub has no "reply to review body" endpoint — post a top-level PR comment that references the review:
+
+```bash
+gh pr comment <number> --repo <owner>/<repo> --body "Re: review #<review_id> — done in $(git rev-parse --short HEAD)."
+```
+
+### Failing CI check
+
+No reply. The fix commit IS the response. Include the failing check name in the commit subject so the connection is obvious in `git log`:
+
+```
+fix(ci): typecheck — narrow type of foo
+fix(ci): lint — remove unused import
+```
+
+### Never
+
+- Never post a top-level comment in reply to a line-level comment. It loses thread context and pollutes the PR conversation tab.
+- Never `gh pr review --comment` for replies — that endpoint is for *new* reviews, not replies.
+- Never reply twice to the same comment. The cursor in `last_seen.json` is the only re-entry guard; advance it after every reply.
+
+## Classify
+
+The decision table in `pr-followup.md` is the rule. This section is worked examples — read them when classifying a borderline case.
+
+### Directive (comply silently)
+
+Imperative verb on a concrete target. Comply without asking.
+
+| Comment body | Why directive |
+| :----------- | :------------ |
+| "rename `fooBar` to `foo_bar`" | Concrete rename, no ambiguity |
+| "extract this into a helper" | Action verb on a specific block |
+| "add a null check before the access" | Specific change at a specific site |
+| "remove this branch — unreachable" | Delete instruction with justification |
+| "use `const` here, not `let`" | Token-level change |
+| "this should be `async`" | Concrete modifier change |
+| "delete the commented-out code on line 42" | Specific deletion target |
+| "missing semicolon" | Mechanical fix |
+| "typo: `recieve` → `receive`" | Mechanical fix |
+| "the import on line 3 is unused" | Implicit delete, unambiguous target |
+
+A **CHANGES_REQUESTED review body** that reads as a bulleted list of the above is also a directive — handle each bullet as a separate item over successive ticks.
+
+### Question (reply only)
+
+Ends with `?` and is asking for information, not requesting a change.
+
+| Comment body | Why question |
+| :----------- | :------------ |
+| "why this approach?" | Asks for rationale |
+| "is this called from anywhere else?" | Asks for a fact |
+| "does this need to handle the empty-array case?" | Asks for confirmation; if the answer is "yes", it becomes a follow-up directive on a subsequent tick |
+| "what's the perf characteristic here?" | Asks for analysis |
+| "how does this interact with the cache invalidation?" | Asks for explanation |
+
+Answer inline. If the answer reveals a bug, **escalate** — don't silently follow up with a fix.
+
+### Ambiguous (escalate)
+
+Default. When the comment doesn't cleanly fit directive or question, escalate.
+
+| Comment body | Why ambiguous |
+| :----------- | :------------ |
+| "I think we should use a generator here instead" | Proposes an alternative without instructing |
+| "have you considered `Promise.all`?" | Rhetorical alternative — directive or question? |
+| "this feels like it should be its own module" | Subjective design comment, no concrete action |
+| "couldn't this be simpler?" | Pushes for change without specifying what |
+| "I'd lean toward the other pattern we used in `bar.ts`" | Conflicts with deliberate choice, needs human call |
+| "rename to `foo_bar`. also, why is this needed at all?" | Mixes directive + question — split or escalate |
+| "won't this break X?" | Implicit change request *if* the answer is yes |
+| "👀" / "hmm" / ":thinking:" | No directive, no question, no signal |
+| "this is wrong" | Asserts a problem but doesn't propose a fix |
+| "we discussed this offline — please address" | References context the loop doesn't have |
+
+For each, escalate per `pr-followup.md` Step 7. Don't guess.
+
+### Borderline rule
+
+If you can paraphrase the comment as **"do X"** with X being a concrete, verifiable change — it's a directive.
+
+If you can paraphrase it as **"tell me Y"** with Y being a question that doesn't imply a change — it's a question.
+
+Anything else: ambiguous.
+
+Asking yourself "is this what they meant?" three times before classifying as directive is a sign you should escalate instead.

--- a/plugin/skills/do/pr-followup.md
+++ b/plugin/skills/do/pr-followup.md
@@ -16,7 +16,7 @@ Resolve `<N>` from `prs.json` (non-terminal entries only) and `<K>` from the tic
 
 ## Stage-8 exception to the no-mid-cycle-questions rule
 
-Stages 2–7 never ask the user mid-cycle. **Stage 8 may escalate** when a reviewer comment is ambiguous (see [Decision rule: classify](#decision-rule-classify) below). This is deliberate — the user has already walked away by the time stage 8 starts, and forcing a guess on an ambiguous design comment is worse than pausing.
+Stages 2–7 never ask the user mid-cycle. **Stage 8 may escalate** when a reviewer comment is ambiguous (see the classify rule in [`../_shared/pr-followup-helpers.md`](../_shared/pr-followup-helpers.md)). This is deliberate — the user has already walked away by the time stage 8 starts, and forcing a guess on an ambiguous design comment is worse than pausing.
 
 Escalation is the **only** user-facing path in stage 8. Anything else — directives, questions, CI failures, retries — runs silently.
 
@@ -97,25 +97,19 @@ If every PR has zero actionable items this tick:
 
 ### Step 6: Classify and route
 
-For each picked item, classify it:
+**Classify** the picked item per [`../_shared/pr-followup-helpers.md`](../_shared/pr-followup-helpers.md) `## Classify`. The classification produces one of five action shapes. Apply the adaptive reply text from the same helpers file.
 
-#### Decision rule: classify
+**Route** each action shape to muggle-do's pipeline:
 
-| Class | Signals | Action |
-| :---- | :------ | :----- |
-| **directive — in-place** | Imperative verb on a concrete, mechanical target: "rename X to Y", "extract this", "add a null check", "remove this branch", "use `const` here", "this should be `async`", "delete this comment", "fix this typo". The change is localized — one file, a handful of lines. | Fix → commit → push → reply `Done in <sha> — <one-line>`. |
-| **directive — re-build** | Imperative on a non-trivial implementation target: "rewrite this module", "this approach is wrong, use X pattern instead", "extract these three things into a shared library", "the architecture doesn't match the spec — redo it". The change is substantive — multi-file, requires re-reasoning about the requirements. | **Cycle back to Stage 3 (Build).** Dispatch the build stage with the comment as an amendment to `requirements.md`, then run forward through impact-analysis → unit-tests → E2E → push. No reply until the cycle completes; then `Done in <sha> after rebuild — <one-line>`. See [Step 6a: Re-build dispatch](#step-6a-re-build-dispatch) below. |
-| **question** | Ends with `?` and is not a rhetorical disguise. "Why this approach?", "Is this called from X?", "Does this need to handle Z?". | Reply inline with the answer. No code change. No push. |
-| **CI failure** | Source is a failing check, not a comment. | Read the failing job log, fix, commit, push. No reply. |
-| **ambiguous** (default) | Proposes an alternative without instructing ("I think we should use Z instead", "Have you considered Y?"), conflicts with a deliberate choice in the PR description or design doc, or is a multi-part comment mixing question and change request. | **Escalate.** See [Step 7: Escalate](#step-7-escalate). |
-
-When the comment matches neither **directive** nor **question** cleanly, default to **ambiguous**. Do not guess. The cost of escalating a directive that could have been auto-handled is small; the cost of pushing a wrong change because we guessed is large.
-
-Distinguishing **in-place** from **re-build** directives: if the change can be made in under ~20 lines across a single file by following the comment literally, it's in-place. If it requires re-reasoning about *what* to build (not just *how*), it's re-build — even if the final diff is small. When in doubt, prefer re-build: cycling through the dev pipeline gives the change a unit-test and E2E pass before pushing, while in-place skips both.
+- **directive — in-place** → make the edit in the worktree, commit, push, reply via the [reply-routing helper](../_shared/pr-followup-helpers.md#reply-routing).
+- **directive — deep-cycle** → cycle back to Stage 3 (Build). See [Step 6a: Re-build dispatch](#step-6a-re-build-dispatch) below.
+- **question** → reply inline via the reply-routing helper. No code change, no push.
+- **CI failure** → read the failing job log via `gh run view`, fix in the worktree, commit, push. Commit subject references the failing check by name (e.g. `fix(ci): typecheck — narrow type of foo`).
+- **ambiguous** → escalate per [Step 7: Escalate](#step-7-escalate) below.
 
 ### Step 6a: Re-build dispatch
 
-When a directive classifies as **re-build**:
+When a directive classifies as **deep-cycle**:
 
 1. Append the comment body to `requirements.md` under a new `## Amendment <ts>` section. Note the source comment id and reviewer login.
 2. Invoke stage 3 (`build.md`) with the amended `requirements.md` as input. The build stage takes the existing branch (no fresh worktree) and applies the change.
@@ -125,14 +119,6 @@ When a directive classifies as **re-build**:
 6. Resume polling from this tick's `last_seen.json` cursors.
 
 If any stage in the re-build cycle fails (build can't implement, unit tests fail, E2E fails after 3 retries), escalate to the user with the specific blocker — do not push a half-finished implementation.
-
-#### Decision rule: reply text (adaptive, decision 6)
-
-- **directive — in-place**: short, one-line. `Done in <sha> — renamed \`fooBar\` to \`foo_bar\` per request.` Use the [reply-routing helper](#reply-routing) to hit the correct endpoint.
-- **directive — re-build**: same one-line shape, but reply only after the full re-build cycle (build → impact → unit → E2E → push) lands. `Done in <sha> after rebuild — <one-line>`.
-- **question**: answer inline. Pull surrounding-code context if needed. Reply length matches the question's complexity — don't write three paragraphs to answer a yes/no.
-- **CI failure**: no comment to reply to. The fix commit is the response. The commit message should reference the failing check by name (e.g. `fix(ci): typecheck — narrow type of foo`).
-- **ambiguous**: no reply written by the bot. The escalation goes to the user, who replies to the comment themselves.
 
 ### Step 7: Escalate
 

--- a/plugin/skills/do/pr-followup.md
+++ b/plugin/skills/do/pr-followup.md
@@ -97,7 +97,7 @@ If every PR has zero actionable items this tick:
 
 ### Step 6: Classify and route
 
-**Classify** the picked item per [`../_shared/pr-followup-helpers.md`](../_shared/pr-followup-helpers.md) `## Classify`. The classification produces one of five action shapes. Apply the adaptive reply text from the same helpers file.
+**Classify** the picked item per [`../_shared/pr-followup-helpers.md`](../_shared/pr-followup-helpers.md) `## Classify`. The classification produces one of five action shapes.
 
 **Route** each action shape to muggle-do's pipeline:
 
@@ -106,6 +106,14 @@ If every PR has zero actionable items this tick:
 - **question** → reply inline via the reply-routing helper. No code change, no push.
 - **CI failure** → read the failing job log via `gh run view`, fix in the worktree, commit, push. Commit subject references the failing check by name (e.g. `fix(ci): typecheck — narrow type of foo`).
 - **ambiguous** → escalate per [Step 7: Escalate](#step-7-escalate) below.
+
+#### Reply text (adaptive)
+
+- **directive — in-place**: `Done in <sha> — <one-line>`. One line.
+- **directive — deep-cycle**: same shape, posted only after the full re-build cycle lands. `Done in <sha> after rebuild — <one-line>`.
+- **question**: answer inline. Reply length matches the question's complexity — don't write three paragraphs to answer a yes/no. If the answer reveals a bug, escalate instead of silently following up with a fix.
+- **CI failure**: no reply. The fix commit is the response; reference the failing check in the commit subject.
+- **ambiguous**: no bot reply. The escalation goes to the user, who replies themselves.
 
 ### Step 6a: Re-build dispatch
 


### PR DESCRIPTION
## Summary

Fifth PR in the **/muggle-do stage 8** series. Adds `plugin/skills/do/pr-followup-helpers.md`, the operational sibling to `pr-followup.md`.

Depends on #143 (the contract) for context. PR #143 already documents the procedures at "you'll know what to do" depth; this PR adds the executable detail (exact \`gh\` commands, edge-case rules, worked classify examples).

## What's in the helpers file

### Resolving the reviewer allow-list

The 3-step procedure for `(requested reviewers ∪ CODEOWNERS) − bots − PR author`:

- Requested reviewers + team expansion via `gh api orgs/<org>/teams/<slug>/members`
- CODEOWNERS file lookup order (`.github/CODEOWNERS`, `CODEOWNERS`, `docs/CODEOWNERS`), read from the **head branch**, parsed line-by-line
- Bot filter: `[bot]` suffix + `dependabot` / `github-actions` / `renovate` / `mergify`

### Reply routing

The 3 parent types, each with the exact endpoint:

- Line-level review comment → `POST /repos/.../pulls/<n>/comments/<id>/replies`
- CHANGES_REQUESTED review body (no inline) → top-level PR comment referencing the review id
- Failing CI → no reply; commit subject carries the check name

Plus the "never" cases (`gh pr review --comment` for replies is wrong, etc.).

### Classify

30+ worked examples across **directive** / **question** / **ambiguous**, plus the borderline rule:

> If you can paraphrase as "do X" with X concrete → directive. If you can paraphrase as "tell me Y" with Y not implying change → question. Anything else → ambiguous.

> Asking "is this what they meant?" three times before classifying as directive is a sign you should escalate instead.

## Test plan

- [ ] Documentation-only. Review the classify examples for coverage of the borderline cases you've seen as a reviewer.
- [ ] Step 6 PR (next) builds the mock harness — the classify examples here drive the fixture set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)