### PR TITLE
feat(mcp): thread local lane through local-execution upload + generation

### DIFF
--- a/packages/mcps/src/mcp/e2e/contracts/index.ts
+++ b/packages/mcps/src/mcp/e2e/contracts/index.ts
@@ -408,7 +408,7 @@ export const WorkflowStartTestScriptGenerationInputSchema = z.object({
   precondition: z.string().min(1).describe("Preconditions"),
   instructions: z.string().min(1).describe("Step-by-step instructions"),
   expectedResult: z.string().min(1).describe("Expected result"),
-  type: RunEnvironmentInputSchema,
+  runEnvironmentType: RunEnvironmentInputSchema,
   workflowParams: WorkflowParamsSchema,
 });
 

--- a/packages/mcps/src/mcp/e2e/contracts/index.ts
+++ b/packages/mcps/src/mcp/e2e/contracts/index.ts
@@ -5,8 +5,10 @@
 import { z } from "zod";
 
 import { MuggleEntityIdSchema } from "../../contracts/muggle-entity-id-schema.js";
+import { RunEnvironmentInputSchema } from "./run-environment.js";
 
 export { MuggleEntityIdSchema };
+export * from "./run-environment.js";
 export * from "./local-run-schemas.js";
 
 /**
@@ -406,6 +408,7 @@ export const WorkflowStartTestScriptGenerationInputSchema = z.object({
   precondition: z.string().min(1).describe("Preconditions"),
   instructions: z.string().min(1).describe("Step-by-step instructions"),
   expectedResult: z.string().min(1).describe("Expected result"),
+  type: RunEnvironmentInputSchema,
   workflowParams: WorkflowParamsSchema,
 });
 

--- a/packages/mcps/src/mcp/e2e/contracts/local-run-schemas.ts
+++ b/packages/mcps/src/mcp/e2e/contracts/local-run-schemas.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { MuggleEntityIdSchema } from "../../contracts/muggle-entity-id-schema.js";
+import { RunEnvironmentInputSchema } from "./run-environment.js";
 
 /**
  * Local execution context schema for local-run upload.
@@ -25,6 +26,7 @@ export const LocalRunUploadInputSchema = z.object({
   useCaseId: MuggleEntityIdSchema.describe("Use case ID (UUID) for the local run"),
   testCaseId: MuggleEntityIdSchema.describe("Test case ID (UUID) for the local run"),
   runType: z.enum(["generation", "replay"]).describe("Type of local run to upload"),
+  type: RunEnvironmentInputSchema,
   productionUrl: z.string().url().describe("Cloud production URL associated with the run"),
   localExecutionContext: LocalExecutionContextInputSchema.describe("Local execution metadata"),
   actionScript: z.array(z.unknown()).min(1).describe("Generated action script steps from local execution"),

--- a/packages/mcps/src/mcp/e2e/contracts/local-run-schemas.ts
+++ b/packages/mcps/src/mcp/e2e/contracts/local-run-schemas.ts
@@ -26,7 +26,7 @@ export const LocalRunUploadInputSchema = z.object({
   useCaseId: MuggleEntityIdSchema.describe("Use case ID (UUID) for the local run"),
   testCaseId: MuggleEntityIdSchema.describe("Test case ID (UUID) for the local run"),
   runType: z.enum(["generation", "replay"]).describe("Type of local run to upload"),
-  type: RunEnvironmentInputSchema,
+  runEnvironmentType: RunEnvironmentInputSchema,
   productionUrl: z.string().url().describe("Cloud production URL associated with the run"),
   localExecutionContext: LocalExecutionContextInputSchema.describe("Local execution metadata"),
   actionScript: z.array(z.unknown()).min(1).describe("Generated action script steps from local execution"),

--- a/packages/mcps/src/mcp/e2e/contracts/run-environment.ts
+++ b/packages/mcps/src/mcp/e2e/contracts/run-environment.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+/**
+ * Environment lane a test run belongs to. The cloud versions runSettings (and
+ * thus credentials) per `(projectId, type)` lane: a `local` run resolves the
+ * developer's localhost credentials instead of the remote managed-profile pool,
+ * which a dev tenant rejects.
+ */
+export enum RunEnvironment {
+  Local = "local",
+  Remote = "remote",
+}
+
+export const RunEnvironmentSchema = z.enum([RunEnvironment.Local, RunEnvironment.Remote]);
+
+/**
+ * Lane field shared by generation/replay/upload contracts. Optional with no
+ * default so omitting it stays omitted on the wire — the backend treats a
+ * missing `type` as remote, which keeps pre-lane behavior unchanged.
+ */
+export const RunEnvironmentInputSchema = RunEnvironmentSchema.optional().describe(
+  "Environment lane for the run: 'local' (developer localhost) or 'remote' (deployed). " +
+    "Selects which versioned runSettings/credentials lane the cloud resolves. Omit for remote (default).",
+);

