### PR TITLE
fix(skills): exclude reply-wrapper reviews from watcher dispatch

### DIFF
--- a/plugin/skills/_shared/github-cli-recipes/submitted-reviews.md
+++ b/plugin/skills/_shared/github-cli-recipes/submitted-reviews.md
@@ -13,3 +13,4 @@ Filter client-side:
 - `id` not in `last_seen.escalated_review_ids`
 - `user.login` in the resolved allow-list
 - `state` in `{CHANGES_REQUESTED, COMMENTED}`, OR `APPROVED` with a non-empty body or at least one line comment
+- **Not a reply-wrapper.** `POST /pulls/<n>/comments/<id>/replies` creates an implicit review whose comments all have `in_reply_to_id` set. Fetch each candidate review's comments via `gh api repos/<owner>/<repo>/pulls/<n>/reviews/<id>/comments` and drop the review if every comment has a non-null `in_reply_to_id` (no new top-level critique). Without this clause, the loop's own threaded replies — submitted under the PR author's identity in single-account workflows — pass the allow-list and re-dispatch `/muggle-do` on a no-op cycle.

--- a/plugin/skills/_shared/pr-followup-helpers/allow-list.md
+++ b/plugin/skills/_shared/pr-followup-helpers/allow-list.md
@@ -2,7 +2,7 @@
 
 The address-reviews flow only acts on reviews submitted by users in the **allow-list** = (requested reviewers ∪ CODEOWNERS ∪ {PR author}) − bots. Re-resolve every invocation — never cache across cycles.
 
-The PR author is implicitly a valid reviewer: in single-account workflows, the human running the agent and the PR's author are the same identity, and the agent must honor their reviews. The agent itself never appears in the submitted-reviews list (it pushes commits and posts inline replies; it does not submit GitHub reviews), so there's no self-loop risk from including the author.
+The PR author is implicitly a valid reviewer: in single-account workflows, the human running the agent and the PR's author are the same identity, and the agent must honor their reviews. Self-loop is prevented at the watcher's filter layer rather than here: `POST /pulls/<n>/comments/<id>/replies` does create an implicit review under the loop user's identity, and the watcher drops it via the reply-wrapper clause in [`../github-cli-recipes/submitted-reviews.md`](../github-cli-recipes/submitted-reviews.md). Including the PR author in this allow-list is therefore safe.
 
 ## Step 1: requested reviewers
 


### PR DESCRIPTION
## Why
The `muggle-pr-followup` watcher dispatches `/muggle-do` on its own threaded-reply activity, looping forever. `POST /pulls/<n>/comments/<id>/replies` creates an implicit GitHub review whose comments all carry `in_reply_to_id`. With the PR author in the allow-list (correct for legitimate self-review), every wrapper from the loop user passes the state + allow-list filters and re-dispatches `/muggle-do` on a no-op cycle.

Concrete repro from a recent session:
1. Watcher sees a real review R₁ from the PR author → dispatches `/muggle-do`.
2. `/muggle-do` pushes commit C and posts three threaded replies via `POST /comments/{id}/replies` → GitHub creates R₂, R₃, R₄ (all `login = PR author`, `state = COMMENTED`, body empty, line comment with `in_reply_to_id` set).
3. Watcher next tick: R₂..R₄ have `id > cursor`, `submitted_at != null`, login in allow-list, state allowed → all pass → watcher dispatches `/muggle-do` again with empty work.
4. Repeats until the cursor advances by accident.

## What changes
- **`_shared/github-cli-recipes/submitted-reviews.md`**: adds a "not a reply-wrapper" filter clause. For each candidate review past cursor, fetch its line comments via `gh api .../reviews/<id>/comments` and drop the review when every comment has a non-null `in_reply_to_id`.
- **`_shared/pr-followup-helpers/allow-list.md`**: corrects the assertion that "the agent never appears in the submitted-reviews list" — it does, via reply wrappers. Points to the watcher-layer filter as the self-loop guard. The PR author stays in the allow-list (correct for legitimate self-review).

Doc-only changes; no runtime code touched.

## Test plan
- [ ] On a PR where the loop user posts threaded replies, verify the watcher's next poll surfaces zero new reviews to dispatch.
- [ ] On a PR where the PR author posts a NEW top-level review (not a reply), verify the watcher still detects it.
- [ ] Mixed case: a review containing both a top-level comment AND a reply to an earlier thread is treated as actionable (at least one comment with `in_reply_to_id == null` triggers dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)