### PR TITLE
test: raise src coverage to ~94% with enforced thresholds

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@types/uuid": "^11.0.0",
     "@typescript-eslint/eslint-plugin": "^8.34.0",
     "@typescript-eslint/parser": "^8.34.0",
+    "@vitest/coverage-v8": "4.1.5",
     "eslint": "^10.2.0",
     "eslint-plugin-unused-imports": "^4.2.0",
     "rimraf": "^6.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^8.34.0
         version: 8.59.2(eslint@10.3.0)(typescript@6.0.3)
+      '@vitest/coverage-v8':
+        specifier: 4.1.5
+        version: 4.1.5(vitest@4.1.5)
       eslint:
         specifier: ^10.2.0
         version: 10.3.0
@@ -86,7 +89,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.0.18
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.2)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(@vitest/coverage-v8@4.1.5)(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.2)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/commands: {}
 
@@ -100,7 +103,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: '*'
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.2)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(@vitest/coverage-v8@4.1.5)(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.2)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/workflows:
     devDependencies:
@@ -109,7 +112,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: '*'
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.2)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(@vitest/coverage-v8@4.1.5)(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.2)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.9.0))
 
 packages:
 
@@ -239,9 +242,30 @@ packages:
     resolution: {integrity: sha512-Y8rZOIMXQY/GwNRL+uLVuwIn9aEa/KnnggyYUmFxC1MigmRJCNH5NxMmxKSpddXF9SW6Z1ijRd6Pptd2A5OhGw==}
     engines: {node: '>=20.0.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
@@ -1166,6 +1190,15 @@ packages:
     resolution: {integrity: sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==}
     engines: {node: '>=20.0.0'}
 
+  '@vitest/coverage-v8@4.1.5':
+    resolution: {integrity: sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==}
+    peerDependencies:
+      '@vitest/browser': 4.1.5
+      vitest: 4.1.5
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.5':
     resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
 
@@ -1254,6 +1287,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.2:
+    resolution: {integrity: sha512-dKmJxJsGItLmc5CYZKuEjuG6GnBs6PG4gohMhyFOWKaNQoYCuRZJDECaBlHmcG0lv2wc2E0uU8lESmBEumC3DQ==}
 
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
@@ -1676,6 +1712,10 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
@@ -1691,6 +1731,9 @@ packages:
   hono@4.12.10:
     resolution: {integrity: sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==}
     engines: {node: '>=16.9.0'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -1786,12 +1829,27 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -1957,6 +2015,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -2335,6 +2400,10 @@ packages:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
 
   text-hex@1.0.0:
     resolution: {integrity: sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==}
@@ -2843,7 +2912,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
   '@babel/runtime@7.29.2': {}
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@colors/colors@1.6.0': {}
 
@@ -3730,6 +3814,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.5
+      ast-v8-to-istanbul: 1.0.2
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.1
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(@vitest/coverage-v8@4.1.5)(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.2)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.9.0))
+
   '@vitest/expect@4.1.5':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -3849,6 +3947,12 @@ snapshots:
       - supports-color
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.2:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   async@3.2.6: {}
 
@@ -4304,6 +4408,8 @@ snapshots:
 
   gopd@1.2.0: {}
 
+  has-flag@4.0.0: {}
+
   has-symbols@1.1.0: {}
 
   has-tostringtag@1.0.2:
@@ -4315,6 +4421,8 @@ snapshots:
       function-bind: 1.1.2
 
   hono@4.12.10: {}
+
+  html-escaper@2.0.2: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -4405,9 +4513,24 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jose@6.2.2: {}
 
   joycon@3.1.1: {}
+
+  js-tokens@10.0.0: {}
 
   json-buffer@3.0.1: {}
 
@@ -4552,6 +4675,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.3:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.1
 
   math-intrinsics@1.1.0: {}
 
@@ -4978,6 +5111,10 @@ snapshots:
       tinyglobby: 0.2.15
       ts-interface-checker: 0.1.13
 
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
   text-hex@1.0.0: {}
 
   thenify-all@1.6.0:
@@ -5115,7 +5252,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.2)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.9.0)):
+  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(@vitest/coverage-v8@4.1.5)(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.2)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(vite@8.0.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.2)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.9.0))
@@ -5140,6 +5277,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 25.6.2
+      '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
     transitivePeerDependencies:
       - msw
 

