### PR TITLE
feat(pr-followup): seed E2E validation context at bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ coverage/
 # Turborepo cache
 .turbo/
 .worktrees
+
+# muggle-do / pr-followup session state (runtime, never committed)
+.muggle-do/

--- a/plugin/skills/_shared/e2e-validation-context.md
+++ b/plugin/skills/_shared/e2e-validation-context.md
@@ -1,17 +1,17 @@
 # E2E Validation Context
 
-The resolution-and-persistence contract for the facts a non-interactive cycle needs to run Stage 6 (E2E acceptance): validation strategy, local URL, backend status, Muggle Test project, test credentials, and auth. Two seeders write these into `state.md`; one consumer reads them.
+The context Stage 6 (E2E acceptance) needs to run unattended: validation strategy, local URL, backend status, Muggle Test project, test credentials, auth. Two seeders write it to `state.md`; one consumer reads it.
 
-- **Seeders:** [`../do/pre-flight.md`](../do/pre-flight.md) (forward pipeline, Stage 1) and [`../muggle-pr-followup/bootstrap.md`](../muggle-pr-followup/bootstrap.md) (watcher bootstrapped from a PR URL).
+- **Seeders:** [`../do/pre-flight.md`](../do/pre-flight.md) (forward pipeline, Stage 1) and [`../muggle-pr-followup/bootstrap.md`](../muggle-pr-followup/bootstrap.md) (URL-bootstrapped watcher).
 - **Consumer:** [`../do/e2e-acceptance.md`](../do/e2e-acceptance.md) Step 0.
 
-A watcher spawned by a forward `/muggle-do` run inherits these from pre-flight through the shared session slot. A watcher bootstrapped directly from a PR URL never runs pre-flight, so bootstrap resolves them once at launch — when the user is present — and persists them for every later non-interactive tick.
+A forward-spawned watcher inherits this from pre-flight via the shared session slot. A URL-bootstrapped watcher never runs pre-flight, so bootstrap resolves it once at launch (user present) and persists it for every later tick.
 
 ## Silent detection
 
 Resolve without prompting; use as questionnaire defaults:
 
-1. Running dev server + backend health — per [`dev-server-readiness.md`](dev-server-readiness.md).
+1. Dev server + backend health — per [`dev-server-readiness.md`](dev-server-readiness.md).
 2. Muggle Test MCP auth — `muggle-remote-auth-status`.
 3. Candidate projects — `muggle-remote-project-list`, ranked against the repo's dev URL and the PR title.
 4. Existing test-user secrets — `muggle-remote-secret-list` per candidate project (`managed_profile_email` / `managed_profile_password`).
@@ -19,7 +19,7 @@ Resolve without prompting; use as questionnaire defaults:
 
 ## Questions
 
-Present the E2E-validation subset of pre-flight's questionnaire in a single `AskUserQuestion`, using detected values as defaults. The canonical option wording lives in [`../do/pre-flight.md`](../do/pre-flight.md) — reference it, do not fork it:
+One `AskUserQuestion` for the validation subset, detected values as defaults. Canonical wording in [`../do/pre-flight.md`](../do/pre-flight.md) — reference, don't fork:
 
 - Validation strategy — pre-flight Q4
 - Local URL — pre-flight Q5
@@ -28,13 +28,13 @@ Present the E2E-validation subset of pre-flight's questionnaire in a single `Ask
 - Test-user credentials — pre-flight Q8
 - Re-auth Muggle Test MCP — pre-flight Q10
 
-The chosen **validation strategy is the standing decision for every cycle** of this session. It subsumes the [`autoE2ETest`](../muggle-preferences/preference-gates/autoE2ETest.md) gate's per-run prompting (pre-flight Q13), which has no meaning in a non-interactive loop: `local-e2e` runs Stage 6 each cycle; `unit-only` / `skip` stands down each cycle. The gate's `always` default makes `local-e2e` the strategy default when a dev server was detected.
+The chosen **validation strategy is the standing decision for every cycle** — no per-tick re-prompt. It subsumes the [`autoE2ETest`](../muggle-preferences/preference-gates/autoE2ETest.md) gate (pre-flight Q13), meaningless in a loop: `local-e2e` runs Stage 6 each cycle; `unit-only` / `skip` stands down. The gate's `always` default makes `local-e2e` the default when a dev server is detected.
 
-Skip the forward-only questions (task scope, repo selection, branch name, PR target, worktree, rebase) — the PR's repo and head branch are already the checked-out working tree.
+Skip the forward-only questions (task scope, repo, branch, PR target, worktree, rebase) — the PR's repo and head branch are already checked out.
 
 ## Persisted fields
 
-Write into `state.md` under a `## Pre-flight answers` block — the same shape pre-flight emits, so the consumer reads one format regardless of seeder:
+Write to `state.md` under a `## Pre-flight answers` block — pre-flight's shape, so the consumer reads one format:
 
 - `Validation: <local-e2e | staging-replay | unit-only | skip>`
 - `Local URL: <url | N/A>`
@@ -42,6 +42,6 @@ Write into `state.md` under a `## Pre-flight answers` block — the same shape p
 - `Muggle Test project: <name> (<uuid>)`
 - `Test credentials: <existing | new | skip>`
 - `Auth status: <ok | re-authed | N/A>`
