### PR TITLE
fix(skills): move muggle-do session state to ~/.muggle-ai/muggle-do/sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ OPEN_PRS      → PR #42 opened
 DONE          → 1 iteration, all green
 ```
 
-- Session-based with crash recovery (`.muggle-do/sessions/`)
+- Session-based with crash recovery (`~/.muggle-ai/muggle-do/sessions/`)
 - Auto-triage: analyzes failures and loops back to fix (max 3 iterations)
 - Multi-repo support via `muggle-repos.json`
 - PRs include E2E acceptance results and screenshots in the description

--- a/internal/skills/pr-followup-fixtures/bootstrap/01-fresh-url-with-reviews.json
+++ b/internal/skills/pr-followup-fixtures/bootstrap/01-fresh-url-with-reviews.json
@@ -37,13 +37,13 @@
     "preamble": "**muggle-pr-followup bootstrap** — seeding state for acme/widget#142.",
     "outcome": "bootstrapped",
     "state_writes": {
-      ".muggle-do/sessions/acme-widget-pr142/prs.json": "single entry: {repo:acme/widget, number:142, url:..., head_sha:abc1230, state:open}",
-      ".muggle-do/sessions/acme-widget-pr142/last_seen.json": "key 'acme/widget#142' with reviewId:0 (default; first tick will dispatch both existing reviews), last_pushed_sha:null, idle_tick_count:0, cycles_completed:0, escalated_review_ids:[], pushed_shas:[]",
-      ".muggle-do/sessions/acme-widget-pr142/state.md": "PR url, slug, loop_user: stan4git, Bootstrapped from URL: yes"
+      "~/.muggle-ai/muggle-do/sessions/acme-widget-pr142/prs.json": "single entry: {repo:acme/widget, number:142, url:..., head_sha:abc1230, state:open}",
+      "~/.muggle-ai/muggle-do/sessions/acme-widget-pr142/last_seen.json": "key 'acme/widget#142' with reviewId:0 (default; first tick will dispatch both existing reviews), last_pushed_sha:null, idle_tick_count:0, cycles_completed:0, escalated_review_ids:[], pushed_shas:[]",
+      "~/.muggle-ai/muggle-do/sessions/acme-widget-pr142/state.md": "PR url, slug, loop_user: stan4git, Bootstrapped from URL: yes"
     },
     "files_NOT_written": [
-      ".muggle-do/sessions/acme-widget-pr142/cycle.json",
-      ".muggle-do/sessions/acme-widget-pr142/requirements.md"
+      "~/.muggle-ai/muggle-do/sessions/acme-widget-pr142/cycle.json",
+      "~/.muggle-ai/muggle-do/sessions/acme-widget-pr142/requirements.md"
     ],
     "telemetry_events": [
       {

--- a/internal/skills/pr-followup-fixtures/bootstrap/03-fresh-url-forward-only.json
+++ b/internal/skills/pr-followup-fixtures/bootstrap/03-fresh-url-forward-only.json
@@ -37,9 +37,9 @@
     "preamble": "**muggle-pr-followup bootstrap** — seeding state for acme/widget#142.",
     "outcome": "bootstrapped",
     "state_writes": {
-      ".muggle-do/sessions/acme-widget-pr142/prs.json": "single entry: {repo:acme/widget, number:142, url:..., head_sha:abc1230, state:open}",
-      ".muggle-do/sessions/acme-widget-pr142/last_seen.json": "key 'acme/widget#142' with reviewId:4295962850 (max — --forward-only), last_pushed_sha:null, idle_tick_count:0, cycles_completed:0, escalated_review_ids:[], pushed_shas:[]",
-      ".muggle-do/sessions/acme-widget-pr142/state.md": "PR url, slug, loop_user: stan4git, Bootstrapped from URL: yes"
+      "~/.muggle-ai/muggle-do/sessions/acme-widget-pr142/prs.json": "single entry: {repo:acme/widget, number:142, url:..., head_sha:abc1230, state:open}",
+      "~/.muggle-ai/muggle-do/sessions/acme-widget-pr142/last_seen.json": "key 'acme/widget#142' with reviewId:4295962850 (max — --forward-only), last_pushed_sha:null, idle_tick_count:0, cycles_completed:0, escalated_review_ids:[], pushed_shas:[]",
+      "~/.muggle-ai/muggle-do/sessions/acme-widget-pr142/state.md": "PR url, slug, loop_user: stan4git, Bootstrapped from URL: yes"
     },
     "telemetry_events": [
       {

--- a/plugin/skills/_shared/resolve-e2e-validation-context.md
+++ b/plugin/skills/_shared/resolve-e2e-validation-context.md
@@ -8,7 +8,7 @@ The sections below are the steps in order: reuse an existing context if one is o
 
 ## Reuse an existing context
 
-If a `## Pre-flight answers` block already exists for this working tree — the current session slot, or the most recent sibling session under `.muggle-do/sessions/*` — fire the [`autoReuseValidationContext`](../muggle-preferences/preference-gates/autoReuseValidationContext.md) gate before gathering anything:
+If a `## Pre-flight answers` block already exists for this working tree — the current session slot, or the most recent sibling session under `~/.muggle-ai/muggle-do/sessions/*` — fire the [`autoReuseValidationContext`](../muggle-preferences/preference-gates/autoReuseValidationContext.md) gate before gathering anything:
 
 - `always` → copy the existing block into this session; skip the questionnaire.
 - `never` → ignore it; run the full gather below.

