### PR TITLE
docs(muggle-preferences): verified entrance routes cleanly (4/4)

### DIFF
--- a/plugin/skills/_routing-eval/reports/optimization-log.md
+++ b/plugin/skills/_routing-eval/reports/optimization-log.md
@@ -55,3 +55,7 @@ Bulk-fill scripts for project test cases that lack one. Distinct from muggle-tes
 ## muggle-pr-visual-walkthrough — verified 5/5
 
 Post existing E2E results/screenshots to a PR. Distinct from muggle-test, which runs the tests.
+
+## muggle-preferences — verified 4/4
+
+View/set/reset Muggle config. Distinct from configuring unrelated tooling (prettier, eslint, git).


### PR DESCRIPTION
Stacked on `eval/route-verify-09-muggle-pr-visual-walkthrough`.

**muggle-preferences** routed at **4/4** recall with **0 false triggers** in the baseline router eval. Its entrance is confirmed correct, so the description is unchanged — editing a passing description only risks regression.

**Boundary verified:** View/set/reset Muggle config. Distinct from configuring unrelated tooling (prettier, eslint, git).

See `plugin/skills/_routing-eval/reports/optimization-log.md` and `reports/baseline.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)