### PR TITLE
fix(muggle-pr-followup): self-unschedule cron on terminal PR

### DIFF
--- a/plugin/skills/muggle-pr-followup/contract.md
+++ b/plugin/skills/muggle-pr-followup/contract.md
@@ -37,7 +37,8 @@ If `state` is `MERGED` or `CLOSED`:
 2. Write `result.md` per [`state-schemas.md`](state-schemas.md#resultmd).
 3. Append a terminal line to `followup.log` per [`output-templates/watcher-log.md`](output-templates/watcher-log.md).
 4. Emit a `tick` event with `terminal: true` per [`../_shared/telemetry-events/pr-followup-tick.md`](../_shared/telemetry-events/pr-followup-tick.md).
-5. Exit. **Do not schedule another tick.** The `/loop` framework stops invoking this skill once it sees no follow-up dispatch.
+5. **Cancel the cron schedule that fires this watcher.** `/loop 1m ...` from bootstrap was registered via `CronCreate`; a fixed-interval cron keeps firing regardless of whether the skill re-dispatches. Call `CronList`, find any job whose command ends with `/muggle:muggle-pr-followup <slug> <pr-number>` (exact two-arg match), and `CronDelete` it. No-op if none matches — the tick may have been invoked manually rather than via `/loop`.
+6. Exit. The watcher has now unscheduled itself; no future ticks will fire for this PR.
 
 ### Step 3 — Fetch new submitted reviews
 
@@ -66,7 +67,7 @@ The watcher does **not** classify. Classification, batching, replying, escalatio
    ```
 3. Append a dispatching line to `followup.log` per [`output-templates/watcher-log.md`](output-templates/watcher-log.md).
 4. Emit a `tick` event with `reviews_seen: <count>`, `dispatched_review_ids: [<id>, ...]`.
-5. Exit. **Do not schedule another tick.** `/muggle-do` will respawn the watcher at the end of its cycle.
+5. Exit. The cron schedule from bootstrap keeps firing the watcher every minute, so the next tick still arrives even though this turn dispatched `/muggle-do`. The watcher only self-unschedules in Step 2 (terminal).
 
 ## Output
 


### PR DESCRIPTION
## Summary

- Terminal step in `contract.md` now explicitly cancels its own cron job via `CronList` + `CronDelete` instead of relying on the (false) assumption that `/loop` auto-stops.
- Dispatch step's wording corrected: it's the cron that keeps the tick alive between dispatches, not a respawn from \`/muggle-do\`.

## Root cause

Bootstrap registers \`/loop 1m /muggle:muggle-pr-followup <slug> <n>\` which under the hood is a \`CronCreate\` on a fixed 1-min interval. The contract's Step 2 (terminal) said "Exit. Do not schedule another tick. The /loop framework stops invoking this skill once it sees no follow-up dispatch." — but a cron schedule fires on its clock, not on what the skill does. After a PR merged, the watcher kept firing every minute, logging \`terminal=merged already-recorded\` indefinitely.

## Fix

\`contract.md\` Step 2 now adds a substep before exit:
- Call \`CronList\`
- Find the job whose command ends with \`/muggle:muggle-pr-followup <slug> <pr-number>\` (exact two-arg match)
- \`CronDelete\` it
- No-op if no match (covers manual-invocation case)

## Test plan

- [ ] Bootstrap a watcher on a test PR
- [ ] Verify \`CronList\` shows the job
- [ ] Merge or close the PR
- [ ] Next tick fires once, marks terminal, cancels its own cron
- [ ] \`CronList\` no longer shows the job
- [ ] Re-running the slash command manually after terminal does NOT recreate the cron (just logs already-recorded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)