### PR TITLE
feat(skills): /mprfollowup shortcut + autoWatchPR suggestion gate

### DIFF
--- a/plugin/commands/mprfollowup.md
+++ b/plugin/commands/mprfollowup.md
@@ -1,0 +1,7 @@
+---
+description: Watch a PR for review follow-ups (alias for /muggle-pr-followup)
+argument-hint: [PR url | slug pr-number | empty to auto-track]
+allowed-tools: [Skill]
+---
+
+Invoke the `muggle-pr-followup` skill via the Skill tool. Forward `$ARGUMENTS` as the skill's `args`.

--- a/plugin/skills/_aliases.json
+++ b/plugin/skills/_aliases.json
@@ -12,6 +12,7 @@
         "mimport",
         "mtestlocal",
         "mtestprep",
-        "mregen"
+        "mregen",
+        "mprfollowup"
     ]
 }

--- a/plugin/skills/mprfollowup/SKILL.md
+++ b/plugin/skills/mprfollowup/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: mprfollowup
+description: Explicit short alias for the `muggle-pr-followup` skill. ONLY invoke when the user explicitly types `mprfollowup` or `/mprfollowup` — never auto-trigger from any other phrasing.
+---
+
+# mprfollowup — alias for muggle-pr-followup
+
+Invoke the `muggle-pr-followup` skill via the Skill tool. Forward any user-provided arguments unchanged.

--- a/plugin/skills/muggle-preferences/ops/configure.md
+++ b/plugin/skills/muggle-preferences/ops/configure.md
@@ -28,7 +28,8 @@ For each option: label = key name, description = first paragraph of `preference-
 - `multiSelect: true`, `header: "Auth & session"` — `autoLogin`, `autoSelectProject`, `checkForUpdates`, `verboseOutput`
 - `multiSelect: true`, `header: "Test setup"` — `autoSelectLocalHost`, `autoDetectChanges`, `autoReuseValidationContext`
 - `multiSelect: true`, `header: "Test run"` — `showElectronBrowser`, `openTestResultsAfterRun`, `autoPublishLocalResults`
-- `multiSelect: true`, `header: "Suggestions & PR"` — `suggestRelatedUseCases`, `suggestRelatedTestCases`, `postPRVisualWalkthrough`, `autoCreatePR`
+- `multiSelect: true`, `header: "Suggestions"` — `suggestRelatedUseCases`, `suggestRelatedTestCases`
+- `multiSelect: true`, `header: "PR"` — `postPRVisualWalkthrough`, `autoCreatePR`, `autoWatchPR`
 - `multiSelect: true`, `header: "Branch hygiene"` — `autoUseWorktree`, `autoRebase`, `autoCleanup`
 - `multiSelect: false`, `header: "E2E acceptance"` — `autoE2ETest`. Options: `Always run Stage 6 at the end` (`always` — default), `Ask each cycle` (`ask`). No `never` option.
 - `multiSelect: false`, `header: "Default mode"` — `defaultExecutionMode`. Options: `Local — run on my computer` (`local`), `Remote — run in the Muggle Test cloud` (`remote`), `Ask each time` (don't change).

--- a/plugin/skills/muggle-preferences/preference-gates/autoWatchPR.md
+++ b/plugin/skills/muggle-preferences/preference-gates/autoWatchPR.md
@@ -1,0 +1,13 @@
+# `autoWatchPR`
+
+After a PR is sent at the end of a test run, controls whether Muggle starts a `muggle-pr-followup` watcher on it — a loop that polls the PR for newly submitted reviews and hands them to `/muggle-do` to address — or leaves you to start one yourself with `/mprfollowup`. Fires once a PR exists (muggle-test, muggle-test-feature-local), reusing the E2E validation context from that run so the watcher never re-prompts. Substitute `{pr}`.
+
+**Picker 1** — header `Watch PR?`, question `"Watch '{pr}' for review follow-ups and address them as they land?"`
+- `Watch it` — `Start a muggle-pr-followup loop on this PR.` → `always`
+- `Ask me next time` — `Decide per run.` → `ask`
+- `Skip — I'll watch it myself` — `Leave it; run /mprfollowup later if you want.` → `never`
+
+**Silent action**
+- `always` → `Watching {pr} for review follow-ups`
+- `ask` → `Asking about PR watching`
+- `never` → `Not watching {pr}`

--- a/plugin/skills/muggle-test-feature-local/SKILL.md
+++ b/plugin/skills/muggle-test-feature-local/SKILL.md
@@ -51,6 +51,7 @@ Gates run per `preference-gates/README.md`.
 | `openTestResultsAfterRun` | 8 | Open results page on Muggle Test dashboard after run |
 | `postPRVisualWalkthrough` | 10 | Post visual walkthrough to PR after results |
 | `autoCreatePR` | 10 (if no PR) | Auto-create the PR when posting the walkthrough has no PR to target |
