### PR TITLE
test(routing-eval): partial expanded-run report (7/14 skills) + new findings

### DIFF
--- a/internal/skill-routing-eval/reports/expanded-eval-partial.json
+++ b/internal/skill-routing-eval/reports/expanded-eval-partial.json
@@ -1,0 +1,2034 @@
+{
+  "model": "opus(partial)",
+  "runs_per_query": 3,
+  "results": [
+    {
+      "query": "Log into my LinkedIn (handle @sarah.kowalczyk) and post this update: \"Thrilled to announce I've joined Acme Robotics as Head of Platform. Building the future of warehouse automation \u2014 DMs open.\" Add the hashtags #robotics #hiring and hit post.",
+      "expected_skill": "muggle-do-task",
+      "fired": [
+        "none",
+        "muggle-do-task",
+        "none"
+      ],
+      "majority": "none",
+      "pass": false,
+      "note": "Core post-content action \u2014 log in then publish; clear accomplish-the-task intent, no verification."
+    },
+    {
+      "query": "go to https://app.notion.so and create a new page in the \"Q3 Planning\" workspace titled \"Sprint 14 retro\", paste in the three bullets i'll give you, then share it with marcus@northwind.io as a commenter",
+      "expected_skill": "muggle-do-task",
+      "fired": [
+        "muggle-do-task",
+        "muggle-do-task",
+        "muggle-do-task"
+      ],
+      "majority": "muggle-do-task",
+      "pass": true,
+      "note": "Navigate + create + populate + share \u2014 multi-step content action on a real-sounding site."
+    },
+    {
+      "query": "fill out the contact form on https://bluewave-consulting.com/contact \u2014 name Priya Anand, email priya@gmail.com, company Lumen Health, message \"Interested in your HIPAA compliance package, please send pricing\" \u2014 and submit it",
+      "expected_skill": "muggle-do-task",
+      "fired": [
+        "muggle-do-task",
+        "none",
+        "muggle-do-task"
+      ],
+      "majority": "muggle-do-task",
+      "pass": true,
+      "note": "Classic fill-and-submit a form with named fields; pure action."
+    },
+    {
+      "query": "Can u log into our Shopify admin (store: thistledown-candles.myshopify.com) and add a new product? Title \"Smoked Cedar 8oz\", price $24.50, SKU SC-008, set inventory to 40, and publish it to the online store.",
+      "expected_skill": "muggle-do-task",
+      "fired": [
+        "muggle-do-task",
+        "muggle-do-task",
+        "muggle-do-task"
+      ],
+      "majority": "muggle-do-task",
+      "pass": true,
+      "note": "Login + add item + configure + publish; casual register with typo."
+    },
+    {
+      "query": "Open the AWS console, go to IAM, and create a new user named ci-deploy-bot with programmatic access only, attach the AmazonS3FullAccess policy, then download the access keys.",
+      "expected_skill": "muggle-do-task",
+      "fired": [
+        "none",
+        "none",
+        "none"
+      ],
+      "majority": "none",
+      "pass": false,
+      "note": "Navigate console + create resource + toggle settings + complete flow; admin web action."
+    },
+    {
+      "query": "send a message to the #general channel in our Slack (muggle-eng workspace): \"Heads up \u2014 deploy freeze starts at 5pm PT today, get your PRs merged before then \ud83d\ude80\"",
+      "expected_skill": "muggle-do-task",
+      "fired": [
+        "none",
+        "none",
+        "none"
+      ],
+      "majority": "none",
+      "pass": false,
+      "note": "Send a message action in a chat app; accomplish intent only."
+    },
+    {
+      "query": "I need you to log into Stripe dashboard and refund the last charge for customer cus_PQ9x2 \u2014 it was $149.00, reason \"duplicate\". Just process the refund please.",
+      "expected_skill": "muggle-do-task",
+      "fired": [
+        "none",
+        "none",
+        "none"
+      ],
+      "majority": "none",
+      "pass": false,
+      "note": "Login + navigate + perform a transactional action; explicit 'process' verb."
+    },
+    {
+      "query": "Go to my WordPress admin at https://travelwithjo.com/wp-admin, draft a new blog post titled \"5 Hidden Caf\u00e9s in Lisbon\", set the category to Travel, add the featured image i uploaded, and schedule it for next Tuesday 9am.",
+      "expected_skill": "muggle-do-task",
+      "fired": [
+        "muggle-do-task",
+        "muggle-do-task",
+        "muggle-do-task"
+      ],
+      "majority": "muggle-do-task",
+      "pass": true,
+      "note": "Multi-step content creation + scheduling + settings toggle on a CMS."
+    },
+    {
+      "query": "toggle dark mode on in my GitHub settings and also switch my default branch naming to 'main' under repository defaults, then save",
+      "expected_skill": "muggle-do-task",
+      "fired": [
+        "muggle-do-task",
+        "muggle-do-task",
+        "muggle-do-task"
+      ],
+      "majority": "muggle-do-task",
+      "pass": true,
+      "note": "Navigate + toggle settings + save; settings-action intent."
+    },
+    {
+      "query": "add 3 items to my cart on amazon \u2014 the Anker 737 power bank, a pack of AA Eneloops, and the Logitech MX Master 3S in graphite \u2014 then go to checkout but stop before paying so i can review",
+      "expected_skill": "muggle-do-task",
+      "fired": [
+        "muggle-do-task",
+        "muggle-do-task",
+        "muggle-do-task"
+      ],
+      "majority": "muggle-do-task",
+      "pass": true,
+      "note": "Add items + navigate checkout flow; explicit task to perform, stops short of payment."
+    },
+    {
+      "query": "pls reply to the latest review on our Google Business Profile (Bella Vista Trattoria) \u2014 the 2-star one from \"Derek M\" \u2014 with: \"Hi Derek, so sorry to hear about the wait time on Saturday. We've added staff since then \u2014 please give us another try and ask for Tony, dinner's on us.\" and submit it",
+      "expected_skill": "muggle-do-task",
+      "fired": [
+        "muggle-do-task",
+        "muggle-do-task",
+        "muggle-do-task"
+      ],
+      "majority": "muggle-do-task",
+      "pass": true,
+      "note": "Navigate + compose + submit a reply; real backstory, casual."
+    },
+    {
+      "query": "Log into Mailchimp (account: pinecrest-yoga) and add these 4 emails to the \"Newsletter\" audience as subscribed contacts, then tag them all \"spring-promo\".",
+      "expected_skill": "muggle-do-task",
+      "fired": [
+        "muggle-do-task",
+        "muggle-do-task",
+        "muggle-do-task"
+      ],
+      "majority": "muggle-do-task",
+      "pass": true,
+      "note": "Login + add records + apply settings/tags; bulk data-entry action."
+    },
+    {
+      "query": "open jira, create a new bug ticket in the PAY project: summary \"Apple Pay button missing on mobile checkout\", priority High, assign to me, label mobile-regression, and submit",
+      "expected_skill": "muggle-do-task",
+      "fired": [
+        "none",
+        "muggle-do-task",
+        "muggle-do-task"
+      ],
+      "majority": "muggle-do-task",
+      "pass": true,
+      "note": "Create + configure + submit an issue; ticketing action."
+    },
+    {
+      "query": "Update my profile on the company intranet at https://intra.globex.local/profile \u2014 change my title to \"Senior Staff Engineer\", set my pronouns to she/her, upload the new headshot, and click Save Changes.",
+      "expected_skill": "muggle-do-task",
+      "fired": [
+        "muggle-do-task",
+        "muggle-do-task",
+        "muggle-do-task"
+      ],
+      "majority": "muggle-do-task",
+      "pass": true,
+      "note": "Navigate + edit profile fields + upload + save; settings-update action."
+    },
+    {
+      "query": "RSVP yes to the \"Founders Dinner\" event on our Luma page (lu.ma/founders-dinner-jun) using email contacts@muggle-ai.com, add a +1 named Alex Rivera, and submit the registration",
+      "expected_skill": "muggle-do-task",
+      "fired": [
+        "muggle-do-task",
+        "muggle-do-task",
+        "muggle-do-task"
+      ],
+      "majority": "muggle-do-task",
+      "pass": true,
+      "note": "Fill registration + submit on an events site; complete-the-flow intent."
+    },
+    {
+      "query": "go through the new-customer onboarding wizard on https://app.fathom-analytics.test, accept the cookie banner, enter site name \"muggle-ai.com\", pick the Free plan, skip the team-invite step, and finish setup",
+      "expected_skill": "muggle-do-task",
+      "fired": [
+        "muggle-do-task",
+        "muggle-do-task",
+        "muggle-do-task"
+      ],
+      "majority": "muggle-do-task",
+      "pass": true,
+      "note": "Click through a multi-step flow and complete it \u2014 the goal is to finish onboarding, not assert each screen renders. Borderline-flow phrasing but accomplish intent."
+    },
+    {
+      "query": "i set up the new password-reset page on localhost:3000 \u2014 can you actually run it end to end? enter dave@test.io, click send reset link, open the link from the mailhog inbox, set the new password to Hunter2!Hunter2!, and get me logged in. i just need to land on the dashboard with a working session, not a report.",
+      "expected_skill": "muggle-do-task",
+      "fired": [
+        "muggle-do-task",
+        "muggle-do-task",
+        "muggle-do-task"
+      ],
+      "majority": "muggle-do-task",
+      "pass": true,
+      "note": "HARD vs muggle-test-feature-local: 'run it end to end' on localhost sounds like a test, but the user explicitly wants the action accomplished (logged in, working session) and says 'not a report' \u2014 stays do-task."
+    },
+    {
+      "query": "walk through the checkout on our staging store and place a real order for me \u2014 add the Midnight Hoodie size L, apply promo code LAUNCH20, fill shipping as 14 Birch Ln, Austin TX 78701, and complete the purchase with the saved test card. i need the order to actually go through.",
+      "expected_skill": "muggle-do-task",
+      "fired": [
+        "muggle-do-task",
+        "muggle-do-task",
+        "muggle-do-task"
+      ],
+      "majority": "muggle-do-task",
+      "pass": true,
+      "note": "HARD vs feature-local: 'walk through the checkout' is test-flavored, but the user wants a real order placed ('actually go through') \u2014 accomplishment, not validation."
+    },
+    {
+      "query": "can you exercise the signup form on the deployed beta (beta.canopy.io) \u2014 fill name Jordan Lee, work email jordan@canopy.io, company Canopy, click Create Account \u2014 i want a real account provisioned so the sales team can demo on it tomorrow",
+      "expected_skill": "muggle-do-task",
+      "fired": [
+        "none",
+        "muggle-do-task",
+        "muggle-do-task"
+      ],
+      "majority": "muggle-do-task",
+      "pass": true,
+      "note": "HARD: 'exercise the signup form' reads like testing, but goal is a provisioned demo account \u2014 do-task."
+    },
+    {
+      "query": "go through the booking flow on opentable for Nobu Malibu, party of 4, this Friday 7:30pm under the name Kowalczyk, and lock in the reservation \u2014 make sure it's actually booked, don't just check that the calendar loads",
+      "expected_skill": "muggle-do-task",
+      "fired": [
+        "muggle-do-task",
+        "muggle-do-task",
+        "muggle-do-task"
+      ],
+      "majority": "muggle-do-task",
+      "pass": true,
+      "note": "HARD: 'go through the booking flow' + 'make sure it's actually booked' \u2014 the 'make sure' phrasing flirts with verification, but the action (a real reservation) is the point; explicitly NOT checking the page loads."
+    },
+    {
+      "query": "I need a real entry submitted to the conference CFP at https://cfp.jsconf.test \u2014 title \"Routing 14 skills with one eval\", abstract i'll paste, speaker contacts@muggle-ai.com, track Tooling \u2014 push it through to submitted, not draft. This is a genuine submission, not a dry run.",
+      "expected_skill": "muggle-do-task",
+      "fired": [
+        "muggle-do-task",
+        "muggle-do-task",
+        "muggle-do-task"
+      ],
+      "majority": "muggle-do-task",
+      "pass": true,
+      "note": "HARD: 'push it through' could read as testing the submit path, but the user wants a genuine CFP entry submitted ('not a dry run') \u2014 do-task."
+    },
+    {
+      "query": "run the full add-to-cart-and-checkout path on our prod site for the gift-card SKU GC-50, pay with the corporate Amex, and email me the receipt \u2014 i actually need to buy this gift card today, treat it as a normal purchase not a test",
+      "expected_skill": "muggle-do-task",
+      "fired": [
+        "none",
+        "none",
+        "none"
+      ],
+      "majority": "none",
+      "pass": false,
+      "note": "HARD: 'run the full path' is test vocabulary, but it's a literal purchase on prod ('treat it as a normal purchase not a test') \u2014 strongest accomplish signal."
+    },
+    {
+      "query": "Log into our HubSpot portal and create a deal in the \"Enterprise\" pipeline: name \"Globex - Platform License\", amount $48,000, stage Proposal Sent, close date end of next month, associate it with the Globex company record, and save.",
+      "expected_skill": "muggle-do-task",
+      "fired": [
+        "muggle-do-task",
+        "muggle-do-task",
+        "muggle-do-task"
+      ],
+      "majority": "muggle-do-task",
+      "pass": true,
+      "note": "CRM login + create + configure + save; multi-field data-entry action."
+    },
+    {
+      "query": "head to my router admin at 192.168.1.1, log in, go to wireless settings, change the 5GHz SSID to \"Kowalczyk-5G\", set the password to a strong one, enable WPA3, and apply the changes",
+      "expected_skill": "muggle-do-task",
+      "fired": [
+        "muggle-do-task",
+        "muggle-do-task",
+        "muggle-do-task"
+      ],
+      "majority": "muggle-do-task",
+      "pass": true,
+      "note": "Login + navigate settings + toggle + apply; device-config web action via UI."
+    },
+    {
+      "query": "post a new listing on Facebook Marketplace for me: \"IKEA KALLAX 4x2 shelf, white, great condition, $40, pickup in Capitol Hill\", category Furniture, add the 3 photos from my desktop, and publish it",
+      "expected_skill": "muggle-do-task",
+      "fired": [
+        "muggle-do-task",
+        "muggle-do-task",
+        "muggle-do-task"
+      ],
+      "majority": "muggle-do-task",
+      "pass": true,
+      "note": "Compose + populate + add media + publish a listing; content-posting action."
+    },
+    {
+      "query": "step 3 clicked the wrong button \u2014 it hit Cancel instead of Submit, give feedback on that test",
+      "expected_skill": "muggle-feedback",
+      "fired": [
+        "muggle-feedback",
+        "muggle-feedback",
+        "muggle-feedback"
+      ],
+      "majority": "muggle-feedback",
+      "pass": true,
+      "note": "step-level feedback, names step + wrong element clicked"
+    },
+    {
+      "query": "the muggle test was wrong, it logged in with my personal account instead of the test account",
+      "expected_skill": "muggle-feedback",
+      "fired": [
+        "muggle-feedback",
+        "muggle-feedback",
+        "muggle-feedback"
+      ],
+      "majority": "muggle-feedback",
+      "pass": true,
+      "note": "whole-script feedback, wrong account used"
+    },
+    {
+      "query": "the summary on that last run is incorrect \u2014 it says the checkout passed but it actually never reached the payment page",
+      "expected_skill": "muggle-feedback",
+      "fired": [
+        "muggle-feedback",
+        "muggle-feedback",
+        "muggle-feedback"
+      ],
+      "majority": "muggle-feedback",
+      "pass": true,
+      "note": "summary-wrong feedback on a run"
+    },
+    {
+      "query": "flag this run as bad, the generated script went completely off the rails after the search step",
+      "expected_skill": "muggle-feedback",
+      "fired": [
+        "muggle-feedback",
+        "muggle-feedback",
+        "muggle-feedback"
+      ],
+      "majority": "muggle-feedback",
+      "pass": true,
+      "note": "flag-this-run, whole-script went wrong"
+    },
+    {
+      "query": "show me all the feedback I've submitted so far",
+      "expected_skill": "muggle-feedback",
+      "fired": [
+        "muggle-feedback",
+        "muggle-feedback",
+        "muggle-feedback"
+      ],
+      "majority": "muggle-feedback",
+      "pass": true,
+      "note": "view/list prior feedback"
+    },
+    {
+      "query": "delete that feedback I left on the signup test yesterday, I had it wrong",
+      "expected_skill": "muggle-feedback",
+      "fired": [
+        "muggle-feedback",
+        "muggle-feedback",
+        "muggle-feedback"
+      ],
+      "majority": "muggle-feedback",
+      "pass": true,
+      "note": "delete prior feedback"
+    },
+    {
+      "query": "on step 5 the script typed into the wrong field \u2014 it put the email into the username box, can you record that as feedback?",
+      "expected_skill": "muggle-feedback",
+      "fired": [
+        "muggle-feedback",
+        "muggle-feedback",
+        "muggle-feedback"
+      ],
+      "majority": "muggle-feedback",
+      "pass": true,
+      "note": "step-level, wrong field targeted, explicit capture intent"
+    },
+    {
+      "query": "this whole generated test is garbage, it never actually verified the cart total like it was supposed to \u2014 let muggle know",
+      "expected_skill": "muggle-feedback",
+      "fired": [
+        "muggle-feedback",
+        "muggle-feedback",
+        "muggle-feedback"
+      ],
+      "majority": "muggle-feedback",
+      "pass": true,
+      "note": "whole-script feedback, missing assertion, regenerate intent"
+    },
+    {
+      "query": "give feedback on https://app.muggle.ai/dashboard/runs/8f2a1c \u2014 the script picked the wrong dropdown option in the middle",
+      "expected_skill": "muggle-feedback",
+      "fired": [
+        "muggle-feedback",
+        "muggle-feedback",
+        "muggle-feedback"
+      ],
+      "majority": "muggle-feedback",
+      "pass": true,
+      "note": "pasted Muggle dashboard run URL + step critique"
+    },
+    {
+      "query": "the run summary claims all 4 steps succeeded but step 2 clearly failed to dismiss the cookie banner \u2014 that's wrong",
+      "expected_skill": "muggle-feedback",
+      "fired": [
+        "muggle-feedback",
+        "muggle-feedback",
+        "muggle-feedback"
+      ],
+      "majority": "muggle-feedback",
+      "pass": true,
+      "note": "summary-wrong, contradicts a specific step"
+    },
+    {
+      "query": "list my feedback for the onboarding use case so I can see what I already flagged",
+      "expected_skill": "muggle-feedback",
+      "fired": [
+        "muggle-feedback",
+        "muggle-feedback",
+        "muggle-feedback"
+      ],
+      "majority": "muggle-feedback",
+      "pass": true,
+      "note": "view/list feedback scoped to a use case"
+    },
+    {
+      "query": "remove the feedback entry I added about the wrong button, I want to redo it properly",
+      "expected_skill": "muggle-feedback",
+      "fired": [
+        "muggle-feedback",
+        "muggle-feedback",
+        "muggle-feedback"
+      ],
+      "majority": "muggle-feedback",
+      "pass": true,
+      "note": "delete feedback to resubmit"
+    },
+    {
+      "query": "the script Muggle generated added the wrong product to the cart \u2014 it grabbed the blue one when the step said red, flag it so it regenerates",
+      "expected_skill": "muggle-feedback",
+      "fired": [
+        "muggle-feedback",
+        "muggle-feedback",
+        "muggle-feedback"
+      ],
+      "majority": "muggle-feedback",
+      "pass": true,
+      "note": "step-level wrong selection + explicit regenerate intent"
+    },
+    {
+      "query": "feedback on this run: it used the staging admin login when it should've used a regular member account",
+      "expected_skill": "muggle-feedback",
+      "fired": [
+        "TIMEOUT",
+        "muggle-feedback",
+        "muggle-feedback"
+      ],
+      "majority": "muggle-feedback",
+      "pass": true,
+      "note": "flag-this-run, wrong account/role"
+    },
+    {
+      "query": "the test summary is misleading, it reported a pass but the screenshots show the form errored out \u2014 can we fix that feedback?",
+      "expected_skill": "muggle-feedback",
+      "fired": [
+        "muggle-feedback",
+        "muggle-feedback",
+        "muggle-feedback"
+      ],
+      "majority": "muggle-feedback",
+      "pass": true,
+      "note": "summary-wrong, evidence mismatch"
+    },
+    {
+      "query": "can you pull up the feedback history on the payment-flow script? I think I left notes twice",
+      "expected_skill": "muggle-feedback",
+      "fired": [
+        "muggle-feedback",
+        "muggle-feedback",
+        "muggle-feedback"
+      ],
+      "majority": "muggle-feedback",
+      "pass": true,
+      "note": "view/list feedback for a specific script"
+    },
+    {
+      "query": "here's the muggle script https://app.muggle.ai/dashboard/scripts/proj-42/tc-19 \u2014 steps 6 through 8 are in the wrong order, log that",
+      "expected_skill": "muggle-feedback",
+      "fired": [
+        "muggle-feedback",
+        "muggle-feedback",
+        "muggle-feedback"
+      ],
+      "majority": "muggle-feedback",
+      "pass": true,
+      "note": "pasted Muggle dashboard script URL + multi-step ordering feedback"
+    },
+    {
+      "query": "that generated test clicked through to the wrong page entirely after auth, I want to tell muggle so it regenerates the script",
+      "expected_skill": "muggle-feedback",
+      "fired": [
+        "muggle-feedback",
+        "muggle-feedback",
+        "muggle-feedback"
+      ],
+      "majority": "muggle-feedback",
+      "pass": true,
+      "note": "whole-script wrong navigation + analyze/regenerate intent"
+    },
+    {
+      "query": "the muggle-generated script broke at the submit step \u2014 it kept clicking a submit button that doesn't apply the coupon first, so the test is wrong. record this so it gets regenerated",
+      "expected_skill": "muggle-feedback",
+      "fired": [
+        "muggle-feedback",
+        "muggle-feedback",
+        "muggle-feedback"
+      ],
+      "majority": "muggle-feedback",
+      "pass": true,
+      "note": "HARD near-boundary: reads like debugging 'broke at submit step' but intent is feedback on a Muggle-generated script, clearly about the generated test"
+    },
+    {
+      "query": "the script errored out at the login step on that last muggle run \u2014 but the real problem is muggle generated a step that targets an old selector, flag it so the script gets rebuilt",
+      "expected_skill": "muggle-feedback",
+      "fired": [
+        "muggle-feedback",
+        "muggle-feedback",
+        "muggle-feedback"
+      ],
+      "majority": "muggle-feedback",
+      "pass": true,
+      "note": "HARD near-boundary: 'errored at login step' sounds like debugging, but it's about a bad generated step in a Muggle run, regenerate intent"
+    },
+    {
+      "query": "the muggle test keeps failing on the date-picker step \u2014 it's not my app, the generated script is interacting with the calendar wrong, capture that as feedback",
+      "expected_skill": "muggle-feedback",
+      "fired": [
+        "muggle-feedback",
+        "muggle-feedback",
+        "muggle-feedback"
+      ],
+      "majority": "muggle-feedback",
+      "pass": true,
+      "note": "HARD near-boundary: 'keeps failing' debugging vibe, explicitly NOT user app, generated script is wrong"
+    },
+    {
+      "query": "the generated e2e script crashed halfway through the checkout flow because muggle scripted a wait on an element that never exists \u2014 please flag this run so muggle can analyze and regenerate",
+      "expected_skill": "muggle-feedback",
+      "fired": [
+        "muggle-feedback",
+        "muggle-feedback",
+        "muggle-feedback"
+      ],
+      "majority": "muggle-feedback",
+      "pass": true,
+      "note": "HARD near-boundary: 'crashed halfway' debugging language, but root cause is the generated script + flag/analyze/regenerate intent"
+    },
+    {
+      "query": "the muggle script for the search feature hangs at the results step \u2014 looks like the step it generated scrolls instead of clicking the result, the test is wrong, log feedback on it",
+      "expected_skill": "muggle-feedback",
+      "fired": [
+        "muggle-feedback",
+        "muggle-feedback",
+        "muggle-feedback"
+      ],
+      "majority": "muggle-feedback",
+      "pass": true,
+      "note": "HARD near-boundary: 'hangs at step' reads as debugging, but it's a wrong generated step in a Muggle test, feedback intent"
+    },
+    {
+      "query": "that remote muggle run failed at the upload step and I'm pretty sure it's because the generated script picks the wrong file input \u2014 flag the run as wrong so it regenerates",
+      "expected_skill": "muggle-feedback",
+      "fired": [
+        "muggle-feedback",
+        "muggle-feedback",
+        "muggle-feedback"
+      ],
+      "majority": "muggle-feedback",
+      "pass": true,
+      "note": "HARD near-boundary: 'failed at upload step' on a remote run, but the wrongness is the generated script and intent is to flag + regenerate"
+    },
+    {
+      "query": "The E2E run just finished green \u2014 post the visual walkthrough to PR #482 so the reviewers can see the screenshots.",
+      "expected_skill": "muggle-pr-visual-walkthrough",
+      "fired": [
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough"
+      ],
+      "majority": "muggle-pr-visual-walkthrough",
+      "pass": true,
+      "note": "Core: run already done, publish walkthrough with screenshots to PR."
+    },
+    {
+      "query": "Attach the step-by-step walkthrough from that last Muggle run onto PR 1207.",
+      "expected_skill": "muggle-pr-visual-walkthrough",
+      "fired": [
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough"
+      ],
+      "majority": "muggle-pr-visual-walkthrough",
+      "pass": true,
+      "note": "Core: attach existing per-step walkthrough to a numbered PR."
+    },
+    {
+      "query": "Can you drop the pass/fail summary and the dashboard links into the pull request? The acceptance suite already ran.",
+      "expected_skill": "muggle-pr-visual-walkthrough",
+      "fired": [
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough"
+      ],
+      "majority": "muggle-pr-visual-walkthrough",
+      "pass": true,
+      "note": "Core: add pass/fail summary + dashboard links; run already happened."
+    },
+    {
+      "query": "I want my reviewers to have visual proof the checkout flow works \u2014 share the E2E screenshots on the PR.",
+      "expected_skill": "muggle-pr-visual-walkthrough",
+      "fired": [
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough"
+      ],
+      "majority": "muggle-pr-visual-walkthrough",
+      "pass": true,
+      "note": "Core: give reviewers visual evidence via screenshots on the PR."
+    },
+    {
+      "query": "Post the Muggle results to the PR with the per-step screenshots and the dashboard link for each test case.",
+      "expected_skill": "muggle-pr-visual-walkthrough",
+      "fired": [
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough"
+      ],
+      "majority": "muggle-pr-visual-walkthrough",
+      "pass": true,
+      "note": "Core: post results, per-step screenshots, per-test-case dashboard links."
+    },
+    {
+      "query": "Add the visual walkthrough to PR #93 \u2014 the one with the signup and onboarding screenshots from this morning's run.",
+      "expected_skill": "muggle-pr-visual-walkthrough",
+      "fired": [
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough"
+      ],
+      "majority": "muggle-pr-visual-walkthrough",
+      "pass": true,
+      "note": "Core: add walkthrough to PR referencing this morning's completed run."
+    },
+    {
+      "query": "We finished the acceptance tests. Now put the screenshot summary on the pull request for the reviewers.",
+      "expected_skill": "muggle-pr-visual-walkthrough",
+      "fired": [
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough"
+      ],
+      "majority": "muggle-pr-visual-walkthrough",
+      "pass": true,
+      "note": "Core: explicit 'finished tests' then publish screenshot summary to PR."
+    },
+    {
+      "query": "Drop the dashboard links and the pass/fail breakdown into a comment on PR 558 so the team can click through the runs.",
+      "expected_skill": "muggle-pr-visual-walkthrough",
+      "fired": [
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough"
+      ],
+      "majority": "muggle-pr-visual-walkthrough",
+      "pass": true,
+      "note": "Core: dashboard links + pass/fail breakdown posted to PR; clickable evidence."
+    },
+    {
+      "query": "The run's done \u2014 embed the per-test-case walkthrough with screenshots into PR #2034.",
+      "expected_skill": "muggle-pr-visual-walkthrough",
+      "fired": [
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough"
+      ],
+      "majority": "muggle-pr-visual-walkthrough",
+      "pass": true,
+      "note": "Core: embed per-test-case walkthrough with screenshots; run complete."
+    },
+    {
+      "query": "Give the reviewers on this PR clickable visual evidence that the user flows passed \u2014 screenshots and dashboard links, please.",
+      "expected_skill": "muggle-pr-visual-walkthrough",
+      "fired": [
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough"
+      ],
+      "majority": "muggle-pr-visual-walkthrough",
+      "pass": true,
+      "note": "Core: reviewers + clickable visual evidence (screenshots, dashboard links)."
+    },
+    {
+      "query": "Publish the E2E walkthrough to PR 311 \u2014 include the pass/fail summary at the top and the step screenshots below.",
+      "expected_skill": "muggle-pr-visual-walkthrough",
+      "fired": [
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough"
+      ],
+      "majority": "muggle-pr-visual-walkthrough",
+      "pass": true,
+      "note": "Core: publish walkthrough with summary + step screenshots layout."
+    },
+    {
+      "query": "Stick the Muggle E2E results onto my PR. Reviewers keep asking for screenshots and the dashboard link.",
+      "expected_skill": "muggle-pr-visual-walkthrough",
+      "fired": [
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough"
+      ],
+      "majority": "muggle-pr-visual-walkthrough",
+      "pass": true,
+      "note": "Core: attach existing results to PR; reviewers want screenshots + link."
+    },
+    {
+      "query": "Share the visual walkthrough from the staging run on PR #777 so QA can review the screenshots without re-running.",
+      "expected_skill": "muggle-pr-visual-walkthrough",
+      "fired": [
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough"
+      ],
+      "majority": "muggle-pr-visual-walkthrough",
+      "pass": true,
+      "note": "Core: share existing staging-run walkthrough; explicitly no re-run."
+    },
+    {
+      "query": "Add a pass/fail summary plus the per-step screenshots to the pull request for the login refactor.",
+      "expected_skill": "muggle-pr-visual-walkthrough",
+      "fired": [
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough"
+      ],
+      "majority": "muggle-pr-visual-walkthrough",
+      "pass": true,
+      "note": "Core: pass/fail summary + per-step screenshots to a named PR."
+    },
+    {
+      "query": "Format the latest Muggle run as a visual section and post it to PR 145 with the dashboard links.",
+      "expected_skill": "muggle-pr-visual-walkthrough",
+      "fired": [
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough"
+      ],
+      "majority": "muggle-pr-visual-walkthrough",
+      "pass": true,
+      "note": "Core: format run as visual section, post to PR with dashboard links."
+    },
+    {
+      "query": "Can you put together the screenshot walkthrough and attach it to the PR? The tests already passed locally.",
+      "expected_skill": "muggle-pr-visual-walkthrough",
+      "fired": [
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough"
+      ],
+      "majority": "muggle-pr-visual-walkthrough",
+      "pass": true,
+      "note": "Core: assemble screenshot walkthrough, attach to PR; tests already passed."
+    },
+    {
+      "query": "Post results to the PR \u2014 the reviewers want to see the green checkmarks and the step-by-step screenshots from the run we just did.",
+      "expected_skill": "muggle-pr-visual-walkthrough",
+      "fired": [
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough"
+      ],
+      "majority": "muggle-pr-visual-walkthrough",
+      "pass": true,
+      "note": "Core: post results, pass markers, step screenshots from the run just completed."
+    },
+    {
+      "query": "The acceptance suite passed an hour ago. I just need the visual walkthrough and dashboard links posted to PR #66 now.",
+      "expected_skill": "muggle-pr-visual-walkthrough",
+      "fired": [
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough"
+      ],
+      "majority": "muggle-pr-visual-walkthrough",
+      "pass": true,
+      "note": "HARD: mentions acceptance suite + PR, but run already passed; intent is purely publish."
+    },
+    {
+      "query": "I already ran the E2E tests on the preview deploy \u2014 don't run anything again, just attach the screenshots and pass/fail summary to the PR.",
+      "expected_skill": "muggle-pr-visual-walkthrough",
+      "fired": [
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough"
+      ],
+      "majority": "muggle-pr-visual-walkthrough",
+      "pass": true,
+      "note": "HARD: explicitly already ran + 'don't run again', publish-only to PR."
+    },
+    {
+      "query": "Tests are done and on the dashboard. Take those existing results and put the visual walkthrough on PR 1290 for the reviewers.",
+      "expected_skill": "muggle-pr-visual-walkthrough",
+      "fired": [
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough"
+      ],
+      "majority": "muggle-pr-visual-walkthrough",
+      "pass": true,
+      "note": "HARD: results exist on dashboard; take existing results to PR (not a new run)."
+    },
+    {
+      "query": "We E2E-tested my changes earlier and everything's green \u2014 now I just want the screenshot summary published to the PR before merge.",
+      "expected_skill": "muggle-pr-visual-walkthrough",
+      "fired": [
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough"
+      ],
+      "majority": "muggle-pr-visual-walkthrough",
+      "pass": true,
+      "note": "HARD: 'E2E-tested my changes' phrasing (muggle-test vibe) but run is past; only publish to PR."
+    },
+    {
+      "query": "The Muggle run from this branch already completed. Surface the per-test-case screenshots and dashboard links onto the open PR.",
+      "expected_skill": "muggle-pr-visual-walkthrough",
+      "fired": [
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough"
+      ],
+      "majority": "muggle-pr-visual-walkthrough",
+      "pass": true,
+      "note": "HARD: run completed on branch; surface existing artifacts to PR, no rerun."
+    },
+    {
+      "query": "No need to re-test \u2014 the results from last night's run are still good. Post that walkthrough and pass/fail summary to PR #408.",
+      "expected_skill": "muggle-pr-visual-walkthrough",
+      "fired": [
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough"
+      ],
+      "majority": "muggle-pr-visual-walkthrough",
+      "pass": true,
+      "note": "HARD: explicit no re-test; reuse last night's results, publish walkthrough to PR."
+    },
+    {
+      "query": "Validation already ran and passed on staging. Just generate the visual walkthrough from those results and attach it to the pull request.",
+      "expected_skill": "muggle-pr-visual-walkthrough",
+      "fired": [
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough",
+        "muggle-pr-visual-walkthrough"
+      ],
+      "majority": "muggle-pr-visual-walkthrough",
+      "pass": true,
+      "note": "HARD: 'validation ran and passed' (overlaps muggle-test) but past-tense; only build+attach walkthrough."
+    },
+    {
+      "query": "show me my current muggle preferences",
+      "expected_skill": "muggle-preferences",
+      "fired": [
+        "muggle-preferences",
+        "muggle-preferences",
+        "muggle-preferences"
+      ],
+      "majority": "muggle-preferences",
+      "pass": true,
+      "note": "view settings \u2014 canonical phrasing"
+    },
+    {
+      "query": "what are my muggle settings right now?",
+      "expected_skill": "muggle-preferences",
+      "fired": [
+        "muggle-preferences",
+        "muggle-preferences",
+        "muggle-preferences"
+      ],
+      "majority": "muggle-preferences",
+      "pass": true,
+      "note": "view settings \u2014 colloquial register"
+    },
+    {
+      "query": "set autoLogin to always in muggle",
+      "expected_skill": "muggle-preferences",
+      "fired": [
+        "muggle-preferences",
+        "muggle-preferences",
+        "muggle-preferences"
+      ],
+      "majority": "muggle-preferences",
+      "pass": true,
+      "note": "set a specific pref \u2014 autoLogin"
+    },
+    {
+      "query": "change my default run mode to remote",
+      "expected_skill": "muggle-preferences",
+      "fired": [
+        "muggle-preferences",
+        "muggle-preferences",
+        "muggle-preferences"
+      ],
+      "majority": "muggle-preferences",
+      "pass": true,
+      "note": "set a specific pref \u2014 default local vs remote runs"
+    },
+    {
+      "query": "turn on autoRebase in muggle config",
+      "expected_skill": "muggle-preferences",
+      "fired": [
+        "muggle-preferences",
+        "muggle-preferences",
+        "muggle-preferences"
+      ],
+      "majority": "muggle-preferences",
+      "pass": true,
+      "note": "set a specific pref \u2014 autoRebase"
+    },
+    {
+      "query": "disable autoSelectProject so muggle stops picking a project for me",
+      "expected_skill": "muggle-preferences",
+      "fired": [
+        "muggle-preferences",
+        "muggle-preferences",
+        "muggle-preferences"
+      ],
+      "majority": "muggle-preferences",
+      "pass": true,
+      "note": "change behavior \u2014 autoSelectProject"
+    },
+    {
+      "query": "reset all my muggle preferences back to defaults",
+      "expected_skill": "muggle-preferences",
+      "fired": [
+        "muggle-preferences",
+        "muggle-preferences",
+        "muggle-preferences"
+      ],
+      "majority": "muggle-preferences",
+      "pass": true,
+      "note": "reset to defaults"
+    },
+    {
+      "query": "configure muggle to default to local runs instead of remote",
+      "expected_skill": "muggle-preferences",
+      "fired": [
+        "muggle-preferences",
+        "muggle-preferences",
+        "muggle-preferences"
+      ],
+      "majority": "muggle-preferences",
+      "pass": true,
+      "note": "configure muggle \u2014 default run mode"
+    },
+    {
+      "query": "I want muggle to stop prompting me to log in every time, what setting controls that?",
+      "expected_skill": "muggle-preferences",
+      "fired": [
+        "muggle-preferences",
+        "muggle-preferences",
+        "muggle-preferences"
+      ],
+      "majority": "muggle-preferences",
+      "pass": true,
+      "note": "view + set \u2014 autoLogin discovery"
+    },
+    {
+      "query": "switch off the muggle update-check so it quits nagging me about new versions",
+      "expected_skill": "muggle-preferences",
+      "fired": [
+        "muggle-preferences",
+        "muggle-preferences",
+        "muggle-preferences"
+      ],
+      "majority": "muggle-preferences",
+      "pass": true,
+      "note": "set a specific pref \u2014 update-check"
+    },
+    {
+      "query": "can you walk me through muggle setup and the preferences I should pick?",
+      "expected_skill": "muggle-preferences",
+      "fired": [
+        "muggle-preferences",
+        "muggle-preferences",
+        "muggle-preferences"
+      ],
+      "majority": "muggle-preferences",
+      "pass": true,
+      "note": "configure muggle \u2014 setup/onboarding"
+    },
+    {
+      "query": "make remote the default whenever I kick off a muggle test run",
+      "expected_skill": "muggle-preferences",
+      "fired": [
+        "muggle-preferences",
+        "muggle-preferences",
+        "muggle-preferences"
+      ],
+      "majority": "muggle-preferences",
+      "pass": true,
+      "note": "change behavior \u2014 default run mode without saying 'preference'"
+    },
+    {
+      "query": "list every muggle preference and its current value",
+      "expected_skill": "muggle-preferences",
+      "fired": [
+        "muggle-preferences",
+        "muggle-preferences",
+        "muggle-preferences"
+      ],
+      "majority": "muggle-preferences",
+      "pass": true,
+      "note": "view settings \u2014 exhaustive listing"
+    },
+    {
+      "query": "set my muggle autoLogin preference to never",
+      "expected_skill": "muggle-preferences",
+      "fired": [
+        "muggle-preferences",
+        "muggle-preferences",
+        "muggle-preferences"
+      ],
+      "majority": "muggle-preferences",
+      "pass": true,
+      "note": "set a specific pref \u2014 autoLogin to never"
+    },
+    {
+      "query": "I keep getting auto-rebased on every run, where do I turn autoRebase off in muggle?",
+      "expected_skill": "muggle-preferences",
+      "fired": [
+        "muggle-preferences",
+        "muggle-preferences",
+        "muggle-preferences"
+      ],
+      "majority": "muggle-preferences",
+      "pass": true,
+      "note": "change behavior \u2014 autoRebase off"
+    },
+    {
+      "query": "reset just the run-mode preference in muggle back to its default",
+      "expected_skill": "muggle-preferences",
+      "fired": [
+        "muggle-preferences",
+        "muggle-preferences",
+        "muggle-preferences"
+      ],
+      "majority": "muggle-preferences",
+      "pass": true,
+      "note": "reset a single pref to default"
+    },
+    {
+      "query": "update my muggle config so it auto-selects the project by folder name",
+      "expected_skill": "muggle-preferences",
+      "fired": [
+        "muggle-preferences",
+        "muggle-preferences",
+        "muggle-preferences"
+      ],
+      "majority": "muggle-preferences",
+      "pass": true,
+      "note": "set a specific pref \u2014 autoSelectProject on; HARD: says 'config' but clearly muggle"
+    },
+    {
+      "query": "where do muggle's settings live and how do I edit autoLogin there?",
+      "expected_skill": "muggle-preferences",
+      "fired": [
+        "muggle-preferences",
+        "muggle-preferences",
+        "muggle-preferences"
+      ],
+      "majority": "muggle-preferences",
+      "pass": true,
+      "note": "HARD near-boundary \u2014 sounds like a config-file/dotfile question but is unambiguously about a muggle preference"
+    },
+    {
+      "query": "my muggle config has the wrong default run mode, fix the setting to remote",
+      "expected_skill": "muggle-preferences",
+      "fired": [
+        "muggle-preferences",
+        "muggle-preferences",
+        "muggle-preferences"
+      ],
+      "majority": "muggle-preferences",
+      "pass": true,
+      "note": "HARD near-boundary \u2014 'config' + 'fix' could tempt repair/general-config, but it's a muggle preference change"
+    },
+    {
+      "query": "I've got eslint and prettier dialed in already \u2014 now help me set my muggle preferences, starting with autoRebase",
+      "expected_skill": "muggle-preferences",
+      "fired": [
+        "muggle-preferences",
+        "muggle-preferences",
+        "muggle-preferences"
+      ],
+      "majority": "muggle-preferences",
+      "pass": true,
+      "note": "HARD near-boundary \u2014 explicitly mentions eslint/prettier (negatives) but the actual ask is muggle prefs"
+    },
+    {
+      "query": "is there a muggle setting to skip the login step automatically? if so flip it on",
+      "expected_skill": "muggle-preferences",
+      "fired": [
+        "muggle-preferences",
+        "muggle-preferences",
+        "muggle-preferences"
+      ],
+      "majority": "muggle-preferences",
+      "pass": true,
+      "note": "HARD near-boundary \u2014 'login step' could hint at status/auth, but it's the autoLogin preference"
+    },
+    {
+      "query": "turn off the muggle version update-check the same way I'd disable it in git config",
+      "expected_skill": "muggle-preferences",
+      "fired": [
+        "muggle-preferences",
+        "muggle-preferences",
+        "muggle-preferences"
+      ],
+      "majority": "muggle-preferences",
+      "pass": true,
+      "note": "HARD near-boundary \u2014 references 'git config' as analogy (negative) but targets the muggle update-check pref"
+    },
+    {
+      "query": "change my muggle defaults so new runs go remote and projects auto-select \u2014 both at once",
+      "expected_skill": "muggle-preferences",
+      "fired": [
+        "muggle-preferences",
+        "muggle-preferences",
+        "muggle-preferences"
+      ],
+      "majority": "muggle-preferences",
+      "pass": true,
+      "note": "HARD near-boundary \u2014 'defaults' + multi-setting; clearly muggle run-mode + autoSelectProject prefs, not general tooling"
+    },
+    {
+      "query": "show my muggle config and then set autoLogin to prompt",
+      "expected_skill": "muggle-preferences",
+      "fired": [
+        "muggle-preferences",
+        "muggle-preferences",
+        "muggle-preferences"
+      ],
+      "majority": "muggle-preferences",
+      "pass": true,
+      "note": "view then set \u2014 combined view + set a specific pref"
+    },
+    {
+      "query": "muggle repair",
+      "expected_skill": "muggle-repair",
+      "fired": [
+        "muggle-repair",
+        "muggle-repair",
+        "muggle-repair"
+      ],
+      "majority": "muggle-repair",
+      "pass": true,
+      "note": "Canonical explicit invocation of the repair skill."
+    },
+    {
+      "query": "Run muggle repair, my setup is hosed.",
+      "expected_skill": "muggle-repair",
+      "fired": [
+        "muggle-repair",
+        "muggle-repair",
+        "muggle-repair"
+      ],
+      "majority": "muggle-repair",
+      "pass": true,
+      "note": "Explicit 'muggle repair' plus broken-setup framing."
+    },
+    {
+      "query": "My muggle install is completely busted, can you fix it?",
+      "expected_skill": "muggle-repair",
+      "fired": [
+        "muggle-repair",
+        "muggle-repair",
+        "muggle-repair"
+      ],
+      "majority": "muggle-repair",
+      "pass": true,
+      "note": "Plain 'busted, fix it' broken-install repair intent."
+    },
+    {
+      "query": "The muggle MCP server won't load in Claude \u2014 please repair the install.",
+      "expected_skill": "muggle-repair",
+      "fired": [
+        "muggle-repair",
+        "muggle-repair",
+        "muggle-repair"
+      ],
+      "majority": "muggle-repair",
+      "pass": true,
+      "note": "MCP won't load -> explicit repair request."
+    },
+    {
+      "query": "Reinstall the muggle tooling for me, it's broken.",
+      "expected_skill": "muggle-repair",
+      "fired": [
+        "muggle-repair",
+        "muggle-repair",
+        "muggle-repair"
+      ],
+      "majority": "muggle-repair",
+      "pass": true,
+      "note": "Reinstall/repair tooling, broken install."
+    },
+    {
+      "query": "Something corrupted my muggle setup after the last update. Fix it.",
+      "expected_skill": "muggle-repair",
+      "fired": [
+        "muggle-repair",
+        "muggle-repair",
+        "muggle-repair"
+      ],
+      "majority": "muggle-repair",
+      "pass": true,
+      "note": "Corrupted setup, direct fix command."
+    },
+    {
+      "query": "Claude says the muggle MCP failed to connect. Can you get it working again?",
+      "expected_skill": "muggle-repair",
+      "fired": [
+        "muggle-repair",
+        "muggle-repair",
+        "muggle-repair"
+      ],
+      "majority": "muggle-repair",
+      "pass": true,
+      "note": "MCP failed to connect -> restore/fix intent."
+    },
+    {
+      "query": "Please repair my broken Muggle Test installation.",
+      "expected_skill": "muggle-repair",
+      "fired": [
+        "muggle-repair",
+        "muggle-repair",
+        "muggle-repair"
+      ],
+      "majority": "muggle-repair",
+      "pass": true,
+      "note": "Explicit 'repair' + 'broken installation'."
+    },
+    {
+      "query": "muggle keeps erroring on startup \u2014 reinstall and repair the whole thing.",
+      "expected_skill": "muggle-repair",
+      "fired": [
+        "muggle-repair",
+        "muggle-repair",
+        "muggle-repair"
+      ],
+      "majority": "muggle-repair",
+      "pass": true,
+      "note": "Startup errors, reinstall + repair tooling."
+    },
+    {
+      "query": "The muggle CLI is throwing 'command not found' even though I installed it. Fix the install.",
+      "expected_skill": "muggle-repair",
+      "fired": [
+        "muggle-repair",
+        "muggle-repair",
+        "muggle-repair"
+      ],
+      "majority": "muggle-repair",
+      "pass": true,
+      "note": "Broken binary/PATH, explicit fix the install."
+    },
+    {
+      "query": "My muggle MCP shows up red/disconnected in Claude \u2014 go ahead and fix it.",
+      "expected_skill": "muggle-repair",
+      "fired": [
+        "muggle-repair",
+        "muggle-repair",
+        "muggle-repair"
+      ],
+      "majority": "muggle-repair",
+      "pass": true,
+      "note": "MCP disconnected -> explicit go-ahead to fix (not just report)."
+    },
+    {
+      "query": "I think my muggle config got wiped. Rebuild the install so it works again.",
+      "expected_skill": "muggle-repair",
+      "fired": [
+        "muggle-repair",
+        "muggle-repair",
+        "muggle-repair"
+      ],
+      "majority": "muggle-repair",
+      "pass": true,
+      "note": "Wiped config -> rebuild/repair the install."
+    },
+    {
+      "query": "Repair muggle \u2014 the electron app and MCP are both refusing to start.",
+      "expected_skill": "muggle-repair",
+      "fired": [
+        "muggle-repair",
+        "muggle-repair",
+        "muggle-repair"
+      ],
+      "majority": "muggle-repair",
+      "pass": true,
+      "note": "Explicit repair, multiple components failing."
+    },
+    {
+      "query": "Nuke and reinstall muggle, the current install is beyond fixing.",
+      "expected_skill": "muggle-repair",
+      "fired": [
+        "muggle-repair",
+        "muggle-repair",
+        "muggle-repair"
+      ],
+      "majority": "muggle-repair",
+      "pass": true,
+      "note": "Reinstall tooling from scratch, repair-class action."
+    },
+    {
+      "query": "After upgrading my OS the muggle MCP stopped loading. Get it loading again, please.",
+      "expected_skill": "muggle-repair",
+      "fired": [
+        "muggle-repair",
+        "muggle-repair",
+        "muggle-repair"
+      ],
+      "majority": "muggle-repair",
+      "pass": true,
+      "note": "MCP won't load post-OS-change -> restore/repair."
+    },
+    {
+      "query": "muggle's broken and I have no idea why \u2014 just repair it.",
+      "expected_skill": "muggle-repair",
+      "fired": [
+        "muggle-repair",
+        "muggle-repair",
+        "muggle-repair"
+      ],
+      "majority": "muggle-repair",
+      "pass": true,
+      "note": "Vague brokenness BUT explicit 'just repair it' so it doesn't collapse to status."
+    },
+    {
+      "query": "The muggle MCP won't connect \u2014 diagnose the cause and then fix it for me.",
+      "expected_skill": "muggle-repair",
+      "fired": [
+        "muggle-repair",
+        "muggle-repair",
+        "muggle-repair"
+      ],
+      "majority": "muggle-repair",
+      "pass": true,
+      "note": "HARD vs status: includes diagnose, but the operative ask is the fix; repair owns diagnose-then-fix."
+    },
+    {
+      "query": "muggle status said the MCP is unhealthy. Now actually repair it.",
+      "expected_skill": "muggle-repair",
+      "fired": [
+        "muggle-repair",
+        "muggle-repair",
+        "muggle-repair"
+      ],
+      "majority": "muggle-repair",
+      "pass": true,
+      "note": "HARD vs status: status already ran/reported; user now wants the fix action -> repair."
+    },
+    {
+      "query": "Don't just tell me what's wrong with muggle \u2014 go fix whatever's broken.",
+      "expected_skill": "muggle-repair",
+      "fired": [
+        "muggle-repair",
+        "muggle-repair",
+        "muggle-repair"
+      ],
+      "majority": "muggle-repair",
+      "pass": true,
+      "note": "HARD vs status: explicitly rejects report-only, demands the fix -> repair."
+    },
+    {
+      "query": "muggle's acting up and the MCP keeps dropping. Find the problem and repair the install.",
+      "expected_skill": "muggle-repair",
+      "fired": [
+        "muggle-repair",
+        "muggle-repair",
+        "muggle-repair"
+      ],
+      "majority": "muggle-repair",
+      "pass": true,
+      "note": "HARD vs status: 'acting up' would lean status, but 'repair the install' pins it to repair."
+    },
+    {
+      "query": "Check why the muggle MCP isn't loading and then reinstall whatever's broken to fix it.",
+      "expected_skill": "muggle-repair",
+      "fired": [
+        "muggle-repair",
+        "muggle-repair",
+        "muggle-repair"
+      ],
+      "majority": "muggle-repair",
+      "pass": true,
+      "note": "HARD vs status: check is subordinate to reinstall/fix the broken piece -> repair."
+    },
+    {
+      "query": "Is muggle broken? If so, fix it right now \u2014 don't make me run another command.",
+      "expected_skill": "muggle-repair",
+      "fired": [
+        "muggle-status",
+        "muggle-status",
+        "muggle-repair"
+      ],
+      "majority": "muggle-status",
+      "pass": false,
+      "note": "HARD vs status: starts as a check but the action intent is fix-now -> repair."
+    },
+    {
+      "query": "My muggle auth and MCP both broke at once \u2014 repair the whole installation.",
+      "expected_skill": "muggle-repair",
+      "fired": [
+        "muggle-repair",
+        "muggle-repair",
+        "TIMEOUT"
+      ],
+      "majority": "muggle-repair",
+      "pass": true,
+      "note": "Multiple subsystems broken, explicit repair the installation."
+    },
+    {
+      "query": "Whatever broke in my muggle install during the npm update, undo it and get muggle working again.",
+      "expected_skill": "muggle-repair",
+      "fired": [
+        "muggle-repair",
+        "muggle-repair",
+        "muggle-repair"
+      ],
+      "majority": "muggle-repair",
+      "pass": true,
+      "note": "Broken-by-update install, repair/restore to working state."
+    },
+    {
+      "query": "muggle status",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status",
+        "muggle-status",
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Explicit canonical trigger \u2014 bare status command."
+    },
+    {
+      "query": "Can you run muggle status for me real quick?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status",
+        "muggle-status",
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Explicit status request, casual phrasing."
+    },
+    {
+      "query": "Is my Muggle install healthy right now?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status",
+        "muggle-status",
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Direct health-check intent."
+    },
+    {
+      "query": "Check whether the Muggle MCP is connected properly.",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status",
+        "muggle-status",
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "MCP connection health check."
+    },
+    {
+      "query": "Is my muggle auth still valid or did my login expire?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status",
+        "muggle-status",
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Auth/login validity check."
+    },
+    {
+      "query": "I want to make sure muggle is set up correctly before I start testing.",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status",
+        "muggle-status",
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "\"Is it set up right\" verification intent."
+    },
+    {
+      "query": "Give me a full health report on my Muggle Test setup.",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status",
+        "muggle-status",
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Health report = diagnose/report, status."
+    },
+    {
+      "query": "Are the muggle MCP tools actually loading? Want to confirm they're live.",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "none",
+        "muggle-status",
+        "none"
+      ],
+      "majority": "none",
+      "pass": false,
+      "note": "MCP health, confirm not fix."
+    },
+    {
+      "query": "Did my Muggle session token expire? Check my auth please.",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status",
+        "muggle-status",
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Auth validity diagnose."
+    },
+    {
+      "query": "Verify that everything in my muggle environment is wired up right.",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status",
+        "muggle-status",
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Setup correctness check."
+    },
+    {
+      "query": "Can you confirm Muggle is talking to the backend okay?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status",
+        "muggle-status",
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Connectivity/health confirmation."
+    },
+    {
+      "query": "What's the current state of my muggle installation \u2014 all green?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status",
+        "muggle-status",
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Status report phrasing."
+    },
+    {
+      "query": "I just installed muggle. Can you check it's configured properly?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status",
+        "muggle-status",
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Post-install setup verification."
+    },
+    {
+      "query": "Run a quick diagnostic on muggle and tell me if anything looks off.",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status",
+        "muggle-status",
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Diagnose-only intent, report findings."
+    },
+    {
+      "query": "Is the muggle MCP server reachable from here? Just checking.",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "none",
+        "none",
+        "none"
+      ],
+      "majority": "none",
+      "pass": false,
+      "note": "MCP reachability check, diagnose."
+    },
+    {
+      "query": "muggle's been acting up today \u2014 can you take a look and tell me what's wrong?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "none",
+        "none",
+        "none"
+      ],
+      "majority": "none",
+      "pass": false,
+      "note": "HARD near-boundary: ambiguous \"acting up\" + diagnose intent, leans status (diagnose before fix)."
+    },
+    {
+      "query": "Muggle isn't responding when I try to run tests. Is something broken with it?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "none",
+        "none",
+        "none"
+      ],
+      "majority": "none",
+      "pass": false,
+      "note": "HARD near-boundary: \"is something broken?\" is diagnose, not \"fix it\" \u2192 status."
+    },
+    {
+      "query": "The MCP keeps timing out \u2014 can you figure out if it's a muggle health issue?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "none",
+        "none",
+        "none"
+      ],
+      "majority": "none",
+      "pass": false,
+      "note": "HARD near-boundary: investigate cause vs repair; intent is diagnose \u2192 status."
+    },
+    {
+      "query": "I think my muggle login might be busted. Can you check before I do anything?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "none",
+        "none",
+        "none"
+      ],
+      "majority": "none",
+      "pass": false,
+      "note": "HARD near-boundary: suspects breakage but asks to CHECK first \u2192 status."
+    },
+    {
+      "query": "Muggle commands are failing silently. Is it me or is the install unhealthy?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "none",
+        "none",
+        "none"
+      ],
+      "majority": "none",
+      "pass": false,
+      "note": "HARD near-boundary: \"is the install unhealthy?\" diagnose framing \u2192 status."
+    },
+    {
+      "query": "Something feels off with muggle \u2014 diagnose it for me, don't fix anything yet.",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "none",
+        "none",
+        "none"
+      ],
+      "majority": "none",
+      "pass": false,
+      "note": "HARD near-boundary: explicit diagnose-only, defer fixing \u2192 status."
+    },
+    {
+      "query": "Before I report a bug, can you tell me if my muggle auth and MCP are healthy?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "none",
+        "none",
+        "none"
+      ],
+      "majority": "none",
+      "pass": false,
+      "note": "Health check of auth + MCP, report intent."
+    },
+    {
+      "query": "Why does muggle keep saying it can't connect? Check its status for me.",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "none",
+        "none",
+        "none"
+      ],
+      "majority": "none",
+      "pass": false,
+      "note": "Connectivity symptom + explicit status check."
+    },
+    {
+      "query": "Quick sanity check \u2014 is muggle good to go or is there a problem with the setup?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "none",
+        "none",
+        "none"
+      ],
+      "majority": "none",
+      "pass": false,
+      "note": "Sanity/health check, diagnose whether setup is okay."
+    },
+    {
+      "query": "muggle",
+      "expected_skill": "muggle",
+      "fired": [
+        "muggle",
+        "muggle",
+        "muggle"
+      ],
+      "majority": "muggle",
+      "pass": true,
+      "note": "bare token \u2014 pure router/menu entrance"
+    },
+    {
+      "query": "/muggle",
+      "expected_skill": "muggle",
+      "fired": [
+        "none",
+        "none",
+        "none"
+      ],
+      "majority": "none",
+      "pass": false,
+      "note": "explicit slash command for the router/menu"
+    },
+    {
+      "query": "what can muggle do?",
+      "expected_skill": "muggle",
+      "fired": [
+        "muggle",
+        "muggle",
+        "muggle"
+      ],
+      "majority": "muggle",
+      "pass": true,
+      "note": "capability discovery \u2014 wants the menu of available commands"
+    },
+    {
+      "query": "muggle help",
+      "expected_skill": "muggle",
+      "fired": [
+        "muggle",
+        "muggle",
+        "muggle"
+      ],
+      "majority": "muggle",
+      "pass": true,
+      "note": "help request, no specific intent \u2014 menu fallback"
+    },
+    {
+      "query": "muggle menu",
+      "expected_skill": "muggle",
+      "fired": [
+        "muggle",
+        "muggle",
+        "muggle"
+      ],
+      "majority": "muggle",
+      "pass": true,
+      "note": "explicit menu request"
+    },
+    {
+      "query": "show me the muggle options",
+      "expected_skill": "muggle",
+      "fired": [
+        "muggle",
+        "muggle",
+        "muggle"
+      ],
+      "majority": "muggle",
+      "pass": true,
+      "note": "list available options \u2014 router"
+    },
+    {
+      "query": "hey what commands does muggle have",
+      "expected_skill": "muggle",
+      "fired": [
+        "muggle",
+        "muggle",
+        "muggle"
+      ],
+      "majority": "muggle",
+      "pass": true,
+      "note": "casual capability discovery"
+    },
+    {
+      "query": "i just installed the muggle plugin, what are all the things it can do?",
+      "expected_skill": "muggle",
+      "fired": [
+        "muggle",
+        "muggle",
+        "muggle"
+      ],
+      "majority": "muggle",
+      "pass": true,
+      "note": "new user with backstory, wants full command list"
+    },
+    {
+      "query": "list everything muggle can do for me",
+      "expected_skill": "muggle",
+      "fired": [
+        "muggle",
+        "muggle",
+        "muggle"
+      ],
+      "majority": "muggle",
+      "pass": true,
+      "note": "enumerate all commands \u2014 menu"
+    },
+    {
+      "query": "not sure what to do with muggle, where do i even start",
+      "expected_skill": "muggle",
+      "fired": [
+        "muggle",
+        "muggle",
+        "muggle"
+      ],
+      "majority": "muggle",
+      "pass": true,
+      "note": "intent absent, unsure \u2014 menu fallback"
+    },
+    {
+      "query": "I keep hearing about muggle from my team but I have no idea what it actually offers \u2014 can you lay it out?",
+      "expected_skill": "muggle",
+      "fired": [
+        "muggle",
+        "muggle",
+        "muggle"
+      ],
+      "majority": "muggle",
+      "pass": true,
+      "note": "backstory, genuinely no specific intent \u2014 menu"
+    },
+    {
+      "query": "muggle commands",
+      "expected_skill": "muggle",
+      "fired": [
+        "muggle",
+        "muggle",
+        "muggle"
+      ],
+      "majority": "muggle",
+      "pass": true,
+      "note": "wants the command listing"
+    },
+    {
+      "query": "whats the deal with muggle, give me the rundown of features",
+      "expected_skill": "muggle",
+      "fired": [
+        "muggle",
+        "muggle",
+        "muggle"
+      ],
+      "majority": "muggle",
+      "pass": true,
+      "note": "casual lowercase, overview request \u2014 router"
+    },
+    {
+      "query": "open the muggle menu so I can pick what I need",
+      "expected_skill": "muggle",
+      "fired": [
+        "muggle",
+        "muggle",
+        "muggle"
+      ],
+      "majority": "muggle",
+      "pass": true,
+      "note": "explicitly wants to choose from the menu"
+    },
+    {
+      "query": "im new to muggle ai, walk me through what's available",
+      "expected_skill": "muggle",
+      "fired": [
+        "muggle",
+        "muggle",
+        "muggle"
+      ],
+      "majority": "muggle",
+      "pass": true,
+      "note": "onboarding, no concrete task yet \u2014 menu"
+    },
+    {
+      "query": "muggle ? what are my choices here",
+      "expected_skill": "muggle",
+      "fired": [
+        "muggle",
+        "muggle",
+        "muggle"
+      ],
+      "majority": "muggle",
+      "pass": true,
+      "note": "asking for choices, ambiguous intent \u2014 router"
+    },
+    {
+      "query": "gimme the muggle command list pls",
+      "expected_skill": "muggle",
+      "fired": [
+        "muggle",
+        "muggle",
+        "muggle"
+      ],
+      "majority": "muggle",
+      "pass": true,
+      "note": "casual/abbreviated, command listing"
+    },
+    {
+      "query": "can you show me what muggle offers, im trying to figure out which command fits my situation",
+      "expected_skill": "muggle",
+      "fired": [
+        "muggle",
+        "muggle",
+        "muggle"
+      ],
+      "majority": "muggle",
+      "pass": true,
+      "note": "decision support \u2014 needs the menu to choose"
+    },
+    {
+      "query": "I want to do something with muggle but honestly I'm not sure which feature applies \u2014 show me everything first",
+      "expected_skill": "muggle",
+      "fired": [
+        "muggle",
+        "muggle",
+        "muggle"
+      ],
+      "majority": "muggle",
+      "pass": true,
+      "note": "intent genuinely absent, asks to see all before deciding \u2014 menu"
+    },
+    {
+      "query": "I think I want to use muggle for my testing somehow but I'm not sure which part \u2014 what are the testing-related commands?",
+      "expected_skill": "muggle",
+      "fired": [
+        "muggle",
+        "muggle",
+        "muggle"
+      ],
+      "majority": "muggle",
+      "pass": true,
+      "note": "HARD: mentions testing area but vague across multiple test skills \u2014 wants the menu, not one specific test skill"
+    },
+    {
+      "query": "something to do with muggle and my PR i think? not sure what the right command is, can you show options",
+      "expected_skill": "muggle",
+      "fired": [
+        "muggle",
+        "muggle",
+        "muggle"
+      ],
+      "majority": "muggle",
+      "pass": true,
+      "note": "HARD: mentions PR area but unsure which (walkthrough vs test) \u2014 menu rather than a specific skill"
+    },
+    {
+      "query": "muggle config stuff \u2014 actually wait, what config-ish commands even exist? list them",
+      "expected_skill": "muggle",
+      "fired": [
+        "muggle",
+        "muggle",
+        "muggle"
+      ],
+      "majority": "muggle",
+      "pass": true,
+      "note": "HARD: mentions config but asks to see the broader command set \u2014 router, not preferences directly"
+    },
+    {
+      "query": "I need muggle to help with my scripts but idk if that's import, regenerate, or run \u2014 what are all the muggle script commands?",
+      "expected_skill": "muggle",
+      "fired": [
+        "muggle",
+        "muggle",
+        "muggle"
+      ],
+      "majority": "muggle",
+      "pass": true,
+      "note": "HARD: names a fuzzy area spanning import/regen/test \u2014 too ambiguous for one skill, wants the menu"
+    },
+    {
+      "query": "is there a muggle thing for checking on stuff? not sure if it's status or something else, show me the list",
+      "expected_skill": "muggle",
+      "fired": [
+        "muggle",
+        "muggle",
+        "muggle"
+      ],
+      "majority": "muggle",
+      "pass": true,
+      "note": "HARD: hints at status/health area but unsure \u2014 disambiguate via the menu, not muggle-status directly"
+    }
+  ]
+}

