### PR TITLE
feat(guardrails): foundation + PR-opened → watcher guardrail

### DIFF
--- a/plugin/hooks/README.md
+++ b/plugin/hooks/README.md
@@ -1,0 +1,24 @@
+# Guardrail hooks
+
+Condition-triggered hooks that make Muggle Test's high-value handoffs fire path-independently — no matter whether a change was built via muggle-do, superpowers, or ad-hoc edits.
+
+## Two layers
+
+"Harness" spans two layers, and the distinction is load-bearing:
+
+- **Claude Code layer** — the agent runtime that fires these hooks. A guardrail is a Claude-Code-layer trigger, nothing more.
+- **Muggle Test layer** — the product (muggle-do, muggle-test, the watcher). This is what a guardrail *invokes*.
+
+A guardrail injects an advisory directive (`additionalContext`); the model then runs the Muggle Test flow. The guardrail never reimplements the flow.
+
+Design rationale: `muggle-ai-brain/architecture/2026-06-02-harness-pipeline-integration-design.md`.
+
+## Mechanism
+
+Each guardrail is a thin bash wrapper in `../scripts/` registered in `hooks.json`. The wrapper pipes the event payload (stdin JSON) to the bundled `../scripts/guardrails.mjs <subcommand>`, which holds the decision logic (built from `src/guardrails/`, vitest-covered). Per-session state in `~/.muggle-ai/guardrails/<session_id>.json` makes each guardrail fire once. Any failure degrades to `{}` — a guardrail must never block a turn.
+
+## Guardrails
+
+| Hook event | Wrapper | Condition | Preference | Flow invoked |
+| :--------- | :------ | :-------- | :--------- | :----------- |
+| `PostToolUse` (Bash) | `guardrail-pr-opened.sh` | a `gh pr create`/`gh pr ready` just succeeded | `autoWatchPR` | start a `muggle-pr-followup` watcher on the new PR |

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -11,6 +11,18 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/guardrail-pr-opened.sh\"",
+            "async": false
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugin/scripts/guardrail-pr-opened.sh
+++ b/plugin/scripts/guardrail-pr-opened.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# PR-opened guardrail (PostToolUse/Bash). When a `gh pr create`/`gh pr ready`
+# just succeeded, offer to start a muggle-pr-followup watcher on the new PR
+# (gated by autoWatchPR, deduped per session). Decision logic lives in the
+# bundled guardrails.mjs; this wrapper just pipes the event payload through and
+# degrades to {} so a guardrail can never block a turn.
+root="${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-}}"
+node "${root}/scripts/guardrails.mjs" pr-opened 2>/dev/null || printf '{}'

