### PR TITLE
feat(routing-eval): one-command runnable eval (run.py)

### DIFF
--- a/internal/skill-routing-eval/README.md
+++ b/internal/skill-routing-eval/README.md
@@ -18,16 +18,23 @@ This is faithful in a way isolated single-skill triggering tests are not: it cat
 
 ## Run it
 
-```bash
-python internal/skill-routing-eval/router_eval.py \
-  --eval-set internal/skill-routing-eval/eval-set.json \
-  --repo-root "$(pwd)" \
-  --runs 3 --workers 5 --timeout 180 \
-  --out internal/skill-routing-eval/reports/<name>.json
+One command — chunks per skill, guards against MCP disconnects, aggregates, and writes the report:
 
-python internal/skill-routing-eval/analyze.py report \
-  --in internal/skill-routing-eval/reports/<name>.json \
-  --out internal/skill-routing-eval/reports/<name>.md
+```bash
+python internal/skill-routing-eval/run.py --all          # full set
+python internal/skill-routing-eval/run.py --skill muggle-status   # one skill
+python internal/skill-routing-eval/run.py --all --sync-cache      # see below
+```
+
+Output lands in `reports/run/` (`combined.json` + `combined.md`, plus per-skill `chunk_*.json`). `run.py` runs each skill's queries as a separate `claude -p` batch so an MCP disconnect can only spoil one chunk, not the whole sweep; a positive chunk that comes back all-`none` (the disconnect signature) is re-run once and flagged if it stays empty. Keep `--workers` low (default 3) — high concurrency is what trips the disconnect.
+
+**`--sync-cache`:** the harness routes via the *installed* muggle plugin, not the working tree. When you've edited a `SKILL.md` description but not reinstalled, `claude -p` sees both the cached copy and the bare-name working-tree skill and results are unreliable. `--sync-cache` copies `plugin/skills/*/SKILL.md` over the installed cache first (auto-detected from `~/.claude/plugins/installed_plugins.json`) so the eval tests your edits. Always pass it when validating a description change.
+
+### Lower-level (single set, no chunking)
+
+```bash
+python internal/skill-routing-eval/router_eval.py --eval-set <set.json> --repo-root "$(pwd)" --runs 3 --workers 5 --timeout 180 --out <report.json>
+python internal/skill-routing-eval/analyze.py report --in <report.json> --out <report.md>
 ```
 
 ## Optimization loop (per skill)

--- a/internal/skill-routing-eval/run.py
+++ b/internal/skill-routing-eval/run.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""One-command runner for the skill-routing eval.
+
+Wraps router_eval.py + analyze.py with the operational lessons learned running
+this by hand: per-skill chunking (so an MCP disconnect can't silently crater a
+whole sweep), a disconnect guard (re-run a positive chunk that comes back
+all-`none`), aggregation, and report generation — plus an optional cache sync so
+`claude -p` tests the working-tree descriptions rather than the installed copy.
+
+Usage:
+    python internal/skill-routing-eval/run.py --all
+    python internal/skill-routing-eval/run.py --skill muggle-status
+    python internal/skill-routing-eval/run.py --all --sync-cache
+
+`--sync-cache` copies this repo's plugin/skills/<skill>/SKILL.md over the
+installed muggle plugin cache before running. Without it, the eval reflects
+whatever is installed; with a description edit in the working tree but not the
+cache, `claude -p` sees BOTH (the bare-name local skill and the cached
+`muggle:` one) and results are unreliable — sync first when validating an edit.
+"""
+
+import argparse
+import collections
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[2]  # internal/skill-routing-eval -> repo root
+EVAL_SET = HERE / "eval-set.json"
+ROUTER = HERE / "router_eval.py"
+ANALYZE = HERE / "analyze.py"
+NONE = "none"
+
+
+def find_plugin_cache() -> Path | None:
+    """Locate the installed muggle plugin (so we can sync descriptions into it)."""
+    cfg = Path.home() / ".claude" / "plugins" / "installed_plugins.json"
+    if not cfg.exists():
+        return None
+    data = json.loads(cfg.read_text(encoding="utf-8"))
+    for key, installs in data.get("plugins", {}).items():
+        if "muggle-works" in key or key.startswith("muggleai"):
+            for inst in installs:
+                p = Path(inst["installPath"])
+                if (p / "skills").is_dir():
+                    return p
+    return None
+
+
+def sync_cache(repo_root: Path, cache: Path) -> int:
+    n = 0
+    for skill_md in (repo_root / "plugin" / "skills").glob("*/SKILL.md"):
+        dest = cache / "skills" / skill_md.parent.name / "SKILL.md"
+        if dest.parent.is_dir():
+            dest.write_text(skill_md.read_text(encoding="utf-8"), encoding="utf-8")
+            n += 1
+    return n
+
+
+def run_chunk(items: list[dict], out_file: Path, repo_root: Path, runs: int, workers: int, timeout: int):
+    chunk_file = out_file.with_suffix(".in.json")
+    chunk_file.write_text(json.dumps(items, indent=2), encoding="utf-8")
+    cmd = [
+        sys.executable, str(ROUTER),
+        "--eval-set", str(chunk_file), "--repo-root", str(repo_root),
+        "--runs", str(runs), "--workers", str(workers), "--timeout", str(timeout),
+        "--out", str(out_file),
+    ]
+    subprocess.run(cmd, check=True)
+    return json.loads(out_file.read_text(encoding="utf-8"))
+
+
+def recall(report: dict, skill: str) -> float:
+    rows = [r for r in report["results"] if r["expected_skill"] == skill]
+    if not rows:
+        return 1.0
+    correct = sum(1 for r in rows if r["majority"] == skill)
+    return correct / len(rows)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Run the skill-routing eval (chunked, guarded).")
+    g = ap.add_mutually_exclusive_group()
+    g.add_argument("--all", action="store_true", help="run every skill chunk (default)")
+    g.add_argument("--skill", help="run only this expected_skill chunk")
+    ap.add_argument("--runs", type=int, default=3)
+    ap.add_argument("--workers", type=int, default=3, help="keep low — high concurrency trips the MCP disconnect")
+    ap.add_argument("--timeout", type=int, default=200)
+    ap.add_argument("--out-dir", default=str(HERE / "reports" / "run"))
+    ap.add_argument("--repo-root", default=str(REPO_ROOT))
+    ap.add_argument("--sync-cache", action="store_true", help="copy working-tree descriptions into the installed plugin cache first")
+    args = ap.parse_args()
+
+    repo_root = Path(args.repo_root).resolve()
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.sync_cache:
+        cache = find_plugin_cache()
+        if not cache:
+            print("WARNING: could not find installed muggle plugin cache; skipping sync", file=sys.stderr)
+        else:
+            n = sync_cache(repo_root, cache)
+            print(f"synced {n} descriptions -> {cache}", file=sys.stderr)
+
+    eval_set = json.loads(EVAL_SET.read_text(encoding="utf-8"))
+    by_skill = collections.defaultdict(list)
+    for item in eval_set:
+        by_skill[item.get("expected_skill", NONE)].append(item)
+
+    skills = [args.skill] if args.skill else sorted(by_skill)
+    all_results = []
+    flagged = []
+
+    for skill in skills:
+        items = by_skill.get(skill, [])
+        if not items:
+            print(f"!! no queries for '{skill}'", file=sys.stderr)
+            continue
+        print(f"== {skill} ({len(items)} queries) ==", file=sys.stderr)
+        rep = run_chunk(items, out_dir / f"chunk_{skill}.json", repo_root, args.runs, args.workers, args.timeout)
+        # disconnect guard: a positive-skill chunk that is entirely `none` is almost
+        # certainly a mid-chunk MCP disconnect, not a real 0% — re-run it once.
+        if skill != NONE and recall(rep, skill) == 0.0:
+            print(f"   {skill} came back 0% — re-running once (suspected MCP disconnect)", file=sys.stderr)
+            rep = run_chunk(items, out_dir / f"chunk_{skill}.json", repo_root, args.runs, args.workers, args.timeout)
+            if recall(rep, skill) == 0.0:
+                flagged.append(skill)
+                print(f"   {skill} still 0% — flagged suspected-disconnect/unverified", file=sys.stderr)
+        all_results.extend(rep["results"])
+
+    combined = {"model": "claude (run.py)", "runs_per_query": args.runs, "results": all_results}
+    combined_path = out_dir / "combined.json"
+    combined_path.write_text(json.dumps(combined, indent=2), encoding="utf-8")
+    md_path = out_dir / "combined.md"
+    subprocess.run([sys.executable, str(ANALYZE), "report", "--in", str(combined_path), "--out", str(md_path)], check=True)
+
+    def ok(r):
+        # mirror analyze.py's rule: negatives pass when no muggle skill fires
+        return (not r["majority"].startswith("muggle")) if r["expected_skill"] == NONE else (r["majority"] == r["expected_skill"])
+    passed = sum(1 for r in all_results if ok(r))
+    print(f"\nDone. {passed}/{len(all_results)} = {passed/len(all_results):.1%}", file=sys.stderr)
+    if flagged:
+        print(f"Suspected-disconnect (unverified): {', '.join(flagged)}", file=sys.stderr)
+    print(f"Report: {md_path}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Makes the skill-routing eval repeatable so it doesn't bit-rot as skill descriptions change.

`run.py` wraps the existing `router_eval.py` + `analyze.py` with the operational lessons from running this by hand:

- **Per-skill chunking** — each skill's queries run as a separate `claude -p` batch, so an MCP disconnect can only spoil one chunk, not the whole sweep.
- **Disconnect guard** — a positive chunk that comes back all-`none` (the disconnect signature) is re-run once and flagged if it stays empty.
- **Aggregate + report** in one step → `reports/run/combined.{json,md}`.
- **`--sync-cache`** — copies working-tree `plugin/skills/*/SKILL.md` over the installed plugin cache (auto-detected from `installed_plugins.json`) so `claude -p` tests your *edits*, not the installed copy. This is the dual-registration gotcha that made several earlier runs unreliable; always pass it when validating a description change.

```bash
python internal/skill-routing-eval/run.py --all --sync-cache   # full set, testing working-tree edits
python internal/skill-routing-eval/run.py --skill muggle-status # one skill
```

Smoke-tested end-to-end (help, cache auto-detect, live chunk → aggregate → report). README updated with usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
