### PR TITLE
docs(muggle-test-feature-local): verified entrance routes cleanly (6/6)

### DIFF
--- a/plugin/skills/_routing-eval/reports/optimization-log.md
+++ b/plugin/skills/_routing-eval/reports/optimization-log.md
@@ -39,3 +39,7 @@ Router/menu. Fires on bare `muggle` or "what can muggle do"; any specific intent
 ## muggle-do-task — verified 5/5
 
 Perform an action on a website (post, fill, submit, click a flow). Distinct from muggle-test-feature-local (verify a flow works) and muggle-test (test code changes).
+
+## muggle-test-feature-local — verified 6/6
+
+Real-browser E2E test of one named feature/flow on localhost. Distinct from muggle-test, which is change-driven over the whole diff before push/PR.


### PR DESCRIPTION
Stacked on `eval/route-verify-05-muggle-do-task`.

**muggle-test-feature-local** routed at **6/6** recall with **0 false triggers** in the baseline router eval. Its entrance is confirmed correct, so the description is unchanged — editing a passing description only risks regression.

**Boundary verified:** Real-browser E2E test of one named feature/flow on localhost. Distinct from muggle-test, which is change-driven over the whole diff before push/PR.

See `plugin/skills/_routing-eval/reports/optimization-log.md` and `reports/baseline.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)