--- a/src/test/cli/build-pr-section-command.test.ts
+++ b/src/test/cli/build-pr-section-command.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { Readable } from "stream";
+
+vi.mock("../../cli/pr-section/resolve-urls.js", () => ({
+  resolveGsScreenshotUrls: vi.fn(async (report: unknown) => report),
+}));
+
+import {
+  runBuildPrSection,
+  buildPrSectionCommand,
+  DEFAULT_MAX_BODY_BYTES,
+} from "../../cli/build-pr-section.js";
+
+const validReport = {
+  projectId: "p1",
+  tests: [
+    {
+      name: "A",
+      testCaseId: "a",
+      runId: "ra",
+      viewUrl: "https://example.com/a",
+      status: "passed",
+      steps: [{ stepIndex: 0, action: "Click", screenshotUrl: "https://cdn/a0.png" }],
+    },
+  ],
+};
+
+describe("runBuildPrSection error paths", () => {
+  let stderrChunks: string[];
+  const stderrWrite = (s: string): boolean => {
+    stderrChunks.push(s);
+    return true;
+  };
+  const stdoutWrite = (): boolean => true;
+
+  beforeEach(() => {
+    stderrChunks = [];
+  });
+
+  it("returns 1 when reading stdin throws", async () => {
+    const failing = new Readable({
+      read() {
+        this.destroy(new Error("pipe broken"));
+      },
+    });
+    const code = await runBuildPrSection({
+      stdin: failing,
+      stdoutWrite,
+      stderrWrite,
+      maxBodyBytes: 60_000,
+    });
+    expect(code).toBe(1);
+    expect(stderrChunks.join("")).toMatch(/failed to read stdin: pipe broken/);
+  });
+});
+
+describe("buildPrSectionCommand", () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+  let stdinSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+    stdoutSpy.mockRestore();
+    stdinSpy?.mockRestore();
+    process.exitCode = undefined;
+  });
+
+  it("rejects a non-positive --max-body-bytes without reading stdin", async () => {
+    await buildPrSectionCommand({ maxBodyBytes: "0" });
+    expect(process.exitCode).toBe(1);
+    expect(String(stderrSpy.mock.calls[0][0])).toMatch(/must be a positive number/);
+  });
+
+  it("rejects a non-numeric --max-body-bytes", async () => {
+    await buildPrSectionCommand({ maxBodyBytes: "abc" });
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("succeeds end-to-end reading process.stdin and writing stdout", async () => {
+    stdinSpy = vi
+      .spyOn(process, "stdin", "get")
+      .mockReturnValue(Readable.from([JSON.stringify(validReport)]) as never);
+
+    await buildPrSectionCommand({});
+
+    expect(process.exitCode).toBeUndefined();
+    const written = stdoutSpy.mock.calls.map((c) => String(c[0])).join("");
+    const parsed = JSON.parse(written);
+    expect(parsed.body).toContain("E2E Acceptance Results");
+  });
+
+  it("sets a nonzero exit code when the report is invalid", async () => {
+    stdinSpy = vi
+      .spyOn(process, "stdin", "get")
+      .mockReturnValue(Readable.from(["not json"]) as never);
+
+    await buildPrSectionCommand({ maxBodyBytes: String(DEFAULT_MAX_BODY_BYTES) });
+
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/src/test/cli/cleanup-skills.test.ts
+++ b/src/test/cli/cleanup-skills.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+let dataDir: string;
+let homeDir: string;
+
+vi.mock("os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("os")>();
+  return { ...actual, homedir: vi.fn(() => homeDir) };
+});
+
+vi.mock("../../../packages/mcps/src/index.js", () => ({
+  getDataDir: vi.fn(() => dataDir),
+  getElectronAppVersion: vi.fn(() => "1.0.5"),
+  getLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { listObsoleteSkills, cleanupObsoleteSkills, cleanupCommand } from "../../cli/cleanup.js";
+
+function makeSkill(name: string): void {
+  const dir = join(homeDir, ".cursor", "skills", name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "SKILL.md"), "x".repeat(64));
+}
+
+function writeManifest(skills: string[]): void {
+  writeFileSync(join(dataDir, "install-manifest.json"), JSON.stringify({ skills }));
+}
+
+describe("obsolete skills", () => {
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "mgl-data-"));
+    homeDir = mkdtempSync(join(tmpdir(), "mgl-home-"));
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+    rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it("flags muggle-prefixed and alias skills missing from the manifest", () => {
+    makeSkill("muggle-test");
+    makeSkill("mtest");
+    makeSkill("unrelated-skill");
+    writeManifest(["muggle-test"]);
+
+    const obsolete = listObsoleteSkills();
+    const names = obsolete.map((s) => s.name).sort();
+    expect(names).toEqual(["mtest"]);
+  });
+
+  it("returns empty when no manifest and no skills dir", () => {
+    expect(listObsoleteSkills()).toEqual([]);
+  });
+
+  it("treats all matching skills as obsolete when manifest is absent", () => {
+    makeSkill("muggle-do");
+    makeSkill("mpr");
+    const obsolete = listObsoleteSkills();
+    expect(obsolete.map((s) => s.name).sort()).toEqual(["mpr", "muggle-do"]);
+  });
+
+  it("removes obsolete skills and reports freed bytes", () => {
+    makeSkill("muggle-old");
+    writeManifest([]);
+
+    const result = cleanupObsoleteSkills();
+    expect(result.removed.map((s) => s.name)).toEqual(["muggle-old"]);
+    expect(result.freedBytes).toBeGreaterThan(0);
+    expect(existsSync(join(homeDir, ".cursor", "skills", "muggle-old"))).toBe(false);
+  });
+
+  it("dry run leaves skills on disk", () => {
+    makeSkill("muggle-old");
+    writeManifest([]);
+
+    const result = cleanupObsoleteSkills({ dryRun: true });
+    expect(result.removed).toHaveLength(1);
+    expect(existsSync(join(homeDir, ".cursor", "skills", "muggle-old"))).toBe(true);
+  });
+
+  it("cleanupCommand --skills lists and removes obsolete skills", () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    makeSkill("muggle-old");
+    writeManifest([]);
+
+    return cleanupCommand({ skills: true }).then(() => {
+      const out = logSpy.mock.calls.map((c) => String(c[0])).join("\n");
+      expect(out).toContain("obsolete skill(s)");
+      expect(out).toContain("muggle-old");
+      expect(existsSync(join(homeDir, ".cursor", "skills", "muggle-old"))).toBe(false);
+      logSpy.mockRestore();
+    });
+  });
+
+  it("cleanupCommand --skills with dry run reports would-remove and keeps skills", () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    makeSkill("muggle-keep");
+    writeManifest([]);
+
+    return cleanupCommand({ skills: true, dryRun: true }).then(() => {
+      const out = logSpy.mock.calls.map((c) => String(c[0])).join("\n");
+      expect(out).toContain("Would remove:");
+      expect(existsSync(join(homeDir, ".cursor", "skills", "muggle-keep"))).toBe(true);
+      logSpy.mockRestore();
+    });
+  });
+});

--- a/src/test/cli/cleanup.test.ts
+++ b/src/test/cli/cleanup.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
+import { tmpdir, homedir } from "os";
+import { join } from "path";
+
+let dataDir: string;
+let currentVersion = "1.0.5";
+
+vi.mock("../../../packages/mcps/src/index.js", () => ({
+  getDataDir: vi.fn(() => dataDir),
+  getElectronAppVersion: vi.fn(() => currentVersion),
+  getLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import {
+  formatBytes,
+  listInstalledVersions,
+  cleanupOldVersions,
+  versionsCommand,
+  cleanupCommand,
+  listObsoleteSkills,
+} from "../../cli/cleanup.js";
+
+function makeVersionDir(version: string, fileBytes: number): void {
+  const dir = join(dataDir, "electron-app", version);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "blob.bin"), Buffer.alloc(fileBytes));
+}
+
+describe("formatBytes", () => {
+  it("formats zero, bytes, KB, MB, GB", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(512)).toBe("512.0 B");
+    expect(formatBytes(1536)).toBe("1.5 KB");
+    expect(formatBytes(5 * 1024 * 1024)).toBe("5.0 MB");
+    expect(formatBytes(2 * 1024 * 1024 * 1024)).toBe("2.0 GB");
+  });
+});
+
+describe("listInstalledVersions / cleanupOldVersions", () => {
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "mgl-cleanup-"));
+    currentVersion = "1.0.5";
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("returns empty when no electron-app directory exists", () => {
+    expect(listInstalledVersions()).toEqual([]);
+  });
+
+  it("lists only semver dirs, sorted descending, marking current", () => {
+    makeVersionDir("1.0.5", 100);
+    makeVersionDir("1.0.4", 200);
+    makeVersionDir("1.0.10", 50);
+    mkdirSync(join(dataDir, "electron-app", "not-a-version"), { recursive: true });
+
+    const versions = listInstalledVersions();
+    expect(versions.map((v) => v.version)).toEqual(["1.0.10", "1.0.5", "1.0.4"]);
+    expect(versions.find((v) => v.version === "1.0.5")?.isCurrent).toBe(true);
+    expect(versions.find((v) => v.version === "1.0.4")?.sizeBytes).toBe(200);
+  });
+
+  it("keeps current + one previous by default, removes the rest", () => {
+    makeVersionDir("1.0.5", 100);
+    makeVersionDir("1.0.4", 100);
+    makeVersionDir("1.0.3", 100);
+    makeVersionDir("1.0.2", 100);
+
+    const result = cleanupOldVersions({});
+    expect(result.removed.map((v) => v.version).sort()).toEqual(["1.0.2", "1.0.3"]);
+    expect(existsSync(join(dataDir, "electron-app", "1.0.4"))).toBe(true);
+    expect(existsSync(join(dataDir, "electron-app", "1.0.2"))).toBe(false);
+    expect(result.freedBytes).toBe(200);
+  });
+
+  it("with all=true keeps only current", () => {
+    makeVersionDir("1.0.5", 100);
+    makeVersionDir("1.0.4", 100);
+    makeVersionDir("1.0.3", 100);
+
+    const result = cleanupOldVersions({ all: true });
+    expect(result.removed.map((v) => v.version).sort()).toEqual(["1.0.3", "1.0.4"]);
+  });
+
+  it("dryRun reports removals without deleting", () => {
+    makeVersionDir("1.0.5", 100);
+    makeVersionDir("1.0.4", 100);
+    makeVersionDir("1.0.3", 100);
+
+    const result = cleanupOldVersions({ dryRun: true });
+    expect(result.removed.map((v) => v.version)).toEqual(["1.0.3"]);
+    expect(existsSync(join(dataDir, "electron-app", "1.0.3"))).toBe(true);
+  });
+});
+
+describe("versionsCommand", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "mgl-cleanup-"));
+    currentVersion = "1.0.5";
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("prints a hint when nothing is installed", async () => {
+    await versionsCommand();
+    expect(logSpy.mock.calls.map((c) => String(c[0])).join("\n")).toContain("No versions installed");
+  });
+
+  it("prints versions with current marker and total", async () => {
+    makeVersionDir("1.0.5", 1024);
+    makeVersionDir("1.0.4", 2048);
+    await versionsCommand();
+    const out = logSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(out).toContain("v1.0.5 (current)");
+    expect(out).toContain("Total: 2 version(s)");
+  });
+});
+
+describe("cleanupCommand", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "mgl-cleanup-"));
+    currentVersion = "1.0.5";
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("reports nothing to clean when no versions installed", async () => {
+    await cleanupCommand({});
+    expect(logSpy.mock.calls.map((c) => String(c[0])).join("\n")).toContain("Nothing to clean up");
+  });
+
+  it("reports nothing to clean when only current installed", async () => {
+    makeVersionDir("1.0.5", 100);
+    await cleanupCommand({});
+    expect(logSpy.mock.calls.map((c) => String(c[0])).join("\n")).toContain("Only the current version");
+  });
+
+  it("keeps a previous version by default and reports the kept hint", async () => {
+    makeVersionDir("1.0.5", 100);
+    makeVersionDir("1.0.4", 100);
+    await cleanupCommand({});
+    expect(logSpy.mock.calls.map((c) => String(c[0])).join("\n")).toContain("Keeping one previous version");
+  });
+
+  it("removes old versions with --all and reports freed total", async () => {
+    makeVersionDir("1.0.5", 100);
+    makeVersionDir("1.0.4", 1024);
+    makeVersionDir("1.0.3", 1024);
+    await cleanupCommand({ all: true });
+    const out = logSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(out).toContain("Removed:");
+    expect(out).toContain("Freed:");
+  });
+
+  it("dry run with --all reports the would-remove footer", async () => {
+    makeVersionDir("1.0.5", 100);
+    makeVersionDir("1.0.4", 100);
+    makeVersionDir("1.0.3", 100);
+    await cleanupCommand({ all: true, dryRun: true });
+    const out = logSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(out).toContain("Would remove:");
+    expect(out).toContain("Run without --dry-run");
+  });
+
+  it("reports no old versions to remove for --all when only current+0", async () => {
+    makeVersionDir("1.0.5", 100);
+    makeVersionDir("1.0.4", 100);
+    await cleanupCommand({ all: true });
+    const out = logSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(out).toContain("Removed:");
+  });
+
+  it("scans skills when --skills is passed", async () => {
+    makeVersionDir("1.0.5", 100);
+    await cleanupCommand({ skills: true });
+    const out = logSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(out).toContain("Skills Cleanup");
+  });
+});
+
+describe("listObsoleteSkills", () => {
+  it("returns empty when the cursor skills dir is absent", () => {
+    const skillsDir = join(homedir(), ".cursor", "skills");
+    if (!existsSync(skillsDir)) {
+      expect(listObsoleteSkills()).toEqual([]);
+    } else {
+      expect(Array.isArray(listObsoleteSkills())).toBe(true);
+    }
+  });
+});

