### PR TITLE
docs(muggle-test-regenerate-missing): verified entrance routes cleanly (5/5)

### DIFF
--- a/plugin/skills/_routing-eval/reports/optimization-log.md
+++ b/plugin/skills/_routing-eval/reports/optimization-log.md
@@ -47,3 +47,7 @@ Real-browser E2E test of one named feature/flow on localhost. Distinct from mugg
 ## muggle-test-import — verified 6/6
 
 Bring existing tests/PRDs/specs INTO Muggle. Distinct from muggle-test-regenerate-missing (existing project cases) and from importing a code library.
+
+## muggle-test-regenerate-missing — verified 5/5
+
+Bulk-fill scripts for project test cases that lack one. Distinct from muggle-test-import, which pulls from an external source.


### PR DESCRIPTION
Stacked on `eval/route-verify-07-muggle-test-import`.

**muggle-test-regenerate-missing** routed at **5/5** recall with **0 false triggers** in the baseline router eval. Its entrance is confirmed correct, so the description is unchanged — editing a passing description only risks regression.

**Boundary verified:** Bulk-fill scripts for project test cases that lack one. Distinct from muggle-test-import, which pulls from an external source.

See `plugin/skills/_routing-eval/reports/optimization-log.md` and `reports/baseline.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)