### PR TITLE
feat(muggle-pr-followup): watch CI and auto-fix red checks

### DIFF
--- a/plugin/skills/_shared/ci-check-to-command.md
+++ b/plugin/skills/_shared/ci-check-to-command.md
@@ -1,0 +1,10 @@
+# CI check → local fix command
+
+Map a red CI check to the local command that reproduces and fixes it. Repo-agnostic — read the repo's `package.json` scripts; never hardcode script names.
+
+| Failing check | Local action |
+| :------------ | :----------- |
+| lint / format | Run the repo's lint `--fix` / formatter; restage. |
+| typecheck | Run the typecheck script; read the errors; edit the types. |
+| unit / test | Run the suite; read the failures; fix the code or the test. |
+| out of scope — E2E-in-CI, build/deploy infra, flaky / non-deterministic, or unknown | Do **not** attempt; record for escalation. |

--- a/plugin/skills/_shared/github-cli-recipes.md
+++ b/plugin/skills/_shared/github-cli-recipes.md
@@ -10,6 +10,7 @@ Skills assume a working `gh auth status`. Auth errors surface verbatim from `gh`
 | :----- | :------- |
 | [`pr-metadata`](github-cli-recipes/pr-metadata.md) | Snapshot PR state, head SHA, branch — watcher + bootstrap. |
 | [`submitted-reviews`](github-cli-recipes/submitted-reviews.md) | Fetch reviews past a cursor — watcher's poll. |
+| [`pr-checks`](github-cli-recipes/pr-checks.md) | Check-run rollup for the head SHA — watcher's CI poll. |
 | [`line-comments-for-review`](github-cli-recipes/line-comments-for-review.md) | Pull a review's line comments — `/muggle-do` per-comment routing. |
 | [`unresolved-threads`](github-cli-recipes/unresolved-threads.md) | GraphQL fetch of unresolved comment threads — resolve-reminder. |
 | [`reply-line-comment`](github-cli-recipes/reply-line-comment.md) | POST a threaded reply on a line comment. |

--- a/plugin/skills/_shared/github-cli-recipes/pr-checks.md
+++ b/plugin/skills/_shared/github-cli-recipes/pr-checks.md
@@ -1,0 +1,22 @@
+# PR check-run rollup
+
+Fetch the CI check state for a PR's head — what the watcher polls to detect red CI.
+
+```bash
+gh pr checks <pr-number> --repo <owner>/<repo> --json name,state,bucket,link
+```
+
+Each row:
+
+- `name` — the check's name (e.g. `lint`, `typecheck`, `unit`, `build`).
+- `state` — `SUCCESS` / `FAILURE` / `PENDING` / `SKIPPED` / `CANCELLED` / `NEUTRAL` (gh folds status + conclusion into one field).
+- `bucket` — `pass` / `fail` / `pending` / `skipping` / `cancel`; the coarse rollup — filter on this.
+- `link` — the check's details URL, for pulling logs in the fix-ci stage.
+
+Classify for the watcher:
+
+- **pending** — any row with `bucket == "pending"`. Checks haven't settled → idle.
+- **red** — any row with `bucket == "fail"` (`state` FAILURE / CANCELLED / TIMED_OUT). Candidate for fix-ci.
+- **green** — every row `pass` / `skipping`, or no rows at all.
+
+The fix-ci dispatch carries the `name`s of the red rows. `gh pr checks` exits non-zero when any check fails — capture output regardless of exit code.

--- a/plugin/skills/_shared/telemetry-events/muggle-do-cycle.md
+++ b/plugin/skills/_shared/telemetry-events/muggle-do-cycle.md
@@ -12,9 +12,12 @@ One per address-reviews invocation, regardless of outcome.
   "review_ids_in": [<int>, ...],
   "review_ids_actionable": [<int>, ...],
   "review_ids_ambiguous": [<int>, ...],
+  "ci_checks_in": ["<check-name>", ...],
+  "ci_checks_fixed": ["<check-name>", ...],
+  "ci_checks_escalated": ["<check-name>", ...],
   "head_sha_before": "<sha-or-null>",
   "head_sha_after": "<sha-or-null>",
