### PR TITLE
refactor(worktree): unify path scheme + lifecycle ownership (SoC: C)

### DIFF
--- a/plugin/skills/_shared/pr-branch-worktree.md
+++ b/plugin/skills/_shared/pr-branch-worktree.md
@@ -4,7 +4,7 @@
 
 ## When this applies
 
-A skill receives a GitHub PR URL of the form `github.com/<org>/<repo>/pull/<n>` and needs the PR's branch checked out to test against it locally.
+A skill receives a GitHub PR URL of the form `github.com/<org>/<repo>/pull/<n>` and needs the PR's branch checked out to test against it locally. For worktree principles (one-per-branch, port/data isolation, teardown) see [`use-worktrees.md`](use-worktrees.md) — this file owns only the materialize-an-existing-PR-branch operation.
 
 ## Steps
 

--- a/plugin/skills/_shared/use-worktrees.md
+++ b/plugin/skills/_shared/use-worktrees.md
@@ -7,13 +7,14 @@ Use this for feature development, local validation, and PR iteration.
 - **One worktree per branch.** Never switch branches inside a long-lived checkout.
 - **Isolate runtime resources.** Parallel worktrees need unique ports and isolated mutable test state.
 - **Keep worktrees disposable.** Create for focused work, remove after merge.
+- **Existing PR branch?** Materialize it via [`pr-branch-worktree.md`](pr-branch-worktree.md) — same `<repo>/.claude/worktrees/` path scheme, checking out the existing branch instead of creating a new one.
 
 ## Start new change work
 
 1. Update the base branch (usually `main`).
 2. Create a new worktree and branch:
    ```bash
-   git worktree add <repo>-worktrees/<slug> -b <branch>
+   git worktree add <repo>/.claude/worktrees/<sanitized-branch> -b <branch>
    ```
 3. Install dependencies and run setup in that worktree.
 4. Keep all edits and commits for the change in that same worktree.

--- a/plugin/skills/do/pre-flight.md
+++ b/plugin/skills/do/pre-flight.md
@@ -55,7 +55,7 @@ Present **one `AskUserQuestion`** (or the platform's structured-selection equiva
 8. **Test-user credentials** — only if validation is Local E2E AND the Auth0 tenant in the repo differs from the tenant the managed secrets were created under. Options: "Reuse existing secrets (may fail if tenant mismatch — will surface failure)" / "Create new secrets for this tenant (provide email + password)" / "Switch to staging replay".
 9. **PR target branch** — default: the repo's default branch. "Use default" / "Target a different branch".
 10. **Re-auth Muggle Test MCP?** — only if auth was missing/expired. "Log in now" / "Abort".
-11. **Worktree for this change?** — gate: [`autoUseWorktree`](../muggle-preferences/preference-gates/autoUseWorktree.md). Options: create a sibling worktree, or work in the current checkout.
+11. **Worktree for this change?** — gate: [`autoUseWorktree`](../muggle-preferences/preference-gates/autoUseWorktree.md). Options: create a dedicated worktree (per [`../_shared/use-worktrees.md`](../_shared/use-worktrees.md)), or work in the current checkout.
 12. **Rebase onto `origin/<default>` first?** — gate: [`autoRebase`](../muggle-preferences/preference-gates/autoRebase.md), only if `behind > 0`. Options: rebase before stage 6, or run as-is.
 13. **Run E2E at the end of every cycle?** — gate: [`autoE2ETest`](../muggle-preferences/preference-gates/autoE2ETest.md), only if step 10's silent detection resolved to `ask`. Options: always run stage 6, or ask each cycle.
 

--- a/plugin/skills/muggle-test/SKILL.md
+++ b/plugin/skills/muggle-test/SKILL.md
@@ -475,7 +475,7 @@ This is a suggestion, not automatic invocation. Skip silently if every test pass
 ## Guardrails
 
 - **Always confirm intent first** — never assume local vs remote without asking
-- **PR URLs always run in a dedicated worktree** — never switch the user's main checkout. Create or reuse `<repo>/.claude/worktrees/<sanitized-branch>` and pass that path as the `cwd` parameter to local execute tools. The cross-worktree single-flight lock relies on this to serialize concurrent runs from different branches.
+- **PR URLs always run in a dedicated worktree** — never switch the user's main checkout. Materialize per [`_shared/pr-branch-worktree.md`](../_shared/pr-branch-worktree.md) and pass that path as `cwd` to local execute tools; the cross-worktree single-flight lock relies on it to serialize concurrent runs from different branches.
 - **User MUST select project** — present clickable options via `AskUserQuestion`, wait for explicit choice, never auto-select
 - **Best-effort shortlist use cases** — use the change summary to narrow the list to the most relevant 1–5 use cases and pre-check them; never dump every use case in the project on the user. Always leave an escape hatch to reveal the full list.
 - **Best-effort shortlist test cases** — same idea: pre-check the test cases most relevant to the change summary; never enumerate every test case attached to a use case. Always leave an escape hatch to reveal the full list.


### PR DESCRIPTION
SoC consolidation **C**: the worktree/branch lifecycle was spread across 6+ files with **three incompatible path schemes**.

## Change
- **One path scheme** everywhere: `<repo>/.claude/worktrees/<sanitized-branch>` (the outlier `<repo>-worktrees/<slug>` in `use-worktrees.md` is gone).
- **Clear ownership, mutually cross-referenced:**
  - `use-worktrees.md` — worktree principles + **new-branch** creation + teardown pointer.
  - `pr-branch-worktree.md` — materialize an **existing PR branch** (same scheme).
  - `post-merge-cleanup.md` — single teardown owner (scheme-agnostic; gained the live-checkout safety rule in #228).
- **Callers reference, don't restate:** `muggle-test`'s guardrail and `pre-flight` Q11 now point at the owner instead of restating the path / the old "sibling worktree" wording.

## Tests
`src/test/skills/` green.

## Sequence
C of B/C/D. Done: **B** (#229, E2E run-loop core). Next: **D** (readiness delegation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)