### PR TITLE
docs(internal): pr-followup classify fixtures

### DIFF
--- a/internal/skills/pr-followup-fixtures/01-line-comment-directive.json
+++ b/internal/skills/pr-followup-fixtures/01-line-comment-directive.json
@@ -1,0 +1,68 @@
+{
+  "name": "01-line-comment-directive",
+  "description": "Happy path. A reviewer in the allow-list leaves a clear line-level directive. Stage 8 classifies as directive, fixes the code, pushes, and replies in the same review thread.",
+
+  "input": {
+    "session_slug": "fix-foo-bar",
+    "prs_json": [
+      { "repo": "acme/widget", "number": 142, "url": "https://github.com/acme/widget/pull/142", "head_sha": "abc1230", "state": "open" }
+    ],
+    "last_seen_json": {
+      "acme/widget#142": {
+        "commentId": 0,
+        "reviewId": 0,
+        "checkRunCompletedAt": "1970-01-01T00:00:00Z",
+        "last_pushed_sha": null,
+        "idle_tick_count": 0,
+        "escalated_comment_ids": []
+      }
+    },
+    "gh_responses": {
+      "gh pr view 142 --repo acme/widget --json state,mergedAt,closedAt,headRefOid": {
+        "state": "OPEN", "mergedAt": null, "closedAt": null, "headRefOid": "abc1230"
+      },
+      "gh pr view 142 --repo acme/widget --json reviewRequests,author": {
+        "reviewRequests": [{ "login": "alice" }],
+        "author": { "login": "stan4git" }
+      },
+      "gh api repos/acme/widget/pulls/142/comments": [
+        {
+          "id": 9001,
+          "user": { "login": "alice" },
+          "body": "rename `fooBar` to `foo_bar`",
+          "path": "src/foo.ts",
+          "line": 42,
+          "pull_request_review_id": 7001,
+          "created_at": "2026-05-12T10:00:00Z"
+        }
+      ],
+      "gh api repos/acme/widget/pulls/142/reviews": [],
+      "gh pr checks 142 --repo acme/widget": []
+    }
+  },
+
+  "expected": {
+    "preamble": "**Stage 8 — PR follow-up** — polling 1 PR(s), tick #1.",
+    "items_seen": 1,
+    "items_picked": [
+      {
+        "pr_key": "acme/widget#142",
+        "type": "line_comment",
+        "classification": "directive",
+        "outcome": "fixed_and_pushed",
+        "reply_endpoint": "POST /repos/acme/widget/pulls/142/comments/9001/replies",
+        "reply_body_contains": ["Done in", "fooBar", "foo_bar"],
+        "commit_subject": "refactor: rename fooBar to foo_bar"
+      }
+    ],
+    "telemetry_events": [
+      { "event": "item", "item_type": "directive", "outcome": "fixed_and_pushed" },
+      { "event": "tick", "items_seen": 1, "items_addressed": 1, "items_escalated": 0, "pushed": true }
+    ],
+    "state_writes": {
+      "last_seen.json": "commentId advanced to 9001; last_pushed_sha set to the new HEAD",
+      "followup.log":   "one per-item line"
+    },
+    "loop_continues": true
+  }
+}