--- a/src/test/cli/doctor.test.ts
+++ b/src/test/cli/doctor.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { join } from "path";
+
+const fsState = vi.hoisted(() => ({
+  existing: new Set<string>(),
+  files: new Map<string, string>(),
+  dirEntries: new Map<string, string[]>(),
+  isFile: new Set<string>(),
+  statThrows: new Set<string>(),
+}));
+
+const platformState = vi.hoisted(() => ({ value: "win32", home: "/home/u" }));
+
+const mcpsMocks = vi.hoisted(() => ({
+  getAuthService: vi.fn(() => ({ getAuthStatus: vi.fn(() => ({ authenticated: true, email: "u@e.com" })) })),
+  getBundledElectronAppVersion: vi.fn(() => "1.0.4"),
+  getConfig: vi.fn(() => ({
+    e2e: { promptServiceBaseUrl: "https://prompt" },
+    localQa: { webServiceUrl: "https://web" },
+  })),
+  getCredentialsFilePath: vi.fn(() => "/creds.json"),
+  getDataDir: vi.fn(() => "/data"),
+  getElectronAppDir: vi.fn((v: string) => `/data/electron-app/${v}`),
+  getElectronAppVersion: vi.fn(() => "1.0.5"),
+  getElectronAppVersionSource: vi.fn(() => "bundled"),
+  getLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+  hasApiKey: vi.fn(() => true),
+}));
+
+const fsImpl = vi.hoisted(() => ({
+  existsSync: vi.fn((p: string) => fsState.existing.has(p)),
+  readFileSync: vi.fn((p: string) => fsState.files.get(p) ?? "{}"),
+  readdirSync: vi.fn((p: string) => fsState.dirEntries.get(p) ?? []),
+  statSync: vi.fn((p: string) => {
+    if (fsState.statThrows.has(p)) throw new Error("stat failed");
+    return { isFile: () => fsState.isFile.has(p) };
+  }),
+}));
+
+vi.mock("fs", () => fsImpl);
+vi.mock("os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("os")>();
+  return { ...actual, platform: vi.fn(() => platformState.value), homedir: vi.fn(() => platformState.home) };
+});
+vi.mock("../../../packages/mcps/src/index.js", () => mcpsMocks);
+
+import { doctorCommand } from "../../cli/doctor.js";
+
+const VERSION_DIR = "/data/electron-app/1.0.5";
+const EXE = join(VERSION_DIR, "MuggleAI.exe");
+const META = join(VERSION_DIR, ".install-metadata.json");
+const CURSOR_MCP = join("/home/u", ".cursor", "mcp.json");
+
+function output(logSpy: ReturnType<typeof vi.spyOn>): string {
+  return logSpy.mock.calls.map((c) => String(c[0])).join("\n");
+}
+
+describe("doctorCommand", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fsState.existing.clear();
+    fsState.files.clear();
+    fsState.dirEntries.clear();
+    fsState.isFile.clear();
+    fsState.statThrows.clear();
+    platformState.value = "win32";
+    platformState.home = "/home/u";
+    mcpsMocks.getElectronAppVersionSource.mockReturnValue("bundled");
+    mcpsMocks.getAuthService.mockReturnValue({
+      getAuthStatus: vi.fn(() => ({ authenticated: true, email: "u@e.com" })),
+    } as never);
+    mcpsMocks.hasApiKey.mockReturnValue(true);
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => logSpy.mockRestore());
+
+  it("reports all green for a valid installation and config", async () => {
+    fsState.existing.add("/data");
+    fsState.existing.add(VERSION_DIR);
+    fsState.existing.add(EXE);
+    fsState.existing.add(META);
+    fsState.existing.add("/creds.json");
+    fsState.existing.add(CURSOR_MCP);
+    fsState.isFile.add(EXE);
+    fsState.files.set(
+      CURSOR_MCP,
+      JSON.stringify({ mcpServers: { muggle: { command: "muggle", args: ["serve"] } } }),
+    );
+
+    await doctorCommand();
+
+    const out = output(logSpy);
+    expect(out).toContain("Installed (v1.0.5)");
+    expect(out).toContain("Authenticated as u@e.com");
+    expect(out).toContain("All checks passed");
+  });
+
+  it("flags a missing executable and counts issues", async () => {
+    fsState.existing.add(VERSION_DIR);
+    await doctorCommand();
+    const out = output(logSpy);
+    expect(out).toContain("Not installed");
+    expect(out).toContain("Executable not found");
+    expect(out).toMatch(/issue\(s\) found/);
+  });
+
+  it("detects a partial archive and suggests --force", async () => {
+    fsState.existing.add(VERSION_DIR);
+    fsState.dirEntries.set(VERSION_DIR, ["MuggleAI-win32-x64.zip"]);
+    await doctorCommand();
+    const out = output(logSpy);
+    expect(out).toContain("Download incomplete");
+    expect(out).toContain("--force");
+  });
+
+  it("flags an executable path that is not a regular file", async () => {
+    fsState.existing.add(VERSION_DIR);
+    fsState.existing.add(EXE);
+    await doctorCommand();
+    expect(output(logSpy)).toContain("is not a file");
+  });
+
+  it("flags a broken symlink when statSync throws", async () => {
+    fsState.existing.add(VERSION_DIR);
+    fsState.existing.add(EXE);
+    fsState.statThrows.add(EXE);
+    await doctorCommand();
+    expect(output(logSpy)).toContain("broken symlink");
+  });
+
+  it("notes missing metadata while still valid", async () => {
+    fsState.existing.add(VERSION_DIR);
+    fsState.existing.add(EXE);
+    fsState.isFile.add(EXE);
+    await doctorCommand();
+    expect(output(logSpy)).toContain("[missing metadata]");
+  });
+
+  it("annotates the version source for env and override", async () => {
+    fsState.existing.add(VERSION_DIR);
+    fsState.existing.add(EXE);
+    fsState.existing.add(META);
+    fsState.isFile.add(EXE);
+
+    mcpsMocks.getElectronAppVersionSource.mockReturnValue("env");
+    await doctorCommand();
+    expect(output(logSpy)).toContain("from ELECTRON_APP_VERSION env");
+
+    logSpy.mockClear();
+    mcpsMocks.getElectronAppVersionSource.mockReturnValue("override");
+    await doctorCommand();
+    expect(output(logSpy)).toContain("overridden from bundled");
+  });
+
+  it("reports not-authenticated and missing api key", async () => {
+    mcpsMocks.getAuthService.mockReturnValue({
+      getAuthStatus: vi.fn(() => ({ authenticated: false })),
+    } as never);
+    mcpsMocks.hasApiKey.mockReturnValue(false);
+    await doctorCommand();
+    const out = output(logSpy);
+    expect(out).toContain("Not authenticated");
+    expect(out).toContain("No API key stored");
+  });
+
+  it("reports a missing cursor mcp config", async () => {
+    await doctorCommand();
+    expect(output(logSpy)).toContain("Missing at");
+  });
+
+  it("reports invalid cursor config JSON", async () => {
+    fsState.existing.add(CURSOR_MCP);
+    fsState.files.set(CURSOR_MCP, "{ broken");
+    await doctorCommand();
+    expect(output(logSpy)).toContain("Invalid JSON or schema");
+  });
+
+  it("reports a cursor config missing the serve argument", async () => {
+    fsState.existing.add(CURSOR_MCP);
+    fsState.files.set(CURSOR_MCP, JSON.stringify({ mcpServers: { muggle: { command: "muggle", args: ["x"] } } }));
+    await doctorCommand();
+    expect(output(logSpy)).toContain("does not include 'serve'");
+  });
+
+  it("reports a cursor config whose mcpServers map lacks muggle", async () => {
+    fsState.existing.add(CURSOR_MCP);
+    fsState.files.set(CURSOR_MCP, JSON.stringify({ mcpServers: {} }));
+    await doctorCommand();
+    expect(output(logSpy)).toContain("Missing mcpServers.muggle entry");
+  });
+
+  it("validates a node-command config whose args[0] file is missing", async () => {
+    fsState.existing.add(CURSOR_MCP);
+    fsState.files.set(
+      CURSOR_MCP,
+      JSON.stringify({ mcpServers: { muggle: { command: "node", args: ["serve", "/missing.js"] } } }),
+    );
+    await doctorCommand();
+    expect(output(logSpy)).toContain("does not exist: serve");
+  });
+
+  it("throws for an unsupported platform when resolving the executable path", async () => {
+    platformState.value = "sunos";
+    fsState.existing.add(VERSION_DIR);
+    await expect(doctorCommand()).rejects.toThrow(/Unsupported platform/);
+  });
+});

--- a/src/test/cli/help.test.ts
+++ b/src/test/cli/help.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import {
+  getPostInstallGuidance,
+  getHelpGuidance,
+  helpCommand,
+} from "../../cli/help.js";
+
+const RESET = "\x1b[0m";
+
+describe("help guidance", () => {
+  const originalNoColor = process.env.NO_COLOR;
+
+  afterEach(() => {
+    if (originalNoColor === undefined) {
+      delete process.env.NO_COLOR;
+    } else {
+      process.env.NO_COLOR = originalNoColor;
+    }
+  });
+
+  it("colorizes output when NO_COLOR is unset", () => {
+    delete process.env.NO_COLOR;
+    const out = getPostInstallGuidance();
+    expect(out).toContain(RESET);
+    expect(out).toContain("Installation Complete");
+    expect(out).toContain("muggle help");
+  });
+
+  it("omits ANSI codes when NO_COLOR is set", () => {
+    process.env.NO_COLOR = "1";
+    const out = getHelpGuidance();
+    expect(out).not.toContain("\x1b[");
+    expect(out).toContain("Comprehensive How-To Guide");
+    expect(out).toContain("~/.cursor/mcp.json");
+    expect(out).toContain("muggle serve --local");
+  });
+
+  it("help guidance lists the core CLI commands", () => {
+    process.env.NO_COLOR = "1";
+    const out = getHelpGuidance();
+    for (const cmd of ["muggle setup", "muggle doctor", "muggle upgrade", "muggle login", "muggle cleanup"]) {
+      expect(out).toContain(cmd);
+    }
+  });
+});
+
+describe("helpCommand", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it("prints the full guidance", () => {
+    helpCommand();
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(String(logSpy.mock.calls[0][0])).toContain("Comprehensive How-To Guide");
+  });
+});

