### PR TITLE
docs(muggle-repair): verified entrance routes cleanly (4/4)

### DIFF
--- a/plugin/skills/_routing-eval/reports/optimization-log.md
+++ b/plugin/skills/_routing-eval/reports/optimization-log.md
@@ -63,3 +63,7 @@ View/set/reset Muggle config. Distinct from configuring unrelated tooling (prett
 ## muggle-status — verified 4/4
 
 Health-check/diagnose the Muggle install. Distinct from muggle-repair, which fixes; "is it broken?" leans status.
+
+## muggle-repair — verified 4/4
+
+Fix a broken Muggle install. Distinct from muggle-status (diagnose) and from fixing the user's own app build.


### PR DESCRIPTION
Stacked on `eval/route-verify-11-muggle-status`.

**muggle-repair** routed at **4/4** recall with **0 false triggers** in the baseline router eval. Its entrance is confirmed correct, so the description is unchanged — editing a passing description only risks regression.

**Boundary verified:** Fix a broken Muggle install. Distinct from muggle-status (diagnose) and from fixing the user's own app build.

See `plugin/skills/_routing-eval/reports/optimization-log.md` and `reports/baseline.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)