--- a/plugin/skills/do/address-reviews.md
+++ b/plugin/skills/do/address-reviews.md
@@ -19,7 +19,7 @@ Exact phrasing comes from the watcher's dispatch (see [`../muggle-pr-followup/co
 
 ## Inputs from disk
 
-Read from `.muggle-do/sessions/<slug>/`:
+Read from `~/.muggle-ai/muggle-do/sessions/<slug>/`:
 
 - `prs.json` — to locate the PR's local checkout path (the `repo` field maps to a configured local repo) and capture `head_sha_before`.
 - `last_seen.json` — for `pushed_shas[]` (used by the resolve-reminder stage) and to update the cursor.

--- a/plugin/skills/do/open-prs/forward.md
+++ b/plugin/skills/do/open-prs/forward.md
@@ -40,13 +40,13 @@ Forward pipeline's Stage 7. Invoked by `/muggle-do` after stages 1–6 of a fres
 
 After every repo is processed, build the watcher manifest and dispatch one watcher loop per opened PR. The dispatches are the LAST action this stage takes.
 
-Write `.muggle-do/sessions/<slug>/prs.json` per [`../../muggle-pr-followup/state-schemas.md`](../../muggle-pr-followup/state-schemas.md#prsjson):
+Write `~/.muggle-ai/muggle-do/sessions/<slug>/prs.json` per [`../../muggle-pr-followup/state-schemas.md`](../../muggle-pr-followup/state-schemas.md#prsjson):
 
 ```json
 [{ "repo": "owner/repo", "number": 142, "url": "...", "head_sha": "...", "state": "open" }]
 ```
 
-Seed `.muggle-do/sessions/<slug>/last_seen.json` per [`../../muggle-pr-followup/state-schemas.md`](../../muggle-pr-followup/state-schemas.md#last_seenjson) — empty cursor shape with `pushed_shas: []`. Forward mode never has prior reviews to skip, so `reviewId: 0`.
+Seed `~/.muggle-ai/muggle-do/sessions/<slug>/last_seen.json` per [`../../muggle-pr-followup/state-schemas.md`](../../muggle-pr-followup/state-schemas.md#last_seenjson) — empty cursor shape with `pushed_shas: []`. Forward mode never has prior reviews to skip, so `reviewId: 0`.
 
 **Do not** seed `cycle.json` or `requirements.md`. The watcher is a dumb pipe; `/muggle-do` reads reviews off GitHub.
 

--- a/plugin/skills/do/open-prs/update.md
+++ b/plugin/skills/do/open-prs/update.md
@@ -13,7 +13,7 @@ Does **not** create a PR, seed session state, or dispatch a watcher (`/muggle-do
 ## Inputs
 
 - Per-repo: path, branch (head ref name).
-- The existing PR URL + number from `.muggle-do/sessions/<slug>/prs.json`.
+- The existing PR URL + number from `~/.muggle-ai/muggle-do/sessions/<slug>/prs.json`.
 - **Optional** E2E acceptance report from stage 6. Produced by [`../e2e-acceptance.md`](../e2e-acceptance.md); schema in [`../../muggle-pr-visual-walkthrough/SKILL.md`](../../muggle-pr-visual-walkthrough/SKILL.md).
 
 ## Procedure

--- a/plugin/skills/muggle-do/SKILL.md
+++ b/plugin/skills/muggle-do/SKILL.md
@@ -31,7 +31,7 @@ The pipeline table lists **pointers, not summaries**. Open each stage's file and
 
 **Bootstrap before any code, in order:**
 1. Emit telemetry — [`../_shared/telemetry-emit.md`](../_shared/telemetry-emit.md), `skillName: "muggle-do"`.
-2. Create `.muggle-do/sessions/<slug>/` with `state.md` + `iterations/001.md` (pre-flight owns this; do it even when running unattended).
+2. Create `~/.muggle-ai/muggle-do/sessions/<slug>/` with `state.md` + `iterations/001.md` (pre-flight owns this; do it even when running unattended).
 3. `TodoWrite` one item per stage 1–8 — these stages are the checklist; never swap in your own decomposition.
 
 **Per stage:** read the file → execute it → append a marker to `iterations/<NNN>.md` citing the evidence that file requires (jest exit code, E2E verdict + `runId`, screenshot path). A stage is done only when its evidence is written, never on recollection.
@@ -75,7 +75,7 @@ When in doubt between #3 and #4, ask one question.
 
 ## Session model
 
-`.muggle-do/sessions/<slug>/`. Schemas: [`../muggle-pr-followup/state-schemas.md`](../muggle-pr-followup/state-schemas.md).
+`~/.muggle-ai/muggle-do/sessions/<slug>/`. Schemas: [`../muggle-pr-followup/state-schemas.md`](../muggle-pr-followup/state-schemas.md).
 
 | File | Owner |
 | :--- | :---- |

--- a/plugin/skills/muggle-pr-followup/bootstrap.md
+++ b/plugin/skills/muggle-pr-followup/bootstrap.md
@@ -41,7 +41,9 @@ Default: `<repo>-pr<n>` (e.g. `muggle-ai-works-pr154`). Override: `--slug=<name>
 
 ### Step 5 — Idempotency check
 
-If `~/.muggle-ai/muggle-do/sessions/<slug>/` exists:
+**Legacy-slot migration.** Pre-move sessions lived at the repo-relative `.muggle-do/sessions/<slug>/` ([`state-schemas.md`](state-schemas.md#legacy-location)). If the new home-dir slot is absent but `<working-tree>/.muggle-do/sessions/<slug>/` exists (working tree from Step 3), move it to the new location first — this carries an in-flight watcher's cursor, `escalated_review_ids`, and `pushed_shas` across the upgrade. Bootstrap is the only stage that performs this: it is the one entry point that knows the old repo-relative path (the cwd), and it is the natural re-entry point after a plugin upgrade. A slot that fails to migrate loses nothing durable — GitHub holds the reviews, so a fresh bootstrap (cursor `0`) re-processes them.
+
+If `~/.muggle-ai/muggle-do/sessions/<slug>/` exists (including a slot just migrated above):
 
 - Without `--resume` → exit with the slot-conflict abort. Both remedies (delete + re-run, or pass `--resume`) are spelled out in the message.
 - With `--resume` → refresh `prs.json[0].head_sha` to the current `headRefOid` from Step 2; leave `last_seen.json` and the cursor untouched. If `state.md` already has a `## Pre-flight answers` block, skip to Step 8; if not (older session), run Step 6.5 to backfill it, then skip to Step 8.

--- a/plugin/skills/muggle-pr-followup/bootstrap.md
+++ b/plugin/skills/muggle-pr-followup/bootstrap.md
@@ -37,11 +37,11 @@ Per [`../_shared/github-cli-recipes/verify-working-tree.md`](../_shared/github-c
 
 ### Step 4 — Resolve the slug
 
-Default: `<repo>-pr<n>` (e.g. `muggle-ai-works-pr154`). Override: `--slug=<name>`. Session dir is `.muggle-do/sessions/<slug>/` relative to the caller's working tree.
+Default: `<repo>-pr<n>` (e.g. `muggle-ai-works-pr154`). Override: `--slug=<name>`. Session dir is `~/.muggle-ai/muggle-do/sessions/<slug>/` (under the user's home, shared across repos; the slug's repo-pr<n> prefix keeps it unique).
 
 ### Step 5 — Idempotency check
 
-If `.muggle-do/sessions/<slug>/` exists:
+If `~/.muggle-ai/muggle-do/sessions/<slug>/` exists:
 
 - Without `--resume` → exit with the slot-conflict abort. Both remedies (delete + re-run, or pass `--resume`) are spelled out in the message.
 - With `--resume` → refresh `prs.json[0].head_sha` to the current `headRefOid` from Step 2; leave `last_seen.json` and the cursor untouched. If `state.md` already has a `## Pre-flight answers` block, skip to Step 8; if not (older session), run Step 6.5 to backfill it, then skip to Step 8.
@@ -61,7 +61,7 @@ Capture the fields for Step 7. Do **not** run E2E now — the first watcher tick
 
 Identify the loop user once per [`../_shared/github-cli-recipes/loop-user-identity.md`](../_shared/github-cli-recipes/loop-user-identity.md); cache in `state.md`.
 
-Write under `.muggle-do/sessions/<slug>/`:
+Write under `~/.muggle-ai/muggle-do/sessions/<slug>/`:
 
 **`prs.json`** — see [`state-schemas.md`](state-schemas.md#prsjson). One entry, `state` = `"open"`, `head_sha` from Step 2's `headRefOid`.
 

--- a/plugin/skills/muggle-pr-followup/contract.md
+++ b/plugin/skills/muggle-pr-followup/contract.md
@@ -16,7 +16,7 @@ Routing into this mode is documented in [`SKILL.md`](SKILL.md#routing). The arch
 
 ## Inputs from disk
 
-Read these from `.muggle-do/sessions/<slug>/`:
+Read these from `~/.muggle-ai/muggle-do/sessions/<slug>/`:
 
 - `prs.json` — see [`state-schemas.md`](state-schemas.md#prsjson). The watcher touches the single entry whose `number` matches the dispatched PR number.
 - `last_seen.json` — see [`state-schemas.md`](state-schemas.md#last_seenjson). Keyed by `"<owner>/<repo>#<n>"`.

--- a/plugin/skills/muggle-pr-followup/state-schemas.md
+++ b/plugin/skills/muggle-pr-followup/state-schemas.md
@@ -4,6 +4,10 @@ Canonical shapes for the JSON files in a PR-follow-up session slot. The slot pat
 
 All files are atomic writes — the caller rewrites the whole file each time, never mutates in place. Use a temp file + rename if the platform supports it.
 
+## Legacy location
+
+Before the move to the user's home, slots lived at the repo-relative `.muggle-do/sessions/<slug>/` (one per working tree, still gitignored). Bootstrap's Step 5 migrates a legacy slot to the home-dir location on the next run for that PR; nothing else reads the old path. The state is ephemeral and reconstructible from GitHub, so an un-migrated slot costs only a re-bootstrap, not data.
+
 ## `prs.json`
 
 A list of one entry. (Historical: the file is an array for forward-compat with the original session-wide model. Today, each PR has its own session slot, so the array always has exactly one entry.)

--- a/plugin/skills/muggle-pr-followup/state-schemas.md
+++ b/plugin/skills/muggle-pr-followup/state-schemas.md
@@ -1,6 +1,6 @@
 # Session State Schemas
 
-Canonical shapes for the JSON files in a PR-follow-up session slot. The slot path is `.muggle-do/sessions/<slug>/` (the caller's session dir; `muggle-do` is the current and only caller).
+Canonical shapes for the JSON files in a PR-follow-up session slot. The slot path is `~/.muggle-ai/muggle-do/sessions/<slug>/` (under the user's home, shared across repos; `muggle-do` is the current and only caller).
 
 All files are atomic writes — the caller rewrites the whole file each time, never mutates in place. Use a temp file + rename if the platform supports it.
 


### PR DESCRIPTION
Relocate muggle-do / PR-follow-up session slots from `.muggle-do/sessions/<slug>/` (relative to the **target code repo's** working tree) to **`~/.muggle-ai/muggle-do/sessions/<slug>/`** under the user's home — where the rest of the muggle runtime already lives. This stops the loop from dropping untracked session-state files inside the repo it's reviewing.

The slug already encodes `<repo>-pr<n>`, so a single shared sessions dir stays unique across repos and matches auto-track's cross-repo model. `/muggle-do` still resolves the target checkout from the `Working tree` field recorded in `state.md`, so nothing depends on the session dir being repo-relative anymore.

Path-only documentation change across the skill procedure files — no code paths reference `.muggle-do` (verified). Files touched:
- `muggle-pr-followup/` — bootstrap, contract, state-schemas
- `muggle-do/SKILL.md`
- `do/` — address-reviews, open-prs/forward, open-prs/update
- `_shared/resolve-e2e-validation-context.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
