### PR TITLE
fix(muggle-feedback): correct dashboard URL from app. to www.

### DIFF
--- a/plugin/skills/muggle-feedback/ops/submit.md
+++ b/plugin/skills/muggle-feedback/ops/submit.md
@@ -8,7 +8,7 @@ Pick the first applicable path. Stop at the first that yields an `actionScriptId
 
 ### 1a. Dashboard URL in user's prompt
 
-A Muggle dashboard URL looks like `https://app.muggle-ai.com/muggleTestV0/dashboard/projects/<projectId>/...`. Scan the user's recent message for any `https://app.muggle-ai.com/...` URL.
+A Muggle dashboard URL looks like `https://www.muggle-ai.com/muggleTestV0/dashboard/projects/<projectId>/...`. Scan the user's recent message for any `https://www.muggle-ai.com/...` URL.
 
 - Extract any UUID-shaped path segments. If `/projects/<uuid>` is present, capture as `projectId`. If `/test-scripts/<uuid>` is present, capture as `testScriptId`.
 - If a `testScriptId` was captured: call `muggle-remote-test-script-get` to get the script and read `actionScriptId` off it. Done — proceed to step 2.


### PR DESCRIPTION
## Summary

- \`plugin/skills/muggle-feedback/ops/submit.md\` had \`app.muggle-ai.com\` as the example dashboard URL.
- Canonical URL across the rest of the codebase is \`www.muggle-ai.com\` (42 refs across 15 files; \`app.\` had 0 other refs).
- Without this fix, the URL-detection rule in step 1a never matches real dashboard URLs.

## Test plan

- [x] Confirmed \`app.muggle-ai.com\` had no other references in the repo
- [x] Confirmed \`www.muggle-ai.com\` is used in CLI help, render, test fixtures, MCPs, other skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)