### PR TITLE
fix(muggle-pr-followup): reconcile sweep for slots whose PR went terminal while polling lapsed

### DIFF
--- a/plugin/skills/CLAUDE.md
+++ b/plugin/skills/CLAUDE.md
@@ -1,0 +1,15 @@
+# Skill authoring conventions
+
+Rules for every skill under `plugin/skills/`. Read before adding or editing one.
+
+## One-way dependencies — no reverse references
+
+Skill cross-references form a one-way graph. If any file in skill **A** references skill **B** — a markdown link to B's files, or a documented dependency on B's internals — then **no file in B may reference A back**. Reference *downward*, toward the more general / lower-level skill you depend on; pass anything the other direction needs as input, not as a link.
+
+A reverse reference (A → B and B → A) couples the depended-on skill to its caller, creates a cycle no one can reason about in isolation, and makes every edit ripple both ways. The lower-level skill must stay reusable by callers it has never heard of.
+
+**Runtime dispatch is not a doc reference.** A dumb-pipe skill may *fire* another skill's slash command at runtime (hand off and forget) — that is an action, not a dependency. What the rule forbids is a procedure file **linking to** or **encoding the internals of** the skill it hands off to.
+
+**Worked example.** `muggle-pr-followup` (the dumb-pipe watcher) is lower-level than `muggle-do` (the executor that orchestrates it). `muggle-do` references `muggle-pr-followup`; `muggle-pr-followup`'s files must not link back to `muggle-do`. A watcher tick still dispatches `/muggle-do …` at runtime — allowed — but no watcher file links a `do/` file or restates its steps, and shared primitives like `muggle-pr-followup/finalize.md` stay dispatch-free so any caller can reuse them.
+
+When you feel the urge to link "up" to a caller, that is the smell — restructure so the caller passes what is needed in.

--- a/plugin/skills/muggle-pr-followup/CLAUDE.md
+++ b/plugin/skills/muggle-pr-followup/CLAUDE.md
@@ -23,7 +23,4 @@ Shared with other skills, under `../_shared/`:
 - [`telemetry-events.md`](../_shared/telemetry-events.md) — TOC of canonical event shapes; per-event files in `_shared/telemetry-events/`.
 - [`github-cli-recipes.md`](../_shared/github-cli-recipes.md) — TOC of reusable `gh` / `git` snippets; per-recipe files in `_shared/github-cli-recipes/`.
 
-Caller-specific, under `../do/`:
-
-- [`open-prs.md`](../do/open-prs.md) — TOC for the create-or-update PR stage; per-mode files in `do/open-prs/`.
-- [`resolve-reminder.md`](../do/resolve-reminder.md) — `/muggle-do`'s per-round stage that nudges the reviewer to resolve addressed-but-still-open threads.
+Callers (e.g. `/muggle-do`) reference this folder, not the reverse — see [`../CLAUDE.md`](../CLAUDE.md) for the one-way-dependency rule.

--- a/plugin/skills/muggle-pr-followup/CLAUDE.md
+++ b/plugin/skills/muggle-pr-followup/CLAUDE.md
@@ -8,6 +8,8 @@ This folder holds the watcher loop for PR review follow-ups. The watcher is a **
 - [`auto-track.md`](auto-track.md) — the no-args procedure: discovers PRs pushed this session (any repo) and seeds one poll-only watcher each. Seeds no E2E context — the watcher only watches.
 - [`bootstrap.md`](bootstrap.md) — the bootstrap procedure (asks once for the E2E validation context, seeds state, dispatches the first watcher).
 - [`contract.md`](contract.md) — the watcher per-tick procedure (poll → dispatch → exit).
+- [`finalize.md`](finalize.md) — shared termination sequence for a terminal PR (mark terminal, `result.md`, log/telemetry, unschedule cron, post-merge cleanup handoff). Called by `contract.md` and `reconcile.md`.
+- [`reconcile.md`](reconcile.md) — sweep that finalizes slots whose PR went terminal while polling lapsed; runs at the top of auto-track and on demand.
 - [`state-schemas.md`](state-schemas.md) — canonical JSON shapes of session state files.
 - [`output-templates.md`](output-templates.md) — TOC of message templates; per-group files in `output-templates/`.
 