--- a/src/test/cli/login.test.ts
+++ b/src/test/cli/login.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const getAuthStatus = vi.fn();
+
+vi.mock("../../../packages/mcps/src/index.js", () => ({
+  getAuthService: vi.fn(() => ({ getAuthStatus })),
+  getLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+  hasApiKey: vi.fn(),
+  performLogin: vi.fn(),
+  performLogout: vi.fn(),
+}));
+
+import { loginCommand, logoutCommand, statusCommand } from "../../cli/login.js";
+import {
+  hasApiKey,
+  performLogin,
+  performLogout,
+} from "../../../packages/mcps/src/index.js";
+
+const mockedHasApiKey = vi.mocked(hasApiKey);
+const mockedPerformLogin = vi.mocked(performLogin);
+const mockedPerformLogout = vi.mocked(performLogout);
+
+describe("loginCommand", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(((): never => undefined as never));
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("prints success details and default 90d expiry when login succeeds", async () => {
+    mockedPerformLogin.mockResolvedValue({
+      success: true,
+      credentials: { email: "a@b.com", apiKey: "k" },
+    } as never);
+
+    await loginCommand({});
+
+    expect(mockedPerformLogin).toHaveBeenCalledWith(undefined, "90d");
+    const out = logSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(out).toContain("Login successful");
+    expect(out).toContain("a@b.com");
+    expect(out).toContain("API key created");
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("passes through key name and custom expiry", async () => {
+    mockedPerformLogin.mockResolvedValue({ success: true, credentials: {} } as never);
+    await loginCommand({ keyName: "ci", keyExpiry: "1y" });
+    expect(mockedPerformLogin).toHaveBeenCalledWith("ci", "1y");
+  });
+
+  it("reports error and device code, then exits 1 on failure", async () => {
+    mockedPerformLogin.mockResolvedValue({
+      success: false,
+      error: "denied",
+      deviceCodeResponse: {
+        verificationUriComplete: "https://verify/abc",
+        userCode: "WXYZ",
+      },
+    } as never);
+
+    await loginCommand({});
+
+    const err = errSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(err).toContain("Login failed");
+    expect(err).toContain("denied");
+    const out = logSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(out).toContain("https://verify/abc");
+    expect(out).toContain("WXYZ");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});
+
+describe("logoutCommand", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => logSpy.mockRestore());
+
+  it("clears credentials", async () => {
+    await logoutCommand();
+    expect(mockedPerformLogout).toHaveBeenCalledOnce();
+    expect(logSpy.mock.calls.map((c) => String(c[0])).join("\n")).toContain("cleared");
+  });
+});
+
+describe("statusCommand", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => logSpy.mockRestore());
+
+  it("prints authenticated details including expired token note and api key", async () => {
+    getAuthStatus.mockReturnValue({
+      authenticated: true,
+      email: "u@e.com",
+      userId: "uid-1",
+      expiresAt: new Date("2020-01-01T00:00:00Z").getTime(),
+      isExpired: true,
+    });
+    mockedHasApiKey.mockReturnValue(true);
+
+    await statusCommand();
+
+    const out = logSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(out).toContain("Authenticated");
+    expect(out).toContain("u@e.com");
+    expect(out).toContain("uid-1");
+    expect(out).toContain("expired");
+    expect(out).toContain("API Key: Yes");
+  });
+
+  it("prints not-authenticated guidance", async () => {
+    getAuthStatus.mockReturnValue({ authenticated: false });
+    mockedHasApiKey.mockReturnValue(false);
+
+    await statusCommand();
+
+    const out = logSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(out).toContain("Not authenticated");
+    expect(out).toContain("muggle login");
+  });
+});

