### PR TITLE
fix(postinstall): timeouts on fetch + pipeline, guaranteed exit (#167)

### DIFF
--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* global AbortController */
 /**
  * Postinstall script for @muggleai/works.
  * Downloads the Electron app binary for local testing.
@@ -30,6 +31,8 @@ const VERSION_DIRECTORY_NAME_PATTERN = /^\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.-]+)?$/;
 const INSTALL_METADATA_FILE_NAME = ".install-metadata.json";
 const INSTALL_MANIFEST_FILE_NAME = "install-manifest.json";
 const LOG_FILE_NAME = "postinstall.log";
+const FETCH_TIMEOUT_MS = 90_000;
+const STREAM_TIMEOUT_MS = 5 * 60_000;
 const VERSION_OVERRIDE_FILE_NAME = "electron-app-version-override.json";
 const CURSOR_SKILLS_DIRECTORY_NAME = ".cursor";
 const CURSOR_SKILLS_SUBDIRECTORY_NAME = "skills";
@@ -625,9 +628,22 @@ async function downloadElectronApp() {
         // Create directories
         mkdirSync(versionDir, { recursive: true });
 
-        // Download using fetch
+        // Download using fetch. Both fetch and pipeline get hard timeouts so a
+        // hung CDN/proxy can never pin this process — see issue #167.
         log("Fetching...");
-        const response = await fetch(downloadUrl);
+        const fetchController = new AbortController();
+        const fetchTimer = setTimeout(() => fetchController.abort(), FETCH_TIMEOUT_MS);
+        let response;
+        try {
+            response = await fetch(downloadUrl, { signal: fetchController.signal });
+        } catch (error) {
+            if (error && error.name === "AbortError") {
+                throw new Error(`Fetch timed out after ${FETCH_TIMEOUT_MS}ms — ${downloadUrl}`, { cause: error });
+            }
+            throw error;
+        } finally {
+            clearTimeout(fetchTimer);
+        }
         if (!response.ok) {
             const errorBody = await response.text().catch(() => "");
             throw new Error(
@@ -642,7 +658,18 @@ async function downloadElectronApp() {
 
         const tempFile = join(versionDir, binaryName);
         const fileStream = createWriteStream(tempFile);
-        await pipeline(response.body, fileStream);
+        const streamController = new AbortController();
+        const streamTimer = setTimeout(() => streamController.abort(), STREAM_TIMEOUT_MS);
+        try {
+            await pipeline(response.body, fileStream, { signal: streamController.signal });
+        } catch (error) {
+            if (error && error.name === "AbortError") {
+                throw new Error(`Download stream stalled — aborted after ${STREAM_TIMEOUT_MS}ms`, { cause: error });
+            }
+            throw error;
+        } finally {
+            clearTimeout(streamTimer);
+        }
 
         log("Download complete, verifying checksum...");
 
@@ -895,10 +922,14 @@ function syncClaudePluginCache() {
     }
 }
 
-// Run postinstall
+// Run postinstall. The explicit `process.exit` guarantees the script doesn't
+// linger when something below (a hung socket, an EPERM rmSync retry on
+// Windows) keeps the event loop alive — see issue #167.
 initLogFile();
 removeVersionOverrideFile();
 syncCursorSkills();
 syncClaudePluginCache();
 upsertCursorMcpConfig();
-downloadElectronApp().catch(logError);
+downloadElectronApp()
+    .catch(logError)
+    .finally(() => process.exit(0));


### PR DESCRIPTION
## Summary

Closes #167.

`scripts/postinstall.mjs` → `downloadElectronApp()` used `fetch` and `pipeline` without timeouts, and the top-level promise had no explicit `process.exit`. When the Electron archive download hangs (slow CDN, transient DNS, AV/WDAC inspection), the postinstall pinned itself open forever — Node's event loop stayed alive on the dangling socket / file stream. Each subsequent `npm install -g @muggleai/works` added another zombie node process; in one session I accumulated **60+** and tripped EPERM on bin links the next install.

## Changes

1. **`AbortSignal` timeouts**
   - 90s on `fetch` — well above any realistic GitHub Releases response, well below \"forever.\"
   - 5min on the body `pipeline` — bounded by realistic Electron-zip sizes (~150 MB) over slow corporate links.
   - Aborts re-throw with a clear `Fetch timed out after Nms` / `Download stream stalled after Nms` message (with `cause` preserved so the existing `preserve-caught-error` lint rule passes). The error message in `~/.muggle-ai/postinstall.log` now actually tells you what happened instead of generic `fetch failed`.

2. **`.finally(() => process.exit(0))`** at the top-level chain.
   Guarantees exit even when something below pins a handle — e.g. an `rmSync` retry loop on a Windows file lock, or a half-finished extraction's open fd. The pre-existing `.catch(logError)` already swallows errors into the log; this makes sure the script doesn't outlive that catch.

3. **`/* global AbortController */`** at the top of the file so ESLint accepts the (Node 22 global) constructor. Node 15+ has had `AbortController` as a global; the lint env on this project just didn't declare it.

## Files

- `scripts/postinstall.mjs` (+36 / −5)

No new dependencies. Build output unchanged (`scripts/` isn't bundled).

## Test plan

- [x] `pnpm run lint:check` — passes, no new warnings
- [x] `pnpm run typecheck`
- [x] `pnpm test` — full vitest suite
- [x] `pnpm run build`
- [x] `pnpm run verify:plugin`
- [x] `pnpm run verify:contracts`
- [x] `pnpm run verify:electron-release-checksums`
- [ ] Manual smoke: install on a normal network → no behavior change; postinstall exits cleanly with `Electron app installed to …`.
- [ ] Manual smoke: install with `downloadBaseUrl` pointed at a tarpit (e.g. `https://httpbin.org/delay/3600`) → script aborts within `FETCH_TIMEOUT_MS + buffer`, logs `Fetch timed out after 90000ms — …`, and `Get-CimInstance Win32_Process | Where { $_.CommandLine -like '*postinstall.mjs*' }` is empty within 2 minutes after.
- [ ] Process audit after 5 consecutive installs: zero lingering `postinstall.mjs` processes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)