### PR TITLE
fix(replay): localUrl swap covers subdomains + forces first navigate (#163)

### DIFF
--- a/packages/mcps/src/mcp/local/services/execution-service.ts
+++ b/packages/mcps/src/mcp/local/services/execution-service.ts
@@ -23,6 +23,7 @@ import {
 import { getLogger } from "../../../shared/logger.js";
 import type { TestCaseDetails, TestScriptDetails } from "../contracts/project-schemas.js";
 import { getAuthService, getRunResultStorageService, getStorageService } from "./index.js";
+import { rewriteActionScriptUrls } from "./replay-url-rewrite.js";
 import type { ILocalExecutionContext } from "./run-result-storage-service.js";
 import type { RunResultStatus } from "./run-result-storage-service.js";
 
@@ -971,38 +972,6 @@ export async function executeReplay(params: {
   }
 }
 
-/**
- * Rewrite URLs in action script to use local URL.
- *
- * @param params - Rewrite parameters.
- * @param params.actionScript - Original action script steps.
- * @param params.originalUrl - Original cloud URL to replace.
- * @param params.localUrl - Local URL to use.
- * @returns Action script with rewritten URLs.
- */
-function rewriteActionScriptUrls(params: {
-  actionScript: unknown[];
-  originalUrl?: string;
-  localUrl: string;
-}): unknown[] {
-  const { actionScript, originalUrl, localUrl } = params;
-
-  if (!originalUrl) {
-    return actionScript;
-  }
-
-  // Deep clone and replace URLs
-  const serialized = JSON.stringify(actionScript);
-  const rewritten = serialized.replace(new RegExp(escapeRegex(originalUrl), "g"), localUrl);
-  return JSON.parse(rewritten) as unknown[];
-}
-
-/**
- * Escape special regex characters in a string.
- */
-function escapeRegex(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
 
 /**
  * Cancel an active execution.

--- a/packages/mcps/src/mcp/local/services/replay-url-rewrite.ts
+++ b/packages/mcps/src/mcp/local/services/replay-url-rewrite.ts
@@ -1,34 +1,10 @@
-/**
- * URL rewriting for action-script replay against a local dev URL.
- *
- * Cloud-recorded action scripts encode the original environment's URLs in
- * both the top-level testScript metadata and inside individual step
- * operations (especially the first `navigate`, which is usually a stateful
- * auth redirect like `login.<host>/u/login?state=...`). When replaying
- * locally we want those URLs pointed at the local origin so the journey
- * actually exercises the local app.
- */
+/** Point cloud-recorded action script URLs at a local dev URL for replay. */
 
 /**
- * Rewrite URLs in an action script to use `localUrl` instead of the cloud
- * URL the script was recorded against.
- *
- * Substitution covers two cases:
- *   1. Any URL whose hostname equals or is a subdomain of `originalUrl`'s
- *      hostname is rewritten to `localUrl`'s origin (so e.g.
- *      `login.staging.muggle-ai.com/...` rewrites alongside
- *      `staging.muggle-ai.com/...` when the original is `staging.muggle-ai.com`).
- *      Unrelated hosts like `accounts.google.com` are left alone.
- *   2. The first `navigate` step's URL is forced to `localUrl` regardless of
- *      what was recorded. The recorded URL is often a stateful auth redirect
- *      that's invalid in the local env; starting the journey at `localUrl`
- *      lets the local app's own auth redirect chain take over.
- *
- * @param params - Rewrite parameters.
- * @param params.actionScript - Original action script steps.
- * @param params.originalUrl - Original cloud URL the script was recorded against.
- * @param params.localUrl - Local URL to redirect to.
- * @returns Action script with rewritten URLs.
+ * Rewrite URLs in an action script for local replay: any URL whose host
+ * equals or is a subdomain of `originalUrl`'s host swaps to `localUrl`'s
+ * origin, and the first `navigate` step is forced to `localUrl` (the
+ * recorded value is usually a stateful auth redirect that can't replay).
  */
 export function rewriteActionScriptUrls(params: {
   actionScript: unknown[];
@@ -65,9 +41,6 @@ export function rewriteActionScriptUrls(params: {
   return result;
 }
 
-/**
- * Force the first `navigate` step's URL to `localUrl`. Mutates `steps`.
- */
 function forceFirstNavigateUrl(params: { steps: unknown[]; localUrl: string }): void {
   for (const step of params.steps) {
     if (!isPlainObject(step)) continue;

--- a/packages/mcps/src/mcp/local/services/replay-url-rewrite.ts
+++ b/packages/mcps/src/mcp/local/services/replay-url-rewrite.ts
@@ -1,0 +1,88 @@
+/**
+ * URL rewriting for action-script replay against a local dev URL.
+ *
+ * Cloud-recorded action scripts encode the original environment's URLs in
+ * both the top-level testScript metadata and inside individual step
+ * operations (especially the first `navigate`, which is usually a stateful
+ * auth redirect like `login.<host>/u/login?state=...`). When replaying
+ * locally we want those URLs pointed at the local origin so the journey
+ * actually exercises the local app.
+ */
+
+/**
+ * Rewrite URLs in an action script to use `localUrl` instead of the cloud
+ * URL the script was recorded against.
+ *
+ * Substitution covers two cases:
+ *   1. Any URL whose hostname equals or is a subdomain of `originalUrl`'s
+ *      hostname is rewritten to `localUrl`'s origin (so e.g.
+ *      `login.staging.muggle-ai.com/...` rewrites alongside
+ *      `staging.muggle-ai.com/...` when the original is `staging.muggle-ai.com`).
+ *      Unrelated hosts like `accounts.google.com` are left alone.
+ *   2. The first `navigate` step's URL is forced to `localUrl` regardless of
+ *      what was recorded. The recorded URL is often a stateful auth redirect
+ *      that's invalid in the local env; starting the journey at `localUrl`
+ *      lets the local app's own auth redirect chain take over.
+ *
+ * @param params - Rewrite parameters.
+ * @param params.actionScript - Original action script steps.
+ * @param params.originalUrl - Original cloud URL the script was recorded against.
+ * @param params.localUrl - Local URL to redirect to.
+ * @returns Action script with rewritten URLs.
+ */
+export function rewriteActionScriptUrls(params: {
+  actionScript: unknown[];
+  originalUrl?: string;
+  localUrl: string;
+}): unknown[] {
+  const { actionScript, originalUrl, localUrl } = params;
+
+  if (!originalUrl) {
+    return actionScript;
+  }
+
+  let originalHost: string;
+  let localOrigin: string;
+  try {
+    originalHost = new URL(originalUrl).hostname;
+    localOrigin = new URL(localUrl).origin;
+  } catch {
+    const serialized = JSON.stringify(actionScript);
+    const rewritten = serialized.replace(new RegExp(escapeRegex(originalUrl), "g"), localUrl);
+    return JSON.parse(rewritten) as unknown[];
+  }
+
+  const hostPattern = new RegExp(
+    `https?://(?:[a-z0-9-]+\\.)*${escapeRegex(originalHost)}(?=[/?#:"'\\\\]|$)`,
+    "gi",
+  );
+
+  const serialized = JSON.stringify(actionScript);
+  const rewritten = serialized.replace(hostPattern, localOrigin);
+  const result = JSON.parse(rewritten) as unknown[];
+
+  forceFirstNavigateUrl({ steps: result, localUrl: localUrl });
+  return result;
+}
+
+/**
+ * Force the first `navigate` step's URL to `localUrl`. Mutates `steps`.
+ */
+function forceFirstNavigateUrl(params: { steps: unknown[]; localUrl: string }): void {
+  for (const step of params.steps) {
+    if (!isPlainObject(step)) continue;
+    const operation = step["operation"];
+    if (!isPlainObject(operation)) continue;
+    if (operation["action"] !== "navigate") continue;
+    operation["url"] = params.localUrl;
+    return;
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/packages/mcps/src/test/replay-url-rewrite.test.ts
+++ b/packages/mcps/src/test/replay-url-rewrite.test.ts
@@ -1,8 +1,4 @@
-/**
- * Tests for rewriteActionScriptUrls — the local-replay URL substitution
- * that points cloud-recorded action scripts at a local dev URL. See
- * `mcp/local/services/replay-url-rewrite.ts` and issue #163.
- */
+/** Tests for `rewriteActionScriptUrls` (local-replay URL swap, issue #163). */
 
 import { describe, expect, it } from "vitest";
 

--- a/packages/mcps/src/test/replay-url-rewrite.test.ts
+++ b/packages/mcps/src/test/replay-url-rewrite.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests for rewriteActionScriptUrls — the local-replay URL substitution
+ * that points cloud-recorded action scripts at a local dev URL. See
+ * `mcp/local/services/replay-url-rewrite.ts` and issue #163.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { rewriteActionScriptUrls } from "../mcp/local/services/replay-url-rewrite.js";
+
+const ORIGINAL = "https://staging.muggle-ai.com/muggleTestV0/dashboard";
+const LOCAL = "http://localhost:3999";
+
+function makeStep(operation: Record<string, unknown>): Record<string, unknown> {
+  return { briefExplanation: "", operation: operation, comment: "" };
+}
+
+describe("rewriteActionScriptUrls", () => {
+  it("returns the input unchanged when originalUrl is missing", () => {
+    const steps = [makeStep({ action: "click", elementId: 3 })];
+    const result = rewriteActionScriptUrls({
+      actionScript: steps,
+      localUrl: LOCAL,
+    });
+    expect(result).toEqual(steps);
+  });
+
+  it("rewrites the first navigate step's URL to localUrl regardless of recorded value", () => {
+    const steps = [
+      makeStep({
+        action: "navigate",
+        url: "https://login.staging.muggle-ai.com/u/login?state=abc",
+      }),
+    ];
+    const result = rewriteActionScriptUrls({
+      actionScript: steps,
+      originalUrl: ORIGINAL,
+      localUrl: LOCAL,
+    });
+    const firstNavigate = (result[0] as { operation: { url: string } }).operation;
+    expect(firstNavigate.url).toBe(LOCAL);
+  });
+
+  it("rewrites subdomain hostnames of the original host inside any operation field", () => {
+    const steps = [
+      makeStep({ action: "click", elementId: 1, domainUrl: "login.staging.muggle-ai.com" }),
+      makeStep({
+        action: "navigate",
+        url: "https://login.staging.muggle-ai.com/u/login?state=abc",
+      }),
+      makeStep({ action: "click", domainUrl: "staging.muggle-ai.com" }),
+    ];
+    const result = rewriteActionScriptUrls({
+      actionScript: steps,
+      originalUrl: ORIGINAL,
+      localUrl: LOCAL,
+    }) as Array<{ operation: Record<string, unknown> }>;
+
+    expect(result[0]!.operation["domainUrl"]).toBe("login.staging.muggle-ai.com");
+    expect(JSON.stringify(result)).not.toContain("https://login.staging.muggle-ai.com");
+    expect(JSON.stringify(result)).not.toContain("https://staging.muggle-ai.com");
+    expect(JSON.stringify(result)).toContain(LOCAL);
+  });
+
+  it("does not rewrite unrelated hosts like accounts.google.com", () => {
+    const steps = [
+      makeStep({
+        action: "navigate",
+        url: "https://staging.muggle-ai.com/start",
+      }),
+      makeStep({
+        action: "secretInput",
+        domainUrl: "accounts.google.com",
+        elementId: 1,
+      }),
+      makeStep({
+        action: "click",
+        url: "https://accounts.google.com/signin/oauth",
+      }),
+    ];
+    const result = rewriteActionScriptUrls({
+      actionScript: steps,
+      originalUrl: ORIGINAL,
+      localUrl: LOCAL,
+    }) as Array<{ operation: Record<string, unknown> }>;
+
+    expect(result[1]!.operation["domainUrl"]).toBe("accounts.google.com");
+    expect(result[2]!.operation["url"]).toBe("https://accounts.google.com/signin/oauth");
+  });
+
+  it("leaves scripts with no navigate step otherwise functional", () => {
+    const steps = [
+      makeStep({ action: "click", elementId: 1, domainUrl: "staging.muggle-ai.com" }),
+      makeStep({ action: "halt" }),
+    ];
+    const result = rewriteActionScriptUrls({
+      actionScript: steps,
+      originalUrl: ORIGINAL,
+      localUrl: LOCAL,
+    }) as Array<{ operation: Record<string, unknown> }>;
+
+    expect(result).toHaveLength(2);
+    expect(result[0]!.operation["action"]).toBe("click");
+    expect(result[1]!.operation["action"]).toBe("halt");
+  });
+
+  it("forces only the first navigate step, leaves later navigates' subdomain-rewritten URLs intact", () => {
+    const steps = [
+      makeStep({
+        action: "navigate",
+        url: "https://login.staging.muggle-ai.com/u/login?state=abc",
+      }),
+      makeStep({ action: "click", elementId: 7 }),
+      makeStep({
+        action: "navigate",
+        url: "https://staging.muggle-ai.com/muggleTestV0/dashboard/projects/1",
+      }),
+    ];
+    const result = rewriteActionScriptUrls({
+      actionScript: steps,
+      originalUrl: ORIGINAL,
+      localUrl: LOCAL,
+    }) as Array<{ operation: Record<string, unknown> }>;
+
+    expect(result[0]!.operation["url"]).toBe(LOCAL);
+    expect(result[2]!.operation["url"]).toBe(`${LOCAL}/muggleTestV0/dashboard/projects/1`);
+  });
+
+  it("preserves localUrl with a non-default port and arbitrary scheme", () => {
+    const steps = [
+      makeStep({ action: "navigate", url: "https://staging.muggle-ai.com/start" }),
+      makeStep({ action: "click", domainUrl: "api.staging.muggle-ai.com" }),
+    ];
+    const result = rewriteActionScriptUrls({
+      actionScript: steps,
+      originalUrl: ORIGINAL,
+      localUrl: "http://localhost:3999",
+    }) as Array<{ operation: Record<string, unknown> }>;
+
+    expect(result[0]!.operation["url"]).toBe("http://localhost:3999");
+    expect(result[1]!.operation["domainUrl"]).toBe("api.staging.muggle-ai.com");
+  });
+
+  it("falls back to a literal-string substitution when originalUrl is not a parseable URL", () => {
+    const literal = "not a url at all 123";
+    const steps = [
+      makeStep({
+        action: "navigate",
+        url: `${literal}/dashboard`,
+      }),
+    ];
+    const result = rewriteActionScriptUrls({
+      actionScript: steps,
+      originalUrl: literal,
+      localUrl: LOCAL,
+    }) as Array<{ operation: Record<string, unknown> }>;
+
+    expect(result[0]!.operation["url"]).toBe(`${LOCAL}/dashboard`);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #163. Two-part fix inside `rewriteActionScriptUrls`, extracted from `execution-service.ts` into a dedicated `replay-url-rewrite.ts` so it's testable in isolation.

1. **Hostname-aware substitution.** Rewrite any URL whose hostname equals or is a subdomain of `originalUrl`'s hostname to `localUrl`'s origin — `staging.muggle-ai.com` *and* `login.staging.muggle-ai.com` both rewrite, while unrelated hosts like `accounts.google.com` are left alone. Falls back to the previous literal-string substitution when `originalUrl` doesn't parse as a URL.

2. **First-navigate override.** After the hostname pass, the first `navigate` step's `operation.url` is forced to `localUrl`. The recorded value is typically a stateful auth redirect (`login.<host>/u/login?state=...`) that's invalid in the local env; the local app's own auth redirect chain has to start from `localUrl`.

## Why this matters

Before: `muggle-local-execute-replay` claimed to run against `localUrl` but actually navigated to the original cloud host in step #1 (the auth subdomain), silently testing the cloud env. PR 303's walkthrough on `muggle-ai-ui` hit this — the replay's first step landed on staging Auth0's `Oops, something went wrong` page instead of `localhost:3999`. See #163 for the full reproduction.

After: `localUrl` is honored end-to-end. The browser starts at the local origin, the local app drives its own auth redirect chain.

## Files

- `packages/mcps/src/mcp/local/services/replay-url-rewrite.ts` *(new)* — the rewrite logic + helpers
- `packages/mcps/src/mcp/local/services/execution-service.ts` — drop the inlined function, import from the new module
- `packages/mcps/src/test/replay-url-rewrite.test.ts` *(new)* — 8 vitest cases

## Test plan

- [x] **Unit:** `pnpm exec vitest run src/test/replay-url-rewrite.test.ts` — 8 tests passing
  - returns input unchanged when `originalUrl` is missing
  - first navigate forced to `localUrl` regardless of recorded value
  - subdomain hostnames (`login.staging.muggle-ai.com`) rewritten everywhere they appear
  - unrelated hosts (`accounts.google.com`) not rewritten
  - scripts with no navigate step process correctly
  - only the *first* navigate is forced; later navigates use the hostname-rewritten URL
  - non-default `localUrl` ports preserved
  - non-parseable `originalUrl` falls back to literal substitution
- [x] `pnpm run lint:check`
- [x] `pnpm run typecheck`
- [x] `pnpm test` — full suite
- [x] `pnpm run build`
- [x] `pnpm run verify:plugin`
- [x] `pnpm run verify:contracts`
- [x] `pnpm run verify:electron-release-checksums`
- [ ] Smoke test post-release: invoke `muggle-local-execute-replay` against `muggle-ai-ui` PR 303 with `localUrl=http://localhost:3999`; first step's screenshot lands on `localhost:3999`, not staging Auth0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)