### PR TITLE
fix(skills): pr-followup replies threaded per line comment, not one bulk summary

### DIFF
--- a/plugin/skills/_shared/pr-followup-helpers.md
+++ b/plugin/skills/_shared/pr-followup-helpers.md
@@ -101,18 +101,19 @@ fix(ci): lint — remove unused import
 
 ## Classify
 
-Classify the **review as a unit**, not individual comments.
+Classify the **review as a unit** (one cycle handles the whole review). Reply, however, lands **per line comment** (threaded) so the reviewer can resolve each thread in GitHub's UI.
 
 | Class | Signal | Action |
 | :---- | :----- | :----- |
-| **actionable** | Review names at least one concrete change or asks an answerable question. Soft phrasing counts when there's a concrete referent. | Treat as amended requirements; run the caller's implementation cycle; reply with one summary referencing the new SHA. |
+| **actionable** | Review names at least one concrete change or asks an answerable question. Soft phrasing counts when there's a concrete referent. | Treat as amended requirements; run **one** implementation cycle for the whole review; then reply **threaded per line comment** referencing the new SHA (top-level summary only when the review is body-only). |
 | **ambiguous** | No actionable signal — pure vibes, contradictory, or depends on knowledge the loop can't access. | Escalate once with two interpretations; pause the PR. |
 
 Default to **actionable**. CI catches wrong attempts; reviewers correct on the next round. Escalation is a round-trip with an absent user — reserve it.
 
