### PR TITLE
fix(muggle-do): post-merge cleanup trigger + tree guard, via single-owner delegation

### DIFF
--- a/plugin/skills/_shared/post-merge-cleanup.md
+++ b/plugin/skills/_shared/post-merge-cleanup.md
@@ -5,6 +5,6 @@ Gated by [`autoCleanup`](../muggle-preferences/preference-gates/autoCleanup.md).
 On `always`, the four steps below run as one pre-authorized sequence (no per-step prompts). Stop on the first failure; do not force.
 
 1. `git worktree remove {worktreePath}` — only if a worktree was used.
-2. `git branch -d {branch}` then `git push origin --delete {branch}`.
+2. `git branch -d {branch}` — **skip when no worktree was used**: the branch is the user's current live checkout (a bootstrap/auto-track watcher), and the checked-out branch must never be deleted. Then `git push origin --delete {branch}`.
 3. Clear `.muggle-ai/` session folders for this branch's runs and stale `/tmp/muggle-prepare-*.log` files. Cloud results stay.
 4. Invoke `commit-commands:clean_gone` via the `Skill` tool.

--- a/plugin/skills/do/address-reviews.md
+++ b/plugin/skills/do/address-reviews.md
@@ -63,6 +63,8 @@ The user clarifies on GitHub by submitting a new review. The next watcher tick p
 
 If `actionable_review_ids` is empty, skip the rest of Step 4 and Step 5; proceed to Step 5.5 (resolve-reminder) then Step 6. Otherwise:
 
+Before any edits, confirm the working tree is the PR's branch. For a worktree-backed session (`worktreePath` in `state.md`), run all git and edit commands from there. Otherwise a bootstrap or auto-track session runs against the user's live checkout: verify per [`../_shared/github-cli-recipes/verify-working-tree.md`](../_shared/github-cli-recipes/verify-working-tree.md); on a branch mismatch run `gh pr checkout <n>` in the PR's local repo first, and if the tree is dirty with unrelated work, escalate per Step 7 rather than editing the wrong branch.
+
 #### 4a. Flatten the work
 
 The actionable reviews together carry a flat list of change items, one per line comment plus any directive in the review body. Each item is design, code logic, or test in nature; the cycle does **not** treat each item as a separate cycle iteration — it plans them together and runs the work **once** for the whole batch.

--- a/plugin/skills/do/address-reviews.md
+++ b/plugin/skills/do/address-reviews.md
@@ -63,7 +63,7 @@ The user clarifies on GitHub by submitting a new review. The next watcher tick p
 
 If `actionable_review_ids` is empty, skip the rest of Step 4 and Step 5; proceed to Step 5.5 (resolve-reminder) then Step 6. Otherwise:
 
-Before any edits, confirm the working tree is the PR's branch. For a worktree-backed session (`worktreePath` in `state.md`), run all git and edit commands from there. Otherwise a bootstrap or auto-track session runs against the user's live checkout: verify per [`../_shared/github-cli-recipes/verify-working-tree.md`](../_shared/github-cli-recipes/verify-working-tree.md); on a branch mismatch run `gh pr checkout <n>` in the PR's local repo first, and if the tree is dirty with unrelated work, escalate per Step 7 rather than editing the wrong branch.
+Before any edits, ensure the PR's branch workspace is the working directory. If `state.md` carries a `worktreePath` (forward-mode session), use it. Otherwise materialize the PR branch per [`../_shared/pr-branch-worktree.md`](../_shared/pr-branch-worktree.md) — the single owner of checking out a PR branch in isolation — so a bootstrap or auto-track watcher never edits the user's live checkout. If the resolved tree is dirty with unrelated work, escalate per Step 7 rather than editing it.
 
 #### 4a. Flatten the work
 

--- a/plugin/skills/do/cleanup.md
+++ b/plugin/skills/do/cleanup.md
@@ -1,0 +1,17 @@
+# Post-Merge Cleanup Stage
+
+Invoked by `/muggle-do` when the watcher's terminal tick hands off cleanup after a PR merges. Tears down the merged change's worktree, branch, and local artifacts. Gated by `autoCleanup`; never runs while the PR is open.
+
+## Input
+
+`$ARGUMENTS` carries the session slug as `slug=<slug>`. No PR URL, no review ids.
+
+## Procedure
+
+1. Read the session slot `~/.muggle-ai/muggle-do/sessions/<slug>/`:
+   - `prs.json` — the PR's `repo`, `number`, and observed `state`.
+   - `state.md` — `worktreePath` (present only if a worktree was used) and the target branch (`headRefName`).
+2. Confirm `prs.json` shows the PR `merged`. If it is still open or was closed unmerged, do nothing and exit — this stage is post-merge only.
+3. Run [`../_shared/post-merge-cleanup.md`](../_shared/post-merge-cleanup.md), substituting `{worktreePath}` and `{branch}`. It honors the `autoCleanup` gate (`always` runs the full sequence, `ask` confirms first, `never` skips).
+4. **Worktree-aware safety.** When no `worktreePath` was recorded — a bootstrap or auto-track session running in the user's own checkout — skip the worktree-remove and local `git branch -d` steps: the user is on that branch in their live checkout, and deleting it would disrupt their workspace. Limit cleanup to the remote-branch delete and artifact prune.
+5. Append a cleanup line to the session's `followup.log`.

