### PR TITLE
feat(muggle-do): opt-in autonomous rebase-conflict resolution (autoResolveConflicts)

### DIFF
--- a/plugin/skills/_shared/rebase-before-e2e.md
+++ b/plugin/skills/_shared/rebase-before-e2e.md
@@ -10,6 +10,12 @@ default=$(git symbolic-ref refs/remotes/origin/HEAD --short | sed 's|origin/||')
 behind=$(git rev-list --count "HEAD..origin/${default}")
 ```
 
-Pass `{behind}` and `{default}` to the picker prompts. On `always`, run `git rebase origin/${default}`; stop and report on conflicts — never auto-resolve.
+Pass `{behind}` and `{default}` to the picker prompts. On `always`:
+
+1. Capture the rollback point: `pre_rebase_sha=$(git rev-parse HEAD)`.
+2. `git rebase origin/${default}`.
+3. On conflict, branch by [`autoResolveConflicts`](../muggle-preferences/preference-gates/autoResolveConflicts.md):
+   - `never` (default) → `git rebase --abort`; stop and report, naming the conflicted files. Never auto-resolve.
+   - `always` → hand off to [`resolve-rebase-conflicts.md`](resolve-rebase-conflicts.md) with `pre_rebase_sha`; it resolves, runs the verify-or-rollback gate, and either proceeds or restores `pre_rebase_sha` and escalates.
 
 Stale branches produce false failures and false greens — that's why this gate exists.

--- a/plugin/skills/_shared/resolve-rebase-conflicts.md
+++ b/plugin/skills/_shared/resolve-rebase-conflicts.md
@@ -1,0 +1,60 @@
+# Auto-Resolve Rebase Conflicts
+
+Invoked from [`rebase-before-e2e.md`](rebase-before-e2e.md) when `git rebase origin/{default}` reports conflicts **and** [`autoResolveConflicts`](../muggle-preferences/preference-gates/autoResolveConflicts.md) is `always`. Under the default `never` the caller aborts and escalates instead — this file never runs.
+
+Contract: never push an auto-resolved rebase that has not passed the verify gate, and always keep the branch restorable to its pre-rebase state.
+
+## Inputs
+
+- `pre_rebase_sha` — branch HEAD captured by the caller **before** `git rebase`; the rollback point.
+- `default` — the branch being rebased onto.
+- Session context: slug, PR url/number, and the persisted validation strategy (for the E2E step).
+
+## Procedure
+
+### Step 1 — Enumerate and classify conflicts
+
+```bash
+git diff --name-only --diff-filter=U
+```
+
+Classify each conflicted path:
+
+- **Mechanical** — lockfiles (`package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, `Cargo.lock`, …), generated output (`dist/`, build artifacts, snapshots), or pure formatting / import-order churn.
+- **Semantic** — anything carrying logic: source, behavior-changing config, tests.
+
+### Step 2 — Resolve
+
+- **Mechanical** → resolve deterministically: regenerate the lockfile with the repo's package manager; regenerate or take-incoming for generated files; run the repo's formatter. Never hand-merge a lockfile.
+- **Semantic** → a reasoned 3-way resolution preserving the intent of **both** sides (ours = the PR's change, theirs = the new default-branch line). If intent in load-bearing logic can't be confidently reconciled, do not guess → Step 5.
+
+Then `git add -A && git rebase --continue`, and repeat Steps 1–2 for each remaining conflicted commit until the rebase completes.
+
+### Step 3 — Verify gate (mandatory)
+
+Each must pass, in order:
+
+1. **Build** — typecheck + lint on the changed surface, per [`../do/build.md`](../do/build.md).
+2. **Unit suite** — per [`../do/unit-tests.md`](../do/unit-tests.md); record PASS.
+3. **E2E** — per [`../do/e2e-acceptance.md`](../do/e2e-acceptance.md) and the persisted [`autoE2ETest`](../muggle-preferences/preference-gates/autoE2ETest.md) strategy. A poll-only session with no validation context reports `SKIPPED`, same as the normal cycle.
+
+### Step 4 — Pass → proceed
+
+Return success. The caller resumes the normal flow; the push happens downstream, so a resolved rebase ships only after it has verified.
+
+### Step 5 — Fail → restore + escalate
+
+On an unreconcilable semantic conflict (Step 2) or any verify failure (Step 3):
+
+```bash
+git rebase --abort 2>/dev/null || true
+git reset --hard <pre_rebase_sha>
+```
+
+The branch is now byte-for-byte its pre-rebase state. Emit one terminal escalation per [`../muggle-pr-followup/output-templates/escalation.md`](../muggle-pr-followup/output-templates/escalation.md) naming the conflicted files and the failing step, plus the `muggle-do:escalation` event with `kind: "rebase-conflict"` ([`telemetry-events/muggle-do-escalation.md`](telemetry-events/muggle-do-escalation.md)). Do not push.
+
+## Invariants
+
+- A push never follows a verify failure.
+- The branch is always restorable to `pre_rebase_sha`.
+- This file runs only under `autoResolveConflicts = always`; `never` is the caller's unchanged abort-and-escalate path.

--- a/plugin/skills/_shared/resolve-rebase-conflicts.md
+++ b/plugin/skills/_shared/resolve-rebase-conflicts.md
@@ -1,6 +1,6 @@
 # Auto-Resolve Rebase Conflicts
 
-Invoked from [`rebase-before-e2e.md`](rebase-before-e2e.md) when `git rebase origin/{default}` reports conflicts **and** [`autoResolveConflicts`](../muggle-preferences/preference-gates/autoResolveConflicts.md) is `always`. Under the default `never` the caller aborts and escalates instead — this file never runs.
+The autonomous conflict-resolution body, run when a rebase onto `origin/{default}` reports conflicts **and** [`autoResolveConflicts`](../muggle-preferences/preference-gates/autoResolveConflicts.md) is `always`. Under the default `never` the caller aborts and escalates instead, and this file never runs. The caller hands off the inputs below; this file names no caller — the dependency runs one way.
 
 Contract: never push an auto-resolved rebase that has not passed the verify gate, and always keep the branch restorable to its pre-rebase state.
 

--- a/plugin/skills/_shared/telemetry-events/muggle-do-escalation.md
+++ b/plugin/skills/_shared/telemetry-events/muggle-do-escalation.md
@@ -9,7 +9,7 @@ Zero or one per address-reviews invocation. Fires when `/muggle-do` emits a term
   "session_slug": "<slug>",
   "repo": "<owner>/<repo>",
   "pr_number": <int>,
-  "kind": "ambiguous-review" | "design-adjustment",
+  "kind": "ambiguous-review" | "design-adjustment" | "rebase-conflict",
   "review_ids": [<int>, ...]
 }
 ```
@@ -17,3 +17,4 @@ Zero or one per address-reviews invocation. Fires when `/muggle-do` emits a term
 `kind`:
 - `"ambiguous-review"` — one or more reviews classified ambiguous in this batch.
 - `"design-adjustment"` — mid-cycle, the work surfaced a design-level conflict.
+- `"rebase-conflict"` — an opt-in auto-rebase hit conflicts that couldn't be resolved and verified; the branch was restored to its pre-rebase SHA. `review_ids` may be empty.

--- a/plugin/skills/do/address-reviews.md
+++ b/plugin/skills/do/address-reviews.md
@@ -27,6 +27,10 @@ Read from `~/.muggle-ai/muggle-do/sessions/<slug>/`:
 
 ## Procedure
 
+### Step 0 — Track the default branch
+
+Before assembling work, rebase onto the latest default branch so the cycle addresses reviews against current master, not a stale base. Run [`../_shared/rebase-before-e2e.md`](../_shared/rebase-before-e2e.md) — gated by [`autoRebase`](../muggle-preferences/preference-gates/autoRebase.md), fires only when `behind > 0`. Conflict handling follows [`autoResolveConflicts`](../muggle-preferences/preference-gates/autoResolveConflicts.md): the default `never` aborts and escalates (`kind: "rebase-conflict"`); `always` resolves behind the verify-or-rollback gate. If the rebase escalates, stop the cycle — do not push.
+
 ### Step 1 — Assemble the work set
 
 Two sources, combined into one batch (dedupe by comment id):

--- a/plugin/skills/muggle-do/SKILL.md
+++ b/plugin/skills/muggle-do/SKILL.md
@@ -70,8 +70,9 @@ When in doubt between #3 and #4, ask one question.
 | Preference | Gate |
 | :--------- | :--- |
 | `autoE2ETest` | Stage 6 — run E2E every cycle (default `always`), or fold into pre-flight |
+| `autoResolveConflicts` | On rebase conflict — resolve autonomously behind a verify-or-rollback gate (opt-in), or abort + escalate (default `never`) |
 
-`autoUseWorktree`, `autoRebase`, `autoCreatePR`, `autoCleanup` fire from per-stage files.
+`autoUseWorktree`, `autoRebase`, `autoResolveConflicts`, `autoCreatePR`, `autoCleanup` fire from per-stage files.
 
 ## Session model
 

--- a/plugin/skills/muggle-preferences/preference-gates/autoResolveConflicts.md
+++ b/plugin/skills/muggle-preferences/preference-gates/autoResolveConflicts.md
@@ -1,0 +1,11 @@
+# `autoResolveConflicts`
+
+When a rebase onto `origin/{default}` hits conflicts, resolve them autonomously behind a verify-or-rollback gate, or stop and escalate. Default `never` — the loop aborts the rebase and escalates exactly as before. Opt in with `always` to resolve conflicts without a human.
+
+**Picker 1** — header `Resolve rebase conflicts?`, question `"Rebase onto origin/{default} hit conflicts in {conflicted} file(s) — resolve them autonomously?"`
+- `Resolve autonomously` — `Resolve the conflicts, then re-verify (build + unit + E2E) before any push; roll back and escalate if verification fails.` → `always`
+- `Stop and escalate` — `Abort the rebase, restore the branch, and hand the conflict to me.` → `never`
+
+**Silent action**
+- `always` → `Resolving rebase conflicts autonomously (verify-or-rollback)`
+- `never` → `Aborting rebase and escalating — conflicts in {conflicted} file(s)`


### PR DESCRIPTION
Workstream **B** of the merged design ([architecture/2026-05-30-…-design.md](https://github.com/multiplex-ai/muggle-ai-brain/blob/master/architecture/2026-05-30-muggle-do-conflict-resolution-ci-autofix-and-browser-task-rename-design.md)). Independent of [#232](https://github.com/multiplex-ai/muggle-ai-works/pull/232) (rename); **C** (CI auto-fix) follows.

## What changes
- **New gate `autoResolveConflicts`** — default `never` = abort + escalate, **byte-for-byte today's behavior**; opt-in `always` = resolve autonomously. Auto-registered via the `preference-gates/` directory listing.
- **New `_shared/resolve-rebase-conflicts.md`** — the resolution body: capture the pre-rebase SHA, classify conflicts (mechanical: lockfiles/generated/formatting → deterministic; semantic: logic → reasoned 3-way), then a **mandatory verify gate** (build + unit + E2E per `autoE2ETest`). Pass → proceed; fail or unreconcilable semantic conflict → `git reset --hard <pre_rebase_sha>` + escalate.
- **`rebase-before-e2e.md`** branches conflict handling on the new gate (the old "never auto-resolve" is now the `never` path, unchanged).
- **`address-reviews.md` Step 0** — per-cycle rebase so the loop tracks master across cycles, not only at pre-flight.
- **`muggle-do:escalation`** event gains `kind: "rebase-conflict"`.

## Invariants
- Never pushes an auto-resolved rebase that hasn't passed the verify gate.
- The branch is always restorable to the captured pre-rebase SHA.
- `never` (default) is exactly today's behavior.

## Choices (per design defaults)
- **No** per-cycle semantic-conflict file cap — the verify-or-rollback gate is the safety net.
- Reuses the existing escalation event rather than minting a new one.

## Verification
- `verify-plugin-marketplace.mjs` → **passed** (built `dist/plugin`); `verify-compatibility-contracts.mjs` → **passed**. Gate file resolves via `ls preference-gates/*.md`; all cross-links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)