--- a/internal/skill-routing-eval/reports/expanded-eval-partial.md
+++ b/internal/skill-routing-eval/reports/expanded-eval-partial.md
@@ -1,0 +1,25 @@
+# Expanded eval — partial run (7 of 14 skills)
+
+Status: **incomplete.** The expanded 391-case run (~1,092 `claude -p` sessions) hit the account session limit partway through. 7 skills completed (169 queries); the rest (`muggle-test`, `-test-feature-local`, `-test-import`, `-test-prepare`, `-test-regenerate-missing`, `muggle-upgrade`, `muggle-pr-followup`, and the `none` negatives) are queued for a resumed run. Re-run the remaining chunks after the limit resets; see `README.md` for the per-skill chunked recipe.
+
+Partial accuracy on the completed 7: **151/169 = 89.3%**. These misses are interleaved with passes (not a contiguous all-`none` tail), so they are genuine recall gaps, not the MCP-disconnect artifact described in `final.md`.
+
+## Completed skills
+
+| skill | recall | note |
+|---|---|---|
+| muggle-feedback | 24/24 | clean |
+| muggle-pr-visual-walkthrough | 24/24 | clean |
+| muggle-preferences | 24/24 | clean |
+| muggle | 23/24 | bare `/muggle` → none ×3 |
+| muggle-repair | 23/24 | "is it broken? fix it" → muggle-status (status/repair boundary) |
+| muggle-do-task | 20/25 | 5 action queries → none |
+| muggle-status | 13/24 | **54% — question-phrased health checks → none** |
+
+## New findings (not visible in the 78-case set, which scored these 100%)
+
+1. **muggle-status under-triggers on diagnostic *questions*.** "Is the muggle MCP reachable? just checking", "muggle's been acting up — take a look", "is my muggle login busted?", "why does muggle keep saying it can't connect?" route to `none` — Claude answers conversationally. The description leads with "Check health… / muggle status" and doesn't claim question-shaped "is muggle ok / why is muggle failing" intents. Candidate fix: broaden to own "is muggle working / why is muggle failing / are the MCP tools loading" phrasings.
+2. **muggle-do-task misses some real-website actions.** Genuine gaps (LinkedIn post, Slack message) mixed with consequential real-account actions (AWS IAM user, Stripe refund) Claude is reluctant to auto-drive. Worth deciding whether those belong to do-task at all.
+3. **muggle-repair vs muggle-status** stays a soft boundary ("is it broken? fix it" leaned status) — acceptable.
+
+Full per-query data: `expanded-eval-partial.json`.


