### PR TITLE
chore(release): @muggleai/works 4.11.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.11.3"
+      "version": "4.11.4"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.11.3"
+      "version": "4.11.4"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@muggleai/works",
     "mcpName": "io.github.multiplex-ai/muggle",
-    "version": "4.11.3",
+    "version": "4.11.4",
     "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
     "type": "module",
     "main": "dist/index.js",
@@ -42,14 +42,14 @@
         "test:watch": "vitest"
     },
     "muggleConfig": {
-        "electronAppVersion": "1.0.87",
+        "electronAppVersion": "1.0.88",
         "downloadBaseUrl": "https://github.com/multiplex-ai/muggle-ai-works/releases/download",
         "runtimeTargetDefault": "dev",
         "checksums": {
-            "darwin-arm64": "df04c98269e22ae427bb863956215b3f20cbf2ff0b51c037647d6e734a7b7502",
-            "darwin-x64": "e9f5b8a61f4a9f47743aaabb27d6e4c462dca5aa922ba66ae04f0a0133b8a7eb",
-            "win32-x64": "75e552672757d280259637bdcbe0aae0eecc2417ed9a6e5bd49f42d3466f66cf",
-            "linux-x64": "2c8b64cf549f9a6682db959b17c5f04578d632d5bcdba1ac9efbb45d6a097802"
+            "darwin-arm64": "dbcefc10f2cdeabe8be74490354ed83f600eb18d8f411b3f1dec266e5eb2e95b",
+            "darwin-x64": "ac4430824e18d15476ed91a6bbe81d0880239b758006cbf721d8e7d58a0c3676",
+            "win32-x64": "16119743fb344990f2b67fa2a9844a50a46d70f6fbf3f72435b5ce1d7a635cd9",
+            "linux-x64": "4e43f3946c80918f972a4c587a5f83873ccaeb5338f6eb8b5296022ba096f059"
         }
     },
     "dependencies": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "4.11.3",
+  "version": "4.11.4",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "4.11.3",
+  "version": "4.11.4",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "4.11.3",
+  "version": "4.11.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "4.11.3",
+      "version": "4.11.4",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
## Summary

- `4.11.3 → 4.11.4` (patch).
- Ships `#165` (closes `#163`) — `fix(replay): localUrl swap covers subdomains + forces first navigate`. End users running `muggle-local-execute-replay` against a `localUrl` now actually land on the local origin instead of the original cloud auth subdomain.
- **Electron bump**: `1.0.87 → 1.0.88`. All four `muggleConfig.checksums` refreshed from `electron-app-v1.0.88/checksums.txt`.

## Manifests touched by `sync:versions`

- `package.json`
- `.claude-plugin/marketplace.json`
- `.cursor-plugin/marketplace.json`
- `plugin/.claude-plugin/plugin.json`
- `plugin/.cursor-plugin/plugin.json`
- `server.json`

(No hand-edits — `pnpm run sync:versions`.)

## Test plan

- [x] `pnpm run lint:check`
- [x] `pnpm run typecheck`
- [x] `pnpm test` — full suite
- [x] `pnpm run build`
- [x] `pnpm run verify:plugin`
- [x] `pnpm run verify:contracts`
- [x] `pnpm run verify:electron-release-checksums` — `electron-app-v1.0.88` checksums verified
- [ ] CI verify + package-audit + publish jobs (OIDC trusted publishing)
- [ ] `npm view @muggleai/works version` → `4.11.4`
- [ ] Post-install smoke: `muggle --version` reports `4.11.4`, `muggle serve` boots, and a fresh `muggle-local-execute-replay` against `localhost:3999` lands on `localhost` in step #1 (not on the original cloud auth subdomain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)