-  "outcome": "pushed" | "escalated" | "mixed" | "no-op" | "self-loop-skip"
+  "outcome": "pushed" | "escalated" | "mixed" | "no-op" | "self-loop-skip" | "ci-fixed" | "ci-escalated"
 }
 ```
 
@@ -24,3 +27,7 @@ One per address-reviews invocation, regardless of outcome.
 - `"mixed"` — both branches happened in the same invocation.
 - `"no-op"` — every input id was already in the escalated set; no work.
 - `"self-loop-skip"` — review was a synthetic wrapper around the agent's own reply (every line comment is a reply carrying the loop marker `<!-- muggle-do:bot -->`). Cursor advanced silently; no work, no escalation.
+- `"ci-fixed"` — a watcher-dispatched fix-ci cycle pushed a fix for one or more red checks.
+- `"ci-escalated"` — fix-ci exhausted its 3 attempts for the SHA or the failing checks were out of scope; the SHA was added to `ci_escalated_shas`. No further auto-fix on it.
+
+For fix-ci cycles (`ci-fixed` / `ci-escalated`) the `review_ids_*` arrays are empty and the `ci_checks_*` arrays carry the data: `ci_checks_in` (red checks dispatched), `ci_checks_fixed` (made green and pushed), `ci_checks_escalated` (out-of-scope or unresolved).

--- a/plugin/skills/_shared/telemetry-events/pr-followup-tick.md
+++ b/plugin/skills/_shared/telemetry-events/pr-followup-tick.md
@@ -11,6 +11,8 @@ One per watcher iteration (idle or not).
   "pr_number": <int>,
   "reviews_seen": <int>,
   "dispatched_review_ids": [<int>, ...],
+  "checks_red": <int>,
+  "dispatched_ci_fix": true | false,
   "terminal": true | false,
   "idle": true | false,
   "tick_duration_ms": <int>
@@ -19,5 +21,7 @@ One per watcher iteration (idle or not).
 
 - `reviews_seen`: count of new submitted reviews past the cursor, **after** filtering by the escalated set.
 - `dispatched_review_ids`: review ids handed to `/muggle-do`. Empty when idle.
+- `checks_red`: count of failing checks on the head SHA. `0` when reviews were dispatched (reviews preempt the CI poll) or CI was green/pending.
+- `dispatched_ci_fix`: true when this tick dispatched `/muggle-do` with a fix-ci directive.
 - `terminal`: true when this tick observed the PR merged or closed and wrote `result.md`.
 - `idle`: true when no reviews were dispatched this tick.

--- a/plugin/skills/do/fix-ci.md
+++ b/plugin/skills/do/fix-ci.md
@@ -1,0 +1,66 @@
+# Fix-CI (watcher-dispatched)
+
+Resolve red CI on a PR's head — lint/format, typecheck, and failing unit tests — verifying green before re-push. Invoked by the [`muggle-pr-followup`](../muggle-pr-followup/contract.md) watcher (Step 5) when a tick sees failing checks and the fix budget for that SHA isn't spent. Like address-reviews, this is a dumb-pipe dispatch: the watcher detects, this stage fixes.
+
+## Turn preamble
+
+```
+**/muggle-do fix-ci** — fixing <count> red check(s) on <owner>/<repo>#<n>.
+```
+
+## Input
+
+`$ARGUMENTS` carries a `github.com/.../pull/<n>` URL, `slug=<slug>`, and the failing check names (no review ids). Parse all three.
+
+## Inputs from disk
+
+From `~/.muggle-ai/muggle-do/sessions/<slug>/`: `prs.json` (PR + local checkout / branch), `last_seen.json` (`ci_fix_attempts`, `ci_escalated_shas`, `pushed_shas`), `state.md` (worktree path, validation strategy).
+
+## Procedure
+
+### Step 1 — Re-attach
+
+Check out the PR branch in the session's working tree (per `state.md`). Capture `red_sha = prs.json[0].head_sha`.
+
+### Step 2 — Map each failing check to a local command
+
+Read the repo's `package.json` scripts (repo-agnostic — never hardcode script names). For each failing check:
+
+- **lint / format** → run the repo's lint `--fix` / formatter; restage.
+- **typecheck** → run the typecheck script; read errors; edit types.
+- **unit / test** → run the suite; read failures; fix the code or the test.
+- **Out of scope** — E2E-in-CI, build/deploy infra, flaky / non-deterministic, or unknown → do **not** attempt; record for escalation (Step 6).
+
+### Step 3 — Verify before push
+
+- Build (typecheck + lint on the changed surface) + unit suite must pass.
+- Run E2E (per [`../muggle-preferences/preference-gates/autoE2ETest.md`](../muggle-preferences/preference-gates/autoE2ETest.md)) only if the fix touched app logic; lint/format-only fixes skip E2E.
+
+A fix that can't be made green locally is not pushed → Step 6.
+
+### Step 4 — Commit + push
+
+Commit per the `fix(ci): <check> — <what>` convention ([`../_shared/pr-followup-helpers/reply-routing.md`](../_shared/pr-followup-helpers/reply-routing.md)). Push. Append the new SHA to `last_seen.pushed_shas`. **No PR replies** — the fix commit is the response.
+
+### Step 5 — Update state + respawn
+
+- Increment `last_seen.ci_fix_attempts[red_sha]`.
+- Respawn the watcher (`/loop 1m /muggle:muggle-pr-followup <slug> <n>`). The next tick re-checks CI on the new SHA — CI is the verify loop. If still red and `ci_fix_attempts[sha] < 3`, the watcher re-dispatches; once attempts reach 3 or only out-of-scope checks remain, escalate (Step 6).
+
+### Step 6 — Escalate (budget spent or out of scope)
+
+When the failing checks are all out of scope, or `ci_fix_attempts[red_sha]` has reached 3 with CI still red:
+
+1. Add `red_sha` to `last_seen.ci_escalated_shas` so the watcher stops re-dispatching it.
+2. Emit one terminal message naming the unresolved checks.
+3. Emit the cycle event with `outcome: "ci-escalated"` (Step 7). Do not loop further on this SHA.
+
+### Step 7 — Telemetry
+
+Emit one `muggle-do:cycle` event ([`../_shared/telemetry-events/muggle-do-cycle.md`](../_shared/telemetry-events/muggle-do-cycle.md)): `outcome: "ci-fixed"` when a fix pushed, `"ci-escalated"` when escalated — with `ci_checks_in` / `ci_checks_fixed` / `ci_checks_escalated`.
+
+## Guardrails
+
+- Max 3 fix attempts per SHA; out-of-scope checks escalate immediately rather than churn.
+- A review landing always wins a tick over CI (watcher Step 4 precedes Step 5).
+- No PR replies; the fix commit is the response.

--- a/plugin/skills/do/fix-ci.md
+++ b/plugin/skills/do/fix-ci.md
@@ -1,6 +1,6 @@
 # Fix-CI (watcher-dispatched)
 
-Resolve red CI on a PR's head — lint/format, typecheck, and failing unit tests — verifying green before re-push. Invoked by the [`muggle-pr-followup`](../muggle-pr-followup/contract.md) watcher (Step 5) when a tick sees failing checks and the fix budget for that SHA isn't spent. Like address-reviews, this is a dumb-pipe dispatch: the watcher detects, this stage fixes.
+Resolve red CI on a PR's head — lint/format, typecheck, and failing unit tests — verifying green before re-push. A dumb-pipe dispatch like address-reviews: the executor receives a PR URL, slug, and the failing check names, and fixes them — it owns the fix, not the decision to dispatch.
 
 ## Turn preamble
 
@@ -24,12 +24,7 @@ Check out the PR branch in the session's working tree (per `state.md`). Capture 
 
 ### Step 2 — Map each failing check to a local command
 
-Read the repo's `package.json` scripts (repo-agnostic — never hardcode script names). For each failing check:
-
-- **lint / format** → run the repo's lint `--fix` / formatter; restage.
-- **typecheck** → run the typecheck script; read errors; edit types.
-- **unit / test** → run the suite; read failures; fix the code or the test.
-- **Out of scope** — E2E-in-CI, build/deploy infra, flaky / non-deterministic, or unknown → do **not** attempt; record for escalation (Step 6).
+Per [`../_shared/ci-check-to-command.md`](../_shared/ci-check-to-command.md). Fix the in-scope checks in the working tree; record out-of-scope checks for escalation (Step 6).
 
 ### Step 3 — Verify before push
 
@@ -45,13 +40,13 @@ Commit per the `fix(ci): <check> — <what>` convention ([`../_shared/pr-followu
 ### Step 5 — Update state + respawn
 
 - Increment `last_seen.ci_fix_attempts[red_sha]`.