--- a/plugin/skills/muggle-pr-followup/SKILL.md
+++ b/plugin/skills/muggle-pr-followup/SKILL.md
@@ -26,6 +26,9 @@ The skill recognizes its mode by inspecting `$ARGUMENTS` and falling back to on-
 | `<pr-number>` alone | zero or multiple matches | **error:** ambiguous; list candidates and exit |
 | empty | — | **auto-track** → [`auto-track.md`](auto-track.md) |
 | `help` / `?` | — | **help:** list active loops per [`output-templates/help.md`](output-templates/help.md) |
+| `reconcile` / `sweep` (optional `<slug>`) | — | **reconcile** → [`reconcile.md`](reconcile.md) |
+
+Auto-track runs **reconcile** first, so a no-arg invocation also finalizes any slot whose PR merged or closed while its watcher was down (expired cron, ended session). Reconcile never re-arms a watcher.
 
 Bootstrap accepts three optional trailing flags:
 

--- a/plugin/skills/muggle-pr-followup/auto-track.md
+++ b/plugin/skills/muggle-pr-followup/auto-track.md
@@ -16,6 +16,10 @@ Auto-track discovers the PRs you pushed or opened during this Claude Code sessio
 
 ## Procedure
 
+### Step 0 — Reconcile existing slots
+
+Run [`reconcile.md`](reconcile.md) first. A no-arg invocation is the natural moment to finalize any slot whose PR merged or closed while its watcher was down — an expired `/loop` cron or an ended session leaves termination un-run (see reconcile's rationale). Then continue discovering new PRs below.
+
 ### Step 1 — Discover candidate PRs from session context
 
 A PR counts as **pushed this session** if, earlier in this conversation, you:

--- a/plugin/skills/muggle-pr-followup/auto-track.md
+++ b/plugin/skills/muggle-pr-followup/auto-track.md
@@ -2,7 +2,7 @@
 
 The procedure for the **auto-track mode** of `muggle-pr-followup` — invoked when the skill is dispatched with **no arguments**. Routing is in [`SKILL.md`](SKILL.md#routing).
 
-Auto-track discovers the PRs you pushed or opened during this Claude Code session — across **any repo** — and starts one **poll-only watcher** per PR. The watcher only watches: it seeds nothing about E2E. Running and posting E2E is `/muggle-do`'s job; a watcher with no validation context yields a `SKIPPED` E2E verdict when `/muggle-do` runs — see [`../do/e2e-acceptance.md`](../do/e2e-acceptance.md) Step 0.
+Auto-track discovers the PRs you pushed or opened during this Claude Code session — across **any repo** — and starts one **poll-only watcher** per PR. The watcher only watches: it seeds nothing about E2E. Running and posting E2E is `/muggle-do`'s job; a watcher with no validation context yields a `SKIPPED` E2E verdict when `/muggle-do` runs.
 
 ## Turn preamble
 

--- a/plugin/skills/muggle-pr-followup/contract.md
+++ b/plugin/skills/muggle-pr-followup/contract.md
@@ -31,7 +31,18 @@ Per [`../_shared/github-cli-recipes/pr-metadata.md`](../_shared/github-cli-recip
 
 ### Step 2 — Termination check
 
-If `state` is `MERGED` or `CLOSED`, finalize the slot per [`finalize.md`](finalize.md) (mark terminal, write `result.md`, log + telemetry, unschedule this watcher's cron, and hand off post-merge cleanup on `MERGED`) and exit. The watcher has unscheduled itself; no future ticks fire for this PR.
+If `state` is `MERGED` or `CLOSED`:
+
+1. Finalize the slot per [`finalize.md`](finalize.md) — mark terminal, write `result.md`, log + telemetry, unschedule this watcher's cron.
+2. **If `MERGED`**, hand off post-merge cleanup as the last action of the turn (skip on `CLOSED` — unmerged, leave the branch and any worktree intact):
+
+   ```
+   /muggle-do post-merge cleanup slug=<slug>
+   ```
+
+   `/muggle-do` owns the worktree/branch knowledge and honors the `autoCleanup` gate. This is a runtime dispatch, not a doc dependency on `/muggle-do` — see the one-way rule in [`../CLAUDE.md`](../CLAUDE.md).
+3. Exit. The watcher has unscheduled itself; no future ticks fire for this PR.
+
 
 ### Step 3 — Fetch new submitted reviews
 

--- a/plugin/skills/muggle-pr-followup/contract.md
+++ b/plugin/skills/muggle-pr-followup/contract.md
@@ -31,21 +31,7 @@ Per [`../_shared/github-cli-recipes/pr-metadata.md`](../_shared/github-cli-recip
 
 ### Step 2 — Termination check
 
-If `state` is `MERGED` or `CLOSED`:
-
-1. Mark the entry terminal in `prs.json`.
-2. Write `result.md` per [`state-schemas.md`](state-schemas.md#resultmd).
-3. Append a terminal line to `followup.log` per [`output-templates/watcher-log.md`](output-templates/watcher-log.md).
-4. Emit a `tick` event with `terminal: true` per [`../_shared/telemetry-events/pr-followup-tick.md`](../_shared/telemetry-events/pr-followup-tick.md).
-5. **Cancel the cron schedule that fires this watcher.** `/loop 1m ...` from bootstrap was registered via `CronCreate`; a fixed-interval cron keeps firing regardless of whether the skill re-dispatches. Call `CronList`, find any job whose command ends with `/muggle:muggle-pr-followup <slug> <pr-number>` (exact two-arg match), and `CronDelete` it. No-op if none matches — the tick may have been invoked manually rather than via `/loop`.
-6. **If `state` is `MERGED`, hand off post-merge cleanup.** Dispatch `/muggle-do` with a cleanup directive carrying the slug, as the last action of this turn:
-
-   ```
-   /muggle-do post-merge cleanup slug=<slug>
-   ```
-
-   `/muggle-do` owns the session's worktree/branch knowledge and honors the `autoCleanup` gate; the watcher never runs cleanup itself. Skip when `state` is `CLOSED` (unmerged: leave the branch and any worktree intact).
-7. Exit. The watcher has now unscheduled itself; no future ticks will fire for this PR.
+If `state` is `MERGED` or `CLOSED`, finalize the slot per [`finalize.md`](finalize.md) (mark terminal, write `result.md`, log + telemetry, unschedule this watcher's cron, and hand off post-merge cleanup on `MERGED`) and exit. The watcher has unscheduled itself; no future ticks fire for this PR.
 
 ### Step 3 — Fetch new submitted reviews
 

--- a/plugin/skills/muggle-pr-followup/finalize.md
+++ b/plugin/skills/muggle-pr-followup/finalize.md
@@ -1,0 +1,37 @@
+# Finalize a Terminal PR
+
+The shared termination sequence for a follow-up slot whose PR is `MERGED` or `CLOSED`. Called by [`contract.md`](contract.md) Step 2 (a tick observed the transition) and [`reconcile.md`](reconcile.md) (a sweep found a slot whose polling lapsed before the transition). One slot, run once.
+
+## Inputs
+
+- `<slug>`, `<owner>/<repo>`, `<n>` — the slot's PR.
+- `state` — `MERGED` or `CLOSED`, from a fresh [`../_shared/github-cli-recipes/pr-metadata.md`](../_shared/github-cli-recipes/pr-metadata.md).
+- `mergeCommit` + `mergedAt` when `MERGED`.
+
+## Procedure
+
+### Step 1 — Mark the slot terminal
+
+Rewrite `prs.json[0].state` to `merged` / `closed` ([`state-schemas.md`](state-schemas.md#prsjson)). That state plus the `result.md` written next are the terminal marker — there is no separate flag.
+
+### Step 2 — Write `result.md`
+
+Once, per [`state-schemas.md`](state-schemas.md#resultmd). Pull `cycles_completed`, `pushed_shas`, and `escalated_review_ids` from `last_seen.json`.
+
+### Step 3 — Log and telemetry
+
+Append the terminal line per [`output-templates/watcher-log.md`](output-templates/watcher-log.md). Emit one `tick` event with `terminal: true` per [`../_shared/telemetry-events/pr-followup-tick.md`](../_shared/telemetry-events/pr-followup-tick.md).
+
+### Step 4 — Unschedule the cron
+
+Call `CronList`, find any job whose command ends with `/muggle:muggle-pr-followup <slug> <n>` (exact two-arg match), and `CronDelete` it. No-op when none matches — a manually-run tick, or a cron that already expired. Recurring `/loop` crons auto-expire after 7 days; that lapse is the gap [`reconcile.md`](reconcile.md) exists to catch.
+
+### Step 5 — Post-merge cleanup (`MERGED` only)
+
+Dispatch `/muggle-do` with the cleanup directive as a closing action of the turn — the tick emits exactly one, a reconcile sweep emits one per merged slot:
+
+```
+/muggle-do post-merge cleanup slug=<slug>
+```
+
+`/muggle-do` owns the worktree/branch knowledge and honors the `autoCleanup` gate. Skip on `CLOSED` — unmerged, so leave the branch and any worktree intact.

--- a/plugin/skills/muggle-pr-followup/finalize.md
+++ b/plugin/skills/muggle-pr-followup/finalize.md
@@ -1,6 +1,8 @@
 # Finalize a Terminal PR
 
-The shared termination sequence for a follow-up slot whose PR is `MERGED` or `CLOSED`. Called by [`contract.md`](contract.md) Step 2 (a tick observed the transition) and [`reconcile.md`](reconcile.md) (a sweep found a slot whose polling lapsed before the transition). One slot, run once.
+The shared, **pure** termination sequence for a follow-up slot whose PR is `MERGED` or `CLOSED`. Called by [`contract.md`](contract.md) Step 2 (a tick observed the transition) and [`reconcile.md`](reconcile.md) (a sweep found a slot whose polling lapsed before the transition). One slot, run once.
+
+This step only finalizes — marks the slot terminal, writes the record, unschedules the cron. It **dispatches nothing**. Post-merge cleanup is a separate, caller-owned concern: the tick ([`contract.md`](contract.md)) hands it off; a reconcile backfill skips it.
 
 ## Inputs
 
@@ -25,13 +27,3 @@ Append the terminal line per [`output-templates/watcher-log.md`](output-template
 ### Step 4 — Unschedule the cron
 
 Call `CronList`, find any job whose command ends with `/muggle:muggle-pr-followup <slug> <n>` (exact two-arg match), and `CronDelete` it. No-op when none matches — a manually-run tick, or a cron that already expired. Recurring `/loop` crons auto-expire after 7 days; that lapse is the gap [`reconcile.md`](reconcile.md) exists to catch.
-
-### Step 5 — Post-merge cleanup (`MERGED` only)
-
-Dispatch `/muggle-do` with the cleanup directive as a closing action of the turn — the tick emits exactly one, a reconcile sweep emits one per merged slot:
-
-```
-/muggle-do post-merge cleanup slug=<slug>
-```
-
-`/muggle-do` owns the worktree/branch knowledge and honors the `autoCleanup` gate. Skip on `CLOSED` — unmerged, so leave the branch and any worktree intact.

--- a/plugin/skills/muggle-pr-followup/reconcile.md
+++ b/plugin/skills/muggle-pr-followup/reconcile.md
@@ -20,7 +20,7 @@ For each candidate, fetch the PR per [`../_shared/github-cli-recipes/pr-metadata
 
 ### Step 3 — Finalize the terminal ones
 
-For each candidate whose live `state` is `MERGED` or `CLOSED`, run [`finalize.md`](finalize.md). Slots still `open` are left untouched — reconcile finalizes, it does not re-arm a watcher (re-arming an open PR is [`auto-track.md`](auto-track.md)'s job).
+For each candidate whose live `state` is `MERGED` or `CLOSED`, run [`finalize.md`](finalize.md). `finalize.md` dispatches nothing, so a backfilled merge gets no post-merge cleanup — its branch is typically long gone, and the `autoCleanup` gate governs if the user runs cleanup later. Slots still `open` are left untouched — reconcile finalizes, it does not re-arm a watcher (re-arming an open PR is [`auto-track.md`](auto-track.md)'s job).
 
 ### Step 4 — Report
 

--- a/plugin/skills/muggle-pr-followup/reconcile.md
+++ b/plugin/skills/muggle-pr-followup/reconcile.md
@@ -1,0 +1,33 @@
+# Reconcile Procedure
+
+The procedure for the **reconcile mode** of `muggle-pr-followup` — a sweep that finalizes session slots whose PR went terminal while polling was lapsed. Routing is in [`SKILL.md`](SKILL.md#routing).
+
+Termination is otherwise tick-driven ([`contract.md`](contract.md) Step 2): a slot finalizes only when a tick fires and observes `MERGED` / `CLOSED`. If the tick stream stops first — the recurring `/loop` cron auto-expires after 7 days, the session ends, or the machine is off when the PR merges — no tick catches the transition, and the slot is left un-finalized: no `result.md`, no post-merge cleanup, and a surviving cron would keep polling a dead PR. Reconcile is the catch-up.
+
+## Input
+
+`$ARGUMENTS` is `reconcile` (or `sweep`), optionally followed by a `<slug>` to scope the sweep to one slot.
+
+## Procedure
+
+### Step 1 — Enumerate slots
+
+List `~/.muggle-ai/muggle-do/sessions/*/` dirs that contain a `prs.json`. Skip any that already have a `result.md` — those are finalized. Scope to a single `<slug>` if the arg gave one.
+
+### Step 2 — Refresh live state
+
+For each candidate, fetch the PR per [`../_shared/github-cli-recipes/pr-metadata.md`](../_shared/github-cli-recipes/pr-metadata.md) using `prs.json[0].url`. A `gh` failure on one slot (deleted repo, missing auth) → log it to that slot's `followup.log` and skip; never abort the whole sweep.
+
+### Step 3 — Finalize the terminal ones
+
+For each candidate whose live `state` is `MERGED` or `CLOSED`, run [`finalize.md`](finalize.md). Slots still `open` are left untouched — reconcile finalizes, it does not re-arm a watcher (re-arming an open PR is [`auto-track.md`](auto-track.md)'s job).
+
+### Step 4 — Report
+
+One line: slots scanned, finalized (with final state each), and left open. Silent only when zero slots exist.
+
+## Invariants
+
+- **Idempotent.** A slot with `result.md` is never re-finalized; once everything terminal is swept, re-running is a no-op.
+- **Finalize-only.** Reconcile never seeds, re-arms, or dispatches a watcher. Open slots pass through untouched.
+- **Per-slot isolation.** One slot's `gh` failure never blocks finalizing the others.


### PR DESCRIPTION
## The bug you flagged

The watcher kept "tracking" #234 after it merged. Root cause: **termination is tick-driven.** `contract.md` Step 1 (refresh state) + Step 2 (terminate on `MERGED`/`CLOSED`) *do* poll state every tick — but a slot only finalizes when a tick actually fires and observes the transition. If the tick stream stops first, nothing catches it:

- the recurring `/loop` cron **auto-expires after 7 days**,
- the session ends, or
- the machine is off at merge time.

→ the slot is left un-finalized: no `result.md`, no post-merge cleanup, and a surviving cron would keep polling a dead PR. (#234 merged at 17:27Z, hours after the last tick fired — so no tick was alive to finalize it.)

So it wasn't "doesn't check state" — the poll is correct; the gap is the **lack of a catch-up when polling lapses.**

## Fix

- **`reconcile.md`** — a sweep mode: scan session slots, refresh each tracked PR's live state, and finalize the terminal ones. Finalize-only — it never seeds or re-arms a watcher (re-arming an open PR stays auto-track's job). Idempotent (skips slots that already have `result.md`); per-slot isolated (one `gh` failure never blocks the rest).
- **`finalize.md`** — the termination sequence (mark terminal → `result.md` → log/telemetry → unschedule cron → post-merge cleanup handoff) extracted into one shared file. `contract.md` Step 2 and `reconcile.md` both call it, so there's a single source of truth.
- **Wiring** — reconcile runs at **`auto-track` Step 0** (the natural no-arg re-entry, so a bare `/muggle-pr-followup` now also finalizes orphaned terminal slots), plus an explicit **`reconcile` / `sweep`** route.

## Verification

Docs-only (skill markdown). `verify:plugin` and `verify:contracts` pass; all intra-folder links resolve. No unit tests cover skill `.md`; no E2E (this is the skill definition, not app code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)