### PR TITLE
feat(muggle-test-local): resolve test-case parent chain before run

### DIFF
--- a/packages/mcps/src/mcp/e2e/contracts/index.ts
+++ b/packages/mcps/src/mcp/e2e/contracts/index.ts
@@ -312,6 +312,10 @@ export const TestCaseGetInputSchema = z.object({
   testCaseId: IdSchema.describe("Test case ID (UUID) to retrieve"),
 });
 
+export const TestCaseAncestorsGetInputSchema = z.object({
+  testCaseId: IdSchema.describe("Test case ID (UUID) to resolve the test-plan-graph ancestor chain for"),
+});
+
 export const TestCaseListByUseCaseInputSchema = z.object({
   useCaseId: IdSchema.describe("Use case ID (UUID) to list test cases for"),
 });

--- a/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
+++ b/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
@@ -299,6 +299,19 @@ const testCaseTools: IQaToolDefinition[] = [
     },
   },
   {
+    name: "muggle-remote-test-case-ancestors-get",
+    description:
+      "Resolve a test case's prerequisite chain from the project's test-plan graph. Returns { testCaseId, ancestors, orphan } where `ancestors` is an array of test case IDs ordered immediate-parent → root (empty when the case is a graph root). `orphan: true` means the case has no graph node, so it has no prerequisites. Call this before generating or replaying a script to ensure every prerequisite test case already has a ready script.",
+    inputSchema: schemas.TestCaseAncestorsGetInputSchema,
+    mapToUpstream: (input) => {
+      const data = input as z.infer<typeof schemas.TestCaseAncestorsGetInputSchema>;
+      return {
+        method: "GET",
+        path: `${MUGGLE_TEST_PREFIX}/test-plan-graph/test-cases/${data.testCaseId}/ancestors`,
+      };
+    },
+  },
+  {
     name: "muggle-remote-test-case-list-by-use-case",
     description: "List test cases for a specific use case.",
     inputSchema: schemas.TestCaseListByUseCaseInputSchema,

--- a/packages/mcps/src/test/test-case-ancestors.test.ts
+++ b/packages/mcps/src/test/test-case-ancestors.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Tests for the muggle-remote-test-case-ancestors-get tool, which proxies the
+ * test-plan-graph ancestor endpoint so callers can resolve a test case's
+ * prerequisite chain before generating or replaying its script.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../shared/config.js", () => ({
+  getConfig: () => ({
+    logLevel: "silent",
+    serverName: "test",
+    serverVersion: "0.0.0",
+    e2e: {
+      promptServiceBaseUrl: "http://test.invalid",
+      requestTimeoutMs: 1000,
+      workflowTimeoutMs: 5000,
+    },
+  }),
+}));
+
+vi.mock("../shared/logger.js", () => {
+  const noop = () => undefined;
+  const fakeLogger = {
+    info: noop,
+    warn: noop,
+    error: noop,
+    debug: noop,
+    verbose: noop,
+    silly: noop,
+    child: () => fakeLogger,
+  };
+  return {
+    getLogger: () => fakeLogger,
+    createChildLogger: () => fakeLogger,
+    resetLogger: noop,
+  };
+});
+
+vi.mock("../mcp/e2e/upstream-client.js", () => ({
+  getPromptServiceClient: () => ({ execute: vi.fn() }),
+}));
+
+vi.mock("../shared/auth.js", () => ({
+  getCallerCredentialsAsync: vi.fn(async () => ({ bearerToken: "test-token" })),
+}));
+
+import { TestCaseAncestorsGetInputSchema } from "../mcp/e2e/contracts/index.js";
+import { getQaToolByName } from "../mcp/tools/e2e/tool-registry.js";
+
+const TEST_CASE_ID = "33333333-3333-4333-8333-333333333333";
+
+describe("muggle-remote-test-case-ancestors-get", () => {
+  it("is registered and requires auth by default", () => {
+    const tool = getQaToolByName("muggle-remote-test-case-ancestors-get");
+    expect(tool).toBeDefined();
+    expect(tool!.requiresAuth).not.toBe(false);
+  });
+
+  it("maps to the test-plan-graph ancestors GET endpoint", () => {
+    const tool = getQaToolByName("muggle-remote-test-case-ancestors-get")!;
+    const call = tool.mapToUpstream({ testCaseId: TEST_CASE_ID });
+    expect(call.method).toBe("GET");
+    expect(call.path).toBe(
+      `/v1/protected/muggle-test/test-plan-graph/test-cases/${TEST_CASE_ID}/ancestors`,
+    );
+  });
+
+  it("rejects a non-UUID testCaseId", () => {
+    expect(() => TestCaseAncestorsGetInputSchema.parse({ testCaseId: "not-a-uuid" })).toThrow();
+  });
+});