--- a/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
+++ b/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
@@ -597,6 +597,7 @@ const workflowTools: IQaToolDefinition[] = [
           precondition: data.precondition,
           instructions: data.instructions,
           expectedResult: data.expectedResult,
+          ...(data.type && { type: data.type }),
           ...(data.workflowParams && { workflowParams: data.workflowParams }),
         },
         timeoutMs: getWorkflowTimeoutMs(),
@@ -778,6 +779,7 @@ const workflowTools: IQaToolDefinition[] = [
           useCaseId: data.useCaseId,
           testCaseId: data.testCaseId,
           runType: data.runType,
+          ...(data.type && { type: data.type }),
           productionUrl: data.productionUrl,
           localExecutionContext: {
             originalUrl: data.localExecutionContext.originalUrl,

--- a/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
+++ b/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
@@ -597,7 +597,7 @@ const workflowTools: IQaToolDefinition[] = [
           precondition: data.precondition,
           instructions: data.instructions,
           expectedResult: data.expectedResult,
-          ...(data.type && { type: data.type }),
+          ...(data.runEnvironmentType && { runEnvironmentType: data.runEnvironmentType }),
           ...(data.workflowParams && { workflowParams: data.workflowParams }),
         },
         timeoutMs: getWorkflowTimeoutMs(),

--- a/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
+++ b/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
@@ -779,7 +779,7 @@ const workflowTools: IQaToolDefinition[] = [
           useCaseId: data.useCaseId,
           testCaseId: data.testCaseId,
           runType: data.runType,
-          ...(data.type && { type: data.type }),
+          ...(data.runEnvironmentType && { runEnvironmentType: data.runEnvironmentType }),
           productionUrl: data.productionUrl,
           localExecutionContext: {
             originalUrl: data.localExecutionContext.originalUrl,

--- a/packages/mcps/src/mcp/tools/local/tool-registry.ts
+++ b/packages/mcps/src/mcp/tools/local/tool-registry.ts
@@ -10,6 +10,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 
 import { getPromptServiceClient } from "../../e2e/upstream-client.js";
+import { RunEnvironment } from "../../e2e/contracts/run-environment.js";
 import { getCallerCredentialsAsync } from "../../../shared/auth.js";
 import { getLogger } from "../../../shared/logger.js";
 import { EventName, Outcome, ToolSurface, track } from "@muggleai/telemetry";
@@ -521,6 +522,10 @@ const publishTestScriptTool: ILocalMcpTool = {
             useCaseId: runResult.useCaseId,
             testCaseId: input.cloudTestCaseId,
             runType: runResult.runType,
+            // A published run always originates from local Electron execution, so it
+            // belongs to the local lane — the cloud must resolve the developer's
+            // localhost credentials, not the remote managed-profile pool.
+            type: RunEnvironment.Local,
             productionUrl: runResult.productionUrl,
             localExecutionContext: {
               originalUrl: runResult.localExecutionContext.originalUrl,

--- a/packages/mcps/src/mcp/tools/local/tool-registry.ts
+++ b/packages/mcps/src/mcp/tools/local/tool-registry.ts
@@ -525,7 +525,7 @@ const publishTestScriptTool: ILocalMcpTool = {
             // A published run always originates from local Electron execution, so it
             // belongs to the local lane — the cloud must resolve the developer's
             // localhost credentials, not the remote managed-profile pool.
-            type: RunEnvironment.Local,
+            runEnvironmentType: RunEnvironment.Local,
             productionUrl: runResult.productionUrl,
             localExecutionContext: {
               originalUrl: runResult.localExecutionContext.originalUrl,

--- a/packages/mcps/src/test/publish-test-script.test.ts
+++ b/packages/mcps/src/test/publish-test-script.test.ts
@@ -193,6 +193,20 @@ describe("muggle-local-publish-test-script — summaryStep forwarding", () => {
     });
   });
 
+  it("tags the upload as the local lane so the cloud resolves local credentials", async () => {
+    seedHappyPath({ includeSummaryStep: true });
+
+    const tool = getTool("muggle-local-publish-test-script");
+    const result = await tool!.execute({
+      input: { runId: RUN_ID, cloudTestCaseId: CLOUD_TEST_CASE_ID },
+      correlationId: "test-corr",
+    } as never);
+
+    expect(result.isError).toBe(false);
+    const requestConfig = mockExecute.mock.calls[0][0] as { body: Record<string, unknown> };
+    expect(requestConfig.body.type).toBe("local");
+  });
+
   it("forwards undefined summaryStep when the test script does not have one", async () => {
     seedHappyPath({ includeSummaryStep: false });
 

--- a/packages/mcps/src/test/publish-test-script.test.ts
+++ b/packages/mcps/src/test/publish-test-script.test.ts
@@ -204,7 +204,7 @@ describe("muggle-local-publish-test-script — summaryStep forwarding", () => {
 
     expect(result.isError).toBe(false);
     const requestConfig = mockExecute.mock.calls[0][0] as { body: Record<string, unknown> };
-    expect(requestConfig.body.type).toBe("local");
+    expect(requestConfig.body.runEnvironmentType).toBe("local");
   });
 
   it("forwards undefined summaryStep when the test script does not have one", async () => {

--- a/packages/mcps/src/test/run-environment-lane.test.ts
+++ b/packages/mcps/src/test/run-environment-lane.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for threading the environment lane (`type`) through the cloud
+ * generation and local-run upload contracts. A local run must reach the cloud
+ * tagged `type: "local"` so versioned runSettings resolve the developer's
+ * localhost credentials instead of the remote managed-profile pool. Omitting
+ * `type` must keep the pre-lane wire shape (backend defaults missing → remote).
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../shared/config.js", () => ({
+  getConfig: () => ({
+    logLevel: "silent",
+    serverName: "test",
+    serverVersion: "0.0.0",
+    e2e: {
+      promptServiceBaseUrl: "http://test.invalid",
+      requestTimeoutMs: 1000,
+      workflowTimeoutMs: 5000,
+    },
+  }),
+}));
+
+vi.mock("../shared/logger.js", () => {
+  const noop = () => undefined;
+  const fakeLogger = {
+    info: noop,
+    warn: noop,
+    error: noop,
+    debug: noop,
+    verbose: noop,
+    silly: noop,
+    child: () => fakeLogger,
+  };
+  return {
+    getLogger: () => fakeLogger,
+    createChildLogger: () => fakeLogger,
+    resetLogger: noop,
+  };
+});
+
+vi.mock("../mcp/e2e/upstream-client.js", () => ({
+  getPromptServiceClient: () => ({ execute: vi.fn() }),
+}));
+
+vi.mock("../shared/auth.js", () => ({
+  getCallerCredentialsAsync: vi.fn(async () => ({ bearerToken: "test-token" })),
+}));
+
+import {
+  LocalRunUploadInputSchema,
+  RunEnvironment,
+  WorkflowStartTestScriptGenerationInputSchema,
+} from "../mcp/e2e/contracts/index.js";
+import { getQaToolByName } from "../mcp/tools/e2e/tool-registry.js";
+
+const PROJECT_ID = "11111111-1111-4111-8111-111111111111";
+const USE_CASE_ID = "22222222-2222-4222-8222-222222222222";
+const TEST_CASE_ID = "33333333-3333-4333-8333-333333333333";
+
+function baseUploadInput(): Record<string, unknown> {
+  return {
+    projectId: PROJECT_ID,
+    useCaseId: USE_CASE_ID,
+    testCaseId: TEST_CASE_ID,
+    runType: "generation",
+    productionUrl: "https://staging.example.com/",
+    localExecutionContext: {
+      originalUrl: "http://localhost:3000/",
+      productionUrl: "https://staging.example.com/",
+      runByUserId: "auth0|test",
+      localExecutionCompletedAt: 1,
+      uploadedAt: 2,
+    },
+    actionScript: [{ step: 1 }],
+    status: "passed",
+    executionTimeMs: 100,
+  };
+}
+
+describe("RunEnvironment lane contracts", () => {
+  it("LocalRunUploadInputSchema accepts type: local", () => {
+    const parsed = LocalRunUploadInputSchema.parse({
+      ...baseUploadInput(),
+      type: RunEnvironment.Local,
+    });
+    expect(parsed.type).toBe(RunEnvironment.Local);
+  });
+
+  it("LocalRunUploadInputSchema leaves type undefined when omitted", () => {
+    const parsed = LocalRunUploadInputSchema.parse(baseUploadInput());
+    expect(parsed.type).toBeUndefined();
+  });
+
+  it("LocalRunUploadInputSchema rejects an unknown lane", () => {
+    expect(() =>
+      LocalRunUploadInputSchema.parse({ ...baseUploadInput(), type: "preview" }),
+    ).toThrow();
+  });
+
+  it("WorkflowStartTestScriptGenerationInputSchema accepts type: local", () => {
+    const parsed = WorkflowStartTestScriptGenerationInputSchema.parse({
+      projectId: PROJECT_ID,
+      useCaseId: USE_CASE_ID,
+      testCaseId: TEST_CASE_ID,
+      name: "gen",
+      url: "https://staging.example.com/",
+      goal: "goal",
+      precondition: "pre",
+      instructions: "do it",
+      expectedResult: "done",
+      type: RunEnvironment.Local,
+    });
+    expect(parsed.type).toBe(RunEnvironment.Local);
+  });
+});
+
+describe("muggle-remote-local-run-upload lane forwarding", () => {
+  it("forwards type into the upload body when provided", () => {
+    const tool = getQaToolByName("muggle-remote-local-run-upload")!;
+    const call = tool.mapToUpstream({ ...baseUploadInput(), type: RunEnvironment.Local });
+    expect((call.body as Record<string, unknown>).type).toBe(RunEnvironment.Local);
+  });
+
+  it("omits type from the upload body when not provided", () => {
+    const tool = getQaToolByName("muggle-remote-local-run-upload")!;
+    const call = tool.mapToUpstream(baseUploadInput());
+    expect(call.body as Record<string, unknown>).not.toHaveProperty("type");
+  });
+});
+
+describe("muggle-remote-workflow-start-test-script-generation lane forwarding", () => {
+  function genInput(extra: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+      projectId: PROJECT_ID,
+      useCaseId: USE_CASE_ID,
+      testCaseId: TEST_CASE_ID,
+      name: "gen",
+      url: "https://staging.example.com/",
+      goal: "goal",
+      precondition: "pre",
+      instructions: "do it",
+      expectedResult: "done",
+      ...extra,
+    };
+  }
+
+  it("forwards type: local into the workflow body", () => {
+    const tool = getQaToolByName("muggle-remote-workflow-start-test-script-generation")!;
+    const call = tool.mapToUpstream(genInput({ type: RunEnvironment.Local }));
+    expect((call.body as Record<string, unknown>).type).toBe(RunEnvironment.Local);
+  });
+
+  it("omits type from the workflow body when not provided", () => {
+    const tool = getQaToolByName("muggle-remote-workflow-start-test-script-generation")!;
+    const call = tool.mapToUpstream(genInput());
+    expect(call.body as Record<string, unknown>).not.toHaveProperty("type");
+  });
+});

--- a/packages/mcps/src/test/run-environment-lane.test.ts
+++ b/packages/mcps/src/test/run-environment-lane.test.ts
@@ -1,9 +1,10 @@
 /**
- * Tests for threading the environment lane (`type`) through the cloud
- * generation and local-run upload contracts. A local run must reach the cloud
- * tagged `type: "local"` so versioned runSettings resolve the developer's
- * localhost credentials instead of the remote managed-profile pool. Omitting
- * `type` must keep the pre-lane wire shape (backend defaults missing → remote).
+ * Tests for threading the environment lane (`runEnvironmentType`) through the
+ * cloud generation and local-run upload contracts. A local run must reach the
+ * cloud tagged `runEnvironmentType: "local"` so versioned runSettings resolve
+ * the developer's localhost credentials instead of the remote managed-profile
+ * pool. Omitting it must keep the pre-lane wire shape (backend defaults missing
+ * → remote).
  */
 
 import { describe, expect, it, vi } from "vitest";
@@ -79,22 +80,22 @@ function baseUploadInput(): Record<string, unknown> {
 }
 
 describe("RunEnvironment lane contracts", () => {
-  it("LocalRunUploadInputSchema accepts type: local", () => {
+  it("LocalRunUploadInputSchema accepts runEnvironmentType: local", () => {
     const parsed = LocalRunUploadInputSchema.parse({
       ...baseUploadInput(),
-      type: RunEnvironment.Local,
+      runEnvironmentType: RunEnvironment.Local,
     });
-    expect(parsed.type).toBe(RunEnvironment.Local);
+    expect(parsed.runEnvironmentType).toBe(RunEnvironment.Local);
   });
 
-  it("LocalRunUploadInputSchema leaves type undefined when omitted", () => {
+  it("LocalRunUploadInputSchema leaves runEnvironmentType undefined when omitted", () => {
     const parsed = LocalRunUploadInputSchema.parse(baseUploadInput());
-    expect(parsed.type).toBeUndefined();
+    expect(parsed.runEnvironmentType).toBeUndefined();
   });
 
   it("LocalRunUploadInputSchema rejects an unknown lane", () => {
     expect(() =>
-      LocalRunUploadInputSchema.parse({ ...baseUploadInput(), type: "preview" }),
+      LocalRunUploadInputSchema.parse({ ...baseUploadInput(), runEnvironmentType: "preview" }),
     ).toThrow();
   });
 
@@ -116,16 +117,16 @@ describe("RunEnvironment lane contracts", () => {
 });
 
 describe("muggle-remote-local-run-upload lane forwarding", () => {
-  it("forwards type into the upload body when provided", () => {
+  it("forwards runEnvironmentType into the upload body when provided", () => {
     const tool = getQaToolByName("muggle-remote-local-run-upload")!;
-    const call = tool.mapToUpstream({ ...baseUploadInput(), type: RunEnvironment.Local });
-    expect((call.body as Record<string, unknown>).type).toBe(RunEnvironment.Local);
+    const call = tool.mapToUpstream({ ...baseUploadInput(), runEnvironmentType: RunEnvironment.Local });
+    expect((call.body as Record<string, unknown>).runEnvironmentType).toBe(RunEnvironment.Local);
   });
 
-  it("omits type from the upload body when not provided", () => {
+  it("omits runEnvironmentType from the upload body when not provided", () => {
     const tool = getQaToolByName("muggle-remote-local-run-upload")!;
     const call = tool.mapToUpstream(baseUploadInput());
-    expect(call.body as Record<string, unknown>).not.toHaveProperty("type");
+    expect(call.body as Record<string, unknown>).not.toHaveProperty("runEnvironmentType");
   });
 });
 

--- a/packages/mcps/src/test/run-environment-lane.test.ts
+++ b/packages/mcps/src/test/run-environment-lane.test.ts
@@ -98,7 +98,7 @@ describe("RunEnvironment lane contracts", () => {
     ).toThrow();
   });
 
-  it("WorkflowStartTestScriptGenerationInputSchema accepts type: local", () => {
+  it("WorkflowStartTestScriptGenerationInputSchema accepts runEnvironmentType: local", () => {
     const parsed = WorkflowStartTestScriptGenerationInputSchema.parse({
       projectId: PROJECT_ID,
       useCaseId: USE_CASE_ID,
@@ -109,9 +109,9 @@ describe("RunEnvironment lane contracts", () => {
       precondition: "pre",
       instructions: "do it",
       expectedResult: "done",
-      type: RunEnvironment.Local,
+      runEnvironmentType: RunEnvironment.Local,
     });
-    expect(parsed.type).toBe(RunEnvironment.Local);
+    expect(parsed.runEnvironmentType).toBe(RunEnvironment.Local);
   });
 });
 
@@ -145,15 +145,15 @@ describe("muggle-remote-workflow-start-test-script-generation lane forwarding", 
     };
   }
 
-  it("forwards type: local into the workflow body", () => {
+  it("forwards runEnvironmentType: local into the workflow body", () => {
     const tool = getQaToolByName("muggle-remote-workflow-start-test-script-generation")!;
-    const call = tool.mapToUpstream(genInput({ type: RunEnvironment.Local }));
-    expect((call.body as Record<string, unknown>).type).toBe(RunEnvironment.Local);
+    const call = tool.mapToUpstream(genInput({ runEnvironmentType: RunEnvironment.Local }));
+    expect((call.body as Record<string, unknown>).runEnvironmentType).toBe(RunEnvironment.Local);
   });
 
-  it("omits type from the workflow body when not provided", () => {
+  it("omits runEnvironmentType from the workflow body when not provided", () => {
     const tool = getQaToolByName("muggle-remote-workflow-start-test-script-generation")!;
     const call = tool.mapToUpstream(genInput());
-    expect(call.body as Record<string, unknown>).not.toHaveProperty("type");
+    expect(call.body as Record<string, unknown>).not.toHaveProperty("runEnvironmentType");
   });
 });


### PR DESCRIPTION
## What

Threads the `local` environment lane through the MCP local-execution path so the cloud resolves the developer's localhost credentials for local runs, instead of the remote managed-profile pool that a dev tenant rejects.

Builds against the SHARED CONTRACT: the cloud generation entry point and the local-run upload endpoint accept an optional `type: "local" | "remote"` (default `remote`). All changes guard so that omitting `type` keeps today's behavior — safe to merge ahead of the backend.

## Changes

- New `RunEnvironment` enum + optional (no-default) `RunEnvironmentInputSchema` at the e2e contracts boundary (`run-environment.ts`), single source of truth for the lane.
- `muggle-local-publish-test-script` now always uploads with `type: "local"` — a published run is, by definition, a local-lane run.
- `muggle-remote-local-run-upload` and `muggle-remote-workflow-start-test-script-generation` forward `type` when present; omit it otherwise (backend treats missing → remote).

## Does the local path consume cloud runSettings?

No. The local execution service (`executeTestGeneration`/`executeReplay`) makes **no cloud runSettings/secrets call** — it spawns Electron with the caller's own stored auth token. The **only** cloud touchpoint for a local run is the upload/publish step (`/local-run/upload`), where the cloud creates the workflow run/runtime and resolves the lane. Tagging that upload `type: "local"` is therefore sufficient to close the credential-isolation gap on the MCP side — no follow-up needed in this repo.

## Call sites touched

- `packages/mcps/src/mcp/e2e/contracts/run-environment.ts` (new)
- `packages/mcps/src/mcp/e2e/contracts/local-run-schemas.ts` — `type` on `LocalRunUploadInputSchema`
- `packages/mcps/src/mcp/e2e/contracts/index.ts` — `type` on `WorkflowStartTestScriptGenerationInputSchema` + re-export
- `packages/mcps/src/mcp/tools/e2e/tool-registry.ts` — forward `type` in the upload + generation wrappers
- `packages/mcps/src/mcp/tools/local/tool-registry.ts` — `type: RunEnvironment.Local` in the publish upload body

## Validation

- `tsc --noEmit` (mcps + root): clean
- `vitest run` (mcps): 147 passed, incl. new `run-environment-lane.test.ts` and extended `publish-test-script.test.ts`
- `eslint` on touched files: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)