### PR TITLE
docs(muggle-test-import): verified entrance routes cleanly (6/6)

### DIFF
--- a/plugin/skills/_routing-eval/reports/optimization-log.md
+++ b/plugin/skills/_routing-eval/reports/optimization-log.md
@@ -43,3 +43,7 @@ Perform an action on a website (post, fill, submit, click a flow). Distinct from
 ## muggle-test-feature-local — verified 6/6
 
 Real-browser E2E test of one named feature/flow on localhost. Distinct from muggle-test, which is change-driven over the whole diff before push/PR.
+
+## muggle-test-import — verified 6/6
+
+Bring existing tests/PRDs/specs INTO Muggle. Distinct from muggle-test-regenerate-missing (existing project cases) and from importing a code library.


### PR DESCRIPTION
Stacked on `eval/route-verify-06-muggle-test-feature-local`.

**muggle-test-import** routed at **6/6** recall with **0 false triggers** in the baseline router eval. Its entrance is confirmed correct, so the description is unchanged — editing a passing description only risks regression.

**Boundary verified:** Bring existing tests/PRDs/specs INTO Muggle. Distinct from muggle-test-regenerate-missing (existing project cases) and from importing a code library.

See `plugin/skills/_routing-eval/reports/optimization-log.md` and `reports/baseline.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)