### PR TITLE
chore(muggle-do): execution-protocol gate so stages run from their files

### DIFF
--- a/plugin/skills/do/build.md
+++ b/plugin/skills/do/build.md
@@ -20,7 +20,8 @@ For each affected repo:
 1. **Re-read `requirements.md`.** Treat goal + AC as frozen. If something is unclear at this stage, that's a pre-flight bug — escalate, do not improvise.
 2. **Apply the change** in the repo's worktree. Edit existing files first; create new files only when the requirements demand it. Match the surrounding code's style, naming, and file layout.
 3. **Don't add what wasn't asked for.** No speculative abstractions, no extra logging, no "while I'm here" refactors. Three similar lines is better than a premature abstraction.
-4. **Commit** with a conventional-commit subject:
+4. **Cover new logic with tests.** If you added or changed non-trivial logic (a hook, reducer, parser, state machine, branching util), write its unit tests now — Stage 5 only *runs* the suite, it never authors tests. Untested new logic is a Definition-of-Done failure, not a Stage-5 gap.
+5. **Commit** with a conventional-commit subject:
    - `feat(<scope>): <short>` for new behavior
    - `fix(<scope>): <short>` for bug fixes
    - `refactor(<scope>): <short>` for reshape

--- a/plugin/skills/muggle-do/SKILL.md
+++ b/plugin/skills/muggle-do/SKILL.md
@@ -25,6 +25,31 @@ Runs an autonomous dev cycle from requirements to PR. **Fire and review:** user 
 
 Stage 7 dispatches one watcher per opened PR as its last action.
 
+## Execution protocol (non-negotiable)
+
+The pipeline table lists **pointers, not summaries**. Open each stage's file and execute from it — running a stage off its one-line row here is how tests, E2E, and session state get silently skipped. If you have not read a stage's file this run, you have not run that stage.
+
+**Bootstrap before any code, in order:**
+1. Emit telemetry — [`../_shared/telemetry-emit.md`](../_shared/telemetry-emit.md), `skillName: "muggle-do"`.
+2. Create `.muggle-do/sessions/<slug>/` with `state.md` + `iterations/001.md` (pre-flight owns this; do it even when running unattended).
+3. `TodoWrite` one item per stage 1–8 — these stages are the checklist; never swap in your own decomposition.
+
+**Per stage:** read the file → execute it → append a marker to `iterations/<NNN>.md` citing the evidence that file requires (jest exit code, E2E verdict + `runId`, screenshot path). A stage is done only when its evidence is written, never on recollection.
+
+### "Autonomous" / "without my intervention" collapses exactly one thing
+Best-effort the Stage-1 questionnaire and don't ask. It does **not** license skipping telemetry, session artifacts, requirements, unit tests, E2E (`autoE2ETest` defaults to `always`), browser verification, the gate below, or the watcher hand-off. Run the whole pipeline silently — never a shortcut.
+
+### Definition of Done — gate before Stage 7
+Do not create or update a PR until each line holds, or is waived by a one-line reason written into `state.md` (silence is not a waiver):
+- `requirements.md` written (forward runs)
+- Build clean — typecheck + lint on changed files
+- New/changed logic carries unit tests (authored in Stage 3; Stage 5 only runs the suite)
+- Unit suite run, PASS recorded
+- E2E verdict recorded with `runId` per `autoE2ETest` — or `[E2E FAILING]` / `SKIPPED` + reason
+- UI changes verified in a real browser with evidence (screenshot path or muggle `runId`); `curl` + `grep` is not verification
+
+Opening a PR with an unchecked, unwaived line is a cycle failure.
+
 ## Address-reviews flow
 
 When invoked with the directive (PR URL + slug + review ids), routes to [`../do/address-reviews.md`](../do/address-reviews.md). Shares stages 3–6 + walkthrough with the forward pipeline; skips pre-flight, requirements, and PR creation. See the orchestrator for the cycle's exact step order, classification rules, and respawn logic.


### PR DESCRIPTION
## Problem
`muggle-do/SKILL.md` is a **router** — a table that points at `do/*.md` stage files. But nothing in it tells the orchestrator to *open* those files. On a real run, under a "go all the way without my intervention" directive, the orchestrator pattern-matched "build → PR" straight off the table and **never read** `pre-flight.md`, `unit-tests.md`, or `e2e-acceptance.md`. Result: a PR shipped with no session state, **no unit tests, no E2E run, and `curl`+`grep` standing in for browser verification.**

Two root holes:
1. **No "open the file" mandate.** The stage files are rigorous (`pre-flight.md`: "Missing state.md is a stage failure"; `e2e-acceptance.md`: "No hiding failures"). They just never get read.
2. **Test-writing is unassigned.** `build.md` (Stage 3) implements + commits; `unit-tests.md` (Stage 5) only *runs* `pnpm test`. Authoring tests for new logic is nobody's job.

## Fix (prompt-layer only — no hooks)
**`muggle-do/SKILL.md`** gains an `## Execution protocol (non-negotiable)`:
- Stage rows are **pointers, not summaries** — "if you have not read a stage's file this run, you have not run that stage."
- Bootstrap order: telemetry → `.muggle-do/sessions/<slug>/` → one `TodoWrite` per stage 1–8.
- Per-stage **evidence marker** in `iterations/<NNN>.md` (jest exit code, E2E `runId`, screenshot path) — done means evidence written, not recollection.
- Names the exact failure mode: **"autonomous / without my intervention" collapses only the Stage-1 questionnaire** — never tests, E2E, verification, or session artifacts.
- A **Definition-of-Done checklist** gates Stage 7: no PR until each line holds or is waived with a one-line reason in `state.md` (silence ≠ waiver).

**`do/build.md`** (Stage 3) adds a step assigning test-authoring for new logic, with a note that Stage 5 only runs the suite.

## Honest scope
This is prompt-layer enforcement. It raises adherence substantially but is advisory by nature — an orchestrator under pressure can still skim. True ~99% adherence needs **deterministic harness hooks** (a `PreToolUse` gate on `gh pr create` reading the session manifest; a `Stop` gate while a session is unfinalized). Those were intentionally **not** included here per the maintainer's call to keep the fix to skill + memory, no harness changes.

## Risk
Additive only. The address-reviews flow (shares stages 3–6) is unaffected — the Definition-of-Done gate applies equally before PR create/update, which that flow already does. No stage file's existing contract changed except build.md gaining one step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)