### PR TITLE
chore(release): @muggleai/works 4.11.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.11.1"
+      "version": "4.11.3"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.11.1"
+      "version": "4.11.3"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@muggleai/works",
     "mcpName": "io.github.multiplex-ai/muggle",
-    "version": "4.11.1",
+    "version": "4.11.3",
     "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
     "type": "module",
     "main": "dist/index.js",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "4.11.1",
+  "version": "4.11.3",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "4.11.1",
+  "version": "4.11.3",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "4.11.1",
+  "version": "4.11.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "4.11.1",
+      "version": "4.11.3",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
## Summary

- `4.11.2 → 4.11.3` (patch).
- Ships `#161` (`fix(deps)`: move workspace `file:` deps to `devDependencies`) — unbreaks consumer installs of `@muggleai/works`.
- Ships `#160` (`feat(telemetry)`: wire client telemetry pipeline end-to-end).
- Electron unchanged at `1.0.87`.

## Why now

Before #161, the published tarball declared `@muggleai/mcp` / `@muggleai/workflows` as `file:packages/...` *runtime* deps, but the published tarball doesn't include `packages/` — so consumers' `npm install -g @muggleai/works` could not resolve those refs, leaving partial junctions and (on Windows) racing with neighboring packages' `package.json` files. End users were hitting `ERR_MODULE_NOT_FOUND` on common deps like `axios`. Cutting this release as soon as the fix is on master so the broken `4.11.2` stops being the install users get from `npm install -g`.

## Manifests touched by `sync:versions`

- `package.json`
- `.claude-plugin/marketplace.json`
- `.cursor-plugin/marketplace.json`
- `plugin/.claude-plugin/plugin.json`
- `plugin/.cursor-plugin/plugin.json`
- `server.json`

(No hand-edits.)

## Test plan

- [x] `pnpm run lint:check`
- [x] `pnpm run typecheck`
- [x] `pnpm test` — 52 files, 878 tests passing
- [x] `pnpm run build` — chunks built, release-manifest written for 4.11.3
- [x] `pnpm run verify:plugin` — plugin marketplace verification passed
- [x] `pnpm run verify:contracts` — compatibility contract verification passed
- [x] `pnpm run verify:electron-release-checksums` — `electron-app-v1.0.87` checksums verified
- [ ] CI verify job
- [ ] CI package-audit job
- [ ] CI publish job (OIDC trusted publishing)
- [ ] `npm view @muggleai/works version` → `4.11.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)