### PR TITLE
docs(muggle-do-task): verified entrance routes cleanly (5/5)

### DIFF
--- a/plugin/skills/_routing-eval/reports/optimization-log.md
+++ b/plugin/skills/_routing-eval/reports/optimization-log.md
@@ -35,3 +35,7 @@ These 11 skills routed at 100% recall with zero false triggers in the baseline. 
 ## muggle — verified 4/4
 
 Router/menu. Fires on bare `muggle` or "what can muggle do"; any specific intent routes straight past it to the matching skill.
+
+## muggle-do-task — verified 5/5
+
+Perform an action on a website (post, fill, submit, click a flow). Distinct from muggle-test-feature-local (verify a flow works) and muggle-test (test code changes).


### PR DESCRIPTION
Stacked on `eval/route-verify-04-muggle`.

**muggle-do-task** routed at **5/5** recall with **0 false triggers** in the baseline router eval. Its entrance is confirmed correct, so the description is unchanged — editing a passing description only risks regression.

**Boundary verified:** Perform an action on a website (post, fill, submit, click a flow). Distinct from muggle-test-feature-local (verify a flow works) and muggle-test (test code changes).

See `plugin/skills/_routing-eval/reports/optimization-log.md` and `reports/baseline.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)