### PR TITLE
chore(release): @muggleai/works 4.12.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.12.3"
+      "version": "4.12.4"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.12.3"
+      "version": "4.12.4"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@muggleai/works",
   "mcpName": "io.github.multiplex-ai/muggle",
-  "version": "4.12.3",
+  "version": "4.12.4",
   "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
   "type": "module",
   "main": "dist/index.js",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "4.12.3",
+  "version": "4.12.4",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "4.12.3",
+  "version": "4.12.4",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "4.12.3",
+  "version": "4.12.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "4.12.3",
+      "version": "4.12.4",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
## Release: 4.12.3 → 4.12.4 (patch)

### Shipping
- fix(skills): exclude reply-wrapper reviews from watcher dispatch (#188)
- fix(muggle-pr-followup): self-unschedule cron on terminal PR (#187)
- fix(muggle-feedback): correct dashboard URL from app. to www. (#186)

### Electron
Unchanged at **1.0.94** (latest GitHub release tag).

### Manifests touched by sync:versions
- package.json
- .claude-plugin/marketplace.json
- .cursor-plugin/marketplace.json
- plugin/.claude-plugin/plugin.json
- plugin/.cursor-plugin/plugin.json
- server.json

### Test plan
- [x] `pnpm run lint:check` — 0 errors
- [x] `pnpm run typecheck`
- [x] `pnpm test` — 126/126 passed
- [x] `pnpm run build`
- [x] `pnpm run verify:plugin`
- [x] `pnpm run verify:contracts`
- [x] `pnpm run verify:electron-release-checksums`