### PR TITLE
docs(muggle-upgrade): verified entrance routes cleanly (3/3)

### DIFF
--- a/plugin/skills/_routing-eval/reports/optimization-log.md
+++ b/plugin/skills/_routing-eval/reports/optimization-log.md
@@ -67,3 +67,7 @@ Health-check/diagnose the Muggle install. Distinct from muggle-repair, which fix
 ## muggle-repair — verified 4/4
 
 Fix a broken Muggle install. Distinct from muggle-status (diagnose) and from fixing the user's own app build.
+
+## muggle-upgrade — verified 3/3
+
+Update Muggle to latest. Distinct from upgrading app deps and from muggle-works-npm-release (publish).


### PR DESCRIPTION
Stacked on `eval/route-verify-12-muggle-repair`.

**muggle-upgrade** routed at **3/3** recall with **0 false triggers** in the baseline router eval. Its entrance is confirmed correct, so the description is unchanged — editing a passing description only risks regression.

**Boundary verified:** Update Muggle to latest. Distinct from upgrading app deps and from muggle-works-npm-release (publish).

See `plugin/skills/_routing-eval/reports/optimization-log.md` and `reports/baseline.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)