### PR TITLE
fix(skills): bootstrap cursor defaults to 0; --forward-only opts in

### DIFF
--- a/internal/skills/pr-followup-fixtures/bootstrap/03-fresh-url-forward-only.json
+++ b/internal/skills/pr-followup-fixtures/bootstrap/03-fresh-url-forward-only.json
@@ -1,9 +1,9 @@
 {
-  "name": "01-fresh-url-with-reviews",
-  "description": "Bootstrap on a PR that already has two submitted reviews from prior manual back-and-forth. Default cursor is 0, so the watcher will pick up both existing reviews on its first tick. Seeds prs.json + last_seen.json + state.md, then dispatches the first watcher.",
+  "name": "03-fresh-url-forward-only",
+  "description": "Bootstrap with the --forward-only flag on a PR with prior reviews. Cursor pins to max(existing review id); the watcher skips history.",
 
   "input": {
-    "args": "https://github.com/acme/widget/pull/142",
+    "args": "https://github.com/acme/widget/pull/142 --forward-only",
     "cwd_state": {
       "is_git_repo": true,
       "toplevel": "/home/stan/repos/widget",
@@ -21,7 +21,7 @@
         "state": "OPEN",
         "mergedAt": null,
         "closedAt": null,
-        "body": "## Goal\n\nDo the thing.\n\n## Acceptance Criteria\n\n- Thing is done.\n",
+        "body": "## Goal\n\nDo the thing.\n",
         "title": "Do the thing",
         "author": { "login": "stan4git" }
       },
@@ -38,13 +38,9 @@
     "outcome": "bootstrapped",
     "state_writes": {
       ".muggle-do/sessions/acme-widget-pr142/prs.json": "single entry: {repo:acme/widget, number:142, url:..., head_sha:abc1230, state:open}",
-      ".muggle-do/sessions/acme-widget-pr142/last_seen.json": "key 'acme/widget#142' with reviewId:0 (default; first tick will dispatch both existing reviews), last_pushed_sha:null, idle_tick_count:0, cycles_completed:0, escalated_review_ids:[], pushed_shas:[]",
+      ".muggle-do/sessions/acme-widget-pr142/last_seen.json": "key 'acme/widget#142' with reviewId:4295962850 (max — --forward-only), last_pushed_sha:null, idle_tick_count:0, cycles_completed:0, escalated_review_ids:[], pushed_shas:[]",
       ".muggle-do/sessions/acme-widget-pr142/state.md": "PR url, slug, loop_user: stan4git, Bootstrapped from URL: yes"
     },
-    "files_NOT_written": [
-      ".muggle-do/sessions/acme-widget-pr142/cycle.json",
-      ".muggle-do/sessions/acme-widget-pr142/requirements.md"
-    ],
     "telemetry_events": [
       {
         "skill": "muggle-pr-followup",
@@ -53,15 +49,15 @@
         "session_slug": "acme-widget-pr142",
         "repo": "acme/widget",
         "pr_number": 142,
-        "cursor_review_id": 0,
+        "cursor_review_id": 4295962850,
         "resume": false
       }
     ],
     "side_effects": [
-      "Print bootstrap success summary (Cursor: 0 — will process 2 existing review(s) on first tick)",
+      "Print bootstrap success summary (Cursor: review #4295962850, forward-only)",
       "/loop 1m /muggle:muggle-pr-followup acme-widget-pr142 142"
     ],
     "respawned": false,
-    "notes": "Default cursor=0 — first tick will dispatch /muggle-do for both reviews 4295962800 and 4295962850. To skip prior history, pass --forward-only."
+    "notes": "--forward-only restores the previous default behavior (pin past existing reviews). Use when bootstrapping a PR with stale/already-handled prior reviews."
   }
 }

--- a/plugin/skills/muggle-pr-followup/SKILL.md
+++ b/plugin/skills/muggle-pr-followup/SKILL.md
@@ -27,10 +27,11 @@ The skill recognizes two modes by inspecting `$ARGUMENTS` and falling back to on
 | `<pr-number>` alone | zero or multiple matches | **error:** ambiguous; list candidates and exit |
 | empty / `help` / `?` | — | **help:** list active loops per [`output-templates/help.md`](output-templates/help.md) |
 
-Bootstrap accepts two optional trailing flags:
+Bootstrap accepts three optional trailing flags:
 
 - `--slug=<name>` — override the default `<repo>-pr<n>` slug
 - `--resume` — opt in to reusing an existing session slot (default is refuse on conflict)