--- a/src/test/cli/serve.test.ts
+++ b/src/test/cli/serve.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const {
+  getQaTools,
+  getLocalQaTools,
+  registerTools,
+  createUnifiedMcpServer,
+  startStdioServer,
+  hasShownDisclosure,
+  markDisclosureShown,
+  initTelemetry,
+  track,
+} = vi.hoisted(() => ({
+  getQaTools: vi.fn(() => [{ name: "qa1" }]),
+  getLocalQaTools: vi.fn(() => [{ name: "local1" }]),
+  registerTools: vi.fn(),
+  createUnifiedMcpServer: vi.fn(() => ({ kind: "server" })),
+  startStdioServer: vi.fn(async () => undefined),
+  hasShownDisclosure: vi.fn(() => false),
+  markDisclosureShown: vi.fn(),
+  initTelemetry: vi.fn(),
+  track: vi.fn(),
+}));
+
+vi.mock("../../../packages/mcps/src/index.js", () => ({
+  getConfig: vi.fn(() => ({ serverVersion: "9.9.9" })),
+  getQaTools,
+  getLocalQaTools,
+  getLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+vi.mock("@muggleai/telemetry", () => ({
+  EventName: { SystemStartup: "SystemStartup" },
+  ServiceName: { MuggleMcp: "MuggleMcp" },
+  Surface: { McpLocal: "McpLocal" },
+  getDisclosureCopy: vi.fn(() => "disclosure copy"),
+  hasShownDisclosure,
+  markDisclosureShown,
+  initTelemetry,
+  track,
+}));
+
+vi.mock("../../server/index.js", () => ({
+  createUnifiedMcpServer,
+  registerTools,
+  startStdioServer,
+}));
+
+import { serveCommand } from "../../cli/serve.js";
+
+describe("serveCommand", () => {
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hasShownDisclosure.mockReturnValue(false);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(((): never => undefined as never));
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("registers both tool sets by default and shows the first-run disclosure", async () => {
+    await serveCommand({});
+
+    expect(getQaTools).toHaveBeenCalledOnce();
+    expect(getLocalQaTools).toHaveBeenCalledOnce();
+    expect(registerTools).toHaveBeenCalledTimes(2);
+    expect(createUnifiedMcpServer).toHaveBeenCalledWith({
+      enableQaTools: true,
+      enableLocalTools: true,
+    });
+    expect(startStdioServer).toHaveBeenCalledWith({ kind: "server" });
+    expect(stderrSpy).toHaveBeenCalledWith("disclosure copy\n");
+    expect(markDisclosureShown).toHaveBeenCalledOnce();
+    expect(initTelemetry).toHaveBeenCalledOnce();
+    expect(track).toHaveBeenCalledOnce();
+  });
+
+  it("registers only cloud tools when --e2e is set", async () => {
+    await serveCommand({ e2e: true });
+    expect(getQaTools).toHaveBeenCalledOnce();
+    expect(getLocalQaTools).not.toHaveBeenCalled();
+    expect(createUnifiedMcpServer).toHaveBeenCalledWith({
+      enableQaTools: true,
+      enableLocalTools: false,
+    });
+  });
+
+  it("registers only local tools when --local is set", async () => {
+    await serveCommand({ local: true });
+    expect(getLocalQaTools).toHaveBeenCalledOnce();
+    expect(getQaTools).not.toHaveBeenCalled();
+    expect(createUnifiedMcpServer).toHaveBeenCalledWith({
+      enableQaTools: false,
+      enableLocalTools: true,
+    });
+  });
+
+  it("skips the disclosure when already shown", async () => {
+    hasShownDisclosure.mockReturnValue(true);
+    await serveCommand({});
+    expect(markDisclosureShown).not.toHaveBeenCalled();
+    expect(stderrSpy).not.toHaveBeenCalledWith("disclosure copy\n");
+  });
+
+  it("swallows telemetry init failures and still starts the server", async () => {
+    initTelemetry.mockImplementationOnce(() => {
+      throw new Error("telemetry down");
+    });
+    await serveCommand({});
+    expect(startStdioServer).toHaveBeenCalledOnce();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("exits 1 when the server fails to start", async () => {
+    startStdioServer.mockRejectedValueOnce(new Error("connect failed"));
+    await serveCommand({});
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/src/test/cli/setup.test.ts
+++ b/src/test/cli/setup.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { join } from "path";
+
+const fsState = vi.hoisted(() => ({
+  existing: new Set<string>(),
+  written: new Map<string, string>(),
+}));
+
+const mcpsMocks = vi.hoisted(() => ({
+  buildElectronAppReleaseAssetUrl: vi.fn(() => "https://dl/MuggleAI.zip"),
+  calculateFileChecksum: vi.fn(async () => "exec-checksum"),
+  getChecksumForPlatform: vi.fn(() => "expected-archive-sum"),
+  getDataDir: vi.fn(() => "/data"),
+  getElectronAppChecksums: vi.fn(() => ({})),
+  getElectronAppDir: vi.fn((v: string) => `/data/electron-app/${v}`),
+  getElectronAppVersion: vi.fn(() => "1.0.5"),
+  getPlatformKey: vi.fn(() => "win32-x64"),
+  isElectronAppInstalled: vi.fn(() => false),
+  isFirstRun: vi.fn(() => false),
+  verifyFileChecksum: vi.fn(async () => ({ valid: true, expected: "e", actual: "e" })),
+  writePreferences: vi.fn(),
+  getLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+const childProcessMock = vi.hoisted(() => ({
+  execFile: vi.fn((_cmd: string, _args: string[], cb: (e: Error | null) => void) => cb(null)),
+}));
+
+const streamMock = vi.hoisted(() => ({ pipeline: vi.fn(async () => undefined) }));
+
+const osState = vi.hoisted(() => ({ platform: "win32", arch: "x64", home: "/home/u" }));
+
+vi.mock("os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("os")>();
+  return {
+    ...actual,
+    platform: vi.fn(() => osState.platform),
+    arch: vi.fn(() => osState.arch),
+    homedir: vi.fn(() => osState.home),
+  };
+});
+
+vi.mock("fs", () => ({
+  existsSync: vi.fn((p: string) => fsState.existing.has(p)),
+  mkdirSync: vi.fn(),
+  rmSync: vi.fn(),
+  readFileSync: vi.fn(() => "{}"),
+  writeFileSync: vi.fn((p: string, c: string) => {
+    fsState.written.set(p, c);
+  }),
+  createWriteStream: vi.fn(() => ({ kind: "ws" })),
+}));
+
+vi.mock("child_process", () => childProcessMock);
+vi.mock("stream/promises", () => streamMock);
+vi.mock("../../../packages/mcps/src/index.js", () => ({
+  ...mcpsMocks,
+  DEFAULT_PREFERENCES: { autoLogin: "ask" },
+  PREFERENCES_FILE_NAME: "preferences.json",
+}));
+
+import { setupCommand } from "../../cli/setup.js";
+
+const VERSION_DIR = "/data/electron-app/1.0.5";
+const EXE_PATH = join(VERSION_DIR, "MuggleAI.exe");
+const META_PATH = join(VERSION_DIR, ".install-metadata.json");
+
+function fetchOk(): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      body: { kind: "body" },
+    })),
+  );
+}
+
+describe("setupCommand", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fsState.existing.clear();
+    fsState.written.clear();
+    osState.platform = "win32";
+    osState.arch = "x64";
+    osState.home = "/home/u";
+    mcpsMocks.isElectronAppInstalled.mockReturnValue(false);
+    mcpsMocks.isFirstRun.mockReturnValue(false);
+    mcpsMocks.verifyFileChecksum.mockResolvedValue({ valid: true, expected: "e", actual: "e" });
+    mcpsMocks.getChecksumForPlatform.mockReturnValue("expected-archive-sum");
+    childProcessMock.execFile.mockImplementation((_c, _a, cb) => cb(null));
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(((): never => undefined as never));
+    fetchOk();
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  it("short-circuits when already installed and not forced", async () => {
+    mcpsMocks.isElectronAppInstalled.mockReturnValue(true);
+    await setupCommand({});
+    expect(logSpy.mock.calls.map((c) => String(c[0])).join("\n")).toContain("already installed");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("writes default preferences on first run", async () => {
+    mcpsMocks.isFirstRun.mockReturnValue(true);
+    // executable shows up after extraction so the success path completes
+    fsState.existing.add(EXE_PATH);
+    await setupCommand({});
+    expect(mcpsMocks.writePreferences).toHaveBeenCalledWith({ autoLogin: "ask" }, "global");
+  });
+
+  it("downloads, verifies checksum, extracts, and writes metadata on success", async () => {
+    fsState.existing.add(EXE_PATH);
+    await setupCommand({ force: true });
+
+    expect(fetch).toHaveBeenCalledWith("https://dl/MuggleAI.zip");
+    expect(streamMock.pipeline).toHaveBeenCalledOnce();
+    expect(childProcessMock.execFile).toHaveBeenCalled();
+    expect(fsState.written.has(META_PATH)).toBe(true);
+    expect(JSON.parse(fsState.written.get(META_PATH) ?? "{}").executableChecksum).toBe("exec-checksum");
+    expect(logSpy.mock.calls.map((c) => String(c[0])).join("\n")).toContain("Checksum verified");
+  });
+
+  it("warns and skips verification when no checksum is configured", async () => {
+    mcpsMocks.getChecksumForPlatform.mockReturnValue("");
+    fsState.existing.add(EXE_PATH);
+    await setupCommand({ force: true });
+    expect(logSpy.mock.calls.map((c) => String(c[0])).join("\n")).toContain("No checksum configured");
+  });
+
+  it("exits 1 when checksum verification fails", async () => {
+    mcpsMocks.verifyFileChecksum.mockResolvedValue({ valid: false, expected: "a", actual: "b" });
+    await setupCommand({ force: true });
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errSpy.mock.calls.map((c) => String(c[0])).join("\n")).toContain("Failed to download");
+  });
+
+  it("exits 1 when the extracted executable is missing", async () => {
+    // executable never added to fsState -> extraction verification fails
+    await setupCommand({ force: true });
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("exits 1 when the HTTP download is not ok across all retries", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: false, status: 503, statusText: "Unavailable", body: null })),
+    );
+    vi.useFakeTimers();
+    const done = setupCommand({ force: true });
+    await vi.runAllTimersAsync();
+    await done;
+    vi.useRealTimers();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("upserts a fresh cursor mcp config when none exists", async () => {
+    fsState.existing.add(EXE_PATH);
+    await setupCommand({ force: true });
+    const written = [...fsState.written.entries()].find(([p]) => p.endsWith("mcp.json"));
+    expect(written).toBeDefined();
+    expect(JSON.parse(written![1]).mcpServers.muggle).toEqual({ command: "muggle", args: ["serve"] });
+  });
+
+  it("merges into an existing cursor config preserving other servers", async () => {
+    const cursorPath = join("/home/u", ".cursor", "mcp.json");
+    fsState.existing.add(cursorPath);
+    fsState.existing.add(EXE_PATH);
+    vi.mocked((await import("fs")).readFileSync).mockReturnValueOnce(
+      JSON.stringify({ mcpServers: { other: { command: "x" } } }) as never,
+    );
+    await setupCommand({ force: true });
+    const written = [...fsState.written.entries()].find(([p]) => p.endsWith("mcp.json"));
+    const parsed = JSON.parse(written![1]);
+    expect(parsed.mcpServers.other).toEqual({ command: "x" });
+    expect(parsed.mcpServers.muggle).toEqual({ command: "muggle", args: ["serve"] });
+  });
+
+  it("skips the cursor upsert when the existing config is an array", async () => {
+    const cursorPath = join("/home/u", ".cursor", "mcp.json");
+    fsState.existing.add(cursorPath);
+    fsState.existing.add(EXE_PATH);
+    vi.mocked((await import("fs")).readFileSync).mockReturnValueOnce("[]" as never);
+    await setupCommand({ force: true });
+    expect(logSpy.mock.calls.map((c) => String(c[0])).join("\n")).toContain("unexpected shape");
+  });
+
+  it("skips the cursor upsert when the existing config is invalid JSON", async () => {
+    const cursorPath = join("/home/u", ".cursor", "mcp.json");
+    fsState.existing.add(cursorPath);
+    fsState.existing.add(EXE_PATH);
+    vi.mocked((await import("fs")).readFileSync).mockReturnValueOnce("{ broken" as never);
+    await setupCommand({ force: true });
+    expect(logSpy.mock.calls.map((c) => String(c[0])).join("\n")).toContain("invalid JSON");
+  });
+
+  it("uses the unzip extractor and darwin paths on macOS", async () => {
+    osState.platform = "darwin";
+    osState.arch = "arm64";
+    const darwinExe = join("/data/electron-app/1.0.5", "MuggleAI.app", "Contents", "MacOS", "MuggleAI");
+    fsState.existing.add(darwinExe);
+    await setupCommand({ force: true });
+    expect(mcpsMocks.buildElectronAppReleaseAssetUrl).toHaveBeenCalled();
+    const [cmd] = childProcessMock.execFile.mock.calls[0];
+    expect(cmd).toBe("unzip");
+  });
+
+  it("exits 1 when extraction itself fails", async () => {
+    fsState.existing.add(EXE_PATH);
+    childProcessMock.execFile.mockImplementation((_c, _a, cb) => cb(new Error("unzip blew up")));
+    await setupCommand({ force: true });
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/src/test/cli/upgrade.test.ts
+++ b/src/test/cli/upgrade.test.ts
@@ -1,0 +1,336 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { join } from "path";
+import { tmpdir } from "node:os";
+import { createRequire } from "node:module";
+
+const realFs = createRequire(import.meta.url)("fs") as typeof import("fs");
+
+const fsState = vi.hoisted(() => ({
+  existing: new Set<string>(),
+  files: new Map<string, string>(),
+  written: new Map<string, string>(),
+}));
+
+const mcpsMocks = vi.hoisted(() => ({
+  buildElectronAppChecksumsUrl: vi.fn(() => "https://dl/checksums.txt"),
+  buildElectronAppReleaseAssetUrl: vi.fn((p: { version: string }) => `https://dl/${p.version}/MuggleAI.zip`),
+  calculateFileChecksum: vi.fn(async () => "exec-sum"),
+  getDataDir: vi.fn(() => "/data"),
+  getElectronAppDir: vi.fn((v: string) => `/data/electron-app/${v}`),
+  getElectronAppVersion: vi.fn(() => "1.0.5"),
+  getPlatformKey: vi.fn(() => "win32-x64"),
+  getLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+  verifyFileChecksum: vi.fn(async () => ({ valid: true, expected: "e", actual: "e" })),
+}));
+
+const cleanupMock = vi.hoisted(() => ({
+  cleanupOldVersions: vi.fn(() => ({ removed: [], freedBytes: 0 })),
+  formatBytes: vi.fn((b: number) => `${b} B`),
+}));
+
+const childProcessMock = vi.hoisted(() => ({
+  execFile: vi.fn((_c: string, _a: string[], cb: (e: Error | null) => void) => cb(null)),
+}));
+const streamMock = vi.hoisted(() => ({ pipeline: vi.fn(async () => undefined) }));
+
+const osMock = vi.hoisted(() => ({ platform: vi.fn(() => "win32") }));
+const procArch = vi.hoisted(() => ({ value: "x64" }));
+
+vi.mock("os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("os")>();
+  return { ...actual, platform: osMock.platform };
+});
+
+const fsImpl = vi.hoisted(() => ({
+  existsSync: vi.fn((p: string) => fsState.existing.has(p)),
+  mkdirSync: vi.fn(),
+  rmSync: vi.fn(),
+  createWriteStream: vi.fn(() => ({ kind: "ws" })),
+  writeFileSync: vi.fn((p: string, c: string) => fsState.written.set(p, c)),
+  readFileSync: vi.fn((p: string) => fsState.files.get(p) ?? "{}"),
+}));
+
+vi.mock("fs", () => fsImpl);
+vi.mock("child_process", () => childProcessMock);
+vi.mock("stream/promises", () => streamMock);
+vi.mock("../../../packages/mcps/src/index.js", () => mcpsMocks);
+vi.mock("../../cli/cleanup.js", () => cleanupMock);
+
+import {
+  getEffectiveElectronAppVersion,
+  upgradeCommand,
+} from "../../cli/upgrade.js";
+
+const VERSION_DIR_106 = "/data/electron-app/1.0.6";
+const EXE_106 = join(VERSION_DIR_106, "MuggleAI.exe");
+
+function stubFetchSequence(responses: Array<Record<string, unknown>>): void {
+  let i = 0;
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => responses[Math.min(i++, responses.length - 1)]),
+  );
+}
+
+function releasesResponse(tags: string[]): Record<string, unknown> {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => tags.map((t) => ({ tag_name: t, prerelease: false, draft: false })),
+  };
+}
+
+function downloadResponse(): Record<string, unknown> {
+  return { ok: true, status: 200, statusText: "OK", body: { kind: "body" } };
+}
+
+describe("getEffectiveElectronAppVersion", () => {
+  // getEffectiveElectronAppVersion reads the override via require("fs"), which
+  // bypasses the ESM "fs" mock, so these scenarios use a real temp data dir.
+  let realDataDir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fsState.existing.clear();
+    fsState.files.clear();
+    realDataDir = realFs.mkdtempSync(join(tmpdir(), "mgl-upgrade-"));
+    mcpsMocks.getDataDir.mockReturnValue(realDataDir);
+  });
+
+  afterEach(() => {
+    realFs.rmSync(realDataDir, { recursive: true, force: true });
+    mcpsMocks.getDataDir.mockReturnValue("/data");
+  });
+
+  it("returns the bundled version when no override file exists", () => {
+    expect(getEffectiveElectronAppVersion()).toBe("1.0.5");
+  });
+
+  it("returns the overridden version when the file is present and valid", () => {
+    const overridePath = join(realDataDir, "electron-app-version-override.json");
+    realFs.writeFileSync(overridePath,JSON.stringify({ version: "2.0.0" }));
+    fsState.existing.add(overridePath);
+    expect(getEffectiveElectronAppVersion()).toBe("2.0.0");
+  });
+
+  it("falls back to bundled version when the override file is malformed", () => {
+    const overridePath = join(realDataDir, "electron-app-version-override.json");
+    realFs.writeFileSync(overridePath,"{ not json");
+    fsState.existing.add(overridePath);
+    expect(getEffectiveElectronAppVersion()).toBe("1.0.5");
+  });
+});
+
+describe("upgradeCommand", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  const originalArch = process.arch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fsState.existing.clear();
+    fsState.files.clear();
+    fsState.written.clear();
+    osMock.platform.mockReturnValue("win32");
+    procArch.value = "x64";
+    Object.defineProperty(process, "arch", { get: () => procArch.value, configurable: true });
+    mcpsMocks.verifyFileChecksum.mockResolvedValue({ valid: true, expected: "e", actual: "e" });
+    cleanupMock.cleanupOldVersions.mockReturnValue({ removed: [], freedBytes: 0 });
+    childProcessMock.execFile.mockImplementation((_c, _a, cb) => cb(null));
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(((): never => undefined as never));
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+    vi.unstubAllGlobals();
+    Object.defineProperty(process, "arch", { value: originalArch, configurable: true });
+  });
+
+  it("--check reports an available update without downloading", async () => {
+    stubFetchSequence([releasesResponse(["electron-app-v1.0.9"])]);
+    await upgradeCommand({ check: true });
+    const out = logSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(out).toContain("Latest version:  1.0.9");
+    expect(out).toContain("Update available");
+    expect(streamMock.pipeline).not.toHaveBeenCalled();
+  });
+
+  it("--check reports up-to-date when no newer release exists", async () => {
+    stubFetchSequence([releasesResponse(["v1.0.5"])]);
+    await upgradeCommand({ check: true });
+    expect(logSpy.mock.calls.map((c) => String(c[0])).join("\n")).toContain("latest version");
+  });
+
+  it("does nothing when already latest and not forced", async () => {
+    stubFetchSequence([releasesResponse(["v1.0.5"])]);
+    await upgradeCommand({});
+    expect(logSpy.mock.calls.map((c) => String(c[0])).join("\n")).toContain("already on the latest");
+    expect(streamMock.pipeline).not.toHaveBeenCalled();
+  });
+
+  it("downloads and installs a newer release, then auto-cleans old versions", async () => {
+    fsState.existing.add(join("/data/electron-app/1.0.6", "MuggleAI.exe"));
+    cleanupMock.cleanupOldVersions.mockReturnValue({
+      removed: [{ version: "1.0.3" }],
+      freedBytes: 2048,
+    } as never);
+    stubFetchSequence([
+      releasesResponse(["v1.0.6"]),
+      downloadResponse(),
+      { ok: true, status: 200, statusText: "OK", text: async () => "" },
+    ]);
+
+    await upgradeCommand({});
+
+    expect(streamMock.pipeline).toHaveBeenCalledOnce();
+    expect(fsState.written.has(join(VERSION_DIR_106, ".install-metadata.json"))).toBe(true);
+    const overridePath = join("/data", "electron-app-version-override.json");
+    expect(JSON.parse(fsState.written.get(overridePath) ?? "{}").version).toBe("1.0.6");
+    expect(cleanupMock.cleanupOldVersions).toHaveBeenCalledWith({ all: false });
+    expect(logSpy.mock.calls.map((c) => String(c[0])).join("\n")).toContain("Cleaned up 1 old version");
+  });
+
+  it("installs a specific --version using the parameterized download URL", async () => {
+    fsState.existing.add(join("/data/electron-app/3.1.4", "MuggleAI.exe"));
+    stubFetchSequence([
+      downloadResponse(),
+      { ok: true, status: 200, statusText: "OK", text: async () => "" },
+    ]);
+    await upgradeCommand({ version: "3.1.4" });
+    expect(mcpsMocks.buildElectronAppReleaseAssetUrl).toHaveBeenCalledWith({
+      version: "3.1.4",
+      assetFileName: "MuggleAI-win32-x64.zip",
+    });
+    expect(fsState.written.has(join("/data/electron-app/3.1.4", ".install-metadata.json"))).toBe(true);
+  });
+
+  it("verifies a checksum parsed from checksums.txt", async () => {
+    fsState.existing.add(EXE_106);
+    mcpsMocks.verifyFileChecksum.mockResolvedValue({ valid: true, expected: "e", actual: "e" });
+    const sum = "a".repeat(64);
+    stubFetchSequence([
+      releasesResponse(["v1.0.6"]),
+      downloadResponse(),
+      { ok: true, status: 200, statusText: "OK", text: async () => `${sum}  MuggleAI-win32-x64.zip\n` },
+    ]);
+    await upgradeCommand({});
+    expect(mcpsMocks.verifyFileChecksum).toHaveBeenCalledWith(expect.any(String), sum);
+    expect(logSpy.mock.calls.map((c) => String(c[0])).join("\n")).toContain("Checksum verified");
+  });
+
+  it("aborts the install when checksum verification fails", async () => {
+    fsState.existing.add(EXE_106);
+    mcpsMocks.verifyFileChecksum.mockResolvedValue({ valid: false, expected: "a", actual: "b" });
+    const sum = "a".repeat(64);
+    stubFetchSequence([
+      releasesResponse(["v1.0.6"]),
+      downloadResponse(),
+      { ok: true, status: 200, statusText: "OK", text: async () => `${sum}  MuggleAI-win32-x64.zip\n` },
+    ]);
+    await upgradeCommand({});
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errSpy.mock.calls.map((c) => String(c[0])).join("\n")).toContain("Upgrade failed");
+  });
+
+  it("exits 1 when the GitHub releases API errors", async () => {
+    stubFetchSequence([{ ok: false, status: 500, statusText: "Server Error" }]);
+    await upgradeCommand({ check: true });
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("exits 1 when extraction yields no executable", async () => {
+    stubFetchSequence([
+      releasesResponse(["v1.0.6"]),
+      downloadResponse(),
+      { ok: true, status: 200, statusText: "OK", text: async () => "" },
+    ]);
+    await upgradeCommand({});
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("re-downloads the current version when --force is set despite no update", async () => {
+    fsState.existing.add(join("/data/electron-app/1.0.5", "MuggleAI.exe"));
+    stubFetchSequence([
+      releasesResponse(["v1.0.5"]),
+      downloadResponse(),
+      { ok: true, status: 200, statusText: "OK", text: async () => "" },
+    ]);
+    await upgradeCommand({ force: true });
+    expect(streamMock.pipeline).toHaveBeenCalledOnce();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("treats releases with no electron-app tag as up-to-date", async () => {
+    stubFetchSequence([releasesResponse(["not-a-version"])]);
+    await upgradeCommand({ check: true });
+    expect(logSpy.mock.calls.map((c) => String(c[0])).join("\n")).toContain("latest version");
+  });
+
+  it("skips prerelease and draft entries when scanning releases", async () => {
+    let i = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        i++;
+        if (i === 1) {
+          return {
+            ok: true,
+            status: 200,
+            statusText: "OK",
+            json: async () => [
+              { tag_name: "v9.9.9", prerelease: true, draft: false },
+              { tag_name: "v8.8.8", prerelease: false, draft: true },
+              { tag_name: "v1.0.7", prerelease: false, draft: false },
+            ],
+          };
+        }
+        return { ok: true, status: 200, statusText: "OK", text: async () => "" };
+      }),
+    );
+    await upgradeCommand({ check: true });
+    const out = logSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(out).toContain("Latest version:  1.0.7");
+  });
+
+  it("warns and skips verification when the checksums file is absent", async () => {
+    fsState.existing.add(EXE_106);
+    stubFetchSequence([
+      releasesResponse(["v1.0.6"]),
+      downloadResponse(),
+      { ok: false, status: 404, statusText: "Not Found" },
+    ]);
+    await upgradeCommand({});
+    expect(logSpy.mock.calls.map((c) => String(c[0])).join("\n")).toContain("No checksum available");
+  });
+
+  it("exits 1 when the download response is not ok", async () => {
+    stubFetchSequence([
+      releasesResponse(["v1.0.6"]),
+      { ok: false, status: 502, statusText: "Bad Gateway" },
+    ]);
+    await upgradeCommand({});
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errSpy.mock.calls.map((c) => String(c[0])).join("\n")).toContain("Upgrade failed");
+  });
+
+  it("uses the unzip extractor and darwin executable path on macOS", async () => {
+    osMock.platform.mockReturnValue("darwin");
+    const darwinExe = join("/data/electron-app/1.0.6", "MuggleAI.app", "Contents", "MacOS", "MuggleAI");
+    fsState.existing.add(darwinExe);
+    procArch.value = "arm64";
+    stubFetchSequence([
+      releasesResponse(["v1.0.6"]),
+      downloadResponse(),
+      { ok: true, status: 200, statusText: "OK", text: async () => "" },
+    ]);
+    await upgradeCommand({});
+    expect(childProcessMock.execFile.mock.calls[0][0]).toBe("unzip");
+  });
+});

--- a/src/test/server/mcp-server.test.ts
+++ b/src/test/server/mcp-server.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { z } from "zod";
+
+const { toolRequiresAuth, getCallerCredentials } = vi.hoisted(() => ({
+  toolRequiresAuth: vi.fn(() => false),
+  getCallerCredentials: vi.fn(() => ({})),
+}));
+
+vi.mock("../../../packages/mcps/src/index.js", () => ({
+  createChildLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+  getCallerCredentials,
+  getConfig: vi.fn(() => ({ serverName: "muggle", serverVersion: "1.2.3" })),
+  getLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })),
+  toolRequiresAuth,
+}));
+
+interface CapturedHandler {
+  schema: { _capturedName?: string };
+  handler: (req: unknown) => unknown;
+}
+
+const handlers: CapturedHandler[] = [];
+
+vi.mock("@modelcontextprotocol/sdk/server/index.js", () => ({
+  Server: vi.fn(function (this: Record<string, unknown>) {
+    this.setRequestHandler = (schema: { _capturedName?: string }, handler: (req: unknown) => unknown) => {
+      handlers.push({ schema, handler });
+    };
+  }),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/types.js", () => ({
+  ListToolsRequestSchema: { _capturedName: "listTools" },
+  CallToolRequestSchema: { _capturedName: "callTool" },
+  ListResourcesRequestSchema: { _capturedName: "listResources" },
+  ReadResourceRequestSchema: { _capturedName: "readResource" },
+}));
+
+import {
+  registerTools,
+  getAllTools,
+  clearTools,
+  createUnifiedMcpServer,
+} from "../../server/mcp-server.js";
+
+function handlerFor(name: string): (req: unknown) => unknown {
+  const found = handlers.find((h) => h.schema._capturedName === name);
+  if (!found) throw new Error(`handler ${name} not registered`);
+  return found.handler;
+}
+
+function makeTool(overrides: Partial<{ name: string; inputSchema: unknown; execute: unknown }> = {}) {
+  return {
+    name: "muggle-remote-x",
+    description: "desc",
+    inputSchema: z.object({ a: z.string() }),
+    execute: vi.fn(async () => ({ content: "ok", isError: false })),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  handlers.length = 0;
+  clearTools();
+  vi.clearAllMocks();
+  toolRequiresAuth.mockReturnValue(false);
+  getCallerCredentials.mockReturnValue({});
+});
+
+describe("tool registry", () => {
+  it("registers, lists, and clears tools", () => {
+    expect(getAllTools()).toEqual([]);
+    registerTools([makeTool({ name: "a" })]);
+    registerTools([makeTool({ name: "b" })]);
+    expect(getAllTools().map((t) => t.name)).toEqual(["a", "b"]);
+    clearTools();
+    expect(getAllTools()).toEqual([]);
+  });
+});
+
+describe("createUnifiedMcpServer handlers", () => {
+  afterEach(() => clearTools());
+
+  it("ListTools converts native zod schemas to JSON schema", () => {
+    registerTools([
+      makeTool({ name: "t1", inputSchema: z.object({ url: z.string(), count: z.number().optional() }) }),
+    ]);
+    createUnifiedMcpServer({ enableQaTools: true, enableLocalTools: true });
+
+    const result = handlerFor("listTools")({}) as { tools: Array<{ name: string; inputSchema: { type: string } }> };
+    expect(result.tools).toHaveLength(1);
+    expect(result.tools[0].name).toBe("t1");
+    expect(result.tools[0].inputSchema.type).toBe("object");
+  });
+
+  it("ListTools falls back to a generic schema for non-zod inputs", () => {
+    registerTools([makeTool({ name: "t2", inputSchema: { not: "zod" } })]);
+    createUnifiedMcpServer({ enableQaTools: true, enableLocalTools: true });
+    const result = handlerFor("listTools")({}) as { tools: Array<{ inputSchema: Record<string, unknown> }> };
+    expect(result.tools[0].inputSchema).toMatchObject({ type: "object", additionalProperties: true });
+  });
+
+  it("CallTool returns NOT_FOUND for an unknown tool", async () => {
+    createUnifiedMcpServer({ enableQaTools: true, enableLocalTools: true });
+    const res = (await handlerFor("callTool")({ params: { name: "nope", arguments: {} } })) as {
+      isError: boolean;
+      content: Array<{ text: string }>;
+    };
+    expect(res.isError).toBe(true);
+    expect(JSON.parse(res.content[0].text).error).toBe("NOT_FOUND");
+  });
+
+  it("CallTool executes a found tool and returns its content", async () => {
+    const execute = vi.fn(async () => ({ content: "done", isError: false }));
+    registerTools([makeTool({ name: "go", execute })]);
+    createUnifiedMcpServer({ enableQaTools: true, enableLocalTools: true });
+
+    const res = (await handlerFor("callTool")({ params: { name: "go", arguments: { a: "1" } } })) as {
+      isError: boolean;
+      content: Array<{ text: string }>;
+    };
+    expect(execute).toHaveBeenCalledWith(expect.objectContaining({ input: { a: "1" } }));
+    expect(res.content[0].text).toBe("done");
+    expect(res.isError).toBe(false);
+  });
+
+  it("CallTool maps ZodError to INVALID_ARGUMENT", async () => {
+    const execute = vi.fn(async () => {
+      z.object({ a: z.string() }).parse({ a: 1 });
+    });
+    registerTools([makeTool({ name: "bad", execute })]);
+    createUnifiedMcpServer({ enableQaTools: true, enableLocalTools: true });
+
+    const res = (await handlerFor("callTool")({ params: { name: "bad", arguments: {} } })) as {
+      isError: boolean;
+      content: Array<{ text: string }>;
+    };
+    expect(res.isError).toBe(true);
+    expect(JSON.parse(res.content[0].text).error).toBe("INVALID_ARGUMENT");
+  });
+
+  it("CallTool maps generic errors to INTERNAL_ERROR", async () => {
+    const execute = vi.fn(async () => {
+      throw new Error("boom");
+    });
+    registerTools([makeTool({ name: "err", execute })]);
+    createUnifiedMcpServer({ enableQaTools: true, enableLocalTools: true });
+
+    const res = (await handlerFor("callTool")({ params: { name: "err", arguments: {} } })) as {
+      content: Array<{ text: string }>;
+    };
+    const parsed = JSON.parse(res.content[0].text);
+    expect(parsed.error).toBe("INTERNAL_ERROR");
+    expect(parsed.message).toBe("boom");
+  });
+
+  it("CallTool defaults arguments to an empty object", async () => {
+    const execute = vi.fn(async () => ({ content: "x", isError: false }));
+    registerTools([makeTool({ name: "noargs", execute })]);
+    createUnifiedMcpServer({ enableQaTools: true, enableLocalTools: true });
+
+    await handlerFor("callTool")({ params: { name: "noargs" } });
+    expect(execute).toHaveBeenCalledWith(expect.objectContaining({ input: {} }));
+  });
+
+  it("ListResources returns an empty list", () => {
+    createUnifiedMcpServer({ enableQaTools: true, enableLocalTools: true });
+    expect(handlerFor("listResources")({})).toEqual({ resources: [] });
+  });
+
+  it("ReadResource echoes a not-found resource for the requested uri", () => {
+    createUnifiedMcpServer({ enableQaTools: true, enableLocalTools: true });
+    const res = handlerFor("readResource")({ params: { uri: "muggle://x" } }) as {
+      contents: Array<{ uri: string; text: string }>;
+    };
+    expect(res.contents[0].uri).toBe("muggle://x");
+    expect(res.contents[0].text).toContain("Resource not found");
+  });
+
+  it("passes credentials through JIT auth for tools that require it", async () => {
+    toolRequiresAuth.mockReturnValue(true);
+    getCallerCredentials.mockReturnValue({ apiKey: "k" });
+    const execute = vi.fn(async () => ({ content: "auth-ok", isError: false }));
+    registerTools([makeTool({ name: "secure", execute })]);
+    createUnifiedMcpServer({ enableQaTools: true, enableLocalTools: true });
+
+    const res = (await handlerFor("callTool")({ params: { name: "secure", arguments: {} } })) as {
+      content: Array<{ text: string }>;
+    };
+    expect(execute).toHaveBeenCalledOnce();
+    expect(res.content[0].text).toBe("auth-ok");
+  });
+
+  it("executes auth-required tools even when no credentials are stored", async () => {
+    toolRequiresAuth.mockReturnValue(true);
+    getCallerCredentials.mockReturnValue({});
+    const execute = vi.fn(async () => ({ content: "ran", isError: false }));
+    registerTools([makeTool({ name: "secure2", execute })]);
+    createUnifiedMcpServer({ enableQaTools: true, enableLocalTools: true });
+
+    await handlerFor("callTool")({ params: { name: "secure2", arguments: {} } });
+    expect(execute).toHaveBeenCalledOnce();
+  });
+});
+
+describe("legacy zod-to-json-schema conversion", () => {
+  function legacy(def: Record<string, unknown>): { _def: Record<string, unknown> } {
+    return { _def: def };
+  }
+
+  function jsonSchemaFor(inputSchema: unknown): Record<string, unknown> {
+    clearTools();
+    registerTools([makeTool({ name: "legacy", inputSchema })]);
+    createUnifiedMcpServer({ enableQaTools: true, enableLocalTools: true });
+    const result = handlerFor("listTools")({}) as {
+      tools: Array<{ inputSchema: Record<string, unknown> }>;
+    };
+    return result.tools[0].inputSchema;
+  }
+
+  beforeEach(() => {
+    handlers.length = 0;
+    clearTools();
+  });
+
+  it("converts an object with required and optional string properties", () => {
+    const schema = legacy({
+      typeName: "ZodObject",
+      shape: () => ({
+        url: legacy({ typeName: "ZodString", description: "u", checks: [{ kind: "min", value: 1 }, { kind: "url" }] }),
+        opt: legacy({ typeName: "ZodOptional", innerType: legacy({ typeName: "ZodString" }) }),
+      }),
+    });
+    const out = jsonSchemaFor(schema);
+    expect(out.type).toBe("object");
+    expect((out.properties as Record<string, unknown>).url).toMatchObject({ type: "string", format: "uri" });
+    expect(out.required).toEqual(["url"]);
+  });
+
+  it("converts number, boolean, array, and enum types", () => {
+    expect(jsonSchemaFor(legacy({ typeName: "ZodNumber", checks: [{ kind: "int" }, { kind: "min", value: 0 }] })))
+      .toMatchObject({ type: "integer", minimum: 0 });
+    expect(jsonSchemaFor(legacy({ typeName: "ZodBoolean", description: "b" }))).toMatchObject({ type: "boolean" });
+    expect(jsonSchemaFor(legacy({ typeName: "ZodArray", element: legacy({ typeName: "ZodString" }) })))
+      .toMatchObject({ type: "array", items: { type: "string" } });
+    expect(jsonSchemaFor(legacy({ typeName: "ZodEnum", values: ["a", "b"] })))
+      .toMatchObject({ type: "string", enum: ["a", "b"] });
+  });
+
+  it("converts unions and falls back to object for unknown types", () => {
+    const union = jsonSchemaFor(
+      legacy({ typeName: "ZodUnion", options: [legacy({ typeName: "ZodString" }), legacy({ typeName: "ZodNumber" })] }),
+    );
+    expect((union.oneOf as unknown[]).length).toBe(2);
+    expect(jsonSchemaFor(legacy({ typeName: "ZodWeird" }))).toMatchObject({ type: "object" });
+  });
+});