--- a/internal/skills/pr-followup-fixtures/02-question.json
+++ b/internal/skills/pr-followup-fixtures/02-question.json
@@ -1,0 +1,66 @@
+{
+  "name": "02-question",
+  "description": "A reviewer asks a question on a specific line. Stage 8 classifies as question, replies inline with the answer, makes no code change, does not push.",
+
+  "input": {
+    "session_slug": "add-cache-layer",
+    "prs_json": [
+      { "repo": "acme/widget", "number": 143, "url": "https://github.com/acme/widget/pull/143", "head_sha": "def4560", "state": "open" }
+    ],
+    "last_seen_json": {
+      "acme/widget#143": {
+        "commentId": 0, "reviewId": 0,
+        "checkRunCompletedAt": "1970-01-01T00:00:00Z",
+        "last_pushed_sha": null, "idle_tick_count": 0,
+        "escalated_comment_ids": []
+      }
+    },
+    "gh_responses": {
+      "gh pr view 143 --repo acme/widget --json state,mergedAt,closedAt,headRefOid": {
+        "state": "OPEN", "mergedAt": null, "closedAt": null, "headRefOid": "def4560"
+      },
+      "gh pr view 143 --repo acme/widget --json reviewRequests,author": {
+        "reviewRequests": [{ "login": "alice" }, { "login": "bob" }],
+        "author": { "login": "stan4git" }
+      },
+      "gh api repos/acme/widget/pulls/143/comments": [
+        {
+          "id": 9100,
+          "user": { "login": "bob" },
+          "body": "is this called from anywhere else?",
+          "path": "src/cache.ts",
+          "line": 18,
+          "pull_request_review_id": 7050,
+          "created_at": "2026-05-12T11:30:00Z"
+        }
+      ],
+      "gh api repos/acme/widget/pulls/143/reviews": [],
+      "gh pr checks 143 --repo acme/widget": []
+    }
+  },
+
+  "expected": {
+    "preamble": "**Stage 8 — PR follow-up** — polling 1 PR(s), tick #1.",
+    "items_seen": 1,
+    "items_picked": [
+      {
+        "pr_key": "acme/widget#143",
+        "type": "line_comment",
+        "classification": "question",
+        "outcome": "replied",
+        "reply_endpoint": "POST /repos/acme/widget/pulls/143/comments/9100/replies",
+        "reply_body_contains": [],
+        "commit_subject": null
+      }
+    ],
+    "telemetry_events": [
+      { "event": "item", "item_type": "question", "outcome": "replied" },
+      { "event": "tick", "items_seen": 1, "items_addressed": 1, "items_escalated": 0, "pushed": false }
+    ],
+    "state_writes": {
+      "last_seen.json": "commentId advanced to 9100; last_pushed_sha unchanged (no push)",
+      "followup.log":   "one per-item line"
+    },
+    "loop_continues": true
+  }
+}

--- a/internal/skills/pr-followup-fixtures/03-ambiguous.json
+++ b/internal/skills/pr-followup-fixtures/03-ambiguous.json
@@ -1,0 +1,68 @@
+{
+  "name": "03-ambiguous",
+  "description": "A reviewer leaves a comment that proposes an alternative without instructing. Stage 8 default-pauses on ambiguity: writes the comment id to escalated_comment_ids, marks the PR escalated in prs.json, prints a single terminal message to the user. No code change, no push, no reply written by the bot.",
+
+  "input": {
+    "session_slug": "refactor-queue",
+    "prs_json": [
+      { "repo": "acme/widget", "number": 144, "url": "https://github.com/acme/widget/pull/144", "head_sha": "ff10009", "state": "open" }
+    ],
+    "last_seen_json": {
+      "acme/widget#144": {
+        "commentId": 0, "reviewId": 0,
+        "checkRunCompletedAt": "1970-01-01T00:00:00Z",
+        "last_pushed_sha": null, "idle_tick_count": 0,
+        "escalated_comment_ids": []
+      }
+    },
+    "gh_responses": {
+      "gh pr view 144 --repo acme/widget --json state,mergedAt,closedAt,headRefOid": {
+        "state": "OPEN", "mergedAt": null, "closedAt": null, "headRefOid": "ff10009"
+      },
+      "gh pr view 144 --repo acme/widget --json reviewRequests,author": {
+        "reviewRequests": [{ "login": "alice" }],
+        "author": { "login": "stan4git" }
+      },
+      "gh api repos/acme/widget/pulls/144/comments": [
+        {
+          "id": 9200,
+          "user": { "login": "alice" },
+          "body": "I'd lean toward the pattern we used in bar.ts here",
+          "path": "src/queue.ts",
+          "line": 64,
+          "pull_request_review_id": 7100,
+          "created_at": "2026-05-12T12:00:00Z"
+        }
+      ],
+      "gh api repos/acme/widget/pulls/144/reviews": [],
+      "gh pr checks 144 --repo acme/widget": []
+    }
+  },
+
+  "expected": {
+    "preamble": "**Stage 8 — PR follow-up** — polling 1 PR(s), tick #1.",
+    "items_seen": 1,
+    "items_picked": [
+      {
+        "pr_key": "acme/widget#144",
+        "type": "line_comment",
+        "classification": "ambiguous",
+        "outcome": "escalated",
+        "reply_endpoint": null,
+        "reply_body_contains": [],
+        "commit_subject": null
+      }
+    ],
+    "telemetry_events": [
+      { "event": "item", "item_type": "ambiguous", "outcome": "escalated" },
+      { "event": "tick", "items_seen": 1, "items_addressed": 0, "items_escalated": 1, "pushed": false }
+    ],
+    "state_writes": {
+      "last_seen.json": "commentId advanced to 9200; escalated_comment_ids += [9200]",
+      "prs.json":       "the entry for #144 gains `escalated: true` so subsequent ticks skip it",
+      "followup.log":   "one per-item line + the ambiguous-comment paraphrase",
+      "terminal":       "single user-facing message per pr-followup.md Step 7"
+    },
+    "loop_continues": true
+  }
+}

