### PR TITLE
fix(pr-followup): skip reply-echo reviews so the watcher never re-triggers on itself

### DIFF
--- a/plugin/skills/_shared/pr-followup-helpers.md
+++ b/plugin/skills/_shared/pr-followup-helpers.md
@@ -12,3 +12,4 @@ Each section is its own file — load only what the current step needs.
 | [`reply-routing`](pr-followup-helpers/reply-routing.md) | Pick the right reply endpoint per comment type (line, body-only, CI failure). |
 | [`classify`](pr-followup-helpers/classify.md) | Per-review binary label: actionable vs ambiguous, with worked examples + borderline rule. |
 | [`loop-signature`](pr-followup-helpers/loop-signature.md) | The signature every loop-posted comment carries, and how to detect loop vs human comments by it. |
+| [`echo-skip`](pr-followup-helpers/echo-skip.md) | Skip reviews that are the loop's own replies (every comment loop-marked), so the watcher never re-triggers on itself. |

--- a/plugin/skills/_shared/pr-followup-helpers/echo-skip.md
+++ b/plugin/skills/_shared/pr-followup-helpers/echo-skip.md
@@ -1,0 +1,16 @@
+# Reply-echo skip
+
+When `/muggle-do` posts a threaded reply to a review comment, GitHub surfaces that reply as a **new submitted review** under the same account. Left unchecked, the next watcher tick reads that review as fresh feedback and dispatches another cycle — which posts another reply, which becomes another review. The loop never converges.
+
+## Rule
+
+A submitted review is an **echo** when **every** comment in it carries the loop marker `<!-- muggle-do:bot -->` (see [`loop-signature.md`](loop-signature.md)). An echo is the loop's own reply wearing a review's clothing, never human intent.
+
+On an echo review, the watcher must:
+
+1. Advance `last_seen.reviewId` past the echo's id (so it is not seen again), and
+2. **Skip it** — never dispatch `/muggle-do` for it.
+
+## Detection
+
+Classify by the marker, never by `author.login` — under a shared account the loop posts as the PR author, so the login cannot tell echo from human. Fetch the review's comments; if the set is non-empty and every comment body contains `<!-- muggle-do:bot -->`, it is an echo. A review with at least one marker-less comment is human feedback and must be processed normally.

--- a/plugin/skills/muggle-pr-followup/contract.md
+++ b/plugin/skills/muggle-pr-followup/contract.md
@@ -46,7 +46,10 @@ If `state` is `MERGED` or `CLOSED`:
 
 ### Step 3 — Fetch new submitted reviews
 
-Per [`../_shared/github-cli-recipes/submitted-reviews.md`](../_shared/github-cli-recipes/submitted-reviews.md). **Also exclude review ids that appear in `last_seen.escalated_review_ids`** — those have already been escalated and the watcher must not re-dispatch them.
+Per [`../_shared/github-cli-recipes/submitted-reviews.md`](../_shared/github-cli-recipes/submitted-reviews.md). Exclude two kinds of review id:
+
+- ids in `last_seen.escalated_review_ids` — already escalated; the watcher must not re-dispatch them.
+- **echo reviews** per [`../_shared/pr-followup-helpers/echo-skip.md`](../_shared/pr-followup-helpers/echo-skip.md) — a review whose every comment carries the loop marker is the loop's own reply, surfaced by GitHub as a new review. Advance `last_seen.reviewId` past it and skip; never dispatch, or the watcher replies to itself forever.
 
 ### Step 4 — If one or more new reviews → dispatch (reviews preempt CI)
 


### PR DESCRIPTION
## Problem

When `/muggle-do` posts a threaded reply to a review comment, GitHub surfaces that reply as a **new submitted review** under the same account. `contract.md` Step 3 excluded only `escalated_review_ids`, so the next watcher tick read the loop's own reply as fresh feedback and dispatched another cycle — which replied again, which became another review. The loop never converges.

Observed live on muggle-ai-brain#76: a loop reply spawned review `4413983031` whose only comment was the loop-marked reply; only a manual cursor bump stopped a re-dispatch.

## Fix

- Add `_shared/pr-followup-helpers/echo-skip.md`: a submitted review is an **echo** when *every* comment in it carries the `<!-- muggle-do:bot -->` marker (per `loop-signature.md`). Detect by the marker, never by `author.login` (shared-account workflows).
- Apply it in `contract.md` Step 3: advance `last_seen.reviewId` past echoes and skip — never dispatch.

Markdown-only; honors the one-way dependency rule (echo-skip references only its sibling `loop-signature.md`).

Part of the harness pipeline-integration work — design: `muggle-ai-brain` PR #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)