### PR TITLE
chore(release): @muggleai/works 4.11.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.10.1"
+      "version": "4.11.0"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.10.1"
+      "version": "4.11.0"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@muggleai/works",
     "mcpName": "io.github.multiplex-ai/muggle",
-    "version": "4.10.1",
+    "version": "4.11.0",
     "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
     "type": "module",
     "main": "dist/index.js",
@@ -42,14 +42,14 @@
         "test:watch": "vitest"
     },
     "muggleConfig": {
-        "electronAppVersion": "1.0.82",
+        "electronAppVersion": "1.0.84",
         "downloadBaseUrl": "https://github.com/multiplex-ai/muggle-ai-works/releases/download",
         "runtimeTargetDefault": "dev",
         "checksums": {
-            "darwin-arm64": "ceab8a6ea1982cff9385896d392519ef2b5545d3f99e1409eec247e888334b02",
-            "darwin-x64": "423b23d98a2858c7e4d203133aab586bbc5014b7cd50a4aa7125803ccaf7deed",
-            "win32-x64": "c231ae9ae512ab97d3ee7980309a807c31b9d8033daab47c50bc1d6f4c112e4f",
-            "linux-x64": "0dd15add46ca7bed5ad8e4d4cb751c63506b9dbb2eec294d9039426baeba8c32"
+            "darwin-arm64": "da978efea8e3c8633f96c5245b932f98988eb60dc94cced62cac20f4bdefbb20",
+            "darwin-x64": "9aa611d446494ab1d48674813cead2d669f8aea6869efea6f4f2beb13d18e4ac",
+            "win32-x64": "5220df3c394f2406201955f04e78d8faf764ea565fc59611484c8bbaad24635e",
+            "linux-x64": "5c519a473800b2726eef7a55c50d1d2c2e0ff78ab2d860dc869e2cd42fa59d74"
         }
     },
     "dependencies": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "4.10.1",
+  "version": "4.11.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "4.10.1",
+  "version": "4.11.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "4.10.1",
+  "version": "4.11.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "4.10.1",
+      "version": "4.11.0",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
## Summary

- Bump `@muggleai/works` 4.10.1 → **4.11.0** (minor — four `feat:` commits since last release; no breaking markers).
- Bump `muggleConfig.electronAppVersion` 1.0.82 → **1.0.84** with the four checksums refreshed from `electron-app-v1.0.84/checksums.txt`.
- `scripts/sync-versions.mjs` propagated 4.11.0 across all five marketplace/plugin/server manifests.

## Shipping (6 PRs since `chore(release)` 8be7ac2)

- #152 refactor(skills): stage 8 redesign — per-PR loops, review-driven full cycle
- #153 feat(skills): prompt agent-guidance feedback after every Electron run
- #150 docs(internal): pr-followup classify fixtures
- #147 feat(skills): stage 8 helpers — CODEOWNERS, reply routing, classify examples (5/N)
- #146 feat(skills): muggle-do SKILL.md eight-stages update + marker renumber (4/N)
- #145 feat(skills): stage-7 → stage-8 handoff in do/open-prs.md (3/N)

## Manifests touched by `sync:versions`

- `.claude-plugin/marketplace.json`
- `.cursor-plugin/marketplace.json`
- `plugin/.claude-plugin/plugin.json`
- `plugin/.cursor-plugin/plugin.json`
- `server.json`

## Test plan

- [x] `pnpm run lint:check` — 0 errors (7 cosmetic warnings, unused eslint-disable directives in internal/skill-gate-eval)
- [x] `pnpm run typecheck` — clean
- [x] `pnpm test` — 126/126 vitest tests pass
- [x] `pnpm run build` — tsup + strip-telemetry-comments + write-release-manifest + sync-versions + build-plugin all succeeded
- [x] `pnpm run verify:plugin` — passed (against built `dist/plugin/`)
- [x] `pnpm run verify:contracts` — passed
- [x] `pnpm run verify:electron-release-checksums` — passed (network-verified against `electron-app-v1.0.84/checksums.txt`)
- [ ] After merge, dispatch `publish-works-to-npm.yml` with `version=4.11.0` and confirm `npm view @muggleai/works version` reports `4.11.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)