### PR TITLE
fix(local-exec) + docs(skills): persist failed-run artifacts and forbid stdout-tail diagnosis

### DIFF
--- a/packages/mcps/src/mcp/local/services/execution-service.ts
+++ b/packages/mcps/src/mcp/local/services/execution-service.ts
@@ -29,9 +29,6 @@ import type { RunResultStatus } from "./run-result-storage-service.js";
 
 const logger = getLogger();
 
-// ========================================
-// Types
-// ========================================
 
 /**
  * Internal execution process tracking.
@@ -81,16 +78,8 @@ export interface ILocalRunResult {
   errorMessage?: string;
 }
 
-// ========================================
-// Active Process Tracking
-// ========================================
-
 /** Map of active execution processes. */
 const activeProcesses: Map<string, IInternalExecutionProcess> = new Map();
-
-// ========================================
-// Auth Helpers
-// ========================================
 
 /**
  * Get the authenticated user ID.
@@ -199,10 +188,6 @@ function buildStudioAuthContent(): { accessToken: string; email: string; userId:
     userId: storedAuth.userId,
   };
 }
-
-// ========================================
-// Temp File Helpers
-// ========================================
 
 /**
  * Ensure temp directory exists.
@@ -600,10 +585,6 @@ async function executeElectronAppAsync(params: {
   });
 }
 
-// ========================================
-// Main Execution Functions
-// ========================================
-
 /**
  * Execute test script generation for a test case.
  *
@@ -716,11 +697,29 @@ export async function executeTestGeneration(params: {
           `Electron exited with code ${executionResult.exitCode}.\n` +
           `STDOUT:\n${executionResult.stdout}\n` +
           `STDERR:\n${executionResult.stderr}`;
+
+        const sessionsDir = getStorageService().getSessionsDir();
+        const artifactsDir = path.join(sessionsDir, runId);
+        const generatedScriptPath = path.join(
+          path.dirname(inputFilePath),
+          `gen_${path.basename(inputFilePath)}`,
+        );
+        // goal_not_achievable and partial-progress failures often still leave a gen_*.json
+        // with the agent's attempted steps + halt summary. Persist it so reviewers can see
+        // what was tried. Silent on missing — early Electron crashes write no gen file.
+        try {
+          await fs.copyFile(generatedScriptPath, path.join(artifactsDir, "action-script.json"));
+          await fs.unlink(generatedScriptPath).catch(() => {});
+        } catch {
+          // No gen file produced before failure.
+        }
+
         storage.updateRunResult(runId, {
           status: "failed",
           testScriptId: localTestScript.id,
           executionTimeMs: executionTimeMs,
           errorMessage: failureMessage,
+          artifactsDir: artifactsDir,
           localExecutionContext: {
             ...localExecutionContextBase,
             localExecutionCompletedAt: completedAt,
@@ -913,10 +912,12 @@ export async function executeReplay(params: {
           `Electron exited with code ${executionResult.exitCode}.\n` +
           `STDOUT:\n${executionResult.stdout}\n` +
           `STDERR:\n${executionResult.stderr}`;
+        const artifactsDir = path.join(getStorageService().getSessionsDir(), runId);
         storage.updateRunResult(runId, {
           status: "failed",
           executionTimeMs: executionTimeMs,
           errorMessage: failureMessage,
+          artifactsDir: artifactsDir,
           localExecutionContext: {
             ...localExecutionContextBase,
             localExecutionCompletedAt: completedAt,

--- a/plugin/skills/_shared/failure-mode-handling.md
+++ b/plugin/skills/_shared/failure-mode-handling.md
@@ -109,11 +109,19 @@ Triggered when `muggle-local-execute-replay` returns `status: "failed"` (or non-
 | **stale-script** | The test script no longer matches the live UI (selectors moved, label paths changed, page renamed). The product still works; the script is out of date. |
 | **product-defect** | The script and infra are fine; the user's app actually misbehaved (assertion failure on previously-passing step, unexpected error, wrong page after action). This is the failure mode acceptance testing exists to catch. |
 
+### Where to read signals
+
+Call `muggle-local-run-result-get` (local) or the remote equivalent and read **structured fields**, not `execute`'s response stdout tail (it's a truncated display excerpt and routinely cuts off mid-sentence). Order:
+
+1. `Status` + `Error` — the verdict and the one-line cause.
+2. `Artifacts` section, when present — opens `artifactsDir`. Read `results.md` (step-by-step + screenshot links) for the per-step verdict, then `action-script.json` for what the agent attempted.
+3. `stdout.log` / `stderr.log` only when the Artifacts section is absent or `results.md` doesn't exist (e.g. early Electron failure).
+
+Replay-mode failures usually have `artifactsDir` because the prior script ran. If a replay run is missing it, treat that itself as an `infra` signal — Electron didn't get far enough to record steps.
+
 ### Initial signal heuristics
 
-Derive signals from the run's per-step results, error messages, and step screenshots (`muggle-local-run-result-get`):
-
-- **infra** signals: `electron-crash`, `chromium-error`, `click-no-effect-on-clickable-element`, `timeout-on-trivial-wait`, `internal-error-in-mcp-output`.
+- **infra** signals: `electron-crash`, `chromium-error`, `click-no-effect-on-clickable-element`, `timeout-on-trivial-wait`, `internal-error-in-mcp-output`, `artifacts-dir-missing-on-replay`.
 - **stale-script** signals: `element-not-found`, `selector-timeout`, `label-path-mismatch`, `nav-target-404`, `aria-label-changed`.
 - **product-defect** signals: `assertion-failed-on-passing-step`, `unexpected-error-toast`, `wrong-page-after-action`, `network-500-from-app`, `form-validation-rejected-valid-input`.
 
@@ -189,9 +197,17 @@ Triggered when `muggle-local-execute-test-generation` (or the remote equivalent)
 | **agent-course** | The generation agent went down a wrong path (chose the wrong button, misread the goal, looped on a blocking modal). The product is fine and the test case is fine — the agent's *course* needs steering. |
 | **product-uxux** | The product itself blocks the test (broken page, missing element, server error). Agent can't proceed because the feature doesn't actually work. |
 
-### Initial signal heuristics
+### Where to read signals
 
-From `muggle-local-run-result-get` (summary, structured summary, last steps, error):
+Same rule as section B: read **structured fields** from `muggle-local-run-result-get`, not `execute`'s response stdout tail. **Failed local regen runs do not get `action-script.json` / `results.md` / per-step screenshots persisted** — only `stdout.log` + `stderr.log` are written to `<sessionsDir>/<runId>/`, and the run record's `Artifacts` section is absent. Don't go hunting elsewhere on disk for the per-step report; it doesn't exist for failed regen.
+
+Order:
+
+1. `Status` + `Error` — the verdict and one-line cause. `Error: Electron exited with code 26` typically means `goal_not_achievable`.
+2. `stdout.log` / `stderr.log` at `<sessionsDir>/<runId>/` — last 100 lines is usually enough; look for the final structured summary the generation agent emitted (it appears near the end as a JSON-ish block, not in the truncated execute tail).
+3. Remote regen — fetch the workflow run with `muggle-remote-wf-get-ts-gen-latest-run`; signals live in `summaryStep` and the per-step list there.
+
+### Initial signal heuristics
 
 - **transient**: `network-error`, `llm-rate-limit`, `single-tool-call-error`, run had partial progress then died.
 - **infra**: `electron-mcp-handler-crash`, `internal-validation-error`, `pipeline-stuck`, identical failure repeated more than twice.

--- a/plugin/skills/_shared/failure-mode-handling.md
+++ b/plugin/skills/_shared/failure-mode-handling.md
@@ -117,11 +117,9 @@ Call `muggle-local-run-result-get` (local) or the remote equivalent and read **s
 2. `Artifacts` section, when present — opens `artifactsDir`. Read `results.md` (step-by-step + screenshot links) for the per-step verdict, then `action-script.json` for what the agent attempted.
 3. `stdout.log` / `stderr.log` only when the Artifacts section is absent or `results.md` doesn't exist (e.g. early Electron failure).
 
-Replay-mode failures usually have `artifactsDir` because the prior script ran. If a replay run is missing it, treat that itself as an `infra` signal — Electron didn't get far enough to record steps.
-
 ### Initial signal heuristics
 
-- **infra** signals: `electron-crash`, `chromium-error`, `click-no-effect-on-clickable-element`, `timeout-on-trivial-wait`, `internal-error-in-mcp-output`, `artifacts-dir-missing-on-replay`.
+- **infra** signals: `electron-crash`, `chromium-error`, `click-no-effect-on-clickable-element`, `timeout-on-trivial-wait`, `internal-error-in-mcp-output`.
 - **stale-script** signals: `element-not-found`, `selector-timeout`, `label-path-mismatch`, `nav-target-404`, `aria-label-changed`.
 - **product-defect** signals: `assertion-failed-on-passing-step`, `unexpected-error-toast`, `wrong-page-after-action`, `network-500-from-app`, `form-validation-rejected-valid-input`.
 
@@ -199,13 +197,14 @@ Triggered when `muggle-local-execute-test-generation` (or the remote equivalent)
 
 ### Where to read signals
 
-Same rule as section B: read **structured fields** from `muggle-local-run-result-get`, not `execute`'s response stdout tail. **Failed local regen runs do not get `action-script.json` / `results.md` / per-step screenshots persisted** — only `stdout.log` + `stderr.log` are written to `<sessionsDir>/<runId>/`, and the run record's `Artifacts` section is absent. Don't go hunting elsewhere on disk for the per-step report; it doesn't exist for failed regen.
+Same rule as section B: read **structured fields** from `muggle-local-run-result-get`, not `execute`'s response stdout tail. The `Artifacts` section is present on failed regen too — `action-script.json` is included when generation reached the step-emission stage (typical for `goal_not_achievable`: the agent's attempted steps + halt summary). `results.md` and per-step screenshots are absent on failure (electron-app emits those only on the successful completion path).
 
 Order:
 
 1. `Status` + `Error` — the verdict and one-line cause. `Error: Electron exited with code 26` typically means `goal_not_achievable`.
-2. `stdout.log` / `stderr.log` at `<sessionsDir>/<runId>/` — last 100 lines is usually enough; look for the final structured summary the generation agent emitted (it appears near the end as a JSON-ish block, not in the truncated execute tail).
-3. Remote regen — fetch the workflow run with `muggle-remote-wf-get-ts-gen-latest-run`; signals live in `summaryStep` and the per-step list there.
+2. `action-script.json` in `artifactsDir` when present — read the steps the agent attempted and the `summaryStep` (halt reason, goal-not-achievable verdict).
+3. `stdout.log` / `stderr.log` at `artifactsDir/` — last 100 lines is usually enough; look for the final structured summary the generation agent emitted (it appears near the end as a JSON-ish block, not in the truncated execute tail).
+4. Remote regen — fetch the workflow run with `muggle-remote-wf-get-ts-gen-latest-run`; signals live in `summaryStep` and the per-step list there.
 
 ### Initial signal heuristics
 

--- a/plugin/skills/muggle-test-feature-local/SKILL.md
+++ b/plugin/skills/muggle-test-feature-local/SKILL.md
@@ -198,8 +198,8 @@ If publish rejects with `has no generated actionScript steps to publish` (true z
 **Do not diagnose from `execute`'s response stdout tail.** That tail is a truncated excerpt for human display and routinely cuts off mid-sentence. The only ground truth is the run record.
 
 - `muggle-local-run-result-get` with the run id from execute.
-- **Read in this order:** `Status` → `Error` → **`Artifacts` section** (when present, it names `artifactsDir` and lists `action-script.json` / `results.md` / `screenshots/` / `stdout.log` / `stderr.log`). On a `passed` run, `results.md` is the step-by-step verdict with screenshot links — read it before summarizing.
-- **Failed local runs do not get `action-script.json` / `results.md` / per-step screenshots** — only `stdout.log` + `stderr.log` are written to `<sessionsDir>/<runId>/`. Don't go hunting elsewhere; the `Artifacts` section being absent **is** the signal that per-step data wasn't persisted, and the `Error` field is the verdict.
+- **Read in this order:** `Status` → `Error` → **`Artifacts` section** (always present after a run completes; names `artifactsDir` and lists the files actually on disk: `action-script.json`, `results.md`, `screenshots/`, `stdout.log`, `stderr.log`). On a `passed` run, `results.md` is the step-by-step verdict with screenshot links — read it before summarizing.
+- **On failure**, the `Artifacts` section is still present. `stdout.log` + `stderr.log` are always there. `action-script.json` is there when generation got far enough to emit it (typical for `goal_not_achievable` / mid-progress crashes — the file holds the agent's attempted steps + halt summary). `results.md` and per-step screenshots are absent on failure (electron-app only emits those on the successful completion path) — don't hunt elsewhere on disk for them.
 - Include in the report: status, duration, pass/fail summary, per-step summary (passed runs), artifact paths, errors if failed, and script view URL when publishing ran.
 
 ### 9a. Route failures through the failure-mode handler

--- a/plugin/skills/muggle-test-feature-local/SKILL.md
+++ b/plugin/skills/muggle-test-feature-local/SKILL.md
@@ -195,8 +195,12 @@ If publish rejects with `has no generated actionScript steps to publish` (true z
 
 ### 9. Report
 
+**Do not diagnose from `execute`'s response stdout tail.** That tail is a truncated excerpt for human display and routinely cuts off mid-sentence. The only ground truth is the run record.
+
 - `muggle-local-run-result-get` with the run id from execute.
-- Include: status, duration, pass/fail summary, per-step summary, artifact/screenshot paths, errors if failed, and script view URL when publishing ran.
+- **Read in this order:** `Status` → `Error` → **`Artifacts` section** (when present, it names `artifactsDir` and lists `action-script.json` / `results.md` / `screenshots/` / `stdout.log` / `stderr.log`). On a `passed` run, `results.md` is the step-by-step verdict with screenshot links — read it before summarizing.
+- **Failed local runs do not get `action-script.json` / `results.md` / per-step screenshots** — only `stdout.log` + `stderr.log` are written to `<sessionsDir>/<runId>/`. Don't go hunting elsewhere; the `Artifacts` section being absent **is** the signal that per-step data wasn't persisted, and the `Error` field is the verdict.
+- Include in the report: status, duration, pass/fail summary, per-step summary (passed runs), artifact paths, errors if failed, and script view URL when publishing ran.
 
 ### 9a. Route failures through the failure-mode handler
 
@@ -242,6 +246,7 @@ After reporting results:
 
 - No silent auth skip.
 - **Never prompt for Electron launch approval** before execution — invoking this skill is the approval. Just run.
+- **Never diagnose a failed run from `execute`'s response stdout tail.** Always call `muggle-local-run-result-get` first; classify only from its structured fields and (when present) the artifacts it names. The execute tail is an excerpt and routinely truncates the failure cause.
 - If replayable scripts exist, do not default to generation without user choice.
 - No hiding failures: surface errors and artifact paths.
 - **Always offer the agent-guidance reminder after every Electron run** (Step 9b) — pass or fail — unless 9a already routed the user into `muggle-feedback`. Never silently end a run without giving the user a one-click path to flag what was wrong.

--- a/plugin/skills/muggle-test/SKILL.md
+++ b/plugin/skills/muggle-test/SKILL.md
@@ -289,9 +289,9 @@ If a run fails, log it and continue to the next — do not abort the batch. Fail
 
 ### Collect results (in parallel)
 
-For every `runId`, issue all `muggle-local-run-result-get` calls in parallel. Extract from the **structured response only** (not from `execute`'s stdout tail, which is a truncated display excerpt): `Status`, `Error`, `Duration`, and the `Artifacts` section when present (`artifactsDir` + the files it lists — `action-script.json` / `results.md` / `screenshots/` / `stdout.log` / `stderr.log`).
+For every `runId`, issue all `muggle-local-run-result-get` calls in parallel. Extract from the **structured response only** (not from `execute`'s stdout tail, which is a truncated display excerpt): `Status`, `Error`, `Duration`, and the `Artifacts` section (always present after a run completes — names `artifactsDir` and lists the files actually on disk).
 
-For passed runs, `results.md` inside `artifactsDir` is the step-by-step verdict — read it before summarizing. For failed runs, the `Artifacts` section is absent because per-step data isn't persisted on failure (only `stdout.log` + `stderr.log` at `<sessionsDir>/<runId>/`) — use `Error` as the verdict and route through Step 7C, don't go hunting on disk.
+For passed runs, `results.md` inside `artifactsDir` is the step-by-step verdict — read it before summarizing. For failed runs, `stdout.log` + `stderr.log` are always present and `action-script.json` is present when generation reached the step-emission stage (typical for `goal_not_achievable`); use `Error` as the headline verdict and route through Step 7C.
 
 ### Publish each run to cloud (gated by `autoPublishLocalResults`)
 

--- a/plugin/skills/muggle-test/SKILL.md
+++ b/plugin/skills/muggle-test/SKILL.md
@@ -289,7 +289,9 @@ If a run fails, log it and continue to the next — do not abort the batch. Fail
 
 ### Collect results (in parallel)
 
-For every `runId`, issue all `muggle-local-run-result-get` calls in parallel. Extract: status, duration, step count, `artifactsDir`.
+For every `runId`, issue all `muggle-local-run-result-get` calls in parallel. Extract from the **structured response only** (not from `execute`'s stdout tail, which is a truncated display excerpt): `Status`, `Error`, `Duration`, and the `Artifacts` section when present (`artifactsDir` + the files it lists — `action-script.json` / `results.md` / `screenshots/` / `stdout.log` / `stderr.log`).
+
+For passed runs, `results.md` inside `artifactsDir` is the step-by-step verdict — read it before summarizing. For failed runs, the `Artifacts` section is absent because per-step data isn't persisted on failure (only `stdout.log` + `stderr.log` at `<sessionsDir>/<runId>/`) — use `Error` as the verdict and route through Step 7C, don't go hunting on disk.
 
 ### Publish each run to cloud (gated by `autoPublishLocalResults`)
 


### PR DESCRIPTION
## Why

Session 311e2e (E2E test of muggle-ai-ui#311) diagnosed a failed run from `execute`'s response stdout tail — the truncated excerpt `\"After 18+ attempts to click vari…\"` — instead of calling `muggle-local-run-result-get`. Then, after being told to use the right tool, it went hunting through `AppData/Roaming/Muggle AI Studio` for per-step artifacts that, on a failed local regen, were never persisted.

**Three distinct gaps caused this**, all fixed here:

1. **No invariant against stdout-tail diagnosis.** Skills said *what to do* (call run-result-get) but not *what not to do* (interpret execute's stdout). In-context stdout always beats a tool call when both look authoritative.
2. **Skills didn't say what the tool actually returns.** `muggle-local-run-result-get` names `artifactsDir` and lists `results.md` / `action-script.json` / `screenshots/` — but the skills never described that shape, so agents went on doomed disk hunts.
3. **Failed runs lost their artifacts.** `moveResultsToArtifacts` was only called on the passed path in `execution-service.ts`. `goal_not_achievable` runs and mid-progress crashes routinely have a `gen_*.json` with the agent's attempted steps + halt summary — that file got cleaned up with the temp dir instead of being persisted. Failures are exactly when per-step replay would be most useful.

## Summary

**Code** — `packages/mcps/src/mcp/local/services/execution-service.ts`:
- Both `executeTestGeneration` and `executeReplay` failure paths now set `artifactsDir` to `<sessionsDir>/<runId>/` on the run result, so the response `Artifacts` section is always present (pointing at the stdout.log/stderr.log that `writeExecutionLogs` always wrote there).
- Generation failure additionally best-effort moves `gen_<run>.json` → `action-script.json` when present. Silent catch on missing — early Electron crashes write no gen file. Net result: `goal_not_achievable` and partial-progress failures now persist the agent's attempted steps + halt summary for human/AI inspection.
- Drive-by: removed banner-comment blocks per CLAUDE.md no-bloat rules.

**Skill docs**:
- `muggle-test-feature-local/SKILL.md` Step 9 rewritten with a read-order (`Status` → `Error` → `Artifacts` section). New non-negotiable: never diagnose from execute's stdout tail.
- `muggle-test/SKILL.md` Step 7A \"Collect results\" gets the same invariant for the batch path.
- `_shared/failure-mode-handling.md` sections B (post-replay) and C (post-regen) each get a new \"Where to read signals\" subsection naming the read order. Section C points at `action-script.json` *before* stdout/stderr — it's the cleanest source for the agent's attempted steps + halt summary on a failed regen.

`muggle-do-task` and `muggle-test-regenerate-missing` delegate to the shared doc, so they inherit the fix without per-skill duplication.

## What still isn't persisted on failure (and why)

`results.md` and per-step screenshots are emitted by the electron-app itself on its successful completion path. The MCP host can't fabricate those after a failure — the agent only writes them once the run reaches that final stage. The docs now state this clearly so the AI doesn't go hunting.

## Test plan

- [ ] Tests pass — `pnpm run test --filter @muggleai/mcp` (126/126 local).
- [ ] Typecheck clean — `pnpm run typecheck --filter @muggleai/mcp`.
- [ ] Run a `muggle-test-feature-local` flow that produces a `goal_not_achievable` failure; verify `run-result-get` returns an `Artifacts` section pointing at `<sessionsDir>/<runId>/` containing `action-script.json` + `stdout.log` + `stderr.log`.
- [ ] Run a passed flow; verify `results.md` is still listed (no regression on the success path).
- [ ] Run a replay that fails on a stale selector; verify the `Artifacts` section is present even though no script regeneration happened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)