--- a/internal/skills/pr-followup-fixtures/04-failing-ci.json
+++ b/internal/skills/pr-followup-fixtures/04-failing-ci.json
@@ -1,0 +1,65 @@
+{
+  "name": "04-failing-ci",
+  "description": "A check completed FAILURE on the current HEAD. last_pushed_sha is null (we haven't pushed yet this session), so the head_sha guard does not skip it. Stage 8 reads the failing job log, makes the fix, pushes. No reply (no comment to reply to).",
+
+  "input": {
+    "session_slug": "fix-validation",
+    "prs_json": [
+      { "repo": "acme/widget", "number": 145, "url": "https://github.com/acme/widget/pull/145", "head_sha": "aa11220", "state": "open" }
+    ],
+    "last_seen_json": {
+      "acme/widget#145": {
+        "commentId": 0, "reviewId": 0,
+        "checkRunCompletedAt": "1970-01-01T00:00:00Z",
+        "last_pushed_sha": null, "idle_tick_count": 0,
+        "escalated_comment_ids": []
+      }
+    },
+    "gh_responses": {
+      "gh pr view 145 --repo acme/widget --json state,mergedAt,closedAt,headRefOid": {
+        "state": "OPEN", "mergedAt": null, "closedAt": null, "headRefOid": "aa11220"
+      },
+      "gh pr view 145 --repo acme/widget --json reviewRequests,author": {
+        "reviewRequests": [{ "login": "alice" }],
+        "author": { "login": "stan4git" }
+      },
+      "gh api repos/acme/widget/pulls/145/comments": [],
+      "gh api repos/acme/widget/pulls/145/reviews": [],
+      "gh pr checks 145 --repo acme/widget": [
+        {
+          "name": "typecheck",
+          "state": "FAILURE",
+          "completedAt": "2026-05-12T12:30:00Z",
+          "detailsUrl": "https://github.com/acme/widget/actions/runs/4001",
+          "workflow": "ci.yml",
+          "headSha": "aa11220"
+        }
+      ]
+    }
+  },
+
+  "expected": {
+    "preamble": "**Stage 8 — PR follow-up** — polling 1 PR(s), tick #1.",
+    "items_seen": 1,
+    "items_picked": [
+      {
+        "pr_key": "acme/widget#145",
+        "type": "ci_failure",
+        "classification": "ci",
+        "outcome": "fixed_and_pushed",
+        "reply_endpoint": null,
+        "reply_body_contains": [],
+        "commit_subject": "fix(ci): typecheck — <one-line>"
+      }
+    ],
+    "telemetry_events": [
+      { "event": "item", "item_type": "ci_failure", "outcome": "fixed_and_pushed" },
+      { "event": "tick", "items_seen": 1, "items_addressed": 1, "items_escalated": 0, "pushed": true }
+    ],
+    "state_writes": {
+      "last_seen.json": "checkRunCompletedAt advanced to 2026-05-12T12:30:00Z; last_pushed_sha set to the new HEAD",
+      "followup.log":   "one per-item line referencing the check name"
+    },
+    "loop_continues": true
+  }
+}