--- a/src/test/server/stdio-server.test.ts
+++ b/src/test/server/stdio-server.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { EventEmitter } from "events";
+
+const { StdioServerTransport } = vi.hoisted(() => ({
+  StdioServerTransport: vi.fn(function (this: Record<string, unknown>) {
+    this.kind = "transport";
+  }),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/server/index.js", () => ({ Server: vi.fn() }));
+vi.mock("@modelcontextprotocol/sdk/server/stdio.js", () => ({ StdioServerTransport }));
+vi.mock("../../../packages/mcps/src/index.js", () => ({
+  getLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { startStdioServer } from "../../server/stdio-server.js";
+
+describe("startStdioServer", () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let processOnSpy: ReturnType<typeof vi.spyOn>;
+  let fakeStdin: EventEmitter;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(((): never => undefined as never));
+    processOnSpy = vi.spyOn(process, "on");
+    fakeStdin = new EventEmitter();
+    vi.spyOn(process, "stdin", "get").mockReturnValue(fakeStdin as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("connects the server to a stdio transport", async () => {
+    const connect = vi.fn(async () => undefined);
+    await startStdioServer({ connect } as never);
+
+    expect(StdioServerTransport).toHaveBeenCalledOnce();
+    expect(connect).toHaveBeenCalledWith(expect.objectContaining({ kind: "transport" }));
+  });
+
+  it("registers SIGTERM/SIGINT handlers that exit cleanly", async () => {
+    const connect = vi.fn(async () => undefined);
+    await startStdioServer({ connect } as never);
+
+    const signals = processOnSpy.mock.calls.map((c) => c[0]);
+    expect(signals).toContain("SIGTERM");
+    expect(signals).toContain("SIGINT");
+
+    const sigterm = processOnSpy.mock.calls.find((c) => c[0] === "SIGTERM")?.[1] as () => void;
+    sigterm();
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it("exits when stdin closes (parent-death detection)", async () => {
+    const connect = vi.fn(async () => undefined);
+    await startStdioServer({ connect } as never);
+
+    fakeStdin.emit("end");
+    expect(exitSpy).toHaveBeenCalledWith(0);
+
+    exitSpy.mockClear();
+    fakeStdin.emit("close");
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,5 +4,26 @@ export default defineConfig({
   test: {
     passWithNoTests: true,
     exclude: ['packages/**', 'apps/**', '**/node_modules/**', '**/.claude/worktrees/**'],
+    coverage: {
+      provider: "v8",
+      all: true,
+      include: ["src/**/*.ts"],
+      exclude: [
+        "src/**/*.test.ts",
+        "src/test/**",
+        // Pure re-export barrels and thin process bootstraps with no branchable logic.
+        "src/index.ts",
+        "src/cli/index.ts",
+        "src/cli/main.ts",
+        "src/server/index.ts",
+      ],
+      reporter: ["text", "json-summary"],
+      thresholds: {
+        lines: 92,
+        statements: 92,
+        functions: 90,
+        branches: 78,
+      },
+    },
   },
 });


### PR DESCRIPTION
## Coverage gate for `src/`

Adds a real coverage provider (`@vitest/coverage-v8`) and an enforced, ratcheted threshold so `src/` coverage can't regress.

| Metric | Before | After |
|---|---|---|
| Statements | 21.6% | **93.3%** |
| Branches | 17.6% | **80.0%** |
| Functions | 31.9% | **95.1%** |
| Lines | 21.1% | **93.8%** |

- **+107 tests** (129 → 236) across 11 new files covering the CLI commands (`help`, `login`, `serve`, `cleanup`, `cleanup-skills`, `doctor`, `setup`, `upgrade`, `build-pr-section`) and the MCP/stdio servers.
- All external boundaries mocked (`fs`, `child_process`, `stream/promises`, `os`, `fetch`, the MCP SDK, telemetry, the `packages/mcps` module) — nothing hits live services.
- `vitest.config.ts` gains `coverage: { all: true, include: ['src/**'] }` so the denominator is the whole source tree, plus thresholds floored just below achieved (lines/stmts 92, fn 90, branches 78) for stable CI.
- Coverage-excluded (pure re-export barrels / thin process bootstraps): `src/index.ts`, `src/cli/index.ts`, `src/cli/main.ts`, `src/server/index.ts`.
- **No production code changed.**

`npx vitest run --coverage` passes with thresholds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
