### PR TITLE
chore(release): @muggleai/works 4.13.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.13.0"
+      "version": "4.13.1"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.13.0"
+      "version": "4.13.1"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@muggleai/works",
   "mcpName": "io.github.multiplex-ai/muggle",
-  "version": "4.13.0",
+  "version": "4.13.1",
   "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
   "type": "module",
   "main": "dist/index.js",
@@ -42,14 +42,14 @@
     "test:watch": "vitest"
   },
   "muggleConfig": {
-    "electronAppVersion": "1.0.99",
+    "electronAppVersion": "1.0.101",
     "downloadBaseUrl": "https://github.com/multiplex-ai/muggle-ai-works/releases/download",
     "runtimeTargetDefault": "dev",
     "checksums": {
-      "darwin-arm64": "6bfad4f1db8ecabdf78c73094b6c10e1554b540a964ad3a545d7f13706aaa0ec",
-      "darwin-x64": "2f8450becd36482842afa5059254e04229533999693feed99f77e4c87d01f2b1",
-      "linux-x64": "302fd730e2ff3ef2f1d70ffbb86f0861ea3b4b1c1fdd81887c86c5172b20d9b6",
-      "win32-x64": "c62660fd08eed2337ead48e60ff365a785e40fe36f8695bcc342aa83b1fc267c"
+      "darwin-arm64": "2c73d9aa22740b6fc90f8dadccdc137c6fa87f1ce17ad5bcfd3f721b305c4807",
+      "darwin-x64": "dcc5e05b8382a15058c691c109af313b07f91e6470bc4a5b7f789ba82e6b7fa3",
+      "linux-x64": "24eeb304e5d302372984f1d2d0a15e337dcf949f7cfcd7b8c351c7d0d9d6e784",
+      "win32-x64": "6a391b516eaf30052f84277b90fa12393d32c1428e3f87c2f0eca241e6504a93"
     }
   },
   "dependencies": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "4.13.0",
+  "version": "4.13.1",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "4.13.0",
+  "version": "4.13.1",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "4.13.0",
+  "version": "4.13.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "4.13.0",
+      "version": "4.13.1",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
## Version delta
- `@muggleai/works`: **4.13.0 → 4.13.1** (patch)
- `muggleConfig.electronAppVersion`: **1.0.99 → 1.0.101** (latest GitHub electron-app release, 2 ahead)

## Shipping
- feat(muggle-test-local): resolve test-case parent chain before run (#194) — new MCP tool `muggle-remote-test-case-ancestors-get` proxying the backend test-plan-graph ancestors endpoint, `_shared/test-case-chain-readiness.md` guidance, and Step 4a wiring. Without this release the merged Step 4a calls a tool that isn't in any installed build.

## Electron
All four `muggleConfig.checksums` refreshed from `electron-app-v1.0.101/checksums.txt`:
- `darwin-arm64`: `2c73d9aa…c4807`
- `darwin-x64`: `dcc5e05b…b7fa3`
- `linux-x64`: `24eeb304…6e784`
- `win32-x64`: `6a391b51…504a93`

`verify:electron-release-checksums` passed against the live release asset.

## Manifests synced by scripts/sync-versions.mjs
- `.claude-plugin/marketplace.json`, `.cursor-plugin/marketplace.json`
- `plugin/.claude-plugin/plugin.json`, `plugin/.cursor-plugin/plugin.json`
- `server.json`

(No hand-edits.)

## Coordinated changes
None — the test-plan-graph ancestors endpoint already ships in `muggle-ai-prompt-service`.

## Test plan
- [x] `pnpm run lint:check` clean (0 errors, 35 unused-eslint-disable warnings in worktree copies — preexisting)
- [x] `pnpm run typecheck`
- [x] `pnpm test` (129/129 root + workspace mcps 149/149)
- [x] `pnpm run build`
- [x] `pnpm run verify:plugin`
- [x] `pnpm run verify:contracts`
- [x] `pnpm run verify:electron-release-checksums`
- [ ] After merge: dispatch `publish-works-to-npm.yml` with `version=4.13.1`; verify `npm view @muggleai/works version` reports 4.13.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)