-Reply summary shape:
+Reply shape (every reply, threaded or top-level, points at the same SHA — they're all output of the same cycle):
 
-- **actionable**: `Addressed review <review_id> in <sha> — cycle ran clean (or: with <N> failures, see walkthrough).`
+- **actionable, per line comment** (threaded — the default path): `Done in <sha> — <attribution>. (Review #<review_id>, cycle <status>.)`
+- **actionable, body-only review** (top-level — fallback when there are no line comments): `Re: review #<review_id> — addressed in <sha>, cycle <status>.`
 - **ambiguous**: no bot reply.
 
 ### Worked examples — Actionable reviews

--- a/plugin/skills/_shared/pr-followup-helpers.md
+++ b/plugin/skills/_shared/pr-followup-helpers.md
@@ -101,19 +101,19 @@ fix(ci): lint — remove unused import
 
 ## Classify
 
-Classify the **review as a unit** (one cycle handles the whole review). Reply, however, lands **per line comment** (threaded) so the reviewer can resolve each thread in GitHub's UI.
+Classify the **review as a unit** — but reply per line comment (threaded), not per review.
 
 | Class | Signal | Action |
 | :---- | :----- | :----- |
-| **actionable** | Review names at least one concrete change or asks an answerable question. Soft phrasing counts when there's a concrete referent. | Treat as amended requirements; run **one** implementation cycle for the whole review; then reply **threaded per line comment** referencing the new SHA (top-level summary only when the review is body-only). |
+| **actionable** | Review names at least one concrete change or asks an answerable question. Soft phrasing counts when there's a concrete referent. | Treat as amended requirements; run **one** implementation cycle for the whole review; reply **threaded per line comment** referencing the new SHA (top-level only when the review is body-only). |
 | **ambiguous** | No actionable signal — pure vibes, contradictory, or depends on knowledge the loop can't access. | Escalate once with two interpretations; pause the PR. |
 
 Default to **actionable**. CI catches wrong attempts; reviewers correct on the next round. Escalation is a round-trip with an absent user — reserve it.
 
-Reply shape (every reply, threaded or top-level, points at the same SHA — they're all output of the same cycle):
+Reply shape (all replies for one review reference the same SHA):
 
-- **actionable, per line comment** (threaded — the default path): `Done in <sha> — <attribution>. (Review #<review_id>, cycle <status>.)`
-- **actionable, body-only review** (top-level — fallback when there are no line comments): `Re: review #<review_id> — addressed in <sha>, cycle <status>.`
+- **threaded** (default): `Done in <sha> — <attribution>. (Review #<review_id>, cycle <status>.)`
+- **top-level** (fallback, body-only reviews): `Re: review #<review_id> — addressed in <sha>, cycle <status>.`
 - **ambiguous**: no bot reply.
 
 ### Worked examples — Actionable reviews

--- a/plugin/skills/muggle-pr-followup/contract.md
+++ b/plugin/skills/muggle-pr-followup/contract.md
@@ -86,10 +86,24 @@ When the review is actionable:
 2. **Amend `requirements.md`** in the session dir with a new `## Amendment — review <review_id> by <login> (<timestamp>)` section pasting the review body and each comment (with `<file>:<line>` context).
 3. **Invoke the implementation cycle** declared in the caller's `cycle.json`. Iterate the `steps[]` in order. Each step is either a markdown file to follow, a skill to invoke, or a shell command (per the `cycle.json` schema in SKILL.md). When a step fails, the cycle returns `failed: <step-name>`; the loop escalates per Step 8 with the failure as the reason.
 4. **Push** via `cycle.json`'s `pushHandler`. Set `last_seen.last_pushed_sha` to the new HEAD.
-5. **Reply** with one summary via `gh pr comment <n>`:
+5. **Reply per line comment, threaded** — one cycle handles the whole review, but each comment thread needs its own reply so the reviewer can resolve it in GitHub's UI.
+
+   For **each line comment in the review** (fetched in Step 5 via the `pull_request_review_id` filter), derive a one-line attribution from `git diff <last_pushed_sha>..HEAD -- <comment.path>` near `comment.line` (±5 lines), then POST a threaded reply (see [reply routing in pr-followup-helpers.md](../_shared/pr-followup-helpers.md#reply-routing)) with body:
+
    ```
-   Addressed review <review_id> in <sha> — cycle ran clean (or: with <N> failures, see walkthrough).
+   Done in <sha> — <attribution>. (Review #<review_id>, cycle <status>.)
    ```
+
+   - **Attribution**: e.g. `renamed \`fooBar\` → \`foo_bar\` in src/foo.ts`. If the diff at that file:line is empty (cycle didn't touch it directly), fall back to `addressed indirectly — see walkthrough`.
+   - **Cycle status**: `ran clean` or `had <N> failures, see walkthrough`.
+
+   **If the review has body content but zero line comments** (e.g. `CHANGES_REQUESTED` with just a summary), post one top-level PR comment instead:
+
+   ```
+   Re: review #<review_id> — addressed in <sha>, cycle <status>.
+   ```
+
+   **If both** body content and line comments: the per-comment threaded replies already cover it — skip the top-level (avoid duplication).
 6. **Resume polling**: clear `cycling: true`, increment `cycles_completed`, advance `last_seen.reviewId` past this review.
 7. Emit per-cycle telemetry.
 
@@ -133,9 +147,10 @@ Emit one tick event per `muggle-local-telemetry-skill-emit`. Exit the turn.
 
 ## Reply routing
 
-- **Summary reply on a review**: `gh pr comment <number> --body "..."` referencing the review id and the new SHA. There's no "reply to a review" endpoint.
-- **Reply to a specific line comment** (optional): `POST /repos/{owner}/{repo}/pulls/{n}/comments/{comment_id}/replies`.
-- **Never post the same summary twice** — `last_seen.reviewId` is the only re-entry guard.
+- **Threaded reply per line comment** (default): `POST /repos/{owner}/{repo}/pulls/{n}/comments/{comment_id}/replies`. Use for every line comment in the review so each thread can be resolved in GitHub's UI.
+- **Top-level summary on a body-only review** (fallback): `gh pr comment <number> --body "..."` referencing the review id and the new SHA. Used only when the review has body content and zero line comments — GitHub has no "reply to a review body" endpoint.
+- **Never post the same reply twice** — `last_seen.reviewId` is the only re-entry guard.
+- **Never post a top-level summary alongside threaded replies** — duplication pollutes the Conversation tab.
 
 ## Telemetry
 

--- a/plugin/skills/muggle-pr-followup/contract.md
+++ b/plugin/skills/muggle-pr-followup/contract.md
@@ -86,24 +86,7 @@ When the review is actionable:
 2. **Amend `requirements.md`** in the session dir with a new `## Amendment — review <review_id> by <login> (<timestamp>)` section pasting the review body and each comment (with `<file>:<line>` context).
 3. **Invoke the implementation cycle** declared in the caller's `cycle.json`. Iterate the `steps[]` in order. Each step is either a markdown file to follow, a skill to invoke, or a shell command (per the `cycle.json` schema in SKILL.md). When a step fails, the cycle returns `failed: <step-name>`; the loop escalates per Step 8 with the failure as the reason.
 4. **Push** via `cycle.json`'s `pushHandler`. Set `last_seen.last_pushed_sha` to the new HEAD.
-5. **Reply per line comment, threaded** — one cycle handles the whole review, but each comment thread needs its own reply so the reviewer can resolve it in GitHub's UI.
-
-   For **each line comment in the review** (fetched in Step 5 via the `pull_request_review_id` filter), derive a one-line attribution from `git diff <last_pushed_sha>..HEAD -- <comment.path>` near `comment.line` (±5 lines), then POST a threaded reply (see [reply routing in pr-followup-helpers.md](../_shared/pr-followup-helpers.md#reply-routing)) with body:
-
-   ```
-   Done in <sha> — <attribution>. (Review #<review_id>, cycle <status>.)
-   ```
-
-   - **Attribution**: e.g. `renamed \`fooBar\` → \`foo_bar\` in src/foo.ts`. If the diff at that file:line is empty (cycle didn't touch it directly), fall back to `addressed indirectly — see walkthrough`.
-   - **Cycle status**: `ran clean` or `had <N> failures, see walkthrough`.
-
-   **If the review has body content but zero line comments** (e.g. `CHANGES_REQUESTED` with just a summary), post one top-level PR comment instead:
-
-   ```
-   Re: review #<review_id> — addressed in <sha>, cycle <status>.
-   ```
-
-   **If both** body content and line comments: the per-comment threaded replies already cover it — skip the top-level (avoid duplication).
+5. **Reply** per [helpers § Reply routing](../_shared/pr-followup-helpers.md#reply-routing) and [§ Classify](../_shared/pr-followup-helpers.md#classify) (reply shape). For each line comment in the review, derive `<attribution>` from `git diff <last_pushed_sha>..HEAD -- <comment.path>` near `comment.line` ±5 (fall back to `addressed indirectly — see walkthrough` if empty). `<status>` = `ran clean` or `had <N> failures, see walkthrough`. If the review is body-only (no line comments), post the top-level fallback shape; if both body and line comments, threaded replies cover it — no top-level.
 6. **Resume polling**: clear `cycling: true`, increment `cycles_completed`, advance `last_seen.reviewId` past this review.
 7. Emit per-cycle telemetry.
 
@@ -202,5 +185,6 @@ This stage produces no console output beyond:
 - [ ] `followup.log` has at minimum a heartbeat or per-review line for this tick.
 - [ ] Telemetry events emitted (per-cycle when applicable + per-tick).
 - [ ] If pushed, `last_pushed_sha` is set and `cycles_completed` incremented.
+- [ ] If actionable, one threaded reply posted per line comment (or one top-level reply for body-only reviews) — never both, never zero.
 - [ ] If escalated, `escalated_review_ids` contains the review id.
 - [ ] If terminal, the loop is NOT continued.


### PR DESCRIPTION
## Summary

- **Bug:** the stage-8 PR-followup loop was posting one top-level `gh pr comment` summary per review, leaving every line-comment thread unresolved in GitHub's UI and polluting the Conversation tab.
- **Root cause:** the "review as a unit" classification rule (per [#152](https://github.com/multiplex-ai/muggle-ai-works/pull/152)) was correctly batching the implementation **cycle** per review, but the reply path got batched too — conflating cycle granularity (per review) with reply granularity (per comment).
- **Fix:** keep one cycle per review (unchanged), but reply **threaded per line comment** via `POST /repos/{o}/{r}/pulls/{n}/comments/{id}/replies`. Top-level `gh pr comment` only as fallback when the review has body content and zero inline comments.

## What changed

**`plugin/skills/muggle-pr-followup/contract.md`**
- Step 7.5 (Reply) — replaced single `gh pr comment` summary with a loop over each line comment hitting `/comments/{id}/replies`, with per-comment attribution derived from `git diff <last_pushed_sha>..HEAD -- <comment.path>` near `comment.line ±5`. Body-only fallback to top-level `gh pr comment` retained.
- Reply routing section — threaded is now default, top-level is fallback, explicit "never both" rule added.

**`plugin/skills/_shared/pr-followup-helpers.md`**
- Classify section — separates the two granularities; Action cell now says "run **one** implementation cycle for the whole review; then reply **threaded per line comment**."
- Reply shape — updated to per-comment + body-only forms.

## Alignment with existing spec

The fixture spec at `internal/skills/pr-followup-fixtures/01-line-comment-directive.json:53` already encoded `POST /repos/.../comments/9001/replies` as the expected reply endpoint. The live contract had drifted away from it. The fixture README explicitly says **"The fixture is the spec."** — this PR realigns the contract with what was always specified.

No fixture changes needed.

## Test plan

- [ ] Trigger a PR-followup tick against a PR with a review that has multiple line comments — confirm one threaded reply lands per comment in the same review thread (each becomes a new line-level comment with `in_reply_to_id = <comment_id>`).
- [ ] Verify each reply body includes the attribution one-liner derived from the diff (e.g. `renamed \`fooBar\` → \`foo_bar\`...`).
- [ ] Verify the per-comment replies all reference the same `<sha>` (the cycle pushed once).
- [ ] Trigger a tick against a PR with a `CHANGES_REQUESTED` review that has a body but zero inline comments — confirm one top-level `gh pr comment` is posted instead, no threaded replies.
- [ ] Trigger a tick against a PR with both body content AND line comments — confirm only the per-comment threaded replies are posted (no duplicate top-level summary).
- [ ] Verify GitHub's "unresolved comments" counter clears as expected once threads are replied to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)