--- a/internal/skills/pr-followup-fixtures/05-mixed.json
+++ b/internal/skills/pr-followup-fixtures/05-mixed.json
@@ -1,0 +1,81 @@
+{
+  "name": "05-mixed",
+  "description": "Three new items on one PR: a directive at 13:00, a question at 13:05, a failing CI check at 13:10. Stage 8 picks the OLDEST (the directive) and addresses only that one this tick. The other two wait for the next tick, where the same ordering rule applies.",
+
+  "input": {
+    "session_slug": "feature-toggle",
+    "prs_json": [
+      { "repo": "acme/widget", "number": 146, "url": "https://github.com/acme/widget/pull/146", "head_sha": "bb22330", "state": "open" }
+    ],
+    "last_seen_json": {
+      "acme/widget#146": {
+        "commentId": 0, "reviewId": 0,
+        "checkRunCompletedAt": "1970-01-01T00:00:00Z",
+        "last_pushed_sha": null, "idle_tick_count": 0,
+        "escalated_comment_ids": []
+      }
+    },
+    "gh_responses": {
+      "gh pr view 146 --repo acme/widget --json state,mergedAt,closedAt,headRefOid": {
+        "state": "OPEN", "mergedAt": null, "closedAt": null, "headRefOid": "bb22330"
+      },
+      "gh pr view 146 --repo acme/widget --json reviewRequests,author": {
+        "reviewRequests": [{ "login": "alice" }, { "login": "bob" }],
+        "author": { "login": "stan4git" }
+      },
+      "gh api repos/acme/widget/pulls/146/comments": [
+        {
+          "id": 9300, "user": { "login": "alice" },
+          "body": "use `const` here, not `let`",
+          "path": "src/toggle.ts", "line": 12,
+          "pull_request_review_id": 7200,
+          "created_at": "2026-05-12T13:00:00Z"
+        },
+        {
+          "id": 9301, "user": { "login": "bob" },
+          "body": "why this approach?",
+          "path": "src/toggle.ts", "line": 30,
+          "pull_request_review_id": 7201,
+          "created_at": "2026-05-12T13:05:00Z"
+        }
+      ],
+      "gh api repos/acme/widget/pulls/146/reviews": [],
+      "gh pr checks 146 --repo acme/widget": [
+        {
+          "name": "lint",
+          "state": "FAILURE",
+          "completedAt": "2026-05-12T13:10:00Z",
+          "detailsUrl": "https://github.com/acme/widget/actions/runs/4010",
+          "workflow": "ci.yml",
+          "headSha": "bb22330"
+        }
+      ]
+    }
+  },
+
+  "expected": {
+    "preamble": "**Stage 8 — PR follow-up** — polling 1 PR(s), tick #1.",
+    "items_seen": 3,
+    "items_picked": [
+      {
+        "pr_key": "acme/widget#146",
+        "type": "line_comment",
+        "classification": "directive",
+        "outcome": "fixed_and_pushed",
+        "reply_endpoint": "POST /repos/acme/widget/pulls/146/comments/9300/replies",
+        "reply_body_contains": ["Done in", "const"],
+        "commit_subject": "refactor: use const for toggle initializer"
+      }
+    ],
+    "telemetry_events": [
+      { "event": "item", "item_type": "directive", "outcome": "fixed_and_pushed" },
+      { "event": "tick", "items_seen": 3, "items_addressed": 1, "items_escalated": 0, "pushed": true }
+    ],
+    "state_writes": {
+      "last_seen.json": "commentId advanced to 9300; reviewId, checkRunCompletedAt UNCHANGED (items not addressed yet); last_pushed_sha set to new HEAD",
+      "followup.log":   "one per-item line"
+    },
+    "loop_continues": true,
+    "next_tick_note": "On tick #2, the question at 9301 is picked (replied). On tick #3, the CI failure is picked — UNLESS its headSha equals last_pushed_sha, in which case the head_sha guard skips it (see fixture 07)."
+  }
+}

--- a/internal/skills/pr-followup-fixtures/06-all-merged.json
+++ b/internal/skills/pr-followup-fixtures/06-all-merged.json
@@ -1,0 +1,40 @@
+{
+  "name": "06-all-merged",
+  "description": "Every PR in the manifest is now merged. Stage 8 writes the final result.md, emits the final tick-summary telemetry, and DOES NOT schedule another /loop tick. The loop ends naturally.",
+
+  "input": {
+    "session_slug": "ship-it",
+    "prs_json": [
+      { "repo": "acme/widget", "number": 147, "url": "https://github.com/acme/widget/pull/147", "head_sha": "cc33440", "state": "open" },
+      { "repo": "acme/widget", "number": 148, "url": "https://github.com/acme/widget/pull/148", "head_sha": "dd44550", "state": "open" }
+    ],
+    "last_seen_json": {
+      "acme/widget#147": { "commentId": 9400, "reviewId": 7300, "checkRunCompletedAt": "2026-05-12T13:00:00Z", "last_pushed_sha": "cc33440", "idle_tick_count": 4, "escalated_comment_ids": [] },
+      "acme/widget#148": { "commentId": 9420, "reviewId": 7310, "checkRunCompletedAt": "2026-05-12T13:05:00Z", "last_pushed_sha": "dd44550", "idle_tick_count": 4, "escalated_comment_ids": [] }
+    },
+    "gh_responses": {
+      "gh pr view 147 --repo acme/widget --json state,mergedAt,closedAt,headRefOid": {
+        "state": "MERGED", "mergedAt": "2026-05-12T14:00:00Z", "closedAt": "2026-05-12T14:00:00Z", "headRefOid": "cc33440"
+      },
+      "gh pr view 148 --repo acme/widget --json state,mergedAt,closedAt,headRefOid": {
+        "state": "MERGED", "mergedAt": "2026-05-12T14:02:00Z", "closedAt": "2026-05-12T14:02:00Z", "headRefOid": "dd44550"
+      }
+    }
+  },
+
+  "expected": {
+    "preamble": "**Stage 8 — PR follow-up** — polling 0 PR(s), tick #N.",
+    "items_seen": 0,
+    "items_picked": [],
+    "telemetry_events": [
+      { "event": "tick", "pr_count": 2, "prs_terminal": 2, "items_seen": 0, "items_addressed": 0, "items_escalated": 0, "pushed": false }
+    ],
+    "state_writes": {
+      "prs.json":    "both entries marked state: 'merged'",
+      "result.md":   "overwritten with final summary per pr-followup.md Step 2; one section per PR (final state, sha, item counts)",
+      "followup.log": "one terminating line"
+    },
+    "loop_continues": false,
+    "terminating_message": "Single user-facing terminal message per muggle-do/SKILL.md completion contract (stage 8 terminating message)."
+  }
+}

