### PR TITLE
feat(telemetry): wire client telemetry pipeline end-to-end

### DIFF
--- a/.github/workflows/publish-works-to-npm.yml
+++ b/.github/workflows/publish-works-to-npm.yml
@@ -103,7 +103,38 @@ jobs:
           RELEASE_BUILD_ID: run-${{ github.run_number }}-${{ github.run_attempt }}
           RELEASE_COMMIT_SHA: ${{ github.sha }}
           RELEASE_TIME: ${{ github.event.repository.updated_at }}
+          # Inlined into dist/ at build time by tsup `define`. Sourced from the
+          # repo secret. Without this, client telemetry from the published
+          # package is a silent no-op on every end-user machine.
+          APPLICATIONINSIGHTS_CONNECTION_STRING: ${{ secrets.APPLICATIONINSIGHTS_CONNECTION_STRING }}
         run: pnpm run build
+
+      - name: Verify telemetry connection string was inlined
+        run: |
+          node <<'NODE'
+          const fs = require("fs");
+          const path = require("path");
+          // tsup `define` can place the substituted literal into any chunk
+          // reachable from the entrypoints, so scan all JS files under dist/.
+          function walk(dir) {
+            const out = [];
+            for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+              const full = path.join(dir, entry.name);
+              if (entry.isDirectory()) out.push(...walk(full));
+              else if (entry.isFile() && entry.name.endsWith(".js")) out.push(full);
+            }
+            return out;
+          }
+          const files = walk("dist");
+          const hit = files.some((f) => fs.readFileSync(f, "utf-8").includes("IngestionEndpoint="));
+          if (!hit) {
+            throw new Error(
+              "AppInsights connection string was not inlined into dist/. " +
+              "Set the APPLICATIONINSIGHTS_CONNECTION_STRING repository secret " +
+              "and re-run. Without it, the published package emits no client telemetry."
+            );
+          }
+          NODE
 
       - name: Extract version from tag
         if: startsWith(github.ref, 'refs/tags/')

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -3,8 +3,37 @@
  */
 
 import { getConfig, getLocalQaTools, getLogger, getQaTools } from "../../packages/mcps/src/index.js";
-import { EventName, initTelemetry, ServiceName, Surface, track } from "@muggleai/telemetry";
+import {
+  EventName,
+  getDisclosureCopy,
+  hasShownDisclosure,
+  initTelemetry,
+  markDisclosureShown,
+  ServiceName,
+  Surface,
+  track,
+} from "@muggleai/telemetry";
 import { createUnifiedMcpServer, registerTools, startStdioServer } from "../server/index.js";
+
+// Connection string is inlined at publish time via tsup `define` from the
+// APPLICATIONINSIGHTS_CONNECTION_STRING env var (set from a GitHub secret in
+// the publish workflow). Empty string in dev builds — telemetry is no-op.
+const APPLICATIONINSIGHTS_CONNECTION_STRING: string =
+  process.env.APPLICATIONINSIGHTS_CONNECTION_STRING ?? "";
+
+// Show the one-time first-run disclosure on stderr before any event fires.
+// Honors the 2026-05-05 client telemetry design: stderr is the only safe
+// channel for an MCP stdio server (stdout is reserved for protocol output,
+// and a blocking modal would break MCP host integrations).
+function showDisclosureIfNeeded(): void {
+  try {
+    if (hasShownDisclosure()) return;
+    process.stderr.write(getDisclosureCopy() + "\n");
+    markDisclosureShown();
+  } catch {
+    // Disclosure write must never break the host process.
+  }
+}
 
 const logger = getLogger();
 
