### PR TITLE
fix(deps): move workspace file: deps to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,6 @@
     },
     "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.3",
-        "@muggleai/mcp": "file:packages/mcps",
-        "@muggleai/workflows": "file:packages/workflows",
         "applicationinsights": "^3.14.0",
         "axios": "^1.7.9",
         "commander": "^14.0.3",
@@ -68,7 +66,9 @@
     "devDependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.133",
         "@eslint/js": "^10.0.1",
+        "@muggleai/mcp": "file:packages/mcps",
         "@muggleai/telemetry": "0.3.2",
+        "@muggleai/workflows": "file:packages/workflows",
         "@types/node": "^25.5.2",
         "@types/uuid": "^11.0.0",
         "@typescript-eslint/eslint-plugin": "^8.34.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,12 +11,6 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.25.3
         version: 1.29.0(zod@4.4.3)
-      '@muggleai/mcp':
-        specifier: file:packages/mcps
-        version: link:packages/mcps
-      '@muggleai/workflows':
-        specifier: file:packages/workflows
-        version: link:packages/workflows
       applicationinsights:
         specifier: ^3.14.0
         version: 3.14.0
@@ -48,9 +42,15 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.3.0)
+      '@muggleai/mcp':
+        specifier: file:packages/mcps
+        version: link:packages/mcps
       '@muggleai/telemetry':
         specifier: 0.3.2
         version: 0.3.2
+      '@muggleai/workflows':
+        specifier: file:packages/workflows
+        version: link:packages/workflows
       '@types/node':
         specifier: ^25.5.2
         version: 25.6.2


### PR DESCRIPTION
## Summary

- Move `@muggleai/mcp` and `@muggleai/workflows` from `dependencies` → `devDependencies` so the published `@muggleai/works` tarball stops shipping unresolvable `file:packages/...` runtime deps.

## Why

End users hit `ERR_MODULE_NOT_FOUND` when the MCP server tries to start:

```
Error: Cannot find package
  'C:\Users\stan4\AppData\Roaming\npm\node_modules\@muggleai\works\node_modules\axios\index.js'
  imported from .../dist/chunk-XXXXXXXX.js
ERR_MODULE_NOT_FOUND
```

That error is Node's ESM legacy fallback firing because the package's `package.json` is gone. Tracing the global install on Windows:

| package | `package.json` present |
|---|---|
| `node_modules/axios` | **missing** |
| `node_modules/form-data` | **missing** |
| `node_modules/ansi-styles` | **missing** |
| `node_modules/@muggleai/mcp` | broken reparse-point with no `package.json` |
| `node_modules/@muggleai/workflows` | broken reparse-point with no `package.json` |

The root cause is the second pair: the published tarball doesn't include `packages/` (it isn't in `files`), so `npm install -g @muggleai/works` can't resolve `file:packages/mcps` / `file:packages/workflows`, npm leaves partial junctions, and on Windows that cleanup is racy enough to occasionally take real neighbors' `package.json` files down with it. The first three packages disappearing is the observable symptom; the unresolvable `file:` runtime deps are the trigger.

## Why moving them is safe

Both packages are build-time only:

- `@muggleai/mcp` is bundled into `dist/chunk-*.js` by tsup — `tsup.config.ts` already has `noExternal: ["@muggleai/mcp"]`, and the published chunks contain the MCP code with no `from "@muggleai/mcp"` import. Nothing at runtime needs to resolve it.
- `@muggleai/workflows` isn't imported by any runtime source file (`grep -rn "from ['\"]@muggleai/workflows" src/ packages/` returns nothing). It's a workspace placeholder.

Moving them to `devDependencies` keeps them resolvable for:

- local `pnpm install` (workspace `packages/` is on disk)
- CI builds (same)
- the existing `prepare`/`build` pipeline (verified — `pnpm run build` succeeds and produces the same chunk layout)

…while removing them from the published runtime dependency graph entirely, so consumer installs no longer have a broken `file:` ref to choke on.

## Test plan

- [x] `pnpm install` in the worktree — clean, only `pnpm-lock.yaml` changes (6 lines shifted from runtime to dev importer block)
- [x] `pnpm run build` — succeeds, `dist/chunk-AYWLYB3F.js` still 264 KB (MCP code is still inlined)
- [x] `pnpm pack` + inspect published `package.json` — `dependencies` block now contains only registry packages (`@modelcontextprotocol/sdk`, `applicationinsights`, `axios`, `commander`, `open`, `ulid`, `uuid`, `winston`, `zod`)
- [ ] Smoke-test once published: `npm install -g @muggleai/works@<this version>` on a fresh machine → `muggle --version` succeeds → MCP server `npx @muggleai/works serve` boots without `ERR_MODULE_NOT_FOUND`

🤖 Generated with [Claude Code](https://claude.com/claude-code)