### PR DESCRIPTION
Follow-up to #196 (merged). Captures the partial result from the expanded 391-case eval run, which hit the account session limit after **7 of 14 skills** (169 queries).

### Partial accuracy: 151/169 = 89.3%
Misses are interleaved with passes (not a contiguous all-`none` tail), so they're genuine recall gaps — **not** the MCP-disconnect artifact noted in `final.md`.

| skill | recall |
|---|---|
| muggle-feedback / pr-visual-walkthrough / preferences | 24/24 |
| muggle | 23/24 (bare `/muggle` → none) |
| muggle-repair | 23/24 |
| muggle-do-task | 20/25 |
| **muggle-status** | **13/24 (54%)** |

### New findings (the 78-case set scored these skills 100%)
1. **muggle-status under-triggers on diagnostic *questions*** — "is the MCP reachable? just checking", "muggle's been acting up, take a look", "why does muggle keep saying it can't connect?" → `none`. Its description leads with "Check health / muggle status" and doesn't claim question-shaped intents. Candidate fix next pass.
2. **muggle-do-task** misses some website actions (LinkedIn post, Slack msg) and consequential real-account ones (AWS IAM, Stripe refund) Claude won't auto-drive.

### Remaining
`muggle-test`, `-test-feature-local`, `-test-import`, `-test-prepare`, `-test-regenerate-missing`, `muggle-upgrade`, `muggle-pr-followup`, and the `none` negatives weren't reached. Resume the per-skill chunked run (see `README.md`) after the limit resets (~8:10pm PT), then optimize the status/do-task gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