+| `autoWatchPR` | 10.5 (if a PR exists) | Start a `muggle-pr-followup` watcher on the PR after the run |
 | `autoCleanup` | post-merge | Run cleanup after the PR for this work is merged (see [`_shared/post-merge-cleanup.md`](../_shared/post-merge-cleanup.md)) |
 
 ## Workflow
@@ -242,11 +243,23 @@ Non-blocking — one click to dismiss. Do not re-ask for the same `runId` within
 
 After reporting results:
 
-1. Fire [`postPRVisualWalkthrough`](../muggle-preferences/preference-gates/postPRVisualWalkthrough.md). On skip → end.
+1. Fire [`postPRVisualWalkthrough`](../muggle-preferences/preference-gates/postPRVisualWalkthrough.md). On skip → 10.5.
 2. `gh pr view --json number,title,url 2>/dev/null` — find the PR.
-3. If no PR: fire [`autoCreatePR`](../muggle-preferences/preference-gates/autoCreatePR.md). On skip → end.
+3. If no PR: fire [`autoCreatePR`](../muggle-preferences/preference-gates/autoCreatePR.md). On skip → 10.5.
 4. Assemble the `E2eReport` — see [`../muggle-pr-visual-walkthrough/e2e-report-assembly.md`](../muggle-pr-visual-walkthrough/e2e-report-assembly.md).
 5. Invoke [`../muggle-pr-visual-walkthrough/SKILL.md`](../muggle-pr-visual-walkthrough/SKILL.md) Mode A with the `E2eReport`.
+
+### 10.5. Offer to watch the PR for review follow-ups
+
+Once a PR exists for this work, offer to keep watching its review thread.
+
+1. Identify the PR — reuse the `gh pr view --json number,title,url` result from section 10 if available, else run it now. No PR (none exists, none created) → end.
+2. Fire [`autoWatchPR`](../muggle-preferences/preference-gates/autoWatchPR.md) with `{pr}` = `<owner>/<repo>#<number>`. On skip → end.
+3. On proceed: start the watcher reusing this run's context so it never re-prompts —
+   - Seed the `muggle-pr-followup` session slot and dispatch its loop per the stage-8 seeding in [`../do/open-prs/forward.md`](../do/open-prs/forward.md) (default slug `<repo>-pr<number>`).
+   - Additionally write `state.md`'s `## Pre-flight answers` block from the context resolved this run — validation strategy, local URL, project, credentials, auth, working tree — per [`../_shared/resolve-e2e-validation-context.md`](../_shared/resolve-e2e-validation-context.md#persisted-fields). Strategy = `local-e2e` for this local E2E run.
+
+The `/mprfollowup` shortcut starts the same watcher manually at any time.
 
 ## Non-negotiables
 

--- a/plugin/skills/muggle-test/SKILL.md
+++ b/plugin/skills/muggle-test/SKILL.md
@@ -49,6 +49,7 @@ Gates run per `preference-gates/README.md`.
 | `showElectronBrowser` | 7A | Show the Electron browser window during local test execution (vs. run headless) |
 | `postPRVisualWalkthrough` | 9 | Post visual walkthrough to PR after results are available |
 | `autoCreatePR` | 9 (if no PR) | Auto-create the PR when posting the walkthrough has no PR to target |
+| `autoWatchPR` | 9.5 (if a PR exists) | Start a `muggle-pr-followup` watcher on the PR after the run |
 
 ## Step 1: Confirm Scope of Work (Always First)
 
@@ -413,11 +414,23 @@ Tell the user:
 
 After reporting results:
 
-1. Fire [`postPRVisualWalkthrough`](../muggle-preferences/preference-gates/postPRVisualWalkthrough.md). On skip → Step 10.
+1. Fire [`postPRVisualWalkthrough`](../muggle-preferences/preference-gates/postPRVisualWalkthrough.md). On skip → Step 9.5.
 2. `gh pr view --json number,title,url 2>/dev/null` — find the PR.
-3. If no PR: fire [`autoCreatePR`](../muggle-preferences/preference-gates/autoCreatePR.md). On skip → Step 10.
+3. If no PR: fire [`autoCreatePR`](../muggle-preferences/preference-gates/autoCreatePR.md). On skip → Step 9.5.
 4. Assemble the `E2eReport` — see [`../muggle-pr-visual-walkthrough/e2e-report-assembly.md`](../muggle-pr-visual-walkthrough/e2e-report-assembly.md). Include all runs from Step 7A (passed and failed).
 5. Invoke [`../muggle-pr-visual-walkthrough/SKILL.md`](../muggle-pr-visual-walkthrough/SKILL.md) Mode A with the `E2eReport`.