--- a/plugin/skills/do/cleanup.md
+++ b/plugin/skills/do/cleanup.md
@@ -1,6 +1,6 @@
 # Post-Merge Cleanup Stage
 
-Invoked by `/muggle-do` when the watcher's terminal tick hands off cleanup after a PR merges. Tears down the merged change's worktree, branch, and local artifacts. Gated by `autoCleanup`; never runs while the PR is open.
+Invoked by `/muggle-do` when the watcher forwards a PR's terminal (`merged`) state. This stage only resolves the session's workspace and **delegates** teardown to the shared procedure — it does not restate the teardown steps. Never runs while the PR is open.
 
 ## Input
 
@@ -8,10 +8,7 @@ Invoked by `/muggle-do` when the watcher's terminal tick hands off cleanup after
 
 ## Procedure
 
-1. Read the session slot `~/.muggle-ai/muggle-do/sessions/<slug>/`:
-   - `prs.json` — the PR's `repo`, `number`, and observed `state`.
-   - `state.md` — `worktreePath` (present only if a worktree was used) and the target branch (`headRefName`).
+1. Read `~/.muggle-ai/muggle-do/sessions/<slug>/`: `prs.json` (PR `repo`, `number`, observed `state`) and `state.md` (`worktreePath` if a worktree was used, and the target branch `headRefName`).
 2. Confirm `prs.json` shows the PR `merged`. If it is still open or was closed unmerged, do nothing and exit — this stage is post-merge only.
-3. Run [`../_shared/post-merge-cleanup.md`](../_shared/post-merge-cleanup.md), substituting `{worktreePath}` and `{branch}`. It honors the `autoCleanup` gate (`always` runs the full sequence, `ask` confirms first, `never` skips).
-4. **Worktree-aware safety.** When no `worktreePath` was recorded — a bootstrap or auto-track session running in the user's own checkout — skip the worktree-remove and local `git branch -d` steps: the user is on that branch in their live checkout, and deleting it would disrupt their workspace. Limit cleanup to the remote-branch delete and artifact prune.
-5. Append a cleanup line to the session's `followup.log`.
+3. Run [`../_shared/post-merge-cleanup.md`](../_shared/post-merge-cleanup.md) with `{worktreePath}` and `{branch}`. That file owns the teardown sequence **and its safety rules** — including skipping worktree-remove and local branch deletion when no worktree was used. This stage adds no teardown logic of its own.
+4. Append a cleanup line to the session's `followup.log`.

--- a/plugin/skills/do/open-prs/forward.md
+++ b/plugin/skills/do/open-prs/forward.md
@@ -71,7 +71,7 @@ If `prs.json` is empty, **do not dispatch** — record the reason in `result.md`
 
 ## Post-merge cleanup
 
-Gated by `autoCleanup`. Fires in a follow-up turn after merge — never from this stage. See [`../../_shared/post-merge-cleanup.md`](../../_shared/post-merge-cleanup.md).
+Gated by `autoCleanup`. Triggered when the watcher's terminal tick observes the merge and dispatches `/muggle-do`'s cleanup directive ([`../cleanup.md`](../cleanup.md)) — never from this stage. See [`../../_shared/post-merge-cleanup.md`](../../_shared/post-merge-cleanup.md).
 
 Append one short reminder tied to the gate value:
 