-- Respawn the watcher (`/loop 1m /muggle:muggle-pr-followup <slug> <n>`). The next tick re-checks CI on the new SHA — CI is the verify loop. If still red and `ci_fix_attempts[sha] < 3`, the watcher re-dispatches; once attempts reach 3 or only out-of-scope checks remain, escalate (Step 6).
+- Respawn the watcher: `/loop 1m /muggle:muggle-pr-followup <slug> <n>`. CI on the new SHA is the verify loop — a still-red SHA returns as a fresh dispatch, bounded by the per-SHA fix budget (Step 6).
 
 ### Step 6 — Escalate (budget spent or out of scope)
 
 When the failing checks are all out of scope, or `ci_fix_attempts[red_sha]` has reached 3 with CI still red:
 
-1. Add `red_sha` to `last_seen.ci_escalated_shas` so the watcher stops re-dispatching it.
+1. Add `red_sha` to `last_seen.ci_escalated_shas` so the SHA is not re-fixed.
 2. Emit one terminal message naming the unresolved checks.
 3. Emit the cycle event with `outcome: "ci-escalated"` (Step 7). Do not loop further on this SHA.
 
@@ -62,5 +57,4 @@ Emit one `muggle-do:cycle` event ([`../_shared/telemetry-events/muggle-do-cycle.
 ## Guardrails
 
 - Max 3 fix attempts per SHA; out-of-scope checks escalate immediately rather than churn.
-- A review landing always wins a tick over CI (watcher Step 4 precedes Step 5).
 - No PR replies; the fix commit is the response.

--- a/plugin/skills/do/input-routing.md
+++ b/plugin/skills/do/input-routing.md
@@ -1,0 +1,12 @@
+# Input routing
+
+How `/muggle-do` resolves `$ARGUMENTS` to a mode. Modes 1–3 are programmatic — dispatched by the watcher — so never ask on those. Inspect in order:
+
+1. **Address-reviews** — a `github.com/.../pull/<n>` URL **and** one or more review ids (integers ≥ 100000000) → [`address-reviews.md`](address-reviews.md).
+2. **Fix-CI** — a `github.com/.../pull/<n>` URL **and** a `fix ci` / `fix-ci` directive with failing check names (no review ids) → [`fix-ci.md`](fix-ci.md).
+3. **Post-merge cleanup** — a `cleanup` token and `slug=<slug>` (no PR URL, no review ids) → [`cleanup.md`](cleanup.md).
+4. **Empty / `help` / `menu` / `?`** → menu + session selector.
+5. **Task automation** (perform an action on a website) → `muggle:muggle-browser-task`.
+6. **Otherwise** → forward pipeline at Stage 1.
+
+When in doubt between #5 and #6, ask one question.

--- a/plugin/skills/muggle-do/SKILL.md
+++ b/plugin/skills/muggle-do/SKILL.md
@@ -59,11 +59,12 @@ When invoked with the directive (PR URL + slug + review ids), routes to [`../do/
 Inspect `$ARGUMENTS` in this order:
 
 1. **Address-reviews** — input contains a `github.com/.../pull/<n>` URL **and** one or more integers ≥ 100000000 (review id shape) → [`../do/address-reviews.md`](../do/address-reviews.md). Programmatic; never ask.
-2. **Empty / `help` / `menu` / `?`** → menu + session selector.
-3. **Task automation** (perform an action on a website) → `muggle:muggle-do-task`.
-4. **Otherwise** → forward pipeline at Stage 1.
+2. **Fix-CI** — input contains a `github.com/.../pull/<n>` URL **and** a `fix ci` / `fix-ci` directive with failing check names (no review ids) → [`../do/fix-ci.md`](../do/fix-ci.md). Programmatic; never ask. Dispatched by the watcher when CI is red.
+3. **Empty / `help` / `menu` / `?`** → menu + session selector.
+4. **Task automation** (perform an action on a website) → `muggle:muggle-do-task`.
+5. **Otherwise** → forward pipeline at Stage 1.
 
-When in doubt between #3 and #4, ask one question.
+When in doubt between #4 and #5, ask one question.
 
 ## Preferences
 

--- a/plugin/skills/muggle-do/SKILL.md
+++ b/plugin/skills/muggle-do/SKILL.md
@@ -56,16 +56,7 @@ When invoked with the directive (PR URL + slug + review ids), routes to [`../do/
 
 ## Input routing
 
-Inspect `$ARGUMENTS` in this order:
-
-1. **Address-reviews** — input contains a `github.com/.../pull/<n>` URL **and** one or more integers ≥ 100000000 (review id shape) → [`../do/address-reviews.md`](../do/address-reviews.md). Programmatic; never ask.
-2. **Fix-CI** — input contains a `github.com/.../pull/<n>` URL **and** a `fix ci` / `fix-ci` directive with failing check names (no review ids) → [`../do/fix-ci.md`](../do/fix-ci.md). Programmatic; never ask. Dispatched by the watcher when CI is red.
-3. **Post-merge cleanup**: input contains `cleanup` and a `slug=<slug>` token (no PR URL, no review ids). Routes to [`../do/cleanup.md`](../do/cleanup.md), dispatched by the watcher's terminal tick after a merge. Programmatic; never ask.
-4. **Empty / `help` / `menu` / `?`** → menu + session selector.
-5. **Task automation** (perform an action on a website) → `muggle:muggle-browser-task`.
-6. **Otherwise** → forward pipeline at Stage 1.
-
-When in doubt between #5 and #6, ask one question.
+`/muggle-do` serves one interactive mode (the forward pipeline, from a fresh task) and three programmatic modes the watcher dispatches (address-reviews, fix-ci, post-merge cleanup). Resolve `$ARGUMENTS` to a mode per [`../do/input-routing.md`](../do/input-routing.md) before doing anything else.
 
 ## Preferences
 

--- a/plugin/skills/muggle-pr-followup/CLAUDE.md
+++ b/plugin/skills/muggle-pr-followup/CLAUDE.md
@@ -1,6 +1,6 @@
 # muggle-pr-followup — folder TOC
 
-This folder holds the watcher loop for PR review follow-ups. The watcher is a **dumb pipe**: it polls for new submitted reviews and dispatches `/muggle-do` when there are any. Cycle execution, classification, replies, and escalation all live in `/muggle-do`'s address-reviews mode — see [stage-8 design](../../../../muggle-ai-brain/architecture/2026-05-08-muggle-do-pr-comment-loop-design.md) for the architectural rationale.
+This folder holds the watcher loop for PR review follow-ups. The watcher is a **dumb pipe**: it polls for new submitted reviews and CI checks and dispatches `/muggle-do` when there's review feedback or fixable red CI. Cycle execution, classification, replies, and escalation all live in `/muggle-do`'s address-reviews mode — see [stage-8 design](../../../../muggle-ai-brain/architecture/2026-05-08-muggle-do-pr-comment-loop-design.md) for the architectural rationale.
 
 ## Files in this folder
 

--- a/plugin/skills/muggle-pr-followup/SKILL.md
+++ b/plugin/skills/muggle-pr-followup/SKILL.md
@@ -7,7 +7,7 @@ description: Use this skill when the user wants a pull request's incoming review
 
 > Telemetry first step: see [`../_shared/telemetry-emit.md`](../_shared/telemetry-emit.md). Use `skillName: "muggle-pr-followup"`.
 
-A watcher that babysits one open PR's review thread. Polls for new submitted reviews; when any land, hands them off to `/muggle-do` and exits. `/muggle-do` is the executor — it classifies the reviews, runs the work, pushes, replies per comment, and respawns the watcher.
+A watcher that babysits one open PR's review thread and CI. Polls for new submitted reviews and check-run state; when review feedback lands or CI goes red, hands the work to `/muggle-do` and exits. `/muggle-do` is the executor — it classifies the reviews or fixes the failing checks, pushes, replies per comment, and respawns the watcher.
 
 **The watcher is a dumb pipe.** It does not classify reviews, iterate cycles, post replies, or escalate. All of that lives in `/muggle-do`. See [stage-8 design](../../../../muggle-ai-brain/architecture/2026-05-08-muggle-do-pr-comment-loop-design.md) for the rationale.
 

--- a/plugin/skills/muggle-pr-followup/contract.md
+++ b/plugin/skills/muggle-pr-followup/contract.md
@@ -1,6 +1,6 @@
 # Watcher Per-Tick Contract
 
-The procedure for the **tick mode** of `muggle-pr-followup` — one polling iteration scoped to one PR. The watcher is a dumb pipe: it polls for new submitted reviews, dispatches `/muggle-do` if there are any, and exits. It does not classify, amend requirements, post replies, run cycles, or escalate.
+The procedure for the **tick mode** of `muggle-pr-followup` — one polling iteration scoped to one PR. The watcher is a dumb pipe: it polls for new submitted reviews and CI checks, dispatches `/muggle-do` if there's review feedback or fixable red CI, and exits. It does not classify, fix, amend requirements, post replies, run cycles, or escalate.
 
 Routing into this mode is documented in [`SKILL.md`](SKILL.md#routing). The architectural rationale lives in the brain doc `architecture/2026-05-08-muggle-do-pr-comment-loop-design.md`.
 
@@ -44,14 +44,7 @@ If `state` is `MERGED` or `CLOSED`:
 
 Per [`../_shared/github-cli-recipes/submitted-reviews.md`](../_shared/github-cli-recipes/submitted-reviews.md). **Also exclude review ids that appear in `last_seen.escalated_review_ids`** — those have already been escalated and the watcher must not re-dispatch them.
 
-### Step 4 — If zero new reviews → idle
-
-1. Increment `last_seen.idle_tick_count`.
-2. Append an idle line to `followup.log` per [`output-templates/watcher-log.md`](output-templates/watcher-log.md).
-3. Emit a `tick` event with `idle: true`, `reviews_seen: 0`, `dispatched_review_ids: []`.
-4. Exit. The next tick fires in 1 min via `/loop`.
-
-### Step 5 — If one or more new reviews → dispatch
+### Step 4 — If one or more new reviews → dispatch (reviews preempt CI)
 
 The watcher does **not** classify. Classification, batching, replying, escalation, and cycle execution all live in `/muggle-do`. The watcher's job is to hand over the list of new review ids and exit.
 
@@ -67,7 +60,27 @@ The watcher does **not** classify. Classification, batching, replying, escalatio
    ```
 3. Append a dispatching line to `followup.log` per [`output-templates/watcher-log.md`](output-templates/watcher-log.md).
 4. Emit a `tick` event with `reviews_seen: <count>`, `dispatched_review_ids: [<id>, ...]`.
-5. Exit. The cron schedule from bootstrap keeps firing the watcher every minute, so the next tick still arrives even though this turn dispatched `/muggle-do`. The watcher only self-unschedules in Step 2 (terminal).
+5. Exit. **Reviews preempt CI** — when reviews land, this tick dispatches address-reviews and never polls CI. The cron keeps firing; the next tick still arrives. The watcher only self-unschedules in Step 2 (terminal).
+
+### Step 5 — No new reviews → poll CI for the head SHA
+
+Fetch the check-run rollup for `prs.json[0].head_sha` per [`../_shared/github-cli-recipes/pr-checks.md`](../_shared/github-cli-recipes/pr-checks.md), then:
+
+- **Any check still pending** (`bucket == "pending"`) → idle (wait for checks to settle).
+- **All checks green / skipped, or no checks** → idle (green path).
+- **One or more checks red** (`bucket == "fail"`), **and** `ci_fix_attempts[head_sha] < 3`, **and** `head_sha` ∉ `ci_escalated_shas` → dispatch and exit:
+  1. Reset `last_seen.idle_tick_count` to 0.
+  2. Dispatch `/muggle-do` with a *fix-ci* directive carrying the PR URL, slug, and the red check names (no review ids):
+     ```
+     /muggle-do fix ci <check-1> <check-2> ... on <pr-url> slug=<slug>
+     ```
+  3. Append a dispatching line to `followup.log`; emit a `tick` event with `checks_red: <count>`, `dispatched_ci_fix: true`.
+  4. Exit. The next tick re-checks CI on the new head SHA — CI itself is the verify loop.
+- **One or more red, but `ci_fix_attempts[head_sha] >= 3` or `head_sha` ∈ `ci_escalated_shas`** → idle. The fix budget is spent; `/muggle-do`'s fix-ci stage already recorded the escalation. The watcher does not re-dispatch.
+
+### Step 6 — Idle
+
+Any idle branch (Steps 4–5 that did not dispatch): increment `last_seen.idle_tick_count`, append an idle line to `followup.log` per [`output-templates/watcher-log.md`](output-templates/watcher-log.md), emit a `tick` event with `idle: true`, `reviews_seen: 0`, `dispatched_review_ids: []`, `checks_red: <count or 0>`, `dispatched_ci_fix: false`. Exit. The next tick fires in 1 min via `/loop`.
 
 ## Output
 

--- a/plugin/skills/muggle-pr-followup/state-schemas.md
+++ b/plugin/skills/muggle-pr-followup/state-schemas.md
@@ -39,7 +39,9 @@ Keyed by `"<owner>/<repo>#<n>"`. One key per PR in the slot.
     "idle_tick_count": <int>,
     "cycles_completed": <int>,
     "escalated_review_ids": [<int>, ...],
-    "pushed_shas": ["<sha>", ...]
+    "pushed_shas": ["<sha>", ...],
+    "ci_fix_attempts": { "<sha>": <int> },
+    "ci_escalated_shas": ["<sha>", ...]
   }
 }
 ```
@@ -50,6 +52,8 @@ Keyed by `"<owner>/<repo>#<n>"`. One key per PR in the slot.
 - `cycles_completed`: incremented each time `/muggle-do` completes an address-reviews invocation (regardless of actionable/ambiguous/mixed).
 - `escalated_review_ids`: review ids classified as ambiguous by `/muggle-do`. The watcher excludes these from future review fetches so the same ambiguous review is never re-dispatched.
 - `pushed_shas`: every SHA `/muggle-do` has pushed for this PR. Append-only. Used by the resolve-reminder stage to recognize threads addressed by the loop.
+- `ci_fix_attempts`: per-SHA count of fix-ci cycles `/muggle-do` has run. The watcher stops dispatching fix-ci for a SHA once its count reaches 3. Keyed by head SHA.
+- `ci_escalated_shas`: head SHAs whose CI the fix-ci stage gave up on (attempts exhausted or only out-of-scope checks). The watcher excludes these from CI dispatch so a hopeless SHA is never re-fixed.
 
 ## `state.md`
 


### PR DESCRIPTION
Workstream **C** of the merged design ([architecture/2026-05-30-…-design.md](https://github.com/multiplex-ai/muggle-ai-brain/blob/master/architecture/2026-05-30-muggle-do-conflict-resolution-ci-autofix-and-browser-task-rename-design.md)). Independent of [#232](https://github.com/multiplex-ai/muggle-ai-works/pull/232) (rename) and [#233](https://github.com/multiplex-ai/muggle-ai-works/pull/233) (conflict resolution).

## What changes
- **New recipe `_shared/github-cli-recipes/pr-checks.md`** — check-run rollup for the head SHA (`gh pr checks --json name,state,bucket,link`).
- **Watcher contract** now polls CI *after* reviews. **Reviews preempt CI** in a tick. With no new reviews: poll checks → pending = idle, green/none = idle, **red** dispatches `/muggle-do fix-ci` (PR url + slug + failing check names) while `ci_fix_attempts[sha] < 3` and `sha ∉ ci_escalated_shas`; otherwise idle.
- **New `last_seen` fields** `ci_fix_attempts` and `ci_escalated_shas`.
- **New `/muggle-do` route Fix-CI → `do/fix-ci.md`** (after address-reviews): map each red check to a local command (lint/format, typecheck, unit), **verify green before push**, commit `fix(ci): <check> — <what>`, **no PR replies** (the commit is the response). Out-of-scope checks (E2E-in-CI, infra, flaky) or a spent budget escalate (sha → `ci_escalated_shas`).
- **Telemetry**: `tick` gains `checks_red` + `dispatched_ci_fix`; `muggle-do:cycle` reuses with `ci_checks_*` fields and outcomes `ci-fixed` / `ci-escalated` (no new event).

## Choices
- **MAX 3** fix attempts per SHA (per your call). CI itself is the verify loop — each fix re-pushes, the next tick re-checks.
- Reviews always win a tick over CI; the dumb-pipe spirit holds (watcher detects + dispatches, never classifies/fixes).

## Verification
- `verify-plugin-marketplace.mjs` → **passed** (built `dist/plugin`); `verify-compatibility-contracts.mjs` → **passed**. New recipe added to the `github-cli-recipes` TOC; all cross-links resolve.

## Merge note
`muggle-do/SKILL.md` input-routing overlaps #232 (which renames route 3's target `muggle-do-task`→`muggle-browser-task`); this PR inserts a Fix-CI route and renumbers. Trivial merge-order resolution — apply both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)