+
+## Step 9.5: Offer to watch the PR for review follow-ups
+
+Once a PR exists for this work, offer to keep watching its review thread.
+
+1. Identify the PR — reuse the `gh pr view --json number,title,url` result from Step 9 if available, else run it now. No PR (none exists, none created) → Step 10.
+2. Fire [`autoWatchPR`](../muggle-preferences/preference-gates/autoWatchPR.md) with `{pr}` = `<owner>/<repo>#<number>`. On skip → Step 10.
+3. On proceed: start the watcher reusing this run's context so it never re-prompts —
+   - Seed the `muggle-pr-followup` session slot and dispatch its loop per the stage-8 seeding in [`../do/open-prs/forward.md`](../do/open-prs/forward.md) (default slug `<repo>-pr<number>`).
+   - Additionally write `state.md`'s `## Pre-flight answers` block from the context resolved this run — validation strategy, local URL, project, credentials, auth, working tree — per [`../_shared/resolve-e2e-validation-context.md`](../_shared/resolve-e2e-validation-context.md#persisted-fields). Strategy = `local-e2e` (local run), `staging-replay` (remote), or `unit-only`/`skip` if no E2E ran.
+
+The `/mprfollowup` shortcut starts the same watcher manually at any time.
 
 ## Step 10: Offer feedback on failures
 

--- a/plugin/skills/muggle/SKILL.md
+++ b/plugin/skills/muggle/SKILL.md
@@ -37,6 +37,7 @@ If the user intent clearly matches one command, route directly — no menu neede
 - test localhost/validate single feature/test a feature → `muggle-test-feature-local`
 - build/implement from request/end-to-end → `muggle-do`
 - post results to PR/attach walkthrough/visual evidence on PR → `muggle-pr-visual-walkthrough`
+- watch my PR for reviews/follow up on PR reviews/babysit PR review thread → `muggle-pr-followup`
 - give feedback on a run/the test was wrong/step N didn't work/show my feedback/delete feedback → `muggle-feedback`
 
 If intent is ambiguous, use `AskUserQuestion` with the most likely options rather than asking the user to type a clarification.


### PR DESCRIPTION
## What

Two asks from the user, for the `muggle-pr-followup` skill:

1. **Shortcut** — new `/mprfollowup` alias for `muggle-pr-followup`.
2. **Suggest after a PR is sent** — new `autoWatchPR` preference gate that offers (or auto-starts, per the user's choice) the PR-review watcher once a PR exists at the end of a test run.

## Changes

- **`mprfollowup` alias** — `plugin/skills/mprfollowup/SKILL.md` + `plugin/commands/mprfollowup.md` + entry in `plugin/skills/_aliases.json` (required so `postinstall.mjs` syncs the non-`muggle`-prefixed dir to Cursor).
- **`autoWatchPR` gate** — `preference-gates/autoWatchPR.md` (`always`/`never`/`ask`, default `ask`), registered in `ops/configure.md` (split the over-full "Suggestions & PR" group into "Suggestions" + "PR" to stay within AskUserQuestion's 4-option cap).
- **Wiring** — `muggle-test` **Step 9.5** and `muggle-test-feature-local` **§10.5** fire `autoWatchPR` once a PR exists. On proceed they seed the watcher session slot reusing the run's E2E validation context (referencing `do/open-prs/forward.md` stage 8 + `_shared/resolve-e2e-validation-context.md`) and dispatch the `/loop` watcher, so it never re-prompts.
- **Router hint** — added a `muggle-pr-followup` line to the `muggle` menu's Routing section.

## Design notes

- **Gate, not silent auto-start.** The user wants the choice remembered, and expects the watcher to also be invoked standalone (`/mprfollowup`) in their own flow **without** E2E — the watcher bootstrap already supports `unit-only`/`skip` validation strategies.
- **`muggle-do` unchanged** — its forward pipeline already auto-dispatches its own watcher (stage 8); no gate added there.
- No duplication — the seeding handoff references the existing forward.md/validation-context procedures.

## Verification

`src/test/skills/preference-gates-lint.test.ts` invariants pass (replicated against these files): `autoWatchPR` is referenced by both skills, its contract file exists, Picker 1 values == Silent-action values (`always`/`ask`/`never`), and no gate is orphaned. `_aliases.json` is valid JSON. `build-plugin.mjs` is a recursive copy, so the new files ship automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)