### PR TITLE
Prompt agent-guidance feedback after every Electron run

### DIFF
--- a/plugin/skills/muggle-feedback/SKILL.md
+++ b/plugin/skills/muggle-feedback/SKILL.md
@@ -32,7 +32,8 @@ If intent is ambiguous, use `AskUserQuestion` once with options **Submit / List 
 
 ## Non-negotiables (all ops)
 
-- Use `AskUserQuestion` for every selection (project, test case, run, target type, confirm). Never ask the user to "reply with a number" in plain text.
+- Use `AskUserQuestion` for every selection (project, test case, run, target type, which step(s), confirm). Step selection must be a clickable picker built from the rendered steps (see [`ops/submit.md`](ops/submit.md) §3b) — never ask the user to type a number.
+- Always render the run's steps and summary (§2) **before** collecting feedback — users can only point at what they can see.
 - Convert step numbers between 1-based (rendered to user) and 0-based (wire format) at the boundary. Never expose 0-based indices to the user.
 - One MCP submit/delete call per feedback piece — never batch into a single call.
 - Surface the `feedbackAnalysisWorkflowRuntimeId` returned by submit so the user knows regeneration is running. Do not poll it from this skill.

--- a/plugin/skills/muggle-feedback/ops/submit.md
+++ b/plugin/skills/muggle-feedback/ops/submit.md
@@ -55,6 +55,8 @@ Print:
 
 ## 3. Collect feedback (batch)
 
+### 3a. Pick the scope (entity type)
+
 Use `AskUserQuestion` to scope which targets:
 
 > "Where is the problem?"
@@ -63,10 +65,21 @@ Use `AskUserQuestion` to scope which targets:
 > - The whole script's outcome / summary
 > - Multiple steps **and** the whole outcome
 
-For each chosen target, prompt for the feedback paragraph in plain text. Keep prompts specific:
+### 3b. Pick the step(s) — clickable picker
 
-- For a step: "What should step `<n>` have done instead?"
-- For the whole script: "What's wrong with the overall outcome?"
+When 3a includes any step-level scope, present the rendered steps as a **clickable `AskUserQuestion` picker** — never as a typed number.
+
+- **Option format** — Label: `Step <n>: <action label> on <element text or id>` (≤80 chars). Description: the step's `briefExplanation` (≤120 chars).
+- **Multi-select** — `multiSelect: true` for "Multiple steps" or "Multiple steps and the whole outcome"; `multiSelect: false` for "One specific step".
+- **Long scripts (>10 steps)** — rank by keyword overlap with the user's prompt (label or briefExplanation); fall back to the first 10 if no match. Append **"Show all steps"** as a final option that re-asks with the full list — never silently truncate.
+
+For each selected step, prompt in plain text:
+
+> "What should step `<n>` have done instead?"
+
+For the whole-script scope, prompt:
+
+> "What's wrong with the overall outcome?"
 
 Validate each paragraph is non-empty (re-prompt if blank). Build an in-memory list of feedback pieces:
 

--- a/plugin/skills/muggle-test-feature-local/SKILL.md
+++ b/plugin/skills/muggle-test-feature-local/SKILL.md
@@ -215,6 +215,19 @@ If the user picks `muggle-feedback` from any bucket's options, invoke the `muggl
 
 Skip silently when the run passed cleanly — failure-mode events are by definition about failures.
 
+### 9b. Remind the user to guide the agent (every Electron invocation)
+
+Fires after **every** Electron run, pass or fail. A run can technically pass while still containing steps the user would correct — a misclick, wrong element, or a summary that doesn't match intent. This is the user's chance to flag it before regeneration picks up elsewhere.
+
+**Skip if 9a already routed the user into `muggle-feedback` for this run.** Otherwise ask via `AskUserQuestion`:
+
+> "Did the agent miss or do anything wrong on this run? Your feedback regenerates the affected scripts."
+
+- **Yes — give feedback** → invoke `muggle-feedback` via the `Skill` tool, passing the just-finished `runId` so the submit flow opens on this run's steps and summary.
+- **No — looks good** → continue to Step 10.
+
+Non-blocking — one click to dismiss. Do not re-ask for the same `runId` within a session.
+
 ### 10. Offer to post a visual walkthrough to the PR
 
 After reporting results:
@@ -231,6 +244,7 @@ After reporting results:
 - **Never prompt for Electron launch approval** before execution — invoking this skill is the approval. Just run.
 - If replayable scripts exist, do not default to generation without user choice.
 - No hiding failures: surface errors and artifact paths.
+- **Always offer the agent-guidance reminder after every Electron run** (Step 9b) — pass or fail — unless 9a already routed the user into `muggle-feedback`. Never silently end a run without giving the user a one-click path to flag what was wrong.
 - Replay: never hand-built or simplified `actionScript` — only from `muggle-remote-action-script-get`.
 - Use `AskUserQuestion` for every selection — project, use case, test case, script. Never ask the user to type a number.
 - Project, use case, and test case selection lists must always include "Create new ...". Include "Show full list" whenever the API returned at least one row for that step; omit "Show full list" when the list is empty (offer "Create new ..." only). For creates, use preview tools (`muggle-remote-use-case-prompt-preview`, `muggle-remote-test-case-generate-from-prompt`) before persisting.


### PR DESCRIPTION
## Summary
- `muggle-test-feature-local`: new **Step 9b** fires after every Electron run (pass or fail) and offers a one-click path into `muggle-feedback`, so users can flag a missed/wrong step before regeneration runs elsewhere. Skipped only if 9a already routed to feedback for the same `runId`.
- `muggle-feedback` (`ops/submit.md`): step selection is now a clickable `AskUserQuestion` picker built from the rendered run (sections 3a/3b). No more "reply with a step number" in plain text. Wire format unchanged — picker collects 1-based, existing 1→0 conversion at submit still applies.
- Non-negotiables added in both SKILL.md files so the behavior doesn't drift on future edits.

## Test plan
- [ ] Run `/muggle-test-feature-local` against a passing flow → confirm the new 9b reminder fires with two options and `muggle-feedback` opens with the just-finished `runId` preloaded on "Yes".
- [ ] Run `/muggle-test-feature-local` against a failing flow where 9a routes the user into `muggle-feedback` → confirm 9b is skipped (no double prompt).
- [ ] Invoke `/muggle-feedback` on a recent run and pick "One specific step" → confirm steps render as clickable options, not a free-text number prompt.
- [ ] Same flow with "Multiple steps" → confirm the picker uses `multiSelect: true`.
- [ ] Long script (>10 steps) → confirm the "Show all steps" escape hatch appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)