--- a/plugin/scripts/guardrails.mjs
+++ b/plugin/scripts/guardrails.mjs
@@ -1,0 +1,72 @@
+import { readFileSync, existsSync, mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+
+// src/guardrails/cli.ts
+var baseDir = (override) => override ?? join(homedir(), ".muggle-ai", "guardrails");
+var fileFor = (sessionId2, override) => join(baseDir(override), `${sessionId2.replace(/[^A-Za-z0-9_-]/g, "_")}.json`);
+function readState(sessionId2, dirOverride) {
+  const f = fileFor(sessionId2, dirOverride);
+  if (!existsSync(f)) return { sessionId: sessionId2, prsHandled: [] };
+  try {
+    const raw = JSON.parse(readFileSync(f, "utf-8"));
+    return { ...raw, sessionId: sessionId2, prsHandled: raw.prsHandled ?? [] };
+  } catch {
+    return { sessionId: sessionId2, prsHandled: [] };
+  }
+}
+function writeState(state, dirOverride) {
+  mkdirSync(baseDir(dirOverride), { recursive: true });
+  writeFileSync(fileFor(state.sessionId, dirOverride), JSON.stringify(state, null, 2));
+}
+function markPrHandled(sessionId2, prUrl, dirOverride) {
+  const state = readState(sessionId2, dirOverride);
+  if (!state.prsHandled.includes(prUrl)) state.prsHandled.push(prUrl);
+  writeState(state, dirOverride);
+}
+
+// src/guardrails/prOpened.ts
+var PR_URL = /https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/\d+/;
+var CREATE_CMD = /\bgh\s+pr\s+(create|ready)\b/;
+function detectPrOpened(input2) {
+  if (input2.tool_name !== "Bash") return null;
+  const cmd = input2.tool_input?.command ?? "";
+  if (!CREATE_CMD.test(cmd)) return null;
+  const out = `${input2.tool_response?.stdout ?? ""}
+${input2.tool_response?.output ?? ""}`;
+  const m = out.match(PR_URL);
+  return m ? m[0] : null;
+}
+
+// src/guardrails/emit.ts
+function envelope(eventName, context, host2) {
+  if (!context) return "{}";
+  if (host2 === "cursor") return JSON.stringify({ additional_context: context });
+  return JSON.stringify({
+    hookSpecificOutput: { hookEventName: eventName, additionalContext: context }
+  });
+}
+
+// src/guardrails/cli.ts
+function readStdin() {
+  try {
+    return JSON.parse(readFileSync(0, "utf-8"));
+  } catch {
+    return {};
+  }
+}
+var host = process.env.CURSOR_PLUGIN_ROOT ? "cursor" : "claude";
+var sub = process.argv[2];
+var input = readStdin();
+var sessionId = input.session_id ?? "unknown";
+function prOpened() {
+  const url = detectPrOpened(input);
+  if (!url) return "{}";
+  if (readState(sessionId).prsHandled.includes(url)) return "{}";
+  markPrHandled(sessionId, url);
+  const ctx = `A pull request was just opened: ${url}
+Per the autoWatchPR preference, a muggle-pr-followup watcher should handle its incoming reviews. If autoWatchPR=always, start it now by invoking /muggle:muggle-pr-followup with the PR URL; if =ask, offer it to the user; if =never, do nothing.`;
+  return envelope("PostToolUse", ctx, host);
+}
+var handlers = { "pr-opened": prOpened };
+process.stdout.write((handlers[sub] ?? (() => "{}"))());

--- a/src/guardrails/cli.ts
+++ b/src/guardrails/cli.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "fs";
+import { readState, markPrHandled } from "./sessionState";
+import { detectPrOpened } from "./prOpened";
+import { envelope, type Host } from "./emit";
+import type { HookInput } from "./types";
+
+function readStdin(): HookInput {
+  try {
+    return JSON.parse(readFileSync(0, "utf-8")) as HookInput;
+  } catch {
+    return {};
+  }
+}
+
+const host: Host = process.env.CURSOR_PLUGIN_ROOT ? "cursor" : "claude";
+const sub = process.argv[2];
+const input = readStdin();
+const sessionId = input.session_id ?? "unknown";
+
+function prOpened(): string {
+  const url = detectPrOpened(input);
+  if (!url) return "{}";
+  if (readState(sessionId).prsHandled.includes(url)) return "{}";
+  markPrHandled(sessionId, url);
+  const ctx =
+    `A pull request was just opened: ${url}\n` +
+    `Per the autoWatchPR preference, a muggle-pr-followup watcher should handle its incoming reviews. ` +
+    `If autoWatchPR=always, start it now by invoking /muggle:muggle-pr-followup with the PR URL; ` +
+    `if =ask, offer it to the user; if =never, do nothing.`;
+  return envelope("PostToolUse", ctx, host);
+}
+
+const handlers: Record<string, () => string> = { "pr-opened": prOpened };
+process.stdout.write((handlers[sub] ?? (() => "{}"))());

--- a/src/guardrails/cli.ts
+++ b/src/guardrails/cli.ts
@@ -1,8 +1,8 @@
 import { readFileSync } from "fs";
-import { readState, markPrHandled } from "./sessionState";
-import { detectPrOpened } from "./prOpened";
-import { envelope, type Host } from "./emit";
-import type { HookInput } from "./types";
+import { readState, markPrHandled } from "./sessionState.js";
+import { detectPrOpened } from "./prOpened.js";
+import { envelope, type Host } from "./emit.js";
+import type { HookInput } from "./types.js";
 
 function readStdin(): HookInput {
   try {

--- a/src/guardrails/emit.ts
+++ b/src/guardrails/emit.ts
@@ -1,0 +1,9 @@
+export type Host = "claude" | "cursor";
+
+export function envelope(eventName: string, context: string, host: Host): string {
+  if (!context) return "{}";
+  if (host === "cursor") return JSON.stringify({ additional_context: context });
+  return JSON.stringify({
+    hookSpecificOutput: { hookEventName: eventName, additionalContext: context },
+  });
+}

--- a/src/guardrails/prOpened.ts
+++ b/src/guardrails/prOpened.ts
@@ -1,4 +1,4 @@
-import type { HookInput } from "./types";
+import type { HookInput } from "./types.js";
 
 const PR_URL = /https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/\d+/;
 const CREATE_CMD = /\bgh\s+pr\s+(create|ready)\b/;

--- a/src/guardrails/prOpened.ts
+++ b/src/guardrails/prOpened.ts
@@ -1,0 +1,13 @@
+import type { HookInput } from "./types";
+
+const PR_URL = /https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/\d+/;
+const CREATE_CMD = /\bgh\s+pr\s+(create|ready)\b/;
+
+export function detectPrOpened(input: HookInput): string | null {
+  if (input.tool_name !== "Bash") return null;
+  const cmd = input.tool_input?.command ?? "";
+  if (!CREATE_CMD.test(cmd)) return null;
+  const out = `${input.tool_response?.stdout ?? ""}\n${input.tool_response?.output ?? ""}`;
+  const m = out.match(PR_URL);
+  return m ? m[0] : null;
+}

--- a/src/guardrails/sessionState.ts
+++ b/src/guardrails/sessionState.ts
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
-import type { GuardrailState } from "./types";
+import type { GuardrailState } from "./types.js";
 
 const baseDir = (override?: string): string =>
   override ?? join(homedir(), ".muggle-ai", "guardrails");

--- a/src/guardrails/sessionState.ts
+++ b/src/guardrails/sessionState.ts
@@ -1,0 +1,36 @@
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import type { GuardrailState } from "./types";
+
+const baseDir = (override?: string): string =>
+  override ?? join(homedir(), ".muggle-ai", "guardrails");
+
+const fileFor = (sessionId: string, override?: string): string =>
+  join(baseDir(override), `${sessionId.replace(/[^A-Za-z0-9_-]/g, "_")}.json`);
+
+export function readState(sessionId: string, dirOverride?: string): GuardrailState {
+  const f = fileFor(sessionId, dirOverride);
+  if (!existsSync(f)) return { sessionId: sessionId, prsHandled: [] };
+  try {
+    const raw = JSON.parse(readFileSync(f, "utf-8")) as Partial<GuardrailState>;
+    return { ...raw, sessionId: sessionId, prsHandled: raw.prsHandled ?? [] };
+  } catch {
+    return { sessionId: sessionId, prsHandled: [] };
+  }
+}
+
+export function writeState(state: GuardrailState, dirOverride?: string): void {
+  mkdirSync(baseDir(dirOverride), { recursive: true });
+  writeFileSync(fileFor(state.sessionId, dirOverride), JSON.stringify(state, null, 2));
+}
+
+export function isPrHandled(sessionId: string, prUrl: string, dirOverride?: string): boolean {
+  return readState(sessionId, dirOverride).prsHandled.includes(prUrl);
+}
+
+export function markPrHandled(sessionId: string, prUrl: string, dirOverride?: string): void {
+  const state = readState(sessionId, dirOverride);
+  if (!state.prsHandled.includes(prUrl)) state.prsHandled.push(prUrl);
+  writeState(state, dirOverride);
+}

--- a/src/guardrails/types.ts
+++ b/src/guardrails/types.ts
@@ -1,0 +1,16 @@
+export interface GuardrailState {
+  sessionId: string;
+  prsHandled: string[];
+  unitTestsGreen?: boolean;
+  e2eRun?: boolean;
+  buildIntentRouted?: boolean;
+}
+
+export interface HookInput {
+  session_id?: string;
+  cwd?: string;
+  tool_name?: string;
+  tool_input?: { command?: string };
+  tool_response?: { stdout?: string; stderr?: string; output?: string };
+  prompt?: string;
+}

--- a/src/test/guardrails/emit.test.ts
+++ b/src/test/guardrails/emit.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { envelope } from "../../guardrails/emit";
+
+describe("envelope", () => {
+  it("wraps context as Claude hookSpecificOutput", () => {
+    const out = JSON.parse(envelope("PostToolUse", 'hello "world"\nline2', "claude"));
+    expect(out.hookSpecificOutput.hookEventName).toBe("PostToolUse");
+    expect(out.hookSpecificOutput.additionalContext).toBe('hello "world"\nline2');
+  });
+
+  it("wraps context as Cursor additional_context", () => {
+    const out = JSON.parse(envelope("PostToolUse", "x", "cursor"));
+    expect(out.additional_context).toBe("x");
+  });
+
+  it("emits an empty object when context is empty", () => {
+    expect(envelope("PostToolUse", "", "claude")).toBe("{}");
+  });
+});

--- a/src/test/guardrails/prOpened.test.ts
+++ b/src/test/guardrails/prOpened.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { detectPrOpened } from "../../guardrails/prOpened";
+
+describe("detectPrOpened", () => {
+  it("extracts the PR url from a successful gh pr create", () => {
+    expect(
+      detectPrOpened({
+        tool_name: "Bash",
+        tool_input: { command: "gh pr create --title x --body y" },
+        tool_response: { stdout: "https://github.com/multiplex-ai/muggle-ai-ui/pull/342\n" },
+      }),
+    ).toBe("https://github.com/multiplex-ai/muggle-ai-ui/pull/342");
+  });
+
+  it("ignores non-PR-create Bash calls", () => {
+    expect(
+      detectPrOpened({
+        tool_name: "Bash",
+        tool_input: { command: "gh pr view 342" },
+        tool_response: { stdout: "https://github.com/o/r/pull/342" },
+      }),
+    ).toBeNull();
+  });
+
+  it("ignores a create call with no url in output (failed)", () => {
+    expect(
+      detectPrOpened({
+        tool_name: "Bash",
+        tool_input: { command: "gh pr create --fill" },
+        tool_response: { stderr: "pull request create failed" },
+      }),
+    ).toBeNull();
+  });
+
+  it("detects gh pr ready (draft → open)", () => {
+    expect(
+      detectPrOpened({
+        tool_name: "Bash",
+        tool_input: { command: "gh pr ready 19" },
+        tool_response: { stdout: "https://github.com/o/r/pull/19" },
+      }),
+    ).toBe("https://github.com/o/r/pull/19");
+  });
+
+  it("ignores non-Bash tools", () => {
+    expect(
+      detectPrOpened({
+        tool_name: "Edit",
+        tool_input: { command: "gh pr create" },
+        tool_response: { stdout: "https://github.com/o/r/pull/1" },
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/test/guardrails/sessionState.test.ts
+++ b/src/test/guardrails/sessionState.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { tmpdir } from "os";
+import { join } from "path";
+import { mkdtempSync } from "fs";
+import { readState, markPrHandled, isPrHandled } from "../../guardrails/sessionState";
+
+describe("sessionState", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "gr-"));
+  });
+
+  it("returns empty state for an unknown session", () => {
+    expect(readState("s1", dir)).toEqual({ sessionId: "s1", prsHandled: [] });
+  });
+
+  it("marks a PR handled and is idempotent", () => {
+    markPrHandled("s1", "https://github.com/o/r/pull/7", dir);
+    expect(isPrHandled("s1", "https://github.com/o/r/pull/7", dir)).toBe(true);
+    markPrHandled("s1", "https://github.com/o/r/pull/7", dir);
+    expect(readState("s1", dir).prsHandled).toEqual(["https://github.com/o/r/pull/7"]);
+  });
+
+  it("isolates state per session id", () => {
+    markPrHandled("s1", "https://github.com/o/r/pull/7", dir);
+    expect(isPrHandled("s2", "https://github.com/o/r/pull/7", dir)).toBe(false);
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -7,27 +7,45 @@ import { defineConfig } from "tsup";
 const APPLICATIONINSIGHTS_CONNECTION_STRING =
   process.env.APPLICATIONINSIGHTS_CONNECTION_STRING ?? "";
 
-export default defineConfig({
-  entry: {
-    "index": "src/index.ts",
-    "cli": "src/cli/main.ts",
+export default defineConfig([
+  {
+    entry: {
+      "index": "src/index.ts",
+      "cli": "src/cli/main.ts",
+    },
+    format: ["esm"],
+    target: "node22",
+    outDir: "dist",
+    clean: true,
+    sourcemap: false,
+    dts: false,
+    splitting: true,
+    treeshake: true,
+    minify: false,
+    define: {
+      "process.env.APPLICATIONINSIGHTS_CONNECTION_STRING": JSON.stringify(
+        APPLICATIONINSIGHTS_CONNECTION_STRING,
+      ),
+    },
+    external: [
+      "@modelcontextprotocol/sdk",
+    ],
+    noExternal: ["@muggleai/mcp"],
   },
-  format: ["esm"],
-  target: "node22",
-  outDir: "dist",
-  clean: true,
-  sourcemap: false,
-  dts: false,
-  splitting: true,
-  treeshake: true,
-  minify: false,
-  define: {
-    "process.env.APPLICATIONINSIGHTS_CONNECTION_STRING": JSON.stringify(
-      APPLICATIONINSIGHTS_CONNECTION_STRING,
-    ),
+  // Guardrail hook logic. Bundled self-contained (node builtins only) into the
+  // plugin tree so the bash hooks can `node scripts/guardrails.mjs <sub>`;
+  // build-plugin then copies plugin/ → dist/plugin/ for publish.
+  {
+    entry: { "guardrails": "src/guardrails/cli.ts" },
+    format: ["esm"],
+    target: "node22",
+    outDir: "plugin/scripts",
+    outExtension: () => ({ js: ".mjs" }),
+    clean: false,
+    sourcemap: false,
+    dts: false,
+    splitting: false,
+    treeshake: true,
+    minify: false,
   },
-  external: [
-    "@modelcontextprotocol/sdk",
-  ],
-  noExternal: ["@muggleai/mcp"],
-});
+]);


### PR DESCRIPTION
First of the condition-triggered **guardrail layer** (design: `muggle-ai-brain` PR #76). Guardrails are Claude-Code-layer hooks that inject an advisory directive to invoke a Muggle Test flow **path-independently** — so the handoff fires no matter which pipeline (muggle-do, superpowers, or ad-hoc edits) built the change.

## What's here

- **`src/guardrails/`** (vitest-covered, 11 tests):
  - `sessionState.ts` — per-session state at `~/.muggle-ai/guardrails/<session_id>.json`, fire-once dedupe.
  - `prOpened.ts` — detect a successful `gh pr create`/`gh pr ready` from a PostToolUse payload, extract the PR URL.
  - `emit.ts` — Claude `hookSpecificOutput` / Cursor `additional_context` envelope.
  - `cli.ts` — stdin-driven dispatcher; never throws (degrades to `{}`).
- **Build:** a second tsup config bundles `cli.ts` → `plugin/scripts/guardrails.mjs` (self-contained, node builtins only); `build-plugin` copies `plugin/` → `dist/plugin/` for publish.
- **Hook:** `PostToolUse(Bash)` → `guardrail-pr-opened.sh`. On a successful PR open it offers a `muggle-pr-followup` watcher, **gated by `autoWatchPR`**, deduped per session. Any failure → `{}`, never blocks a turn.
- **`plugin/hooks/README.md`** documents the layer (Claude Code vs Muggle Test).

## Verification

- `vitest run` → **257 passed (21 files)**.
- Smoke-tested `guardrails.mjs pr-opened`: offers once, dedupes to `{}`, ignores non-PR Bash calls.

## Notes for reviewers

- Customer-facing (ships to all plugin users). Reuses the existing `autoWatchPR` preference — no new behavior when `autoWatchPR=never`.
- Foundation for two follow-ups in the same series: tests-green → E2E gate, and build-intent → orchestrator (each its own PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)