### PR TITLE
chore(release): @muggleai/works 4.15.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.15.0"
+      "version": "4.15.1"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "4.15.0"
+      "version": "4.15.1"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@muggleai/works",
   "mcpName": "io.github.multiplex-ai/muggle",
-  "version": "4.15.0",
+  "version": "4.15.1",
   "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
   "type": "module",
   "main": "dist/index.js",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "4.15.0",
+  "version": "4.15.1",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "4.15.0",
+  "version": "4.15.1",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "4.15.0",
+  "version": "4.15.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "4.15.0",
+      "version": "4.15.1",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
## chore(release): @muggleai/works 4.15.1

Patch release. **Shipping one change:** the muggle-test description revert (#239, `c2e1e42`).

- Drops the over-trigger sentence added in #238. The in-repo router eval (`internal/skill-routing-eval`) showed it net-negative: on a 26-query subset the baseline scored 26/26 (every contested pre-PR query already routed to `muggle-test` 3/3) vs 25/26 with the sentence, which flipped one feature-local query to the built-in `verify` skill. Restores the byte-identical pre-#238 baseline.
- `muggle-do` model-invocability (from 4.15.0) is unaffected.

**Electron:** unchanged at `1.0.109` (latest tag is `electron-app-v1.0.112`; bump deferred — unrelated to this fix).

**Version sync:** `package.json` + `sync:versions` → claude/cursor `marketplace.json`, `plugin.json`, `server.json`.

**Local verify:** build ✓, verify:plugin ✓, verify:contracts ✓, typecheck ✓ (lint/test/platform matrix via CI).

Publish (`publish-works-to-npm.yml`) dispatched after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
