### PR TITLE
docs(muggle-status): verified entrance routes cleanly (4/4)

### DIFF
--- a/plugin/skills/_routing-eval/reports/optimization-log.md
+++ b/plugin/skills/_routing-eval/reports/optimization-log.md
@@ -59,3 +59,7 @@ Post existing E2E results/screenshots to a PR. Distinct from muggle-test, which 
 ## muggle-preferences — verified 4/4
 
 View/set/reset Muggle config. Distinct from configuring unrelated tooling (prettier, eslint, git).
+
+## muggle-status — verified 4/4
+
+Health-check/diagnose the Muggle install. Distinct from muggle-repair, which fixes; "is it broken?" leans status.


### PR DESCRIPTION
Stacked on `eval/route-verify-10-muggle-preferences`.

**muggle-status** routed at **4/4** recall with **0 false triggers** in the baseline router eval. Its entrance is confirmed correct, so the description is unchanged — editing a passing description only risks regression.

**Boundary verified:** Health-check/diagnose the Muggle install. Distinct from muggle-repair, which fixes; "is it broken?" leans status.

See `plugin/skills/_routing-eval/reports/optimization-log.md` and `reports/baseline.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)