### PR TITLE
docs(muggle-pr-visual-walkthrough): verified entrance routes cleanly (5/5)

### DIFF
--- a/plugin/skills/_routing-eval/reports/optimization-log.md
+++ b/plugin/skills/_routing-eval/reports/optimization-log.md
@@ -51,3 +51,7 @@ Bring existing tests/PRDs/specs INTO Muggle. Distinct from muggle-test-regenerat
 ## muggle-test-regenerate-missing — verified 5/5
 
 Bulk-fill scripts for project test cases that lack one. Distinct from muggle-test-import, which pulls from an external source.
+
+## muggle-pr-visual-walkthrough — verified 5/5
+
+Post existing E2E results/screenshots to a PR. Distinct from muggle-test, which runs the tests.


### PR DESCRIPTION
Stacked on `eval/route-verify-08-muggle-test-regenerate-missing`.

**muggle-pr-visual-walkthrough** routed at **5/5** recall with **0 false triggers** in the baseline router eval. Its entrance is confirmed correct, so the description is unchanged — editing a passing description only risks regression.

**Boundary verified:** Post existing E2E results/screenshots to a PR. Distinct from muggle-test, which runs the tests.

See `plugin/skills/_routing-eval/reports/optimization-log.md` and `reports/baseline.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)