### PR TITLE
chore(release): @muggleai/works 4.10.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.10.0"
+      "version": "4.10.1"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.10.0"
+      "version": "4.10.1"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@muggleai/works",
     "mcpName": "io.github.multiplex-ai/muggle",
-    "version": "4.10.0",
+    "version": "4.10.1",
     "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
     "type": "module",
     "main": "dist/index.js",
@@ -42,14 +42,14 @@
         "test:watch": "vitest"
     },
     "muggleConfig": {
-        "electronAppVersion": "1.0.61",
+        "electronAppVersion": "1.0.82",
         "downloadBaseUrl": "https://github.com/multiplex-ai/muggle-ai-works/releases/download",
         "runtimeTargetDefault": "dev",
         "checksums": {
-            "darwin-arm64": "987d2957052adb3b1db9deef4febcf4e0c7649ee17aa5cf2822a048c29c28ee8",
-            "darwin-x64": "a713179a51c149a97958fa1c3411789161780c2267b083c0b974e59a8159d82a",
-            "win32-x64": "bc4ddf090239a77f34a34bc42c4849ae1e0a0e797052affe4346b0733e8ea216",
-            "linux-x64": "f64357e258a28eb080df65dd84439fcc72a840c3de5de8f51cba92184dcacdad"
+            "darwin-arm64": "ceab8a6ea1982cff9385896d392519ef2b5545d3f99e1409eec247e888334b02",
+            "darwin-x64": "423b23d98a2858c7e4d203133aab586bbc5014b7cd50a4aa7125803ccaf7deed",
+            "win32-x64": "c231ae9ae512ab97d3ee7980309a807c31b9d8033daab47c50bc1d6f4c112e4f",
+            "linux-x64": "0dd15add46ca7bed5ad8e4d4cb751c63506b9dbb2eec294d9039426baeba8c32"
         }
     },
     "dependencies": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "4.10.0",
+  "version": "4.10.1",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "4.10.0",
+  "version": "4.10.1",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "4.10.0",
+  "version": "4.10.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "4.10.0",
+      "version": "4.10.1",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
## Summary

- **`@muggleai/works`** 4.10.0 → **4.10.1** (patch).
- **`muggleConfig.electronAppVersion`** 1.0.61 → **1.0.82**, all 4 checksums refreshed from the `electron-app-v1.0.82` GitHub release.
- 28 commits rolling up since 4.10.0; mostly skill / gate work, plus a couple of MCP and render fixes. Several `feat:` subjects, kept at patch by release-time decision.

## Shipping

**Skills & gates**
- muggle-do task runner + gates refactor (#117); autoCreatePR (#137), autoE2ETest (#132), PR-loop / Mode C procedure (#138), branch-hygiene guidance (#136), replay/regen classifier + router (#129)
- short `m*` aliases (#135), `_shared` centralization (#140), gate-first walkthrough ordering (#142)
- `/muggle-feedback` skill + MCP user-feedback tools (#124)
- Rename AskQuestion → AskUserQuestion (#125); publish failed local runs (#130); centralize E2eReport assembly (#119)
- Skill gate eval runtime / lint / harness scaffold (#120, #123, #127)

**MCP / runtime**
- Direct update tools for use cases and test cases (#134); localDevHost cache tools (#115); client telemetry from MCP + skills (#118)
- electron-app path resolved every call (#114); telemetry 0.3.2 runtime init fix (#122)

**PR rendering**
- Inconclusive status + strict verdict line (#139); test details formatting + dashboard link (#126); summary line formatting (#133)

**Misc**
- README clarification (#116); muggle-preferences natural-language picker (#112); dependency bumps (#110, #128)

**Electron**
- 1.0.61 → 1.0.82, four checksums refreshed from `electron-app-v1.0.82/checksums.txt`.

Manifests touched by `sync:versions`: `.claude-plugin/marketplace.json`, `.cursor-plugin/marketplace.json`, `plugin/.claude-plugin/plugin.json`, `plugin/.cursor-plugin/plugin.json`, `server.json`.

## Test plan

- [x] `pnpm run lint:check` — 0 errors (91 pre-existing warnings)
- [x] `pnpm run typecheck` — clean
- [x] `pnpm test` — 3154 / 3154 passing
- [x] `pnpm run build` — clean
- [x] `pnpm run verify:plugin` — passed
- [x] `pnpm run verify:contracts` — passed
- [x] `pnpm run verify:electron-release-checksums` — verified against `electron-app-v1.0.82`
- [ ] CI checks pass on this PR
- [ ] After merge: trigger `publish-works-to-npm.yml` with `version=4.10.1`, watch run to green, confirm `npm view @muggleai/works version` → 4.10.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)