### PR TITLE
refactor(readiness): delegate to muggle-test-prepare (SoC: D)

### DIFF
--- a/plugin/skills/do/e2e-acceptance.md
+++ b/plugin/skills/do/e2e-acceptance.md
@@ -58,7 +58,7 @@ For a `local-e2e` block, use `localUrl`, `projectId`, and the working-tree path 
 
 Before launching the local runner:
 
-1. **Dev-server + backend readiness** — invoke [`muggle-test-prepare`](../muggle-test-prepare/SKILL.md), the readiness/service-start owner (idempotent fast-exit when healthy; probes via `dev-server-readiness.md`). Halt on failure. In autonomous mode a service down mid-cycle is a pre-flight bug, not a prompt.
+1. **Dev-server + backend readiness** — invoke [`muggle-test-prepare`](../muggle-test-prepare/SKILL.md), the readiness/service-start owner (idempotent fast-exit when healthy; probes via `dev-server-readiness.md`). Halt on failure.
 2. **Auth** — `muggle-remote-auth-status` must be `authenticated`; else escalate.
 3. **Identity tenant/domain match** — if test credentials were marked `existing`, confirm the repo's configured identity tenant/domain matches the recorded tenant/domain. Mismatch → halt.
 

--- a/plugin/skills/do/e2e-acceptance.md
+++ b/plugin/skills/do/e2e-acceptance.md
@@ -58,7 +58,7 @@ For a `local-e2e` block, use `localUrl`, `projectId`, and the working-tree path 
 
 Before launching the local runner:
 
-1. **Dev-server + backend readiness** — per [`../_shared/dev-server-readiness.md`](../_shared/dev-server-readiness.md) (port + compile log + backend health). Halt on any failure.
+1. **Dev-server + backend readiness** — invoke [`muggle-test-prepare`](../muggle-test-prepare/SKILL.md), the readiness/service-start owner (idempotent fast-exit when healthy; probes via `dev-server-readiness.md`). Halt on failure. In autonomous mode a service down mid-cycle is a pre-flight bug, not a prompt.
 2. **Auth** — `muggle-remote-auth-status` must be `authenticated`; else escalate.
 3. **Identity tenant/domain match** — if test credentials were marked `existing`, confirm the repo's configured identity tenant/domain matches the recorded tenant/domain. Mismatch → halt.
 

--- a/plugin/skills/do/pre-flight.md
+++ b/plugin/skills/do/pre-flight.md
@@ -26,8 +26,8 @@ Before asking anything, gather every fact you can resolve without the user:
 
 1. **Candidate repo(s).** Match keywords in the task description against configured repo names. If one repo is an obvious match, propose it as the default; if two or three are plausible, list them.
 2. **Current branch and default branch** for each candidate repo. Run `git -C <repo> symbolic-ref refs/remotes/origin/HEAD --short` and `git -C <repo> branch --show-current`. If the current branch is the default, the pre-flight must collect a new branch name.
-3. **Running dev server.** Detect listening ports and reconcile env-file URL/port using [`../_shared/dev-server-readiness.md`](../_shared/dev-server-readiness.md).
-4. **Running backend.** Probe backend health per [`../_shared/dev-server-readiness.md`](../_shared/dev-server-readiness.md) ("Backend health"). Note up/down.
+3. **Local environment readiness.** Invoke [`muggle-test-prepare`](../muggle-test-prepare/SKILL.md) — the owner of dev-server/backend detection and service start (idempotent; it probes via `dev-server-readiness.md` internally). Use what it reports as the dev-server/URL pre-flight signal.
+4. **Backend health.** Covered by the same `muggle-test-prepare` invocation above (it probes backend health); note up/down.
 5. **Muggle Test MCP auth.** Call `muggle-remote-auth-status`. If expired, you will ask to re-auth in the questionnaire.
 6. **Candidate Muggle Test projects.** Call `muggle-remote-project-list` and rank by semantic match against the task description and the repo's dev URL.
 7. **Existing test-user secrets.** For each candidate Muggle Test project, call `muggle-remote-secret-list` and note whether `managed_profile_email` / `managed_profile_password` exist.

--- a/plugin/skills/muggle-test/SKILL.md
+++ b/plugin/skills/muggle-test/SKILL.md
@@ -235,6 +235,10 @@ If the user picks "Override one or more", let them flip the mode for any test ca
 
 ## Step 7A: Execute — Local Mode
 
+### Local environment readiness
+
+Before anything else, invoke [`muggle-test-prepare`](../muggle-test-prepare/SKILL.md) — the readiness/service-start owner (idempotent; halt on what it surfaces). The URL gate below only *selects* the target; prepare is what guarantees something is listening and compiled.
+
 ### Pre-flight question — Local URL (gated by `autoSelectLocalHost`)
 
 Skill responsibilities (the rest is in `preference-gates/autoSelectLocalHost.md`):


### PR DESCRIPTION
SoC consolidation **D** (final of B/C/D): `muggle-test-prepare` owns service readiness + start, but two of its three mandated consumers bypassed it.

## Change
- **`muggle-do` pre-flight (items 3/4)** → invoke `muggle-test-prepare` instead of probing `dev-server-readiness.md` directly.
- **`muggle-do` `e2e-acceptance` Step 0.5** → readiness delegates to prepare (idempotent fast-exit; a mid-cycle down service is a pre-flight bug, not a prompt — preserves autonomy).
- **`muggle-test` local Step 7A** → adds the missing prepare invocation before URL selection (it previously did only an `lsof` port sniff).

`dev-server-readiness.md` remains the low-level probe that prepare uses internally; consumers stop calling it directly. One owner for readiness.

## Tests
`src/test/skills/` green; all `../muggle-test-prepare/SKILL.md` links resolve.

## Sequence — complete
- **B** #229 — E2E run-loop core
- **C** #230 — worktree path scheme + lifecycle ownership
- **D** (this) — readiness delegation

Plus #228 (cleanup trigger + tree guard, reworked to delegate). All four are the "move how-tos into `_shared/`, reference from skills" pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)