--- a/plugin/skills/_shared/test-case-chain-readiness.md
+++ b/plugin/skills/_shared/test-case-chain-readiness.md
@@ -1,0 +1,41 @@
+# Test Case Chain Readiness
+
+A test case may depend on prerequisite ("parent") test cases in the project's **test-plan graph** — e.g. "edit item" depends on "create item". Before generating or replaying the chosen test case, every ancestor in that chain must already have a ready script, or the run starts from missing state and fails for the wrong reason.
+
+This is the **graph the backend owns** — do not infer the chain from titles or `precondition` text. Read it from `muggle-remote-test-case-ancestors-get`.
+
+**Ready** = `muggle-remote-test-script-list` (with the ancestor's `testCaseId`) returns at least one replayable/succeeded script — the same bar Step 5 uses to offer replay.
+
+## Procedure
+
+Run once the target `testCaseId` is chosen and the local URL + services are confirmed (the generation calls below need `localUrl` and `cwd`).
+
+1. **Resolve the chain.** `muggle-remote-test-case-ancestors-get` with the target `testCaseId`. Response: `{ testCaseId, ancestors, orphan }`.
+   - `orphan: true` **or** empty `ancestors` → no prerequisites. Skip the rest; continue to Step 5.
+   - Otherwise `ancestors` is ordered **immediate-parent → root**. Reverse it to **root-first** so prerequisites are satisfied bottom-up.
+
+2. **For each ancestor, root-first:**
+   - Check readiness via `muggle-remote-test-script-list` (`projectId`, `testCaseId` = ancestor). Ready → skip to the next ancestor.
+   - Not ready → **generate its script only (never replay):**
+     1. `muggle-remote-test-case-get` for the ancestor.
+     2. Determine `freshSession` for that ancestor from its own content — same rules as Step 6.
+     3. `muggle-local-execute-test-generation` with the ancestor test case, `localUrl`, `cwd`, and a long `timeoutMs` (see Step 6's timeout guidance). Do **not** call `muggle-local-execute-replay`.
+     4. `muggle-local-publish-test-script` (`runId`, `cloudTestCaseId` = ancestor) so the generated script is promoted as that ancestor's canonical replay script — it now reads as ready for any case downstream.
+
+3. **All ancestors ready** → continue to Step 5 for the target test case.
+
+## When an ancestor's generation fails
+
+If an ancestor's generation does not reach `passed` (read it via `muggle-local-run-result-get`, never the execute stdout tail), the target's prerequisite state is missing. **Halt the chain** and surface which ancestor failed and why, then ask via `AskUserQuestion`:
+
+- **Stop** — don't run the target; the chain is broken.
+- **Proceed anyway** — run the target without the prerequisite (likely to fail; only if the user judges the state already exists).
+- **Give feedback** — invoke the `muggle-feedback` skill with the failed ancestor's `runId`.
+
+Do not silently skip a failed ancestor and run the target.
+
+## Notes
+
+- The target test case is **not** in its own `ancestors` list — only its prerequisites are.
+- Each ancestor is a single path to the root (one parent per node), so the reversed list has no duplicates; generate each at most once per session.
+- This walks the **full** chain to root, not just the immediate parent — a grandparent without a ready script is generated before its child.

--- a/plugin/skills/muggle-test-feature-local/SKILL.md
+++ b/plugin/skills/muggle-test-feature-local/SKILL.md
@@ -127,6 +127,12 @@ Gate `autoSelectLocalHost` per `preference-gates/README.md` + `preference-gates/
 
 Remind them: local URL is only the execution target, not tied to cloud project config.
 
+### 4a. Satisfy the test case chain (prerequisite parents)
+
+Before deciding the target's script, resolve its prerequisite chain from the backend test-plan graph and ensure every ancestor already has a ready script — generating any that don't, **test-generation only**, root-first. Follow [`_shared/test-case-chain-readiness.md`](../_shared/test-case-chain-readiness.md).
+
+`muggle-remote-test-case-ancestors-get` returns the chain; an `orphan` test case has no prerequisites — skip straight to Step 5. Do **not** infer parents from `precondition` text; the graph is authoritative.
+
 ### 5. Existing scripts vs new generation
 
 `muggle-remote-test-script-list` with `testCaseId`.
@@ -247,6 +253,7 @@ After reporting results:
 - No silent auth skip.
 - **Never prompt for Electron launch approval** before execution — invoking this skill is the approval. Just run.
 - **Never diagnose a failed run from `execute`'s response stdout tail.** Always call `muggle-local-run-result-get` first; classify only from its structured fields and (when present) the artifacts it names. The execute tail is an excerpt and routinely truncates the failure cause.
+- Satisfy the prerequisite chain (Step 4a) before generating or replaying the target. Read it from `muggle-remote-test-case-ancestors-get` — never infer parents from `precondition` text. Generate any not-ready ancestor test-generation-only, root-first.
 - If replayable scripts exist, do not default to generation without user choice.
 - No hiding failures: surface errors and artifact paths.
 - **Always offer the agent-guidance reminder after every Electron run** (Step 9b) — pass or fail — unless 9a already routed the user into `muggle-feedback`. Never silently end a run without giving the user a one-click path to flag what was wrong.


### PR DESCRIPTION
## Summary
- Adds `muggle-remote-test-case-ancestors-get` MCP tool — proxies the backend test-plan-graph ancestors endpoint (`GET /v1/protected/muggle-test/test-plan-graph/test-cases/:testCaseId/ancestors`). Response: `{ testCaseId, ancestors (immediate parent → root), orphan }`.
- New `_shared/test-case-chain-readiness.md` guidance: walk the ancestor chain root-first; for each ancestor lacking a replayable/succeeded script, test-generate it and publish so it becomes ready before the target runs.
- `muggle-test-feature-local` gets **Step 4a** referencing the guidance (after Local URL, before script-decision Step 5), plus a non-negotiable forbidding parent inference from `precondition` text.

## Why
Without this, `muggle-test-feature-local` runs the target test case even when its prerequisite parent has no ready script — the run then fails for a missing-state reason rather than the actual target behavior. The backend already models the parent chain via `TestPlanGraph`; we just hadn't surfaced it to the skill.

## Test plan
- [x] mcps suite passes: 149/149 (incl. 3 new ancestors-tool cases)
- [x] mcps + root typecheck clean
- [ ] After release, run `muggle-test-feature-local` against a test case whose graph parent has no ready script — confirm Step 4a generates the parent first (test-gen only), then proceeds to the target
- [ ] Confirm `orphan: true` path skips the chain step cleanly with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)