### PR TITLE
fix(skills/regen): open scripts page, not runs page

### DIFF
--- a/plugin/skills/muggle-test-regenerate-missing/SKILL.md
+++ b/plugin/skills/muggle-test-regenerate-missing/SKILL.md
@@ -180,15 +180,15 @@ Bulk regen does not run replays, so the section B (replay) router does not apply
 
 ### Step 8 — Open the Dashboard
 
-Open the Muggle AI dashboard so the user can watch progress visually:
+Open the Muggle AI dashboard so the user can watch progress visually. Point them at the **scripts** page (where DRAFT → GENERATING → ACTIVE transitions are visible), not `/runs` (which is for replay batches and shows nothing for a regen):
 
 ```bash
-open "https://www.muggle-ai.com/muggleTestV0/dashboard/projects/{projectId}/runs"
+open "https://www.muggle-ai.com/muggleTestV0/dashboard/projects/{projectId}/scripts"
 ```
 
 Tell them:
 
-> "I've opened the project's runs page. Generation jobs typically take a few minutes each — they'll appear here as they progress. Your test cases will move into `ACTIVE` status as scripts complete."
+> "I've opened the project's scripts page. Generation jobs typically take a few minutes each — your test cases will move from `DRAFT` through `GENERATING` to `ACTIVE` as scripts complete."
 
 ### Step 9 (optional) — Poll Status
 


### PR DESCRIPTION
## Summary
- `muggle-test-regenerate-missing` Step 8 pointed the user at `/dashboard/projects/{projectId}/runs` after dispatching script generation.
- That URL shows replay batches — empty / irrelevant for an in-flight regen.
- Switch to `/scripts` (where the user can watch DRAFT → GENERATING → ACTIVE flip in real time) and add an inline guardrail comment so the next refactor doesn't recur.

## Why
Hit this today during a real regen run on project `5365f324…`. The user opened the link and saw nothing useful — the runs page was tracking yesterday's replay batch, not the 124 script generations we'd just dispatched.

## Test plan
- [ ] Invoke `/muggle-test-regenerate-missing` and confirm the final message points at `/scripts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)