### PR TITLE
fix(plugin/scripts): bound + cache muggle setup so SessionStart can't leak procs

### DIFF
--- a/plugin/scripts/ensure-electron-app.sh
+++ b/plugin/scripts/ensure-electron-app.sh
@@ -3,10 +3,35 @@
 set -euo pipefail
 
 # Ensure the Electron browser test runner is installed/up to date (silent, best-effort).
-if command -v muggle >/dev/null 2>&1; then
-  muggle setup >/dev/null 2>&1 || true
-else
-  npx -y @muggleai/works setup >/dev/null 2>&1 || true
+#
+# Bounded + cached: this script runs from a SessionStart hook on every Claude
+# session, so a hung `muggle setup` (e.g. one blocked by host security policy
+# on Windows) must not leak a ~100 MB orphan per session start. We cap the
+# attempt with `timeout` and skip the call entirely if we already checked
+# within the last day.
+ensure_marker_dir="${HOME}/.cache/muggle"
+ensure_marker="${ensure_marker_dir}/electron-app-checked"
+ensure_ttl=$((24 * 60 * 60))
+
+ensure_now=$(date +%s)
+ensure_last=0
+if [ -f "${ensure_marker}" ]; then
+    ensure_last=$(stat -f %m "${ensure_marker}" 2>/dev/null || stat -c %Y "${ensure_marker}" 2>/dev/null || echo 0)
+fi
+
+if [ $((ensure_now - ensure_last)) -ge "${ensure_ttl}" ]; then
+    if command -v timeout >/dev/null 2>&1; then
+        ensure_timeout="timeout -k 5 60"
+    else
+        ensure_timeout=""
+    fi
+    if command -v muggle >/dev/null 2>&1; then
+        ${ensure_timeout} muggle setup >/dev/null 2>&1 || true
+    else
+        ${ensure_timeout} npx -y @muggleai/works setup >/dev/null 2>&1 || true
+    fi
+    mkdir -p "${ensure_marker_dir}" 2>/dev/null || true
+    touch "${ensure_marker}" 2>/dev/null || true
 fi
 
 # --- Context injection ---


### PR DESCRIPTION
## Summary
- `plugin/scripts/ensure-electron-app.sh` runs from a `SessionStart` hook on every Claude session. It currently calls `muggle setup` synchronously with `2>/dev/null` and no timeout.
- On hosts where the Electron spawn chain is blocked by host security policy (observed: Windows with WDAC denying an unsigned child binary), `muggle setup` hangs forever. The failure is invisible because stderr is muted, and every new Claude session adds another ~100 MB orphan that never exits.
- Wrap the call in `timeout -k 5 60` and gate the whole block behind a 24-hour marker at `~/.cache/muggle/electron-app-checked`.

## Numbers
Observed live on a Windows dev box before the fix: 60+ orphan `muggle setup` processes accumulated in under 20 minutes, ~6 GB resident. The orphans don't get reaped because Claude Code times out the hook itself but doesn't kill the descendants.

## How it behaves now
- Marker present + < 24 h old: script does nothing, exits in ~100 ms.
- Marker stale or absent: runs `timeout -k 5 60 muggle setup` (or `npx -y @muggleai/works setup`), touches the marker, and continues. Hard wallclock cap of 65 s.
- Marker is touched on every attempt (success or failure) so a persistent hang only fires once per day instead of once per session.

## Verified
Manual run in a temp `HOME`:
- First run (cold): 62 s real, ends with `timeout` killing the hung `muggle setup` (confirms the underlying hang).
- Second run (warm marker): 0.109 s, no spawn.

## Test plan
- [ ] On a healthy host: confirm `ls ~/.cache/muggle/electron-app-checked` exists after the first session start of the day and is skipped on subsequent starts within 24 h.
- [ ] On a host where `muggle setup` hangs: confirm `ps` shows zero zombie `muggle setup` processes after several session starts in a row.
- [ ] On a host without `timeout`: confirm the script still runs the bare call (no `timeout` prefix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)