### PR TITLE
chore(skills): make muggle-upgrade + muggle-preferences explicit-only

### DIFF
--- a/plugin/skills/muggle-pr-followup/SKILL.md
+++ b/plugin/skills/muggle-pr-followup/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: muggle-pr-followup
+disable-model-invocation: true
 description: Use this skill when the user wants a pull request's incoming review feedback handled for them — it watches one PR's review thread and, each time a reviewer submits new comments, dispatches the work to address them. Engage on PR-review-follow-up intent: "watch my PR and address review comments as they come in", "keep an eye on PR #123 and respond to reviewer feedback", "follow up on my PR's reviews", "babysit my PR's review thread", "auto-handle reviews on the PR I just opened", "I'm stepping away — handle my PR's reviews while I'm gone". Run with no args to track every PR you pushed this session (any repo); pass a PR URL to start watching a specific one. This is PR-review-specific automation: when the recurring thing the user wants handled is a PR's review comments, use this — not the generic `loop` skill. It only watches and dispatches; the actual edits and replies are `muggle-do`. Not for posting test results to a PR (use muggle-pr-visual-walkthrough).
 ---
 

--- a/plugin/skills/muggle-pr-followup/SKILL.md
+++ b/plugin/skills/muggle-pr-followup/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: muggle-pr-followup
-disable-model-invocation: true
 description: Use this skill when the user wants a pull request's incoming review feedback handled for them — it watches one PR's review thread and, each time a reviewer submits new comments, dispatches the work to address them. Engage on PR-review-follow-up intent: "watch my PR and address review comments as they come in", "keep an eye on PR #123 and respond to reviewer feedback", "follow up on my PR's reviews", "babysit my PR's review thread", "auto-handle reviews on the PR I just opened", "I'm stepping away — handle my PR's reviews while I'm gone". Run with no args to track every PR you pushed this session (any repo); pass a PR URL to start watching a specific one. This is PR-review-specific automation: when the recurring thing the user wants handled is a PR's review comments, use this — not the generic `loop` skill. It only watches and dispatches; the actual edits and replies are `muggle-do`. Not for posting test results to a PR (use muggle-pr-visual-walkthrough).
 ---
 

--- a/plugin/skills/muggle-preferences/SKILL.md
+++ b/plugin/skills/muggle-preferences/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: muggle-preferences
+disable-model-invocation: true
 description: >-
   View, set, or reset Muggle AI preferences that control testing behavior.
   Use when user asks to see preferences, change a setting, configure Muggle Test

--- a/plugin/skills/muggle-upgrade/SKILL.md
+++ b/plugin/skills/muggle-upgrade/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: muggle-upgrade
+disable-model-invocation: true
 description: Update Muggle AI to latest version. Use when user types muggle upgrade or asks to update Muggle Test tools.
 ---
 


### PR DESCRIPTION
Sets `disable-model-invocation: true` on `muggle-upgrade` and `muggle-preferences` — deliberate maintenance / config UIs the model should not auto-fire (mirrors the existing `muggle-do` precedent). All real paths survive: `/` menu, short aliases, the `muggle` router, gates.

Per review: `muggle-pr-followup` is **kept model-invocable** — the watcher should auto-fire on "watch my PR" intent to smooth the dev experience, which is compatible with the autoWatchPR gate (model covers explicit intent; gate covers after a run).

## Tests
`src/test/skills/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)