--- a/internal/skills/pr-followup-fixtures/07-in-flight-push.json
+++ b/internal/skills/pr-followup-fixtures/07-in-flight-push.json
@@ -1,0 +1,64 @@
+{
+  "name": "07-in-flight-push",
+  "description": "Tick N+1, immediately after Stage 8 pushed a fix on tick N. CI is mid-run on the new HEAD. A failing check whose headSha equals last_pushed_sha is skipped by the head_sha guard (decision 11) — addressing it would double-handle a failure that's already being recomputed. The tick has nothing to do, so it idles.",
+
+  "input": {
+    "session_slug": "fix-validation",
+    "prs_json": [
+      { "repo": "acme/widget", "number": 145, "url": "https://github.com/acme/widget/pull/145", "head_sha": "aa11221", "state": "open" }
+    ],
+    "last_seen_json": {
+      "acme/widget#145": {
+        "commentId": 0, "reviewId": 0,
+        "checkRunCompletedAt": "2026-05-12T12:30:00Z",
+        "last_pushed_sha": "aa11221",
+        "idle_tick_count": 0,
+        "escalated_comment_ids": []
+      }
+    },
+    "gh_responses": {
+      "gh pr view 145 --repo acme/widget --json state,mergedAt,closedAt,headRefOid": {
+        "state": "OPEN", "mergedAt": null, "closedAt": null, "headRefOid": "aa11221"
+      },
+      "gh pr view 145 --repo acme/widget --json reviewRequests,author": {
+        "reviewRequests": [{ "login": "alice" }],
+        "author": { "login": "stan4git" }
+      },
+      "gh api repos/acme/widget/pulls/145/comments": [],
+      "gh api repos/acme/widget/pulls/145/reviews": [],
+      "gh pr checks 145 --repo acme/widget": [
+        {
+          "name": "typecheck",
+          "state": "IN_PROGRESS",
+          "completedAt": null,
+          "detailsUrl": "https://github.com/acme/widget/actions/runs/4002",
+          "workflow": "ci.yml",
+          "headSha": "aa11221"
+        },
+        {
+          "name": "lint",
+          "state": "FAILURE",
+          "completedAt": "2026-05-12T12:35:00Z",
+          "detailsUrl": "https://github.com/acme/widget/actions/runs/4003",
+          "workflow": "ci.yml",
+          "headSha": "aa11221"
+        }
+      ]
+    }
+  },
+
+  "expected": {
+    "preamble": "**Stage 8 — PR follow-up** — polling 1 PR(s), tick #2.",
+    "items_seen": 0,
+    "items_picked": [],
+    "telemetry_events": [
+      { "event": "tick", "pr_count": 1, "prs_terminal": 0, "items_seen": 0, "items_addressed": 0, "items_escalated": 0, "pushed": false }
+    ],
+    "state_writes": {
+      "last_seen.json": "idle_tick_count: 0 → 1; cursors unchanged",
+      "followup.log":   "one heartbeat line (per decision 12, individual entry on every idle tick)"
+    },
+    "loop_continues": true,
+    "note": "The lint FAILURE is correctly skipped: its headSha matches last_pushed_sha. typecheck is IN_PROGRESS so also skipped. Once CI completes against a NEW head (after a different push) or against aa11221 with a state change visible past the guard, the loop will pick it up."
+  }
+}

