### PR TITLE
feat(mcps): consume backend-paginated test-runs/summary endpoint

### DIFF
--- a/packages/mcps/src/mcp/tools/e2e/test-runs-summary-transform.ts
+++ b/packages/mcps/src/mcp/tools/e2e/test-runs-summary-transform.ts
@@ -4,6 +4,19 @@
  * keeps each row down to the fields an LLM actually reasons about so the
  * page slice doesn't carry duplicated useCase blocks and empty
  * studioAuthInfo nested objects across the wire.
+ *
+ * No input type lives here: the request shape is owned and validated by
+ * `ProjectTestRunsSummaryInputSchema` in `mcp/e2e/contracts`, and the tool
+ * handler in `tool-registry.ts` derives its parameter type from that schema
+ * via `z.infer`. Keeping a parallel TS interface here would create a second
+ * source of truth that could drift from the validator.
+ *
+ * No per-page aggregate (e.g. `byStatus`) is emitted: a status histogram
+ * computed over one page would describe only those entries and mislead the
+ * LLM about project-wide health (page 1 of 6 showing FAILED:18/PASSED:2
+ * reads like a 90% failure rate even when overall failures are 20 of ~116
+ * runs). If a project-wide histogram becomes an LLM requirement, the
+ * backend envelope should carry it.
  */
 
 import type { IUpstreamResponse } from "../../e2e/types.js";

--- a/packages/mcps/src/mcp/tools/e2e/test-runs-summary-transform.ts
+++ b/packages/mcps/src/mcp/tools/e2e/test-runs-summary-transform.ts
@@ -1,11 +1,9 @@
 /**
- * Slim + aggregate + paginate the upstream test-runs/summary payload.
- *
- * Upstream returns the full object graph (use case, test case, workflow run,
- * test script) per test-case row — ~150 lines × N test cases, which blows
- * past LLM token budgets on any non-trivial project. This transform keeps
- * only the fields an LLM needs to reason about run state and paginates the
- * result MCP-side (upstream does not support page params on this endpoint).
+ * Slim the per-row payload returned by the paginated test-runs/summary
+ * endpoint. The backend now handles sort + slice + envelope; this transform
+ * keeps each row down to the fields an LLM actually reasons about so the
+ * page slice doesn't carry duplicated useCase blocks and empty
+ * studioAuthInfo nested objects across the wire.
  */
 
 import type { IUpstreamResponse } from "../../e2e/types.js";
@@ -19,6 +17,15 @@ interface IRawSummaryEntry {
   error?: string;
 }
 