-- `Working tree: <path>` — the verified checkout the cycle runs against (the bootstrap analogue of pre-flight's worktree path)
+- `Working tree: <path>` — the verified checkout the cycle runs against (bootstrap's analogue of pre-flight's worktree path)
 
-A consumer that finds any required field missing treats it as a seeding bug: escalate with the session path and halt. Never silently skip E2E.
+Missing any required field is a seeding bug: escalate with the session path and halt. Never silently skip E2E.

--- a/plugin/skills/_shared/e2e-validation-context.md
+++ b/plugin/skills/_shared/e2e-validation-context.md
@@ -1,0 +1,47 @@
+# E2E Validation Context
+
+The resolution-and-persistence contract for the facts a non-interactive cycle needs to run Stage 6 (E2E acceptance): validation strategy, local URL, backend status, Muggle Test project, test credentials, and auth. Two seeders write these into `state.md`; one consumer reads them.
+
+- **Seeders:** [`../do/pre-flight.md`](../do/pre-flight.md) (forward pipeline, Stage 1) and [`../muggle-pr-followup/bootstrap.md`](../muggle-pr-followup/bootstrap.md) (watcher bootstrapped from a PR URL).
+- **Consumer:** [`../do/e2e-acceptance.md`](../do/e2e-acceptance.md) Step 0.
+
+A watcher spawned by a forward `/muggle-do` run inherits these from pre-flight through the shared session slot. A watcher bootstrapped directly from a PR URL never runs pre-flight, so bootstrap resolves them once at launch — when the user is present — and persists them for every later non-interactive tick.
+
+## Silent detection
+
+Resolve without prompting; use as questionnaire defaults:
+
+1. Running dev server + backend health — per [`dev-server-readiness.md`](dev-server-readiness.md).
+2. Muggle Test MCP auth — `muggle-remote-auth-status`.
+3. Candidate projects — `muggle-remote-project-list`, ranked against the repo's dev URL and the PR title.
+4. Existing test-user secrets — `muggle-remote-secret-list` per candidate project (`managed_profile_email` / `managed_profile_password`).
+5. Auth0 tenant for local dev — grep the repo env file for `*AUTH0_DOMAIN*`.
+
+## Questions
+
+Present the E2E-validation subset of pre-flight's questionnaire in a single `AskUserQuestion`, using detected values as defaults. The canonical option wording lives in [`../do/pre-flight.md`](../do/pre-flight.md) — reference it, do not fork it:
+
+- Validation strategy — pre-flight Q4
+- Local URL — pre-flight Q5
+- Backend reachable — pre-flight Q6
+- Muggle Test project — pre-flight Q7
+- Test-user credentials — pre-flight Q8
+- Re-auth Muggle Test MCP — pre-flight Q10
+
+The chosen **validation strategy is the standing decision for every cycle** of this session. It subsumes the [`autoE2ETest`](../muggle-preferences/preference-gates/autoE2ETest.md) gate's per-run prompting (pre-flight Q13), which has no meaning in a non-interactive loop: `local-e2e` runs Stage 6 each cycle; `unit-only` / `skip` stands down each cycle. The gate's `always` default makes `local-e2e` the strategy default when a dev server was detected.
+
+Skip the forward-only questions (task scope, repo selection, branch name, PR target, worktree, rebase) — the PR's repo and head branch are already the checked-out working tree.
+
+## Persisted fields
+
+Write into `state.md` under a `## Pre-flight answers` block — the same shape pre-flight emits, so the consumer reads one format regardless of seeder:
+
+- `Validation: <local-e2e | staging-replay | unit-only | skip>`
+- `Local URL: <url | N/A>`
+- `Backend status: <up | down | N/A>`
+- `Muggle Test project: <name> (<uuid>)`
+- `Test credentials: <existing | new | skip>`
+- `Auth status: <ok | re-authed | N/A>`
+- `Working tree: <path>` — the verified checkout the cycle runs against (the bootstrap analogue of pre-flight's worktree path)
+
+A consumer that finds any required field missing treats it as a seeding bug: escalate with the session path and halt. Never silently skip E2E.

--- a/plugin/skills/_shared/e2e-validation-context.md
+++ b/plugin/skills/_shared/e2e-validation-context.md
@@ -1,11 +1,16 @@
 # E2E Validation Context
 
-The context Stage 6 (E2E acceptance) needs to run unattended: validation strategy, local URL, backend status, Muggle Test project, test credentials, auth. Two seeders write it to `state.md`; one consumer reads it.
+The context Stage 6 (E2E acceptance) needs to run unattended: validation strategy, local URL, backend status, Muggle Test project, test credentials, auth. A seeder resolves it once and writes it to `state.md` under a `## Pre-flight answers` block; the cycle reads it on every later run.
 
-- **Seeders:** [`../do/pre-flight.md`](../do/pre-flight.md) (forward pipeline, Stage 1) and [`../muggle-pr-followup/bootstrap.md`](../muggle-pr-followup/bootstrap.md) (URL-bootstrapped watcher).
-- **Consumer:** [`../do/e2e-acceptance.md`](../do/e2e-acceptance.md) Step 0.
+## Reuse an existing context
 
-A forward-spawned watcher inherits this from pre-flight via the shared session slot. A URL-bootstrapped watcher never runs pre-flight, so bootstrap resolves it once at launch (user present) and persists it for every later tick.
+If a `## Pre-flight answers` block already exists for this working tree — the current session slot, or the most recent sibling session under `.muggle-do/sessions/*` — fire the [`autoReuseValidationContext`](../muggle-preferences/preference-gates/autoReuseValidationContext.md) gate before gathering anything:
+
+- `always` → copy the existing block into this session; skip the questionnaire.
+- `never` → ignore it; run the full gather below.
+- `ask` → prompt reuse-vs-re-gather.
+
+Run the gather only when no block exists or the user chose to re-gather.
 
 ## Silent detection
 
@@ -19,22 +24,22 @@ Resolve without prompting; use as questionnaire defaults:
 
 ## Questions
 
-One `AskUserQuestion` for the validation subset, detected values as defaults. Canonical wording in [`../do/pre-flight.md`](../do/pre-flight.md) — reference, don't fork:
+One `AskUserQuestion` for the validation subset, detected values as defaults. Canonical wording lives in [`../do/pre-flight.md`](../do/pre-flight.md) — reference, don't fork:
 
 - Validation strategy — pre-flight Q4
-- Local URL — pre-flight Q5
+- Local URL — pre-flight Q5 (defers to [`autoSelectLocalHost`](../muggle-preferences/preference-gates/autoSelectLocalHost.md))
 - Backend reachable — pre-flight Q6
-- Muggle Test project — pre-flight Q7
+- Muggle Test project — pre-flight Q7 (defers to [`autoSelectProject`](../muggle-preferences/preference-gates/autoSelectProject.md))
 - Test-user credentials — pre-flight Q8
 - Re-auth Muggle Test MCP — pre-flight Q10
 
 The chosen **validation strategy is the standing decision for every cycle** — no per-tick re-prompt. It subsumes the [`autoE2ETest`](../muggle-preferences/preference-gates/autoE2ETest.md) gate (pre-flight Q13), meaningless in a loop: `local-e2e` runs Stage 6 each cycle; `unit-only` / `skip` stands down. The gate's `always` default makes `local-e2e` the default when a dev server is detected.
 
-Skip the forward-only questions (task scope, repo, branch, PR target, worktree, rebase) — the PR's repo and head branch are already checked out.
+Skip the forward-only questions (task scope, repo, branch, PR target, worktree, rebase) — the targeted repo and head branch are already checked out.
 
 ## Persisted fields
 
-Write to `state.md` under a `## Pre-flight answers` block — pre-flight's shape, so the consumer reads one format:
+Write to `state.md` under a `## Pre-flight answers` block:
 
 - `Validation: <local-e2e | staging-replay | unit-only | skip>`
 - `Local URL: <url | N/A>`
@@ -42,6 +47,6 @@ Write to `state.md` under a `## Pre-flight answers` block — pre-flight's shape
 - `Muggle Test project: <name> (<uuid>)`
 - `Test credentials: <existing | new | skip>`
 - `Auth status: <ok | re-authed | N/A>`
-- `Working tree: <path>` — the verified checkout the cycle runs against (bootstrap's analogue of pre-flight's worktree path)
+- `Working tree: <path>` — the verified checkout the cycle runs against
 
 Missing any required field is a seeding bug: escalate with the session path and halt. Never silently skip E2E.

--- a/plugin/skills/_shared/resolve-e2e-validation-context.md
+++ b/plugin/skills/_shared/resolve-e2e-validation-context.md
@@ -1,6 +1,10 @@
-# E2E Validation Context
+# Resolving the E2E Validation Context
 
-The context Stage 6 (E2E acceptance) needs to run unattended: validation strategy, local URL, backend status, Muggle Test project, test credentials, auth. A seeder resolves it once and writes it to `state.md` under a `## Pre-flight answers` block; the cycle reads it on every later run.
+**How-to procedure.** Followed by any seeder that prepares a session for unattended Stage 6 (E2E acceptance) runs.
+
+**Goal:** resolve — once, while the user is present — everything Stage 6 needs to run without further prompts (validation strategy, local URL, backend status, Muggle Test project, test credentials, auth), and persist it to `state.md` so every later non-interactive run reads it instead of asking.
+
+The sections below are the steps in order: reuse an existing context if one is on disk, else detect what's resolvable silently, ask the rest in one question, and write the result. The final [`## Persisted fields`](#persisted-fields) section doubles as the schema the cycle reads back.
 
 ## Reuse an existing context
 

--- a/plugin/skills/do/address-reviews.md
+++ b/plugin/skills/do/address-reviews.md
@@ -75,7 +75,7 @@ Invoke [`unit-tests.md`](unit-tests.md). Cover the surface that just changed; re
 
 #### 4d. Run ONE E2E acceptance pass
 
-Invoke [`e2e-acceptance.md`](e2e-acceptance.md). One pass covering all related test cases for this PR, not one pass per comment. The stage reads the persisted validation context (seeded by pre-flight for forward-spawned watchers, or by bootstrap Step 6.5 for URL-bootstrapped ones); the persisted `Validation` strategy is the standing decision for the loop — there is no per-tick `autoE2ETest` prompt. See [`e2e-acceptance.md`](e2e-acceptance.md) Step 0 and [`../_shared/e2e-validation-context.md`](../_shared/e2e-validation-context.md).
+Invoke [`e2e-acceptance.md`](e2e-acceptance.md). One pass covering all related test cases for this PR, not one per comment. The stage reads the persisted validation context (seeded by pre-flight or by bootstrap Step 6.5); the persisted `Validation` strategy is the standing decision — no per-tick `autoE2ETest` prompt. See [`e2e-acceptance.md`](e2e-acceptance.md) Step 0 and [`../_shared/e2e-validation-context.md`](../_shared/e2e-validation-context.md).
 
 #### 4e. Create or update the PR
 

--- a/plugin/skills/do/address-reviews.md
+++ b/plugin/skills/do/address-reviews.md
@@ -75,7 +75,7 @@ Invoke [`unit-tests.md`](unit-tests.md). Cover the surface that just changed; re
 
 #### 4d. Run ONE E2E acceptance pass
 
-Invoke [`e2e-acceptance.md`](e2e-acceptance.md). One pass covering all related test cases for this PR, not one pass per comment. Use the `autoE2ETest` gate per its usual contract.
+Invoke [`e2e-acceptance.md`](e2e-acceptance.md). One pass covering all related test cases for this PR, not one pass per comment. The stage reads the persisted validation context (seeded by pre-flight for forward-spawned watchers, or by bootstrap Step 6.5 for URL-bootstrapped ones); the persisted `Validation` strategy is the standing decision for the loop — there is no per-tick `autoE2ETest` prompt. See [`e2e-acceptance.md`](e2e-acceptance.md) Step 0 and [`../_shared/e2e-validation-context.md`](../_shared/e2e-validation-context.md).
 
 #### 4e. Create or update the PR
 

--- a/plugin/skills/do/address-reviews.md
+++ b/plugin/skills/do/address-reviews.md
@@ -75,7 +75,7 @@ Invoke [`unit-tests.md`](unit-tests.md). Cover the surface that just changed; re
 
 #### 4d. Run ONE E2E acceptance pass
 
-Invoke [`e2e-acceptance.md`](e2e-acceptance.md). One pass covering all related test cases for this PR, not one per comment. The stage reads the persisted validation context (seeded by pre-flight or by bootstrap Step 6.5); the persisted `Validation` strategy is the standing decision — no per-tick `autoE2ETest` prompt. See [`e2e-acceptance.md`](e2e-acceptance.md) Step 0 and [`../_shared/e2e-validation-context.md`](../_shared/e2e-validation-context.md).
+Invoke [`e2e-acceptance.md`](e2e-acceptance.md). One pass covering all related test cases for this PR, not one per comment. The stage reads the persisted validation context (seeded by pre-flight or by bootstrap Step 6.5); the persisted `Validation` strategy is the standing decision — no per-tick `autoE2ETest` prompt. See [`e2e-acceptance.md`](e2e-acceptance.md) Step 0 and [`../_shared/resolve-e2e-validation-context.md`](../_shared/resolve-e2e-validation-context.md).
 
 #### 4e. Create or update the PR
 

--- a/plugin/skills/do/e2e-acceptance.md
+++ b/plugin/skills/do/e2e-acceptance.md
@@ -46,11 +46,11 @@ You receive everything from `state.md` already — pre-flight resolved it:
 
 ### Step 0: Consume the validation context (no user questions)
 
-Read `state.md`. The E2E validation context is seeded by **either** pre-flight (forward pipeline) **or** bootstrap (URL-bootstrapped watcher) per [`../_shared/e2e-validation-context.md`](../_shared/e2e-validation-context.md) — read it the same way regardless of seeder.
+Read `state.md`. The validation context is seeded by **either** pre-flight or bootstrap per [`../_shared/e2e-validation-context.md`](../_shared/e2e-validation-context.md) — read it the same way regardless of seeder.
 
-Resolve the validation mode (`local-e2e`, `staging-replay`, `unit-only`, `skip`) from the persisted `Validation` field; it picks execution vs early-exit below. In a forward run, [`autoE2ETest`](../muggle-preferences/preference-gates/autoE2ETest.md) `ask` was resolved by pre-flight Q13. In an address-reviews / watcher cycle there is no per-tick pre-flight, so the persisted `Validation` strategy **is** the standing decision — do not try to re-resolve `ask`.
+The persisted `Validation` field (`local-e2e`, `staging-replay`, `unit-only`, `skip`) picks execution vs early-exit below. In a forward run, [`autoE2ETest`](../muggle-preferences/preference-gates/autoE2ETest.md) `ask` was resolved by pre-flight Q13; in a watcher cycle there is no per-tick pre-flight, so `Validation` **is** the standing decision — don't re-resolve `ask`.
 
-Use `localUrl`, `projectId`, and the working-tree path from `state.md`. Missing any → context-seeding bug; escalate with the session path and halt; do not ask the user.
+Use `localUrl`, `projectId`, and the working-tree path from `state.md`. Missing any → seeding bug; escalate with the session path and halt; do not ask the user.
 
 ### Step 0.5: Pre-flight verification probes
 

--- a/plugin/skills/do/e2e-acceptance.md
+++ b/plugin/skills/do/e2e-acceptance.md
@@ -46,7 +46,7 @@ You receive everything from `state.md` already — pre-flight resolved it:
 
 ### Step 0: Consume the validation context (no user questions)
 
-Read `state.md`. The validation context is seeded by **either** pre-flight or bootstrap per [`../_shared/e2e-validation-context.md`](../_shared/e2e-validation-context.md) — read it the same way regardless of seeder.
+Read `state.md`. The validation context is seeded by **either** pre-flight or bootstrap per [`../_shared/resolve-e2e-validation-context.md`](../_shared/resolve-e2e-validation-context.md) — read it the same way regardless of seeder.
 
 The persisted `Validation` field (`local-e2e`, `staging-replay`, `unit-only`, `skip`) picks execution vs early-exit below. In a forward run, [`autoE2ETest`](../muggle-preferences/preference-gates/autoE2ETest.md) `ask` was resolved by pre-flight Q13; in a watcher cycle there is no per-tick pre-flight, so `Validation` **is** the standing decision — don't re-resolve `ask`.
 

--- a/plugin/skills/do/e2e-acceptance.md
+++ b/plugin/skills/do/e2e-acceptance.md
@@ -44,11 +44,13 @@ You receive everything from `state.md` already — pre-flight resolved it:
 
 ## Your Job
 
-### Step 0: Consume pre-flight (no user questions)
+### Step 0: Consume the validation context (no user questions)
 
-Read `state.md`. Resolve [`autoE2ETest`](../muggle-preferences/preference-gates/autoE2ETest.md) first — `always` (default, including when unset) runs this stage. `ask` should already have been resolved by pre-flight Q13. Use the resolved validation mode (`local-e2e`, `staging-replay`, `unit-only`, `skip`) to pick execution vs early-exit behavior.
+Read `state.md`. The E2E validation context is seeded by **either** pre-flight (forward pipeline) **or** bootstrap (URL-bootstrapped watcher) per [`../_shared/e2e-validation-context.md`](../_shared/e2e-validation-context.md) — read it the same way regardless of seeder.
 
-Use `localUrl`, `projectId`, and `worktreePath` from `state.md`. Missing any → pre-flight bug; escalate with the session path and halt; do not ask the user.
+Resolve the validation mode (`local-e2e`, `staging-replay`, `unit-only`, `skip`) from the persisted `Validation` field; it picks execution vs early-exit below. In a forward run, [`autoE2ETest`](../muggle-preferences/preference-gates/autoE2ETest.md) `ask` was resolved by pre-flight Q13. In an address-reviews / watcher cycle there is no per-tick pre-flight, so the persisted `Validation` strategy **is** the standing decision — do not try to re-resolve `ask`.
+
+Use `localUrl`, `projectId`, and the working-tree path from `state.md`. Missing any → context-seeding bug; escalate with the session path and halt; do not ask the user.
 
 ### Step 0.5: Pre-flight verification probes
 

--- a/plugin/skills/muggle-pr-followup/CLAUDE.md
+++ b/plugin/skills/muggle-pr-followup/CLAUDE.md
@@ -5,7 +5,7 @@ This folder holds the watcher loop for PR review follow-ups. The watcher is a **
 ## Files in this folder
 
 - [`SKILL.md`](SKILL.md) — public entry. Smart-inference routing between bootstrap mode (URL input) and tick mode (slug + PR number). Read first.
-- [`bootstrap.md`](bootstrap.md) — the bootstrap procedure (one-shot non-interactive seed + watcher dispatch).
+- [`bootstrap.md`](bootstrap.md) — the bootstrap procedure (asks once for the E2E validation context, seeds state, dispatches the first watcher).
 - [`contract.md`](contract.md) — the watcher per-tick procedure (poll → dispatch → exit).
 - [`state-schemas.md`](state-schemas.md) — canonical JSON shapes of session state files.
 - [`output-templates.md`](output-templates.md) — TOC of message templates; per-group files in `output-templates/`.
@@ -14,6 +14,7 @@ This folder holds the watcher loop for PR review follow-ups. The watcher is a **
 
 Shared with other skills, under `../_shared/`:
 
+- [`e2e-validation-context.md`](../_shared/e2e-validation-context.md) — the E2E validation-context contract bootstrap seeds into `state.md` (Step 6.5) and `do/e2e-acceptance.md` consumes.
 - [`pr-followup-helpers.md`](../_shared/pr-followup-helpers.md) — TOC of allow-list / reply-routing / classify; per-section files in `_shared/pr-followup-helpers/`. Called by `/muggle-do`, not by this folder.
 - [`telemetry-emit.md`](../_shared/telemetry-emit.md) — how to emit a telemetry event.
 - [`telemetry-events.md`](../_shared/telemetry-events.md) — TOC of canonical event shapes; per-event files in `_shared/telemetry-events/`.

--- a/plugin/skills/muggle-pr-followup/CLAUDE.md
+++ b/plugin/skills/muggle-pr-followup/CLAUDE.md
@@ -14,7 +14,7 @@ This folder holds the watcher loop for PR review follow-ups. The watcher is a **
 
 Shared with other skills, under `../_shared/`:
 
-- [`e2e-validation-context.md`](../_shared/e2e-validation-context.md) — the E2E validation-context contract bootstrap seeds into `state.md` (Step 6.5) and `do/e2e-acceptance.md` consumes.
+- [`resolve-e2e-validation-context.md`](../_shared/resolve-e2e-validation-context.md) — the E2E validation-context contract bootstrap seeds into `state.md` (Step 6.5) and `do/e2e-acceptance.md` consumes.
 - [`pr-followup-helpers.md`](../_shared/pr-followup-helpers.md) — TOC of allow-list / reply-routing / classify; per-section files in `_shared/pr-followup-helpers/`. Called by `/muggle-do`, not by this folder.
 - [`telemetry-emit.md`](../_shared/telemetry-emit.md) — how to emit a telemetry event.
 - [`telemetry-events.md`](../_shared/telemetry-events.md) — TOC of canonical event shapes; per-event files in `_shared/telemetry-events/`.

--- a/plugin/skills/muggle-pr-followup/SKILL.md
+++ b/plugin/skills/muggle-pr-followup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: muggle-pr-followup
-description: Watcher loop for PR review follow-ups. Polls one PR for new submitted reviews and dispatches `/muggle-do` (address-reviews mode) when there are any. A dumb pipe — no classification, no cycle execution, no replies. Use `/loop 1m /muggle:muggle-pr-followup <slug> <pr-number>` for ongoing polling, or `/muggle:muggle-pr-followup <pr-url>` to bootstrap a fresh watcher on an existing PR.
+description: Watcher loop for PR review follow-ups. Polls one PR for new submitted reviews and dispatches `/muggle-do` (address-reviews mode) when there are any. A dumb pipe — no classification, no cycle execution, no replies. Use `/loop 1m /muggle:muggle-pr-followup <slug> <pr-number>` for ongoing polling, or `/muggle:muggle-pr-followup <pr-url>` to bootstrap a fresh watcher on an existing PR (asks once for the E2E validation context, then runs unattended).
 disable-model-invocation: true
 ---
 

--- a/plugin/skills/muggle-pr-followup/SKILL.md
+++ b/plugin/skills/muggle-pr-followup/SKILL.md
@@ -33,6 +33,12 @@ Bootstrap accepts three optional trailing flags:
 - `--resume` — opt in to reusing an existing session slot (default is refuse on conflict)
 - `--forward-only` — pin cursor past existing reviews (skip history). Default is cursor 0, which processes prior submitted reviews on the first tick.
 
+## Preferences
+
+| Preference | Gate |
+| :--------- | :--- |
+| `autoReuseValidationContext` | Bootstrap reuses an existing validation context instead of re-asking — fired in the Step 6.5 gather per [`../_shared/e2e-validation-context.md`](../_shared/e2e-validation-context.md) |
+
 ## Folder TOC
 
 See [`CLAUDE.md`](CLAUDE.md) for the one-line index of every file in this folder.

--- a/plugin/skills/muggle-pr-followup/SKILL.md
+++ b/plugin/skills/muggle-pr-followup/SKILL.md
@@ -37,7 +37,7 @@ Bootstrap accepts three optional trailing flags:
 
 | Preference | Gate |
 | :--------- | :--- |
-| `autoReuseValidationContext` | Bootstrap reuses an existing validation context instead of re-asking — fired in the Step 6.5 gather per [`../_shared/e2e-validation-context.md`](../_shared/e2e-validation-context.md) |
+| `autoReuseValidationContext` | Bootstrap reuses an existing validation context instead of re-asking — fired in the Step 6.5 gather per [`../_shared/resolve-e2e-validation-context.md`](../_shared/resolve-e2e-validation-context.md) |
 
 ## Folder TOC
 

--- a/plugin/skills/muggle-pr-followup/bootstrap.md
+++ b/plugin/skills/muggle-pr-followup/bootstrap.md
@@ -2,7 +2,7 @@
 
 The procedure for the **bootstrap mode** of `muggle-pr-followup` — invoked when a user dispatches the skill with a GitHub PR URL. Routing into this mode is documented in [`SKILL.md`](SKILL.md#routing).
 
-Bootstrap is **non-interactive**: it runs straight through, prompts the user for nothing, and ends with the first watcher dispatched. The first review the watcher sees triggers `/muggle-do`, where working-tree validation surfaces (via the existing E2E stage / muggle-test).
+Bootstrap asks **one** questionnaire — the E2E validation context the autonomous loop will reuse — then runs straight through to the first watcher dispatch. The user is present at launch, so this is the one place to gather it: every later watcher tick is non-interactive and reads the persisted context from `state.md`. Without it, an address-reviews cycle on a URL-bootstrapped watcher has no `localUrl`/`projectId` and Stage 6 hard-halts instead of running E2E.
 
 ## Turn preamble
 
@@ -44,12 +44,18 @@ Default: `<repo>-pr<n>` (e.g. `muggle-ai-works-pr154`). Override: `--slug=<name>
 If `.muggle-do/sessions/<slug>/` exists:
 
 - Without `--resume` → exit with the slot-conflict abort. Both remedies (delete + re-run, or pass `--resume`) are spelled out in the message.
-- With `--resume` → refresh `prs.json[0].head_sha` to the current `headRefOid` from Step 2. Leave `last_seen.json`, `state.md`, and everything else untouched. Skip to Step 8 (no need to re-seed; no need to refetch the cursor).
+- With `--resume` → refresh `prs.json[0].head_sha` to the current `headRefOid` from Step 2. Leave `last_seen.json` and the cursor untouched. If `state.md` already carries the E2E validation context (a `## Pre-flight answers` block), skip to Step 8. If it predates this block (older session), run Step 6.5 to backfill the context, then skip to Step 8.
 
 ### Step 6 — Resolve the initial cursor
 
 - **Default (no `--forward-only`):** cursor is `0`. The watcher will pick up every existing submitted review on its first tick. This matches the common case where the user opened the PR, left review comments they want addressed, and is now running bootstrap.
 - **With `--forward-only`:** fetch reviews per [`../_shared/github-cli-recipes/submitted-reviews.md`](../_shared/github-cli-recipes/submitted-reviews.md), then take `max(id)`. The watcher only acts on later submissions. Use when bootstrapping a PR with stale/already-handled prior reviews you don't want re-processed.
+
+### Step 6.5 — Resolve E2E validation context
+
+The only interactive step. Run the gather defined in [`../_shared/e2e-validation-context.md`](../_shared/e2e-validation-context.md): silent detection, then one `AskUserQuestion` for the validation subset (strategy, local URL, backend, project, credentials, re-auth). The working tree verified in Step 3 is the checkout the loop runs against — record it as `Working tree`.
+
+Capture the resolved fields for Step 7. Do **not** run E2E now — the first watcher tick that dispatches `/muggle-do` does that.
 
 ### Step 7 — Seed state files
 
@@ -61,7 +67,7 @@ Write under `.muggle-do/sessions/<slug>/`:
 
 **`last_seen.json`** — see [`state-schemas.md`](state-schemas.md#last_seenjson). One key (`"<owner>/<repo>#<n>"`), `reviewId` from Step 6, `last_pushed_sha: null`, `idle_tick_count: 0`, `cycles_completed: 0`, `escalated_review_ids: []`, `pushed_shas: []`.
 
-**`state.md`** — see [`state-schemas.md`](state-schemas.md#statemd). `Bootstrapped from URL: yes`. Cache the loop-user login.
+**`state.md`** — see [`state-schemas.md`](state-schemas.md#statemd). `Bootstrapped from URL: yes`. Cache the loop-user login. Append the `## Pre-flight answers` block with the fields resolved in Step 6.5, per [`../_shared/e2e-validation-context.md`](../_shared/e2e-validation-context.md#persisted-fields).
 
 Do **not** write `cycle.json` or `requirements.md` — those files are no longer part of the session slot.
 
@@ -85,6 +91,7 @@ Emit one event per [`../_shared/telemetry-events/pr-followup-bootstrap.md`](../_
 
 ## Invariants
 
-- All state writes happen in Step 7 — earlier aborts leave nothing on disk.
+- Step 6.5 is the **only** user prompt. If the user cancels it, abort leaving nothing on disk.
+- All state writes happen in Step 7 — earlier aborts (including a cancelled Step 6.5) leave nothing on disk.
 - If Step 7 fails mid-write, surface the OS error and tell the user to `rm -rf <slot>` and re-run; do not dispatch the watcher.
 - Bootstrap never retries.

--- a/plugin/skills/muggle-pr-followup/bootstrap.md
+++ b/plugin/skills/muggle-pr-followup/bootstrap.md
@@ -53,7 +53,7 @@ If `.muggle-do/sessions/<slug>/` exists:
 
 ### Step 6.5 — Resolve E2E validation context
 
-The only step that may prompt the user. Run the gather in [`../_shared/e2e-validation-context.md`](../_shared/e2e-validation-context.md): reuse an existing context if one is found (gated by `autoReuseValidationContext`), else silent detection + one `AskUserQuestion` (strategy, local URL, backend, project, credentials, re-auth). Record Step 3's verified working tree as `Working tree`.
+The only step that may prompt the user. Run the gather in [`../_shared/resolve-e2e-validation-context.md`](../_shared/resolve-e2e-validation-context.md): reuse an existing context if one is found (gated by `autoReuseValidationContext`), else silent detection + one `AskUserQuestion` (strategy, local URL, backend, project, credentials, re-auth). Record Step 3's verified working tree as `Working tree`.
 
 Capture the fields for Step 7. Do **not** run E2E now — the first watcher tick that dispatches `/muggle-do` does that.
 
@@ -67,7 +67,7 @@ Write under `.muggle-do/sessions/<slug>/`:
 
 **`last_seen.json`** — see [`state-schemas.md`](state-schemas.md#last_seenjson). One key (`"<owner>/<repo>#<n>"`), `reviewId` from Step 6, `last_pushed_sha: null`, `idle_tick_count: 0`, `cycles_completed: 0`, `escalated_review_ids: []`, `pushed_shas: []`.
 
-**`state.md`** — see [`state-schemas.md`](state-schemas.md#statemd). `Bootstrapped from URL: yes`. Cache the loop-user login. Append the `## Pre-flight answers` block with the fields resolved in Step 6.5, per [`../_shared/e2e-validation-context.md`](../_shared/e2e-validation-context.md#persisted-fields).
+**`state.md`** — see [`state-schemas.md`](state-schemas.md#statemd). `Bootstrapped from URL: yes`. Cache the loop-user login. Append the `## Pre-flight answers` block with the fields resolved in Step 6.5, per [`../_shared/resolve-e2e-validation-context.md`](../_shared/resolve-e2e-validation-context.md#persisted-fields).
 
 Do **not** write `cycle.json` or `requirements.md` — those files are no longer part of the session slot.
 

--- a/plugin/skills/muggle-pr-followup/bootstrap.md
+++ b/plugin/skills/muggle-pr-followup/bootstrap.md
@@ -53,7 +53,7 @@ If `.muggle-do/sessions/<slug>/` exists:
 
 ### Step 6.5 — Resolve E2E validation context
 
-The only interactive step. Run the gather in [`../_shared/e2e-validation-context.md`](../_shared/e2e-validation-context.md): silent detection, then one `AskUserQuestion` (strategy, local URL, backend, project, credentials, re-auth). Record Step 3's verified working tree as `Working tree`.
+The only step that may prompt the user. Run the gather in [`../_shared/e2e-validation-context.md`](../_shared/e2e-validation-context.md): reuse an existing context if one is found (gated by `autoReuseValidationContext`), else silent detection + one `AskUserQuestion` (strategy, local URL, backend, project, credentials, re-auth). Record Step 3's verified working tree as `Working tree`.
 
 Capture the fields for Step 7. Do **not** run E2E now — the first watcher tick that dispatches `/muggle-do` does that.
 

--- a/plugin/skills/muggle-pr-followup/bootstrap.md
+++ b/plugin/skills/muggle-pr-followup/bootstrap.md
@@ -2,7 +2,7 @@
 
 The procedure for the **bootstrap mode** of `muggle-pr-followup` — invoked when a user dispatches the skill with a GitHub PR URL. Routing into this mode is documented in [`SKILL.md`](SKILL.md#routing).
 
-Bootstrap asks **one** questionnaire — the E2E validation context the autonomous loop will reuse — then runs straight through to the first watcher dispatch. The user is present at launch, so this is the one place to gather it: every later watcher tick is non-interactive and reads the persisted context from `state.md`. Without it, an address-reviews cycle on a URL-bootstrapped watcher has no `localUrl`/`projectId` and Stage 6 hard-halts instead of running E2E.
+Bootstrap asks **one** questionnaire — the E2E validation context the loop will reuse — then runs through to the first watcher dispatch. The user is present at launch, so this is the only place to gather it; every later tick reads it from `state.md`. Without it, a URL-bootstrapped watcher has no `localUrl`/`projectId` and Stage 6 hard-halts instead of running E2E.
 
 ## Turn preamble
 
@@ -44,7 +44,7 @@ Default: `<repo>-pr<n>` (e.g. `muggle-ai-works-pr154`). Override: `--slug=<name>
 If `.muggle-do/sessions/<slug>/` exists:
 
 - Without `--resume` → exit with the slot-conflict abort. Both remedies (delete + re-run, or pass `--resume`) are spelled out in the message.
-- With `--resume` → refresh `prs.json[0].head_sha` to the current `headRefOid` from Step 2. Leave `last_seen.json` and the cursor untouched. If `state.md` already carries the E2E validation context (a `## Pre-flight answers` block), skip to Step 8. If it predates this block (older session), run Step 6.5 to backfill the context, then skip to Step 8.
+- With `--resume` → refresh `prs.json[0].head_sha` to the current `headRefOid` from Step 2; leave `last_seen.json` and the cursor untouched. If `state.md` already has a `## Pre-flight answers` block, skip to Step 8; if not (older session), run Step 6.5 to backfill it, then skip to Step 8.
 
 ### Step 6 — Resolve the initial cursor
 
@@ -53,9 +53,9 @@ If `.muggle-do/sessions/<slug>/` exists:
 
 ### Step 6.5 — Resolve E2E validation context
 
-The only interactive step. Run the gather defined in [`../_shared/e2e-validation-context.md`](../_shared/e2e-validation-context.md): silent detection, then one `AskUserQuestion` for the validation subset (strategy, local URL, backend, project, credentials, re-auth). The working tree verified in Step 3 is the checkout the loop runs against — record it as `Working tree`.
+The only interactive step. Run the gather in [`../_shared/e2e-validation-context.md`](../_shared/e2e-validation-context.md): silent detection, then one `AskUserQuestion` (strategy, local URL, backend, project, credentials, re-auth). Record Step 3's verified working tree as `Working tree`.
 
-Capture the resolved fields for Step 7. Do **not** run E2E now — the first watcher tick that dispatches `/muggle-do` does that.
+Capture the fields for Step 7. Do **not** run E2E now — the first watcher tick that dispatches `/muggle-do` does that.
 
 ### Step 7 — Seed state files
 

--- a/plugin/skills/muggle-pr-followup/state-schemas.md
+++ b/plugin/skills/muggle-pr-followup/state-schemas.md
@@ -60,8 +60,20 @@ Free-form markdown. No required schema beyond a few well-known fields the caller
 **Created:** <ISO-8601>
 **Bootstrapped from URL:** <yes | no>
 
+## Pre-flight answers
+
+- Validation: <local-e2e | staging-replay | unit-only | skip>
+- Local URL: <url | N/A>
+- Backend status: <up | down | N/A>
+- Muggle Test project: <name> (<uuid>)
+- Test credentials: <existing | new | skip>
+- Auth status: <ok | re-authed | N/A>
+- Working tree: <path>
+
 ...free-form notes added by /muggle-do and bootstrap...
 ```
+
+The `## Pre-flight answers` block is the **E2E validation context** consumed by `do/e2e-acceptance.md` Step 0. Bootstrap seeds it (Step 6.5); the forward pipeline seeds the equivalent via pre-flight's output block. Canonical field list and meaning: [`../_shared/e2e-validation-context.md`](../_shared/e2e-validation-context.md#persisted-fields).
 
 The watcher does **not** read or write `state.md`. Only bootstrap, `/muggle-do`, and the caller's stages touch it.
 

--- a/plugin/skills/muggle-pr-followup/state-schemas.md
+++ b/plugin/skills/muggle-pr-followup/state-schemas.md
@@ -73,7 +73,7 @@ Free-form markdown. No required schema beyond a few well-known fields the caller
 ...free-form notes added by /muggle-do and bootstrap...
 ```
 
-The `## Pre-flight answers` block is the **E2E validation context** consumed by `do/e2e-acceptance.md` Step 0 — seeded by bootstrap (Step 6.5) or by pre-flight's output block. Fields: [`../_shared/e2e-validation-context.md`](../_shared/e2e-validation-context.md#persisted-fields).
+The `## Pre-flight answers` block is the **E2E validation context** consumed by `do/e2e-acceptance.md` Step 0 — seeded by bootstrap (Step 6.5) or by pre-flight's output block. Fields: [`../_shared/resolve-e2e-validation-context.md`](../_shared/resolve-e2e-validation-context.md#persisted-fields).
 
 The watcher does **not** read or write `state.md`. Only bootstrap, `/muggle-do`, and the caller's stages touch it.
 

--- a/plugin/skills/muggle-pr-followup/state-schemas.md
+++ b/plugin/skills/muggle-pr-followup/state-schemas.md
@@ -73,7 +73,7 @@ Free-form markdown. No required schema beyond a few well-known fields the caller
 ...free-form notes added by /muggle-do and bootstrap...
 ```
 
-The `## Pre-flight answers` block is the **E2E validation context** consumed by `do/e2e-acceptance.md` Step 0. Bootstrap seeds it (Step 6.5); the forward pipeline seeds the equivalent via pre-flight's output block. Canonical field list and meaning: [`../_shared/e2e-validation-context.md`](../_shared/e2e-validation-context.md#persisted-fields).
+The `## Pre-flight answers` block is the **E2E validation context** consumed by `do/e2e-acceptance.md` Step 0 — seeded by bootstrap (Step 6.5) or by pre-flight's output block. Fields: [`../_shared/e2e-validation-context.md`](../_shared/e2e-validation-context.md#persisted-fields).
 
 The watcher does **not** read or write `state.md`. Only bootstrap, `/muggle-do`, and the caller's stages touch it.
 

--- a/plugin/skills/muggle-preferences/ops/configure.md
+++ b/plugin/skills/muggle-preferences/ops/configure.md
@@ -26,7 +26,7 @@ you can tell me which (if any) should instead be set to `never`.
 For each option: label = key name, description = first paragraph of `preference-gates/<key>.md`. Multi-select question text = `Which of these should auto-proceed (set to "always")?`; selected = `always`.
 
 - `multiSelect: true`, `header: "Auth & session"` — `autoLogin`, `autoSelectProject`, `checkForUpdates`, `verboseOutput`
-- `multiSelect: true`, `header: "Test setup"` — `autoSelectLocalHost`, `autoDetectChanges`
+- `multiSelect: true`, `header: "Test setup"` — `autoSelectLocalHost`, `autoDetectChanges`, `autoReuseValidationContext`
 - `multiSelect: true`, `header: "Test run"` — `showElectronBrowser`, `openTestResultsAfterRun`, `autoPublishLocalResults`
 - `multiSelect: true`, `header: "Suggestions & PR"` — `suggestRelatedUseCases`, `suggestRelatedTestCases`, `postPRVisualWalkthrough`, `autoCreatePR`
 - `multiSelect: true`, `header: "Branch hygiene"` — `autoUseWorktree`, `autoRebase`, `autoCleanup`

--- a/plugin/skills/muggle-preferences/preference-gates/autoReuseValidationContext.md
+++ b/plugin/skills/muggle-preferences/preference-gates/autoReuseValidationContext.md
@@ -1,0 +1,11 @@
+# `autoReuseValidationContext`
+
+Reuse an existing E2E validation context (a prior session's `## Pre-flight answers` block for this working tree) instead of asking the validation questions again. Substitute `{contextSource}` (the slug + age of the block being offered). Fires only when such a block exists; with none, the calling skill runs the full gather and never reaches this gate.
+
+**Picker 1** — header `Validation context`, question `"Reuse the validation context from {contextSource}?"`
+- `Reuse it` — `Same local URL, project, strategy, and credentials as {contextSource}.` → copy the block into this session
+- `Re-gather` — `Ask the validation questions fresh.` → run the full gather
+
+**Silent action**
+- `always` → `Reusing validation context from {contextSource}`
+- `never` → no footer; the gather is the visible step.


### PR DESCRIPTION
## Problem

A `muggle-pr-followup` watcher **bootstrapped from a PR URL** (`/muggle:muggle-pr-followup <pr-url>` — the documented entry) never runs pre-flight, so its `state.md` had no `localUrl` / `projectId` / validation strategy.

When a review landed and the address-reviews cycle reached **Stage 6 (E2E acceptance)**, `e2e-acceptance.md` Step 0 hard-halted:

> *"Missing any → pre-flight bug; escalate and halt; **do not ask the user**."*

So the cycle **neither ran E2E nor asked** — and because `open-prs/update.md` only posts a walkthrough *"if an E2E report exists,"* **nothing reached the PR** either. Only the per-comment replies fired. Forward-spawned watchers were unaffected (a forward `/muggle-do` run's pre-flight seeds the context into the shared session slot).

Secondary gap: `autoE2ETest: ask` is defined as "resolved by pre-flight Q13," which never runs in address-reviews mode.

## Fix

Gather the E2E validation context **once at bootstrap** (the user is present at launch), persist it to `state.md`, and have every later non-interactive tick reuse it. With context always present, Stage 6 runs each cycle → a report exists → the walkthrough posts. Replies already fired.

- **new `_shared/e2e-validation-context.md`** — the seed/consume contract: silent detection, the validation-subset questions (referencing pre-flight **Q4–Q8 / Q10** for canonical wording rather than forking them), and the persisted `state.md` fields.
- **`bootstrap.md`** — new **Step 6.5** runs the gather + persists; `--resume` backfills older sessions; reframed from "non-interactive" to "asks once, then autonomous."
- **`e2e-acceptance.md` Step 0** — reads the context **regardless of seeder** (pre-flight *or* bootstrap); in a loop there's no per-tick pre-flight, so the persisted `Validation` strategy is the standing decision (no `ask` re-resolution).
- **`address-reviews.md` 4d**, **`state-schemas.md`**, **`SKILL.md`**, **`CLAUDE.md`** — aligned with the new contract.

## Design decision

Pre-flight is **left untouched** (option b): the shared file *points at* pre-flight's questions as canonical wording rather than restructuring pre-flight's single-`AskUserQuestion` constraint. Zero blast radius on the working forward pipeline.

## Behavior guarantee

After a followup cycle addresses comments, it now (URL-bootstrapped path included): **runs E2E (or stands down per the strategy the user chose at bootstrap) → posts the result to the PR → replies per comment.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)