### PR TITLE
chore(release): @muggleai/works 4.12.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.11.4"
+      "version": "4.12.0"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.11.4"
+      "version": "4.12.0"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@muggleai/works",
     "mcpName": "io.github.multiplex-ai/muggle",
-    "version": "4.11.4",
+    "version": "4.12.0",
     "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
     "type": "module",
     "main": "dist/index.js",
@@ -42,14 +42,14 @@
         "test:watch": "vitest"
     },
     "muggleConfig": {
-        "electronAppVersion": "1.0.88",
+        "electronAppVersion": "1.0.90",
         "downloadBaseUrl": "https://github.com/multiplex-ai/muggle-ai-works/releases/download",
         "runtimeTargetDefault": "dev",
         "checksums": {
-            "darwin-arm64": "dbcefc10f2cdeabe8be74490354ed83f600eb18d8f411b3f1dec266e5eb2e95b",
-            "darwin-x64": "ac4430824e18d15476ed91a6bbe81d0880239b758006cbf721d8e7d58a0c3676",
-            "win32-x64": "16119743fb344990f2b67fa2a9844a50a46d70f6fbf3f72435b5ce1d7a635cd9",
-            "linux-x64": "4e43f3946c80918f972a4c587a5f83873ccaeb5338f6eb8b5296022ba096f059"
+            "darwin-arm64": "13fc830ede44af479761302e3477c4f2516be142885445c8c5baf574041a7069",
+            "darwin-x64": "02007eb996d2fa2cf5be6546b6a1a01de769f1b12c7e3b2af1e93eb1b4deda0e",
+            "win32-x64": "5ea49f43ce6c432eac42dd10179873c78067ff1fc1328d8f664ce2c81da38f49",
+            "linux-x64": "f92c350bde46c95fb35ceab8c1c115352663a53d44d210ea98316fe1a92cf41e"
         }
     },
     "dependencies": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "4.11.4",
+  "version": "4.12.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "4.11.4",
+  "version": "4.12.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "4.11.4",
+  "version": "4.12.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "4.11.4",
+      "version": "4.12.0",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"

--- a/src/server/stdio-server.ts
+++ b/src/server/stdio-server.ts
@@ -31,4 +31,15 @@ export async function startStdioServer (server: Server): Promise<void> {
 
   process.on("SIGTERM", () => shutdown("SIGTERM"));
   process.on("SIGINT", () => shutdown("SIGINT"));
+
+  // Parent-death detection. Windows does NOT signal child processes when the
+  // parent dies, so SIGTERM/SIGINT alone leak this process when Claude exits
+  // abruptly (crash, sleep, killed bg job). Need to exit on parent-gone too.
+  watchForParentDeath(shutdown);
+}
+
+/** Exit when the MCP host closes our stdin (its end of the pipe). */
+function watchForParentDeath (shutdown: (reason: string) => void): void {
+  process.stdin.on("end", () => shutdown("stdin-end"));
+  process.stdin.on("close", () => shutdown("stdin-close"));
 }


### PR DESCRIPTION
## Summary

Bumps `@muggleai/works` from **4.11.4 → 4.12.0** (minor) and the bundled desktop runtime from **electronAppVersion 1.0.88 → 1.0.90**.

## Shipping

- **feat(skills)** — stage-8 watcher-handoff restructure + bootstrap (#164) — new `muggle-pr-followup` skill set; this is what makes the bump minor rather than patch
- **fix(plugin/scripts)** — bound + cache muggle setup so SessionStart can't leak procs (#170)
- **fix(postinstall)** — timeouts on fetch + pipeline, guaranteed exit (#167) (#169)
- **fix(skills/regen)** — open scripts page, not runs page (#168)
- **fix(server)** — exit stdio MCP server when host closes stdin (new in this PR). Windows doesn't deliver SIGTERM/SIGINT to MCP grandchildren when the host dies, leaving `muggle serve` blocked forever on a dead stdin pipe and accumulating zombie `node.exe` processes. Now we also listen for `process.stdin` `'end'` and `'close'` and exit on either.

## Electron

| | Before | After |
|---|---|---|
| `electronAppVersion` | 1.0.88 | **1.0.90** |
| `checksums.darwin-arm64` | dbcefc10… | **13fc830e…** |
| `checksums.darwin-x64` | ac443082… | **02007eb9…** |
| `checksums.win32-x64` | 16119743… | **5ea49f43…** |
| `checksums.linux-x64` | 4e43f394… | **f92c350b…** |

All four checksums verified against `electron-app-v1.0.90/checksums.txt` via `scripts/verify-electron-release-checksums.mjs`.

## Manifests touched by sync:versions

- `package.json` → 4.12.0
- `.claude-plugin/marketplace.json`
- `.cursor-plugin/marketplace.json`
- `plugin/.claude-plugin/plugin.json`
- `plugin/.cursor-plugin/plugin.json`
- `server.json`

No manual edits to any of the above.

## Test plan

- [x] `pnpm run lint:check` — 0 errors
- [x] `pnpm run typecheck` — clean
- [x] `pnpm test` — 12442 tests pass (68 vendored-zod "failures" inside `.claude/worktrees/*/node_modules/.pnpm/zod@.../tests/` are pre-existing vitest exclude noise, unrelated to this release; tracked separately)
- [x] `pnpm run build` — succeeds
- [x] `pnpm run verify:plugin` — passes
- [x] `pnpm run verify:contracts` — passes
- [x] `pnpm run verify:electron-release-checksums` — passes (verifies 1.0.90 checksums match GitHub)
- [ ] CI passes on this PR
- [ ] After merge: `gh workflow run publish-works-to-npm.yml --field version=4.12.0` succeeds and `npm view @muggleai/works version` returns 4.12.0