@@ -40,7 +69,12 @@ export async function serveCommand (options: IServeOptions): Promise<void> {
 
   // Init client telemetry before any tool dispatch — no-op if not configured.
   try {
-    initTelemetry({ serviceName: ServiceName.MuggleMcp, surface: Surface.McpLocal });
+    showDisclosureIfNeeded();
+    initTelemetry({
+      serviceName: ServiceName.MuggleMcp,
+      surface: Surface.McpLocal,
+      connectionString: APPLICATIONINSIGHTS_CONNECTION_STRING,
+    });
     track({ name: EventName.SystemStartup, props: { serviceName: ServiceName.MuggleMcp } });
   } catch (err) {
     logger.warn("Telemetry init skipped", {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,5 +1,12 @@
 import { defineConfig } from "tsup";
 
+// Inline the AppInsights ingestion connection string at build time. Sourced
+// from the APPLICATIONINSIGHTS_CONNECTION_STRING env var (set from a GitHub
+// secret by the publish workflow). Local/dev builds leave this empty, which
+// keeps client telemetry as a silent no-op outside of release builds.
+const APPLICATIONINSIGHTS_CONNECTION_STRING =
+  process.env.APPLICATIONINSIGHTS_CONNECTION_STRING ?? "";
+
 export default defineConfig({
   entry: {
     "index": "src/index.ts",
@@ -14,6 +21,11 @@ export default defineConfig({
   splitting: true,
   treeshake: true,
   minify: false,
+  define: {
+    "process.env.APPLICATIONINSIGHTS_CONNECTION_STRING": JSON.stringify(
+      APPLICATIONINSIGHTS_CONNECTION_STRING,
+    ),
+  },
   external: [
     "@modelcontextprotocol/sdk",
   ],


### PR DESCRIPTION
## Summary

Wires up the client telemetry pipeline so events from `@muggleai/works` actually reach Application Insights. Implements the [Works Telemetry Pipeline design](https://github.com/multiplex-ai/muggle-ai-brain/blob/main/architecture/2026-05-19-works-telemetry-pipeline-design.md).

**DO NOT MERGE WITHOUT SETTING THE GITHUB SECRET FIRST.** See "Required action" below.

## Problem

Every client event call site (`mcp.tool.invoked`, `mcp.tool.completed`, `skill.invoked`, `skill.completed`, `system.startup`) was wired in code, but no event has ever reached Application Insights — confirmed via direct KQL query against the studio-vmss component (0 client events in 30 days). Root cause: `initTelemetry()` falls back to `process.env.APPLICATIONINSIGHTS_CONNECTION_STRING`, which is never set on end-user machines and is never embedded in the published bundle.

The freshly merged MCP adoption dashboard ([prompt-service #508](https://github.com/multiplex-ai/muggle-ai-prompt-service/pull/508), [follow-up #510](https://github.com/multiplex-ai/muggle-ai-prompt-service/pull/510)) made this visible — every client-event panel reads "No data".

## Changes

| File | What |
| --- | --- |
| `tsup.config.ts` | `define` substitutes `process.env.APPLICATIONINSIGHTS_CONNECTION_STRING` at build time. Dev builds substitute empty string (no-op preserved). |
| `src/cli/serve.ts` | Passes the inlined connection string explicitly to `initTelemetry`. Shows the one-time first-run disclosure on stderr before initializing telemetry. |
| `.github/workflows/publish-works-to-npm.yml` | Sets `APPLICATIONINSIGHTS_CONNECTION_STRING` from `secrets.APPLICATIONINSIGHTS_CONNECTION_STRING` for the `package-audit` build step. Verify step asserts `IngestionEndpoint=` appears in `dist/` before packing — empty/missing secret fails the publish loudly. |

## Disclosure

Stderr-only, on the very first MCP server startup. Wires up the telemetry package's existing `hasShownDisclosure` / `markDisclosureShown` helpers with the canonical `DISCLOSURE_COPY` — no new copy invented here. The 2026-05-05 design required disclosure before any event fires; this honors that.

Stderr is the only safe channel for an MCP stdio server: stdout is protocol output, and a blocking modal would break MCP host integrations.

## Required action before merge

Set the repository secret `APPLICATIONINSIGHTS_CONNECTION_STRING` to the studio-vmss component's connection string:

```
InstrumentationKey=0e28df42-b98e-4089-b3b5-6decefb99447;IngestionEndpoint=https://westus3-1.in.applicationinsights.azure.com/;LiveEndpoint=https://westus3.livediagnostics.monitor.azure.com/;ApplicationId=b64a932f-85ec-40cd-a74b-e181a3660f6c
```

(Same value Electron uses in its `.env.production`.) The publish workflow's verify step will fail otherwise — by design, since a silent no-op is worse than a hard error.

Either scope works:
- Repository secret (recommended — simpler, matches how RELEASE_BUILD_ID etc. flow today)
- `npm-publish` environment secret (already used as the publish environment — slightly more scoped)

## Test plan

- [x] `pnpm run typecheck` clean
- [x] `pnpm test` 126/126 pass
- [x] `pnpm run lint:check` clean (pre-existing warnings only)
- [x] Local `pnpm run build` with `APPLICATIONINSIGHTS_CONNECTION_STRING=<test>` inlines the string into `dist/chunk-*.js` (verified by grep)
- [x] Local `pnpm run build` without env var produces dist/ with no `IngestionEndpoint=` (dev no-op preserved)
- [ ] Set secret, run a dry publish via workflow_dispatch on the branch, confirm verify step passes
- [ ] After merge + first real publish, end users running the npm CLI emit events visible at the studio-vmss component within minutes
- [ ] MCP adoption dashboard at `/d/mai-mcp-overview` populates

## Risk

- Connection string is now a literal in the published bundle — same posture as Electron's `.env.production`. An AppInsights ingestion key is not a hard secret (write-only); this is the accepted pattern in the ecosystem and matches the 2026-05-05 design's stated PII posture.
- First-run disclosure on stderr could be noisy in some MCP host UIs (Claude Code, Cursor, etc.). The disclosure is one-time per machine and not blocking; the cost is one stderr write the first time a user invokes the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)