+interface IRawEnvelope {
+  data?: IRawSummaryEntry[];
+  page?: number;
+  pageSize?: number;
+  totalCount?: number;
+  totalPages?: number;
+  hasMore?: boolean;
+}
+
 interface ISlimSummaryEntry {
   status: string;
   testCaseId?: string;
@@ -30,20 +37,10 @@ interface ISlimSummaryEntry {
   latestWorkflowRunId?: string;
 }
 
-export interface ITestRunsSummaryInput {
-  page: number;
-  pageSize: number;
-  sortBy: "lastRunAt" | "status" | "testCaseTitle";
-  sortOrder: "asc" | "desc";
-}
-
 export interface ITestRunsSummaryOutput {
-  totals: {
-    total: number;
-    byStatus: Record<string, number>;
-  };
   page: number;
   pageSize: number;
+  totalCount: number;
   totalPages: number;
   hasMore: boolean;
   runs: ISlimSummaryEntry[];
@@ -63,57 +60,17 @@ function slimEntry(raw: IRawSummaryEntry): ISlimSummaryEntry {
   return slim;
 }
 
-function aggregateByStatus(entries: readonly IRawSummaryEntry[]): Record<string, number> {
-  const counts: Record<string, number> = {};
-  for (const entry of entries) {
-    const status = entry.status ?? UNKNOWN_STATUS;
-    counts[status] = (counts[status] ?? 0) + 1;
-  }
-  return counts;
-}
-
-function sortRuns(
-  runs: readonly ISlimSummaryEntry[],
-  sortBy: ITestRunsSummaryInput["sortBy"],
-  sortOrder: ITestRunsSummaryInput["sortOrder"],
-): ISlimSummaryEntry[] {
-  const sign = sortOrder === "asc" ? 1 : -1;
-  return [...runs].sort((a, b) => {
-    const av = a[sortBy];
-    const bv = b[sortBy];
-    // Missing values sink to the end under both asc and desc — a page of
-    // failures shouldn't get padded with rows that have no signal — so we
-    // apply this rule before the sortOrder sign flips anything.
-    if (av === undefined && bv === undefined) return 0;
-    if (av === undefined) return 1;
-    if (bv === undefined) return -1;
-    if (av < bv) return -1 * sign;
-    if (av > bv) return 1 * sign;
-    return 0;
-  });
-}
-
-export function mapTestRunsSummary(
-  response: IUpstreamResponse,
-  input?: unknown,
-): ITestRunsSummaryOutput {
-  const params = input as ITestRunsSummaryInput;
-  const raw = Array.isArray(response.data) ? (response.data as IRawSummaryEntry[]) : [];
-
-  const byStatus = aggregateByStatus(raw);
-  const sorted = sortRuns(raw.map(slimEntry), params.sortBy, params.sortOrder);
-
-  const total = sorted.length;
-  const totalPages = Math.max(1, Math.ceil(total / params.pageSize));
-  const start = (params.page - 1) * params.pageSize;
-  const runs = sorted.slice(start, start + params.pageSize);
+export function mapTestRunsSummary(response: IUpstreamResponse): ITestRunsSummaryOutput {
+  const envelope = (response.data ?? {}) as IRawEnvelope;
+  const rawRuns = Array.isArray(envelope.data) ? envelope.data : [];
+  const runs = rawRuns.map(slimEntry);
 
   return {
-    totals: { total: total, byStatus: byStatus },
-    page: params.page,
-    pageSize: params.pageSize,
-    totalPages: totalPages,
-    hasMore: params.page < totalPages,
+    page: envelope.page ?? 1,
+    pageSize: envelope.pageSize ?? runs.length,
+    totalCount: envelope.totalCount ?? runs.length,
+    totalPages: envelope.totalPages ?? (runs.length === 0 ? 0 : 1),
+    hasMore: envelope.hasMore ?? false,
     runs: runs,
   };
 }

--- a/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
+++ b/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
@@ -828,13 +828,19 @@ const reportTools: IQaToolDefinition[] = [
   {
     name: "muggle-remote-project-test-runs-summary-get",
     description:
-      "Get a paginated, slimmed summary of latest test runs for a project. Response shape: { totals: { total, byStatus }, page, pageSize, totalPages, hasMore, runs: [{ status, testCaseId, testCaseTitle, useCaseId, useCaseTitle, lastRunAt, error, latestWorkflowRunId }] }. Returns 20 runs per page by default (max 100). `totals` covers the full project; `runs` is the page slice. Check `hasMore` to decide whether to fetch additional pages. Use muggle-remote-test-case-get / muggle-remote-wf-get-ts-replay-latest-run for full per-run detail.",
+      "Get a paginated, slimmed summary of latest test runs for a project. Response shape: { page, pageSize, totalCount, totalPages, hasMore, runs: [{ status, testCaseId, testCaseTitle, useCaseId, useCaseTitle, lastRunAt, error, latestWorkflowRunId }] }. Returns 20 runs per page by default (max 100). `totalCount` is the project-wide total after the replay-status filter; `runs` is the page slice. Check `hasMore` to decide whether to fetch additional pages. Use muggle-remote-test-case-get / muggle-remote-wf-get-ts-replay-latest-run for full per-run detail.",
     inputSchema: schemas.ProjectTestRunsSummaryInputSchema,
     mapToUpstream: (input) => {
       const data = input as z.infer<typeof schemas.ProjectTestRunsSummaryInputSchema>;
       return {
         method: "GET",
-        path: `${MUGGLE_TEST_PREFIX}/projects/${data.projectId}/test-runs/summary`,
+        path: `${MUGGLE_TEST_PREFIX}/projects/${data.projectId}/test-runs/summary/paginated`,
+        queryParams: {
+          page: data.page,
+          pageSize: data.pageSize,
+          sortBy: data.sortBy,
+          sortOrder: data.sortOrder,
+        },
       };
     },
     mapFromUpstream: mapTestRunsSummary,

--- a/packages/mcps/src/test/test-runs-summary-transform.test.ts
+++ b/packages/mcps/src/test/test-runs-summary-transform.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 
 import {
   mapTestRunsSummary,
-  type ITestRunsSummaryInput,
   type ITestRunsSummaryOutput,
 } from "../mcp/tools/e2e/test-runs-summary-transform.js";
 import type { IUpstreamResponse } from "../mcp/e2e/types.js";
@@ -18,27 +17,21 @@ function makeEntry(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function makeResponse(entries: unknown[]): IUpstreamResponse {
-  return { statusCode: 200, data: entries, headers: {} };
+function makeEnvelopeResponse(envelope: Record<string, unknown>): IUpstreamResponse {
+  return { statusCode: 200, data: envelope, headers: {} };
 }
 
-const DEFAULTS: ITestRunsSummaryInput = {
-  page: 1,
-  pageSize: 20,
-  sortBy: "lastRunAt",
-  sortOrder: "desc",
-};
-
 describe("mapTestRunsSummary", () => {
-  it("slims each entry down to the LLM-relevant fields", () => {
+  it("slims each entry inside the envelope down to LLM-relevant fields", () => {
     const out = mapTestRunsSummary(
-      makeResponse([
-        makeEntry({
-          error: "boom",
-          status: "TEST_REPLAY_FAILED",
-        }),
-      ]),
-      DEFAULTS,
+      makeEnvelopeResponse({
+        data: [makeEntry({ error: "boom", status: "TEST_REPLAY_FAILED" })],
+        page: 1,
+        pageSize: 20,
+        totalCount: 1,
+        totalPages: 1,
+        hasMore: false,
+      }),
     ) as ITestRunsSummaryOutput;
 
     expect(out.runs).toEqual([
@@ -55,33 +48,35 @@ describe("mapTestRunsSummary", () => {
     ]);
   });
 
-  it("aggregates status counts over the full upstream list, not just the page", () => {
-    const entries = [
-      ...Array.from({ length: 30 }, () => makeEntry({ status: "TEST_REPLAY_FAILED" })),
-      ...Array.from({ length: 10 }, () => makeEntry({ status: "TEST_REPLAY_SUCCESS" })),
-    ];
+  it("passes envelope pagination metadata through unchanged", () => {
+    const out = mapTestRunsSummary(
+      makeEnvelopeResponse({
+        data: [makeEntry(), makeEntry()],
+        page: 3,
+        pageSize: 20,
+        totalCount: 116,
+        totalPages: 6,
+        hasMore: true,
+      }),
+    ) as ITestRunsSummaryOutput;
 
-    const out = mapTestRunsSummary(makeResponse(entries), {
-      ...DEFAULTS,
-      pageSize: 5,
-    }) as ITestRunsSummaryOutput;
-
-    expect(out.totals).toEqual({
-      total: 40,
-      byStatus: { TEST_REPLAY_FAILED: 30, TEST_REPLAY_SUCCESS: 10 },
-    });
-    expect(out.runs).toHaveLength(5);
+    expect(out.page).toBe(3);
+    expect(out.pageSize).toBe(20);
+    expect(out.totalCount).toBe(116);
+    expect(out.totalPages).toBe(6);
+    expect(out.hasMore).toBe(true);
   });
 
   it("omits missing optional fields rather than emitting null", () => {
     const out = mapTestRunsSummary(
-      makeResponse([
-        {
-          status: "GENERATION_PENDING",
-          testCase: { id: "tc-X" },
-        },
-      ]),
-      DEFAULTS,
+      makeEnvelopeResponse({
+        data: [{ status: "GENERATION_PENDING", testCase: { id: "tc-X" } }],
+        page: 1,
+        pageSize: 20,
+        totalCount: 1,
+        totalPages: 1,
+        hasMore: false,
+      }),
     ) as ITestRunsSummaryOutput;
 
     expect(out.runs[0]).toEqual({
@@ -92,62 +87,42 @@ describe("mapTestRunsSummary", () => {
 
   it("buckets entries with no status under UNKNOWN", () => {
     const out = mapTestRunsSummary(
-      makeResponse([{ testCase: { id: "tc-1" } }]),
-      DEFAULTS,
+      makeEnvelopeResponse({
+        data: [{ testCase: { id: "tc-1" } }],
+        page: 1,
+        pageSize: 20,
+        totalCount: 1,
+        totalPages: 1,
+        hasMore: false,
+      }),
     ) as ITestRunsSummaryOutput;
 
-    expect(out.totals.byStatus).toEqual({ UNKNOWN: 1 });
     expect(out.runs[0].status).toBe("UNKNOWN");
   });
 
-  it("sorts by lastRunAt desc by default and sinks missing values to the end", () => {
+  it("returns an empty envelope when the upstream page is empty", () => {
     const out = mapTestRunsSummary(
-      makeResponse([
-        makeEntry({ testCase: { id: "old" }, lastRunAt: 100 }),
-        makeEntry({ testCase: { id: "missing" }, lastRunAt: undefined }),
-        makeEntry({ testCase: { id: "new" }, lastRunAt: 500 }),
-      ]),
-      DEFAULTS,
+      makeEnvelopeResponse({
+        data: [],
+        page: 1,
+        pageSize: 20,
+        totalCount: 0,
+        totalPages: 0,
+        hasMore: false,
+      }),
     ) as ITestRunsSummaryOutput;
 
-    expect(out.runs.map((r) => r.testCaseId)).toEqual(["new", "old", "missing"]);
-  });
-
-  it("paginates the slimmed slice and reports hasMore correctly", () => {
-    const entries = Array.from({ length: 25 }, (_, i) =>
-      makeEntry({ testCase: { id: `tc-${i}`, title: `T${i}` }, lastRunAt: i }),
-    );
-
-    const page1 = mapTestRunsSummary(makeResponse(entries), {
-      ...DEFAULTS,
-      pageSize: 10,
-      page: 1,
-    }) as ITestRunsSummaryOutput;
-    const page3 = mapTestRunsSummary(makeResponse(entries), {
-      ...DEFAULTS,
-      pageSize: 10,
-      page: 3,
-    }) as ITestRunsSummaryOutput;
-
-    expect(page1).toMatchObject({ page: 1, totalPages: 3, hasMore: true });
-    expect(page1.runs).toHaveLength(10);
-    expect(page3).toMatchObject({ page: 3, totalPages: 3, hasMore: false });
-    expect(page3.runs).toHaveLength(5);
-  });
-
-  it("returns an empty page with totalPages=1 when upstream returns no entries", () => {
-    const out = mapTestRunsSummary(makeResponse([]), DEFAULTS) as ITestRunsSummaryOutput;
     expect(out).toEqual({
-      totals: { total: 0, byStatus: {} },
       page: 1,
       pageSize: 20,
-      totalPages: 1,
+      totalCount: 0,
+      totalPages: 0,
       hasMore: false,
       runs: [],
     });
   });
 
-  it("dramatically shrinks a realistic 116-entry upstream payload", () => {
+  it("handles a heavy page payload from upstream — backend slices, MCP slims", () => {
     const heavyUseCase = {
       id: "uc-heavy",
       title: "Heavy use case",
@@ -156,22 +131,12 @@ describe("mapTestRunsSummary", () => {
         requirement: "x".repeat(200),
         acceptanceCriteria: "x".repeat(400),
       })),
-      userTestPrompt: { instruction: "x".repeat(900) },
     };
-    const heavyTestCase = {
-      id: "tc-heavy",
-      title: "Heavy",
-      description: "x".repeat(500),
-      tags: ["a", "b", "c"],
-    };
-    const heavyEntries = Array.from({ length: 116 }, () => ({
+    const heavyEntries = Array.from({ length: 20 }, () => ({
       projectId: "p",
       useCase: heavyUseCase,
-      testCase: heavyTestCase,
-      latestWorkflowRun: {
-        id: "wf",
-        taskDef: { studioAuthInfo: { accessToken: "x".repeat(200) } },
-      },
+      testCase: { id: "tc-heavy", title: "Heavy", description: "x".repeat(500) },
+      latestWorkflowRun: { id: "wf", taskDef: { studioAuthInfo: { accessToken: "x".repeat(200) } } },
       testScript: { id: "ts", displayParams: {} },
       status: "TEST_REPLAY_FAILED",
       lastRunAt: 1000,
@@ -179,10 +144,32 @@ describe("mapTestRunsSummary", () => {
     }));
 
     const rawSize = JSON.stringify(heavyEntries).length;
-    const out = mapTestRunsSummary(makeResponse(heavyEntries), DEFAULTS) as ITestRunsSummaryOutput;
+    const out = mapTestRunsSummary(
+      makeEnvelopeResponse({
+        data: heavyEntries,
+        page: 1,
+        pageSize: 20,
+        totalCount: 116,
+        totalPages: 6,
+        hasMore: true,
+      }),
+    ) as ITestRunsSummaryOutput;
     const slimSize = JSON.stringify(out).length;
 
     expect(slimSize).toBeLessThan(rawSize * 0.1);
-    expect(out.totals.total).toBe(116);
+    expect(out.runs).toHaveLength(20);
+    expect(out.totalCount).toBe(116);
+  });
+
+  it("falls back gracefully when the envelope is missing fields", () => {
+    const out = mapTestRunsSummary(
+      makeEnvelopeResponse({ data: [makeEntry()] }),
+    ) as ITestRunsSummaryOutput;
+
+    expect(out.page).toBe(1);
+    expect(out.pageSize).toBe(1);
+    expect(out.totalCount).toBe(1);
+    expect(out.hasMore).toBe(false);
+    expect(out.runs).toHaveLength(1);
   });
 });


### PR DESCRIPTION
> **DRAFT — blocked on [muggle-ai-prompt-service #530](https://github.com/multiplex-ai/muggle-ai-prompt-service/pull/530) being merged AND deployed.** Merging this MCP PR before the backend ships will 404 every call to `muggle-remote-project-test-runs-summary-get`.

## Summary

Switches `muggle-remote-project-test-runs-summary-get` from MCP-side pagination over the array endpoint to direct consumption of the new paginated endpoint added in prompt-service #530:

```
GET /v1/protected/muggle-test/projects/:id/test-runs/summary/paginated
    ?page=1&pageSize=20&sortBy=lastRunAt&sortOrder=desc
```

Each MCP page round-trip now pays for only one slice of JSON. The backend stops doing the N × 2 sequential workflow-run queries on every paginated MCP call, so this PR's value compounds the bigger the project gets.

### What changed

- **`mapToUpstream`** appends `?page=&pageSize=&sortBy=&sortOrder=` and points at the new `/paginated` path.
- **`mapFromUpstream`** simplifies to envelope unwrap + per-row slim. Sort, slice, and `totalCount` / `totalPages` / `hasMore` math all move to the backend.
- **Schema** (`ProjectTestRunsSummaryInputSchema`) already carries `page` / `pageSize` / `sortBy` / `sortOrder` from #183. No client-visible schema change.
- **Tool description** updated to advertise the new response shape (see below).
- **Tests** rewritten: 7 cases covering envelope passthrough, per-row slimming, missing-field omission, UNKNOWN status bucket, empty page, heavy payload size assertion, and graceful fallback when envelope fields are absent.

### What was dropped

`totals.byStatus` aggregate. The previous transform computed it because the MCP had visibility into the whole project's unpaginated payload. Now that the backend ships one page, a per-page byStatus would be misleading — an LLM seeing `FAILED: 18 / 2` on page 1 of 6 would draw a false 90%-failure conclusion. `totalCount` survives so the LLM still understands project scope. If a project-wide status histogram becomes an LLM requirement, it's a small additive change to the backend envelope.

### Response shape now

```json
{
  "page": 1,
  "pageSize": 20,
  "totalCount": 116,
  "totalPages": 6,
  "hasMore": true,
  "runs": [
    { "status": "TEST_REPLAY_FAILED", "testCaseId": "...", "testCaseTitle": "...",
      "useCaseId": "...", "useCaseTitle": "...", "lastRunAt": 1779409117068,
      "error": "Cannot read properties of undefined...", "latestWorkflowRunId": "..." }
  ]
}
```

## Test plan
- [x] `npm run test --filter @muggleai/mcp` — 137/137 passing (7 new transform tests + the 130 prior)
- [x] `npm run typecheck --filter @muggleai/mcp` — clean
- [x] `npm run build --filter @muggleai/mcp` — clean
- [ ] **Blocking**: prompt-service #530 merges + deploys
- [ ] Smoke: invoke `muggle-remote-project-test-runs-summary-get` with `projectId=5365f324-5c5f-4adf-b702-11f457b29b04` against the post-deploy backend and confirm the envelope shape lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)