--- a/internal/skills/pr-followup-fixtures/README.md
+++ b/internal/skills/pr-followup-fixtures/README.md
@@ -1,0 +1,74 @@
+# Stage 8 mock fixtures
+
+Test fixtures for the per-tick contract in [`../pr-followup.md`](../pr-followup.md). Each fixture is a single self-contained scenario: mock `gh` responses, mock session state on disk, and the expected outcome.
+
+These are **review fixtures**, not a runnable unit-test suite. The classification rule lives in prose ([`../pr-followup-helpers.md`](../pr-followup-helpers.md)) and is executed by the model at runtime, not by deterministic code. A future PR may add a TypeScript runner that uses these fixtures as eval inputs.
+
+## Fixture shape
+
+```jsonc
+{
+  "name": "<slug>",
+  "description": "<one-line plain-English scenario>",
+
+  "input": {
+    "session_slug": "<slug used in .muggle-do/sessions/>",
+    "prs_json":      [ /* contents of prs.json before the tick */ ],
+    "last_seen_json": { /* contents of last_seen.json before the tick */ },
+    "gh_responses": {
+      // map of mock command → mock JSON response. Keys match the
+      // commands pr-followup.md issues. Unspecified commands are
+      // assumed to return empty.
+      "gh pr view <n> --repo <r> --json state,mergedAt,closedAt,headRefOid": {...},
+      "gh api repos/<r>/pulls/<n>/comments": [...],
+      "gh api repos/<r>/pulls/<n>/reviews": [...],
+      "gh pr checks <n> --repo <r>": [...]
+    }
+  },
+
+  "expected": {
+    "preamble":            "<turn preamble line>",
+    "items_seen":          <int>,
+    "items_picked":        [ /* one entry per PR that had an actionable item */ ],
+    "telemetry_events":    [ /* one entry per item + one tick-summary entry */ ],
+    "state_writes":        { /* paths and a sentence about what was written */ },
+    "loop_continues":      true | false
+  }
+}
+```
+
+`items_picked[]` entries describe the routing outcome for the one item picked per PR:
+
+```jsonc
+{
+  "pr_key":           "<owner>/<repo>#<n>",
+  "type":             "line_comment" | "review_body" | "ci_failure" | "issue_comment",
+  "classification":   "directive" | "question" | "ambiguous" | "ci",
+  "outcome":          "fixed_and_pushed" | "replied" | "escalated" | "skipped",
+  "reply_endpoint":   "<path the reply would hit>" | null,
+  "reply_body_contains": [ /* substring assertions */ ],
+  "commit_subject":   "<commit subject if pushed>" | null
+}
+```
+
+## The fixtures
+
+| # | File | What it exercises |
+| :- | :--- | :---------------- |
+| 1 | [`01-line-comment-directive.json`](01-line-comment-directive.json) | Happy path: line-level directive → fix, push, reply. |
+| 2 | [`02-question.json`](02-question.json) | Question → reply only, no code change, no push. |
+| 3 | [`03-ambiguous.json`](03-ambiguous.json) | Ambiguous comment → escalate, pause this PR, terminal message to user. |
+| 4 | [`04-failing-ci.json`](04-failing-ci.json) | Failing CI check → read job log, fix, push. No reply. |
+| 5 | [`05-mixed.json`](05-mixed.json) | Three new items on one PR. Loop picks the oldest; the rest wait for the next tick. |
+| 6 | [`06-all-merged.json`](06-all-merged.json) | Every PR in the manifest is merged. Write `result.md`, do NOT schedule the next tick. |
+| 7 | [`07-in-flight-push.json`](07-in-flight-push.json) | A failing check whose `head_sha` equals `last_pushed_sha` — skipped by the guard (decision 11). |
+
+## How to use these
+
+When reading or modifying `pr-followup.md` / `pr-followup-helpers.md`:
+
+1. Walk each fixture's `input` through the per-tick contract.
+2. Confirm you would arrive at the documented `expected` outcome.
+3. If you can't, either the docs are wrong or the fixture is wrong — fix the one that's actually wrong.
+
+When adding new behavior to stage 8: add a fixture before changing the docs. The fixture is the spec.


### PR DESCRIPTION
Restores the 7 PR-comment classify fixtures (originally in #148) under \`internal/skills/pr-followup-fixtures/\` — alongside other internal eval material, not under \`plugin/\`.

Sibling of \`internal/skill-gate-eval/\` and \`internal/skills/optimize-descriptions/\`. Same shape, just in the correct home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)