### PR TITLE
fix(vitest): exclude nested node_modules and .claude/worktrees

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     passWithNoTests: true,
-    exclude: ['packages/**', 'apps/**', 'node_modules/**', '.worktrees/**'],
+    exclude: ['packages/**', 'apps/**', '**/node_modules/**', '**/.claude/worktrees/**'],
   },
 });


### PR DESCRIPTION
## Summary

`node_modules/**` only matched the top-level directory, so vitest walked into nested copies under `.claude/worktrees/*/node_modules/.pnpm/...` and picked up ~12,000 vendored library tests on every run — including 68 zod / anthropic-SDK / MCP-SDK test files that failed for missing dev-deps (`@web-std/file`, `@seriousme/openapi-schema-validator`).

This was spotted during the 4.12.0 release run.

## Change

```diff
- exclude: ['packages/**', 'apps/**', 'node_modules/**', '.worktrees/**'],
+ exclude: ['packages/**', 'apps/**', '**/node_modules/**', '**/.claude/worktrees/**'],
```

- `**/node_modules/**` — match at any depth (the real fix)
- `**/.claude/worktrees/**` — replaces the stale `.worktrees/**` reference; worktrees contain duplicate copies of project `src/` that would otherwise be re-walked

## Result

| | Before | After |
|---|---|---|
| Test files | 1135 | **7** |
| Tests | 12442 | **126** |
| Duration | 23.54s | **0.4s** |
| Spurious "failed" files | 68 | **0** |

Only the project's own root tests run now, as intended. Workspace package tests (`packages/mcps`, `packages/workflows`) are unaffected — they were already excluded via `packages/**` and run via `pnpm test:workspace` / turbo with each package's own config.

## Test plan

- [x] `pnpm test` — 7 files / 126 tests / 0 failed
- [ ] CI passes