+- `--forward-only` — pin cursor past existing reviews (skip history). Default is cursor 0, which processes prior submitted reviews on the first tick.
 
 ## Folder TOC
 

--- a/plugin/skills/muggle-pr-followup/bootstrap.md
+++ b/plugin/skills/muggle-pr-followup/bootstrap.md
@@ -12,11 +12,12 @@ Bootstrap is **non-interactive**: it runs straight through, prompts the user for
 
 ## Input
 
-`$ARGUMENTS = <pr-url> [--slug=<name>] [--resume]`
+`$ARGUMENTS = <pr-url> [--slug=<name>] [--resume] [--forward-only]`
 
 - `<pr-url>` matches `https?://github\.com/[^/]+/[^/]+/pull/\d+` — required.
 - `--slug=<name>` overrides the default `<repo>-pr<n>` slug.
 - `--resume` opts into refreshing an existing slot instead of refusing on conflict.
+- `--forward-only` pins the cursor past existing reviews (skip history). Default is cursor 0 — the watcher will pick up prior submitted reviews on its first tick.
 
 ## Procedure
 
@@ -47,7 +48,8 @@ If `.muggle-do/sessions/<slug>/` exists:
 
 ### Step 6 — Resolve the initial cursor
 
-Fetch reviews per [`../_shared/github-cli-recipes/submitted-reviews.md`](../_shared/github-cli-recipes/submitted-reviews.md) with cursor 0, then take `max(id)`. If none, the cursor is 0. The watcher only acts on `id > cursor`, so this pins forward-only.
+- **Default (no `--forward-only`):** cursor is `0`. The watcher will pick up every existing submitted review on its first tick. This matches the common case where the user opened the PR, left review comments they want addressed, and is now running bootstrap.
+- **With `--forward-only`:** fetch reviews per [`../_shared/github-cli-recipes/submitted-reviews.md`](../_shared/github-cli-recipes/submitted-reviews.md), then take `max(id)`. The watcher only acts on later submissions. Use when bootstrapping a PR with stale/already-handled prior reviews you don't want re-processed.
 
 ### Step 7 — Seed state files
 

--- a/plugin/skills/muggle-pr-followup/output-templates/bootstrap.md
+++ b/plugin/skills/muggle-pr-followup/output-templates/bootstrap.md
@@ -5,7 +5,7 @@
 ```
 Bootstrapped PR follow-up for <owner>/<repo>#<n>
   Slug:           <slug>
-  Cursor:         review #<id> (forward-only) | empty (no prior reviews)
+  Cursor:         0 (will process <N> existing review(s) on first tick) | review #<id> (forward-only) | empty (no prior reviews)
   Working tree:   <toplevel>
   Dispatching:    /loop 1m /muggle:muggle-pr-followup <slug> <n>
 ```


### PR DESCRIPTION
## Summary

Inverts the bootstrap cursor default. Now pins to **0** (process all prior submitted reviews); a new \`--forward-only\` flag restores the old behavior (pin past history).

## Why

Validation run 1 (PR #174) surfaced the edge: the prior default silently skipped review comments the user had left on the PR before bootstrapping. Workflow:

1. User opens PR
2. User writes review comments they want the bot to address
3. User runs \`/muggle:muggle-pr-followup <pr-url>\`
4. Bootstrap pinned cursor to the user's own latest review → first tick skipped it → bot never acts → user confused

The "default cursor 0" path matches this expectation. \`--forward-only\` is for the case where someone runs bootstrap on a PR that has stale/already-handled review history they don't want re-processed.

## Changes

- \`muggle-pr-followup/bootstrap.md\` — input section adds \`--forward-only\`; Step 6 documents the default and the opt-in path.
- \`muggle-pr-followup/SKILL.md\` — routing section lists three flags now (\`--slug=\`, \`--resume\`, \`--forward-only\`).
- \`muggle-pr-followup/output-templates/bootstrap.md\` — success-summary cursor line covers the new default form.
- \`internal/skills/pr-followup-fixtures/bootstrap/01-fresh-url-with-reviews.json\` — refreshed: cursor=0 default, both prior reviews dispatch on first tick.
- \`internal/skills/pr-followup-fixtures/bootstrap/03-fresh-url-forward-only.json\` — new fixture covering the \`--forward-only\` path.

## Test plan

- [x] vitest 126/126 passing
- [ ] Brain doc \`2026-05-19-pr-followup-bootstrap-design.md\` Decision 1 needs a follow-up update (tracked separately — the works-side change is the load-bearing one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)