--- a/plugin/skills/muggle-do/SKILL.md
+++ b/plugin/skills/muggle-do/SKILL.md
@@ -59,11 +59,12 @@ When invoked with the directive (PR URL + slug + review ids), routes to [`../do/
 Inspect `$ARGUMENTS` in this order:
 
 1. **Address-reviews** — input contains a `github.com/.../pull/<n>` URL **and** one or more integers ≥ 100000000 (review id shape) → [`../do/address-reviews.md`](../do/address-reviews.md). Programmatic; never ask.
-2. **Empty / `help` / `menu` / `?`** → menu + session selector.
-3. **Task automation** (perform an action on a website) → `muggle:muggle-do-task`.
-4. **Otherwise** → forward pipeline at Stage 1.
+2. **Post-merge cleanup**: input contains `cleanup` and a `slug=<slug>` token (no PR URL, no review ids). Routes to [`../do/cleanup.md`](../do/cleanup.md), dispatched by the watcher's terminal tick after a merge. Programmatic; never ask.
+3. **Empty / `help` / `menu` / `?`** → menu + session selector.
+4. **Task automation** (perform an action on a website) → `muggle:muggle-do-task`.
+5. **Otherwise** → forward pipeline at Stage 1.
 
-When in doubt between #3 and #4, ask one question.
+When in doubt between #4 and #5, ask one question.
 
 ## Preferences
 

--- a/plugin/skills/muggle-pr-followup/SKILL.md
+++ b/plugin/skills/muggle-pr-followup/SKILL.md
@@ -7,7 +7,7 @@ description: Use this skill when the user wants a pull request's incoming review
 
 > Telemetry first step: see [`../_shared/telemetry-emit.md`](../_shared/telemetry-emit.md). Use `skillName: "muggle-pr-followup"`.
 
-A watcher that babysits one open PR's review thread. Polls for new submitted reviews; when any land, hands them off to `/muggle-do` and exits. `/muggle-do` is the executor — it classifies the reviews, runs the work, pushes, replies per comment, and respawns the watcher.
+A watcher that babysits one open PR's review thread. Polls for new submitted reviews; when any land, hands them off to `/muggle-do` and exits. On merge, it hands off post-merge cleanup to `/muggle-do` the same way. `/muggle-do` is the executor — it classifies the reviews, runs the work, pushes, replies per comment, and respawns the watcher.
 
 **The watcher is a dumb pipe.** It does not classify reviews, iterate cycles, post replies, or escalate. All of that lives in `/muggle-do`. See [stage-8 design](../../../../muggle-ai-brain/architecture/2026-05-08-muggle-do-pr-comment-loop-design.md) for the rationale.
 

--- a/plugin/skills/muggle-pr-followup/contract.md
+++ b/plugin/skills/muggle-pr-followup/contract.md
@@ -38,7 +38,14 @@ If `state` is `MERGED` or `CLOSED`:
 3. Append a terminal line to `followup.log` per [`output-templates/watcher-log.md`](output-templates/watcher-log.md).
 4. Emit a `tick` event with `terminal: true` per [`../_shared/telemetry-events/pr-followup-tick.md`](../_shared/telemetry-events/pr-followup-tick.md).
 5. **Cancel the cron schedule that fires this watcher.** `/loop 1m ...` from bootstrap was registered via `CronCreate`; a fixed-interval cron keeps firing regardless of whether the skill re-dispatches. Call `CronList`, find any job whose command ends with `/muggle:muggle-pr-followup <slug> <pr-number>` (exact two-arg match), and `CronDelete` it. No-op if none matches — the tick may have been invoked manually rather than via `/loop`.
-6. Exit. The watcher has now unscheduled itself; no future ticks will fire for this PR.
+6. **If `state` is `MERGED`, hand off post-merge cleanup.** Dispatch `/muggle-do` with a cleanup directive carrying the slug, as the last action of this turn:
+
+   ```
+   /muggle-do post-merge cleanup slug=<slug>
+   ```
+
+   `/muggle-do` owns the session's worktree/branch knowledge and honors the `autoCleanup` gate; the watcher never runs cleanup itself. Skip when `state` is `CLOSED` (unmerged: leave the branch and any worktree intact).
+7. Exit. The watcher has now unscheduled itself; no future ticks will fire for this PR.
 
 ### Step 3 — Fetch new submitted reviews
 


### PR DESCRIPTION
Closes the two control-flow gaps found while tracing muggle-do — implemented by **delegating to existing single owners**, not by adding overlapping logic (reworked after first-pass feedback).

## 1. Post-merge cleanup never fired (real bug)

`autoCleanup` is meant to run after merge, but the only agent that observes the merge — the watcher's terminal tick — just wrote `result.md`, cancelled its cron, and exited. Worktree/branch/artifacts leaked.

**Fix (separation of concerns):**
- `muggle-pr-followup/contract.md` — on `MERGED`, the watcher *forwards* the terminal event to `/muggle-do` (same pattern as forwarding reviews). It performs no cleanup itself.
- `muggle-do/SKILL.md` — input routing maps the cleanup directive to a stage.
- `do/cleanup.md` *(new)* — **pure delegator**: resolves the session's `worktreePath`/`branch`, confirms merged, hands off to `_shared/post-merge-cleanup.md`. No teardown steps restated.
- `_shared/post-merge-cleanup.md` — gains the live-checkout safety rule (teardown safety lives with the teardown owner).

## 2. address-reviews could edit the wrong branch (fragility)

Bootstrap/auto-track watchers run on the user's live checkout; a branch switch would land edits on the wrong branch.

**Fix:** `do/address-reviews.md` delegates workspace materialization to `_shared/pr-branch-worktree.md` (the single owner of checking out a PR branch in isolation), reusing `state.md`'s `worktreePath` when a forward-mode session already created one. No bespoke `gh pr checkout`.

## One owner per concern (after this PR)
- Posting/screenshots → `muggle-pr-visual-walkthrough`
- Teardown (+ its safety rules) → `_shared/post-merge-cleanup.md`
- PR-branch checkout/isolation → `_shared/pr-branch-worktree.md`

## Not in this PR (tracked separately)
Bigger SoC consolidations surfaced by the audit: E2E run-loop is reimplemented 3–4×; worktree layout has 3 path schemes; `muggle-test`/`muggle-do` bypass `muggle-test-prepare`. Sequenced as follow-up PRs.

## Tests
`src/test/skills/` + `cleanup-skills` — 83 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)