### PR TITLE
chore(release): @muggleai/works 4.14.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.13.1"
+      "version": "4.14.0"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.13.1"
+      "version": "4.14.0"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@muggleai/works",
   "mcpName": "io.github.multiplex-ai/muggle",
-  "version": "4.13.1",
+  "version": "4.14.0",
   "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
   "type": "module",
   "main": "dist/index.js",
@@ -42,14 +42,14 @@
     "test:watch": "vitest"
   },
   "muggleConfig": {
-    "electronAppVersion": "1.0.101",
+    "electronAppVersion": "1.0.107",
     "downloadBaseUrl": "https://github.com/multiplex-ai/muggle-ai-works/releases/download",
     "runtimeTargetDefault": "dev",
     "checksums": {
-      "darwin-arm64": "2c73d9aa22740b6fc90f8dadccdc137c6fa87f1ce17ad5bcfd3f721b305c4807",
-      "darwin-x64": "dcc5e05b8382a15058c691c109af313b07f91e6470bc4a5b7f789ba82e6b7fa3",
-      "linux-x64": "24eeb304e5d302372984f1d2d0a15e337dcf949f7cfcd7b8c351c7d0d9d6e784",
-      "win32-x64": "6a391b516eaf30052f84277b90fa12393d32c1428e3f87c2f0eca241e6504a93"
+      "darwin-arm64": "d10a2d49f4300123c2e6fefe3ad9d85b17b079d97b6326f8ea80547c2e8bf735",
+      "darwin-x64": "5466d9fc9ef280c85a723cb4288fceffa1869e1b1d84156773a6366e85443952",
+      "linux-x64": "24d7ebb5bdb56345644e24180008226b49fdb1b0a605c455ba45950df58faa5e",
+      "win32-x64": "62498ddb31336285dafb1320f1e43199dac7ada2bdd57223cb9eb4f4ac03e5a7"
     }
   },
   "dependencies": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "4.13.1",
+  "version": "4.14.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "4.13.1",
+  "version": "4.14.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "4.13.1",
+  "version": "4.14.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "4.13.1",
+      "version": "4.14.0",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
## Release 4.14.0 (minor)

4.13.1 → **4.14.0**. Additive features, no breaking changes.

### Shipping since 4.13.1
- feat(skills): `/mprfollowup` shortcut + `autoWatchPR` suggestion gate (#222)
- feat(internal): skill routing eval — entrances, harness, report (#196)
- feat(prepare): remember & reuse the prepare plan (#214)
- fix(skills): move muggle-do session state to `~/.muggle-ai/muggle-do/sessions` (#221)
- fix(muggle-status): own diagnostic health-check questions (#220)
- fix(muggle-pr-followup): refine description + document loop-skill collision (#223)
- test(routing-eval): full + partial 14-skill expanded reports (#224, #219)
- test(works): raise src coverage to ~90% with enforced thresholds (#215)
- chore: relocate muggle-works-npm-release to internal/ (#217)
- chore(muggle-do): execution-protocol gate (#197)

### Electron
Desktop bumped **1.0.101 → 1.0.107** — `electronAppVersion` + all four `muggleConfig.checksums`, verified against the `electron-app-v1.0.107` release asset.

### Manifests
Propagated by `sync:versions`: `.claude-plugin/marketplace.json`, `.cursor-plugin/marketplace.json`, `plugin/.claude-plugin/plugin.json`, `plugin/.cursor-plugin/plugin.json`, `server.json`.

### Test plan
- [x] `lint:check` (0 errors)
- [x] `typecheck`
- [x] `test` (243 passed)
- [x] `build`
- [x] `verify:plugin`
- [x] `verify:contracts`
- [x] `verify:electron-release-checksums`

Publish runs via `publish-works-to-npm.yml` (OIDC trusted publishing) after merge — no local `npm publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)