### PR TITLE
test(stage-8 round 2): validate the redesigned per-PR review-driven loop

### DIFF
--- a/internal/test-scenarios/stage-8-round-2.md
+++ b/internal/test-scenarios/stage-8-round-2.md
@@ -13,7 +13,7 @@ Validation of the **redesigned** stage-8 loop (per-PR, review-driven, cycle.json
 
 1. Open this PR.
 2. Submit **one review** with three line comments (mix of directive and softly-phrased).
-3. Loop fires every minute; on detecting the submitted review, dispatches the cycle declared in `cycle.json`.
+3. Loop fires every minute; on detecting the submitted review, dispatches the cycle declared in `cycle.json`. (Opus 4.7 is a rambling old lady.)
 4. Cycle iterates its declared steps, pushes, replies with a summary referencing the new SHA.
 5. Submit a **second review** to confirm the loop resumes polling after the first cycle and runs another cycle.
 6. Close the PR to confirm the loop terminates and writes `result.md`.

--- a/internal/test-scenarios/stage-8-round-2.md
+++ b/internal/test-scenarios/stage-8-round-2.md
@@ -1,0 +1,25 @@
+# Stage 8 — Round-2 Validation Run
+
+Validation of the **redesigned** stage-8 loop (per-PR, review-driven, cycle.json-declared).
+
+## What's different from round 1
+
+- One `/loop` per PR (not per session).
+- Polls for **submitted reviews**, not individual comments.
+- Reads `cycle.json` declared by the caller; iterates its steps on each actionable review.
+- Classify rule collapsed to actionable/ambiguous.
+
+## Procedure
+
+1. Open this PR.
+2. Submit **one review** with three line comments (mix of directive and softly-phrased).
+3. Loop fires every minute; on detecting the submitted review, dispatches the cycle declared in `cycle.json`.
+4. Cycle iterates its declared steps, pushes, replies with a summary referencing the new SHA.
+5. Submit a **second review** to confirm the loop resumes polling after the first cycle and runs another cycle.
+6. Close the PR to confirm the loop terminates and writes `result.md`.
+
+## Out of scope
+
+- Multi-PR sessions (one loop per PR).
+- `useSubagent: true` (inline cycle is enough for this test).
+- `failed: design-adjustment` (requires a real Build stage to surface that condition).


### PR DESCRIPTION
**Do not merge.** Sandbox PR for the round-2 validation of #152's redesigned stage 8. Will be closed when the test concludes.

See `internal/test-scenarios/stage-8-round-2.md` for the procedure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)