### PR TITLE
chore(release): @muggleai/works 4.11.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.11.0"
+      "version": "4.11.1"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.11.0"
+      "version": "4.11.1"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@muggleai/works",
     "mcpName": "io.github.multiplex-ai/muggle",
-    "version": "4.11.0",
+    "version": "4.11.1",
     "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
     "type": "module",
     "main": "dist/index.js",
@@ -42,14 +42,14 @@
         "test:watch": "vitest"
     },
     "muggleConfig": {
-        "electronAppVersion": "1.0.84",
+        "electronAppVersion": "1.0.87",
         "downloadBaseUrl": "https://github.com/multiplex-ai/muggle-ai-works/releases/download",
         "runtimeTargetDefault": "dev",
         "checksums": {
-            "darwin-arm64": "da978efea8e3c8633f96c5245b932f98988eb60dc94cced62cac20f4bdefbb20",
-            "darwin-x64": "9aa611d446494ab1d48674813cead2d669f8aea6869efea6f4f2beb13d18e4ac",
-            "win32-x64": "5220df3c394f2406201955f04e78d8faf764ea565fc59611484c8bbaad24635e",
-            "linux-x64": "5c519a473800b2726eef7a55c50d1d2c2e0ff78ab2d860dc869e2cd42fa59d74"
+            "darwin-arm64": "df04c98269e22ae427bb863956215b3f20cbf2ff0b51c037647d6e734a7b7502",
+            "darwin-x64": "e9f5b8a61f4a9f47743aaabb27d6e4c462dca5aa922ba66ae04f0a0133b8a7eb",
+            "win32-x64": "75e552672757d280259637bdcbe0aae0eecc2417ed9a6e5bd49f42d3466f66cf",
+            "linux-x64": "2c8b64cf549f9a6682db959b17c5f04578d632d5bcdba1ac9efbb45d6a097802"
         }
     },
     "dependencies": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "4.11.0",
+  "version": "4.11.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "4.11.0",
+      "version": "4.11.1",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
## Version delta

- **npm**: 4.11.0 → **4.11.1** (patch)
- **Electron**: 1.0.84 → **1.0.87** (3 patches behind, catching up)

## Bump rationale

One PR shipping since 4.11.0:

- #158 — `fix(skills): pr-followup replies threaded per line comment, not one bulk summary` — pr-followup loop now POSTs `/repos/{o}/{r}/pulls/{n}/comments/{id}/replies` per line comment so each thread becomes resolvable in GitHub's UI. Top-level `gh pr comment` only as fallback for body-only reviews. Self-review pass also tightened contract/helpers to a single source for reply shape and added a self-check gate for replies.

Pure bug fix → patch.

## Electron 1.0.87

Refreshed `muggleConfig.electronAppVersion` and all four `muggleConfig.checksums`:

| Platform | Old | New |
| :--- | :--- | :--- |
| darwin-arm64 | `da978efe…` | `df04c982…` |
| darwin-x64 | `9aa611d4…` | `e9f5b8a6…` |
| win32-x64 | `5220df3c…` | `75e55267…` |
| linux-x64 | `5c519a47…` | `2c8b64cf…` |

`verify:electron-release-checksums` confirmed all four match `https://github.com/multiplex-ai/muggle-ai-works/releases/download/electron-app-v1.0.87/checksums.txt`.

## Manifests touched by sync:versions

- `.claude-plugin/marketplace.json`
- `.cursor-plugin/marketplace.json`
- `plugin/.claude-plugin/plugin.json`
- `plugin/.cursor-plugin/plugin.json`
- `server.json`

(None hand-edited.)

## Test plan

- [x] `pnpm run lint:check` — 0 errors (21 pre-existing warnings in worktrees, not introduced by this release)
- [x] `pnpm run typecheck` — clean
- [x] `pnpm test` — 630/630 passing (37 files)
- [x] `pnpm run build` — clean, dist regenerated
- [x] `pnpm run verify:plugin` — passed
- [x] `pnpm run verify:contracts` — passed
- [x] `pnpm run verify:electron-release-checksums` — passed against `electron-app-v1.0.87`
- [ ] CI green on this PR
- [ ] After merge: `publish-works-to-npm.yml` workflow dispatched with `version=4.11.1`, registry confirms `npm view @muggleai/works version` → 4.11.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)