### PR TITLE
chore(release): @muggleai/works 4.15.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.14.0"
+      "version": "4.15.0"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.14.0"
+      "version": "4.15.0"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@muggleai/works",
   "mcpName": "io.github.multiplex-ai/muggle",
-  "version": "4.14.0",
+  "version": "4.15.0",
   "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
   "type": "module",
   "main": "dist/index.js",
@@ -42,14 +42,14 @@
     "test:watch": "vitest"
   },
   "muggleConfig": {
-    "electronAppVersion": "1.0.107",
+    "electronAppVersion": "1.0.109",
     "downloadBaseUrl": "https://github.com/multiplex-ai/muggle-ai-works/releases/download",
     "runtimeTargetDefault": "dev",
     "checksums": {
-      "darwin-arm64": "d10a2d49f4300123c2e6fefe3ad9d85b17b079d97b6326f8ea80547c2e8bf735",
-      "darwin-x64": "5466d9fc9ef280c85a723cb4288fceffa1869e1b1d84156773a6366e85443952",
-      "linux-x64": "24d7ebb5bdb56345644e24180008226b49fdb1b0a605c455ba45950df58faa5e",
-      "win32-x64": "62498ddb31336285dafb1320f1e43199dac7ada2bdd57223cb9eb4f4ac03e5a7"
+      "darwin-arm64": "9c2fa21b4e090c8b6f1acedf1bdbd824f0032a5d91d6f9abd3ca25cebee7f417",
+      "darwin-x64": "3369988c627be5d362d5d9c8312f9902063a98a53d308695b40873211960501c",
+      "linux-x64": "a986757132b45a4299a44c3dd1f3945ba6814d299e677380e2061f18da44b511",
+      "win32-x64": "29ab5400d7dca049e4a3e75b76bc3e06398b88743f0a49d38fa6ae531fc980fe"
     }
   },
   "dependencies": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "4.14.0",
+  "version": "4.15.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "4.14.0",
+  "version": "4.15.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "4.14.0",
+  "version": "4.15.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "4.14.0",
+      "version": "4.15.0",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
Ships 9 commits since 4.14.0:
- fix(muggle-pr-followup): reconcile sweep finalizes slots whose PR went terminal while polling lapsed (#235)
- feat(muggle-pr-followup): watch CI and auto-fix red checks (#234)
- feat(muggle-do): opt-in autonomous rebase-conflict resolution — autoResolveConflicts (#233)
- fix(muggle-do): post-merge cleanup trigger + tree guard via single-owner delegation (#228)
- refactor(skills): rename muggle-do-task -> muggle-browser-task; /mdo -> harness, add /mbt (#232)
- refactor(dev-loop): single-source the dev loop — SoC B (#229)
- refactor(readiness): delegate to muggle-test-prepare — SoC D (#231)
- refactor(worktree): one path scheme + clear lifecycle ownership (#230)
- feat(routing-eval): one-command runnable eval, run.py (#226)

Electron: bumped 1.0.107 -> 1.0.109 (4 checksums refreshed; verify:electron-release-checksums passes).
Manifests (marketplace x2, plugin x2, server.json) synced via sync:versions.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

## Test plan
- [x] lint:check (0 errors), typecheck clean
- [x] pnpm test — 246 passed
- [x] build + verify:plugin + verify:contracts
- [x] verify:electron-release-checksums — electron-app-v1.0.109 verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)