### PR TITLE
docs(muggle-works-npm-release): verified entrance routes cleanly (4/4)

### DIFF
--- a/plugin/skills/_routing-eval/reports/optimization-log.md
+++ b/plugin/skills/_routing-eval/reports/optimization-log.md
@@ -71,3 +71,7 @@ Fix a broken Muggle install. Distinct from muggle-status (diagnose) and from fix
 ## muggle-upgrade — verified 3/3
 
 Update Muggle to latest. Distinct from upgrading app deps and from muggle-works-npm-release (publish).
+
+## muggle-works-npm-release — verified 4/4
+
+Cut/publish a @muggleai/works npm release. Distinct from muggle-upgrade (consume) and from releasing some other package.


### PR DESCRIPTION
Stacked on `eval/route-verify-13-muggle-upgrade`.

**muggle-works-npm-release** routed at **4/4** recall with **0 false triggers** in the baseline router eval. Its entrance is confirmed correct, so the description is unchanged — editing a passing description only risks regression.

**Boundary verified:** Cut/publish a @muggleai/works npm release. Distinct from muggle-upgrade (consume) and from releasing some other package.

See `plugin/skills/_routing-eval/reports/optimization-log.md` and `reports/baseline.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)