### PR TITLE
feat(guardrails): tests-green → E2E acceptance gate

### DIFF
--- a/plugin/hooks/README.md
+++ b/plugin/hooks/README.md
@@ -23,3 +23,4 @@ Each guardrail is a thin bash wrapper in `../scripts/` registered in `hooks.json
 | :--------- | :------ | :-------- | :--------- | :----------- |
 | `PostToolUse` (Bash) | `guardrail-pr-opened.sh` | a `gh pr create`/`gh pr ready` just succeeded | `autoWatchPR` | start a `muggle-pr-followup` watcher on the new PR |
 | `Stop` | `guardrail-e2e-gate.sh` | unit tests passed this session and no E2E ran yet (recorded by `guardrail-record-tests.sh`) | `autoE2ETest` | run change-driven E2E via `muggle-test` before finishing |
+| `UserPromptSubmit` | `guardrail-build-router.sh` | a build/implement/fix request (first one this session) | `autoRouteBuildToMuggleDo` | route the work through `muggle-do` (build delegated to superpowers) |

--- a/plugin/hooks/README.md
+++ b/plugin/hooks/README.md
@@ -22,3 +22,4 @@ Each guardrail is a thin bash wrapper in `../scripts/` registered in `hooks.json
 | Hook event | Wrapper | Condition | Preference | Flow invoked |
 | :--------- | :------ | :-------- | :--------- | :----------- |
 | `PostToolUse` (Bash) | `guardrail-pr-opened.sh` | a `gh pr create`/`gh pr ready` just succeeded | `autoWatchPR` | start a `muggle-pr-followup` watcher on the new PR |
+| `Stop` | `guardrail-e2e-gate.sh` | unit tests passed this session and no E2E ran yet (recorded by `guardrail-record-tests.sh`) | `autoE2ETest` | run change-driven E2E via `muggle-test` before finishing |

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -20,6 +20,22 @@
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/guardrail-pr-opened.sh\"",
             "async": false
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/guardrail-record-tests.sh\"",
+            "async": false
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/guardrail-e2e-gate.sh\"",
+            "async": false
           }
         ]
       }

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -39,6 +39,17 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/guardrail-build-router.sh\"",
+            "async": false
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugin/scripts/ensure-electron-app.sh
+++ b/plugin/scripts/ensure-electron-app.sh
@@ -109,7 +109,7 @@ if [ -f "$prefs_global_file" ]; then
         postPRVisualWalkthrough:'ask', autoCreatePR:'ask',
         checkForUpdates:'ask', verboseOutput:'ask',
         autoUseWorktree:'ask', autoRebase:'ask', autoCleanup:'ask',
-        autoE2ETest:'always'
+        autoE2ETest:'always', autoRouteBuildToMuggleDo:'ask'
       };
       const cwd = process.env.CLAUDE_CWD || process.env.CURSOR_CWD || process.cwd();
       const pPath = require('path').join(cwd, '.muggle-ai', 'preferences.json');

--- a/plugin/scripts/guardrail-build-router.sh
+++ b/plugin/scripts/guardrail-build-router.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Front-door router (UserPromptSubmit). On the first build/implement/fix prompt
+# of a session, offers to route the work through /muggle-do (build delegated to
+# superpowers), gated by autoRouteBuildToMuggleDo. Fires once per session.
+# Degrades to {} so it never blocks a turn.
+root="${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-}}"
+node "${root}/scripts/guardrails.mjs" build-router 2>/dev/null || printf '{}'

--- a/plugin/scripts/guardrail-e2e-gate.sh
+++ b/plugin/scripts/guardrail-e2e-gate.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# tests-green → E2E gate (Stop). When unit tests passed this session and no E2E
+# acceptance run has happened, offer to run change-driven E2E (gated by
+# autoE2ETest). Fires once per session. Degrades to {} so it never blocks a turn.
+root="${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-}}"
+node "${root}/scripts/guardrails.mjs" e2e-gate 2>/dev/null || printf '{}'

--- a/plugin/scripts/guardrail-record-tests.sh
+++ b/plugin/scripts/guardrail-record-tests.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# tests-green observer (PostToolUse/Bash). Records in per-session state when a
+# unit-test command passed (and when a muggle E2E run happened). Emits no
+# directive — the Stop gate (guardrail-e2e-gate.sh) reads the state. Degrades
+# to {} so it never blocks a turn.
+root="${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-}}"
+node "${root}/scripts/guardrails.mjs" record-tests 2>/dev/null || printf '{}'

--- a/plugin/scripts/guardrails.mjs
+++ b/plugin/scripts/guardrails.mjs
@@ -38,6 +38,30 @@ ${input2.tool_response?.output ?? ""}`;
   return m ? m[0] : null;
 }
 
+// src/guardrails/testsGreen.ts
+var TEST_CMD = /\b(pnpm|npm|yarn)\s+(run\s+)?test\b|\b(jest|vitest|pytest)\b|\bgo\s+test\b|\bcargo\s+test\b/;
+var FAIL = /\b\d+\s+failed\b|\bFAIL\b|✗/;
+var E2E_RUN = /\bmuggle\b[^\n]*\b(execute|test)\b/i;
+function isTestCommand(cmd) {
+  return TEST_CMD.test(cmd);
+}
+function testsPassed(input2) {
+  const out = `${input2.tool_response?.stdout ?? ""}
+${input2.tool_response?.stderr ?? ""}`;
+  if (!out.trim()) return false;
+  return !FAIL.test(out);
+}
+function isE2ERun(input2) {
+  const cmd = input2.tool_input?.command ?? "";
+  const tool = input2.tool_name ?? "";
+  return E2E_RUN.test(cmd) || /muggle.*(execute|test-generation|replay)/i.test(tool);
+}
+
+// src/guardrails/shouldRunE2E.ts
+function shouldRunE2E(state) {
+  return state.unitTestsGreen === true && state.e2eRun !== true;
+}
+
 // src/guardrails/emit.ts
 function envelope(eventName, context, host2) {
   if (!context) return "{}";
@@ -68,5 +92,32 @@ function prOpened() {
 Per the autoWatchPR preference, a muggle-pr-followup watcher should handle its incoming reviews. If autoWatchPR=always, start it now by invoking /muggle:muggle-pr-followup with the PR URL; if =ask, offer it to the user; if =never, do nothing.`;
   return envelope("PostToolUse", ctx, host);
 }
-var handlers = { "pr-opened": prOpened };
+function recordTests() {
+  const cmd = input.tool_input?.command ?? "";
+  const state = readState(sessionId);
+  let changed = false;
+  if (isTestCommand(cmd) && testsPassed(input)) {
+    state.unitTestsGreen = true;
+    changed = true;
+  }
+  if (isE2ERun(input)) {
+    state.e2eRun = true;
+    changed = true;
+  }
+  if (changed) writeState(state);
+  return "{}";
+}
+function e2eGate() {
+  const state = readState(sessionId);
+  if (!shouldRunE2E(state)) return "{}";
+  state.e2eRun = true;
+  writeState(state);
+  const ctx = `Unit tests passed this session and no E2E acceptance run has happened yet. Per the autoE2ETest preference (default: always), run change-driven E2E now via /muggle:muggle-test before finishing. If autoE2ETest=never, skip.`;
+  return envelope("Stop", ctx, host);
+}
+var handlers = {
+  "pr-opened": prOpened,
+  "record-tests": recordTests,
+  "e2e-gate": e2eGate
+};
 process.stdout.write((handlers[sub] ?? (() => "{}"))());

--- a/plugin/scripts/guardrails.mjs
+++ b/plugin/scripts/guardrails.mjs
@@ -62,6 +62,16 @@ function shouldRunE2E(state) {
   return state.unitTestsGreen === true && state.e2eRun !== true;
 }
 
+// src/guardrails/detectBuildIntent.ts
+var BUILD = /\b(implement|build|add|create|write|fix|refactor|wire up|hook up|make (a|the|it)|change the)\b/i;
+var QUESTION = /^\s*(why|what|how|when|where|who|is|are|does|do|can you (explain|tell)|explain)\b/i;
+function detectBuildIntent(prompt) {
+  const p = (prompt ?? "").trim();
+  if (!p || p.startsWith("/")) return false;
+  if (QUESTION.test(p)) return false;
+  return BUILD.test(p);
+}
+
 // src/guardrails/emit.ts
 function envelope(eventName, context, host2) {
   if (!context) return "{}";
@@ -115,9 +125,19 @@ function e2eGate() {
   const ctx = `Unit tests passed this session and no E2E acceptance run has happened yet. Per the autoE2ETest preference (default: always), run change-driven E2E now via /muggle:muggle-test before finishing. If autoE2ETest=never, skip.`;
   return envelope("Stop", ctx, host);
 }
+function buildRouter() {
+  if (!detectBuildIntent(input.prompt ?? "")) return "{}";
+  const state = readState(sessionId);
+  if (state.buildIntentRouted) return "{}";
+  state.buildIntentRouted = true;
+  writeState(state);
+  const ctx = `This looks like a build/implement/fix request. Per the autoRouteBuildToMuggleDo preference, route it through /muggle-do \u2014 which runs requirements \u2192 build (delegated to superpowers' design\u2192plan\u2192review) \u2192 impact \u2192 unit tests \u2192 E2E \u2192 PR \u2192 watcher. If autoRouteBuildToMuggleDo=always, enter that flow; if =ask, offer it; if =never, proceed normally.`;
+  return envelope("UserPromptSubmit", ctx, host);
+}
 var handlers = {
   "pr-opened": prOpened,
   "record-tests": recordTests,
-  "e2e-gate": e2eGate
+  "e2e-gate": e2eGate,
+  "build-router": buildRouter
 };
 process.stdout.write((handlers[sub] ?? (() => "{}"))());

--- a/plugin/skills/do/build.md
+++ b/plugin/skills/do/build.md
@@ -29,6 +29,10 @@ For each affected repo:
 
    The body explains *why* when the why is non-obvious. The diff already says *what*.
 
+## Delegation
+
+For a non-trivial change — multiple files, real design surface, or anything you would otherwise brainstorm before coding — run the implementation through superpowers' design → plan → subagent-driven build, then return to this stage's Output. That is a runtime hand-off (an action), not a doc dependency; do not encode superpowers' internals here. Routing a build request into this pipeline (the `autoRouteBuildToMuggleDo` front-door guardrail) exists to combine superpowers' design rigor with this pipeline's impact analysis, E2E, PR, and watcher — neither delivers both alone.
+
 ## Output
 
 Per repo:

--- a/plugin/skills/muggle-do/SKILL.md
+++ b/plugin/skills/muggle-do/SKILL.md
@@ -63,6 +63,7 @@ When invoked with the directive (PR URL + slug + review ids), routes to [`../do/
 | :--------- | :--- |
 | `autoE2ETest` | Stage 6 — run E2E every cycle (default `always`), or fold into pre-flight |
 | `autoResolveConflicts` | On rebase conflict — resolve autonomously behind a verify-or-rollback gate (opt-in), or abort + escalate (default `never`) |
+| `autoRouteBuildToMuggleDo` | Front-door guardrail — route build/implement/fix requests through this pipeline (build delegated to superpowers); fired by the UserPromptSubmit guardrail, default `ask` |
 
 `autoUseWorktree`, `autoRebase`, `autoResolveConflicts`, `autoCreatePR`, `autoCleanup` fire from per-stage files.
 

--- a/plugin/skills/muggle-preferences/preference-gates/autoRouteBuildToMuggleDo.md
+++ b/plugin/skills/muggle-preferences/preference-gates/autoRouteBuildToMuggleDo.md
@@ -1,0 +1,13 @@
+# `autoRouteBuildToMuggleDo`
+
+When the user asks to build, implement, or fix something, controls whether the front-door guardrail routes the work through `/muggle-do` — the orchestrator that runs requirements → build (delegated to superpowers' design→plan→review) → impact → unit tests → E2E → PR → watcher — or lets the request proceed however the model would otherwise handle it. Fires once per session, on the first build-intent prompt (UserPromptSubmit guardrail).
+
+**Picker 1** — header `Route to muggle-do?`, question `"This looks like a build request — run it through /muggle-do (E2E + PR + watcher, build delegated to superpowers)?"`
+- `Route it` — `Enter the /muggle-do pipeline.` → `always`
+- `Ask me next time` — `Decide per request.` → `ask`
+- `No — proceed normally` — `Handle it without /muggle-do.` → `never`
+
+**Silent action**
+- `always` → `Routing build requests through /muggle-do`
+- `ask` → `Asking about routing to muggle-do`
+- `never` → `Not routing to muggle-do`

--- a/src/guardrails/cli.ts
+++ b/src/guardrails/cli.ts
@@ -1,6 +1,8 @@
 import { readFileSync } from "fs";
-import { readState, markPrHandled } from "./sessionState.js";
+import { readState, writeState, markPrHandled } from "./sessionState.js";
 import { detectPrOpened } from "./prOpened.js";
+import { isTestCommand, testsPassed, isE2ERun } from "./testsGreen.js";
+import { shouldRunE2E } from "./shouldRunE2E.js";
 import { envelope, type Host } from "./emit.js";
 import type { HookInput } from "./types.js";
 
@@ -30,5 +32,37 @@ function prOpened(): string {
   return envelope("PostToolUse", ctx, host);
 }
 
-const handlers: Record<string, () => string> = { "pr-opened": prOpened };
+function recordTests(): string {
+  const cmd = input.tool_input?.command ?? "";
+  const state = readState(sessionId);
+  let changed = false;
+  if (isTestCommand(cmd) && testsPassed(input)) {
+    state.unitTestsGreen = true;
+    changed = true;
+  }
+  if (isE2ERun(input)) {
+    state.e2eRun = true;
+    changed = true;
+  }
+  if (changed) writeState(state);
+  return "{}";
+}
+
+function e2eGate(): string {
+  const state = readState(sessionId);
+  if (!shouldRunE2E(state)) return "{}";
+  state.e2eRun = true;
+  writeState(state);
+  const ctx =
+    `Unit tests passed this session and no E2E acceptance run has happened yet. ` +
+    `Per the autoE2ETest preference (default: always), run change-driven E2E now via /muggle:muggle-test ` +
+    `before finishing. If autoE2ETest=never, skip.`;
+  return envelope("Stop", ctx, host);
+}
+
+const handlers: Record<string, () => string> = {
+  "pr-opened": prOpened,
+  "record-tests": recordTests,
+  "e2e-gate": e2eGate,
+};
 process.stdout.write((handlers[sub] ?? (() => "{}"))());

--- a/src/guardrails/cli.ts
+++ b/src/guardrails/cli.ts
@@ -3,6 +3,7 @@ import { readState, writeState, markPrHandled } from "./sessionState.js";
 import { detectPrOpened } from "./prOpened.js";
 import { isTestCommand, testsPassed, isE2ERun } from "./testsGreen.js";
 import { shouldRunE2E } from "./shouldRunE2E.js";
+import { detectBuildIntent } from "./detectBuildIntent.js";
 import { envelope, type Host } from "./emit.js";
 import type { HookInput } from "./types.js";
 
@@ -60,9 +61,24 @@ function e2eGate(): string {
   return envelope("Stop", ctx, host);
 }
 
+function buildRouter(): string {
+  if (!detectBuildIntent(input.prompt ?? "")) return "{}";
+  const state = readState(sessionId);
+  if (state.buildIntentRouted) return "{}";
+  state.buildIntentRouted = true;
+  writeState(state);
+  const ctx =
+    `This looks like a build/implement/fix request. Per the autoRouteBuildToMuggleDo preference, ` +
+    `route it through /muggle-do — which runs requirements → build (delegated to superpowers' ` +
+    `design→plan→review) → impact → unit tests → E2E → PR → watcher. ` +
+    `If autoRouteBuildToMuggleDo=always, enter that flow; if =ask, offer it; if =never, proceed normally.`;
+  return envelope("UserPromptSubmit", ctx, host);
+}
+
 const handlers: Record<string, () => string> = {
   "pr-opened": prOpened,
   "record-tests": recordTests,
   "e2e-gate": e2eGate,
+  "build-router": buildRouter,
 };
 process.stdout.write((handlers[sub] ?? (() => "{}"))());

--- a/src/guardrails/detectBuildIntent.ts
+++ b/src/guardrails/detectBuildIntent.ts
@@ -1,0 +1,9 @@
+const BUILD = /\b(implement|build|add|create|write|fix|refactor|wire up|hook up|make (a|the|it)|change the)\b/i;
+const QUESTION = /^\s*(why|what|how|when|where|who|is|are|does|do|can you (explain|tell)|explain)\b/i;
+
+export function detectBuildIntent(prompt: string): boolean {
+  const p = (prompt ?? "").trim();
+  if (!p || p.startsWith("/")) return false;
+  if (QUESTION.test(p)) return false;
+  return BUILD.test(p);
+}

--- a/src/guardrails/shouldRunE2E.ts
+++ b/src/guardrails/shouldRunE2E.ts
@@ -1,0 +1,5 @@
+import type { GuardrailState } from "./types.js";
+
+export function shouldRunE2E(state: GuardrailState): boolean {
+  return state.unitTestsGreen === true && state.e2eRun !== true;
+}

--- a/src/guardrails/testsGreen.ts
+++ b/src/guardrails/testsGreen.ts
@@ -1,0 +1,21 @@
+import type { HookInput } from "./types.js";
+
+const TEST_CMD = /\b(pnpm|npm|yarn)\s+(run\s+)?test\b|\b(jest|vitest|pytest)\b|\bgo\s+test\b|\bcargo\s+test\b/;
+const FAIL = /\b\d+\s+failed\b|\bFAIL\b|✗/;
+const E2E_RUN = /\bmuggle\b[^\n]*\b(execute|test)\b/i;
+
+export function isTestCommand(cmd: string): boolean {
+  return TEST_CMD.test(cmd);
+}
+
+export function testsPassed(input: HookInput): boolean {
+  const out = `${input.tool_response?.stdout ?? ""}\n${input.tool_response?.stderr ?? ""}`;
+  if (!out.trim()) return false;
+  return !FAIL.test(out);
+}
+
+export function isE2ERun(input: HookInput): boolean {
+  const cmd = input.tool_input?.command ?? "";
+  const tool = input.tool_name ?? "";
+  return E2E_RUN.test(cmd) || /muggle.*(execute|test-generation|replay)/i.test(tool);
+}

--- a/src/test/guardrails/detectBuildIntent.test.ts
+++ b/src/test/guardrails/detectBuildIntent.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { detectBuildIntent } from "../../guardrails/detectBuildIntent";
+
+describe("detectBuildIntent", () => {
+  it("matches build/implement/fix asks", () => {
+    expect(detectBuildIntent("implement a dark-mode toggle")).toBe(true);
+    expect(detectBuildIntent("can you build the export feature")).toBe(true);
+    expect(detectBuildIntent("fix the null crash in the parser")).toBe(true);
+    expect(detectBuildIntent("add a retry to the upload")).toBe(true);
+  });
+  it("ignores questions and non-build asks", () => {
+    expect(detectBuildIntent("why does the failed job have no screenshots?")).toBe(false);
+    expect(detectBuildIntent("what is next")).toBe(false);
+    expect(detectBuildIntent("explain how auth works")).toBe(false);
+  });
+  it("ignores slash commands (already routed)", () => {
+    expect(detectBuildIntent("/muggle-do address reviews 1 on https://github.com/o/r/pull/2")).toBe(false);
+  });
+});

--- a/src/test/guardrails/shouldRunE2E.test.ts
+++ b/src/test/guardrails/shouldRunE2E.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import { shouldRunE2E } from "../../guardrails/shouldRunE2E";
+
+describe("shouldRunE2E", () => {
+  it("fires when tests green and no e2e yet", () => {
+    expect(shouldRunE2E({ sessionId: "s", prsHandled: [], unitTestsGreen: true, e2eRun: false })).toBe(true);
+  });
+  it("does not fire if e2e already ran", () => {
+    expect(shouldRunE2E({ sessionId: "s", prsHandled: [], unitTestsGreen: true, e2eRun: true })).toBe(false);
+  });
+  it("does not fire if tests never went green", () => {
+    expect(shouldRunE2E({ sessionId: "s", prsHandled: [], unitTestsGreen: false })).toBe(false);
+  });
+});

--- a/src/test/guardrails/testsGreen.test.ts
+++ b/src/test/guardrails/testsGreen.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { isTestCommand, testsPassed, isE2ERun } from "../../guardrails/testsGreen";
+
+describe("testsGreen", () => {
+  it("recognizes common test commands", () => {
+    expect(isTestCommand("pnpm test")).toBe(true);
+    expect(isTestCommand("npx jest src/foo")).toBe(true);
+    expect(isTestCommand("vitest run")).toBe(true);
+    expect(isTestCommand("go test ./...")).toBe(true);
+    expect(isTestCommand("git status")).toBe(false);
+  });
+
+  it("treats a failed run as not green and a passing run as green", () => {
+    expect(testsPassed({ tool_response: { stdout: "Tests: 3 failed, 1 passed" } })).toBe(false);
+    expect(testsPassed({ tool_response: { stdout: "FAIL src/foo.test.ts" } })).toBe(false);
+    expect(testsPassed({ tool_response: { stdout: "Tests: 18 passed", stderr: "" } })).toBe(true);
+    expect(testsPassed({ tool_response: { stdout: "" } })).toBe(false);
+  });
+
+  it("detects a muggle E2E run", () => {
+    expect(isE2ERun({ tool_input: { command: "muggle test --local" } })).toBe(true);
+    expect(isE2ERun({ tool_name: "muggle-local-execute-test-generation" })).toBe(true);
+    expect(isE2ERun({ tool_input: { command: "pnpm test" } })).toBe(false);
+  });
+});


### PR DESCRIPTION
Second guardrail in the series (design: `muggle-ai-brain` PR #76). Makes **"unit tests passed → run E2E acceptance"** a *condition*, not a pipeline stage only muggle-do runs — so it fires regardless of how the change was built.

**Stacked on #243** (`feat/guardrail-pr-opened`). Review/merge that first.

## What's here

- `testsGreen.ts` — recognize unit-test commands, decide pass/fail from output, detect a muggle E2E run (so the gate doesn't double-prompt).
- `shouldRunE2E.ts` — fire when `unitTestsGreen` and not yet `e2eRun`.
- `cli.ts` — `record-tests` observer (PostToolUse/Bash) records state; `e2e-gate` (Stop) fires the directive once.
- Hooks: `guardrail-record-tests.sh` joins the Bash PostToolUse array; `guardrail-e2e-gate.sh` is a new Stop hook. Both degrade to `{}`.

## Behavior / intrusiveness

- **Advisory only** — injects `additionalContext` on Stop; the model decides. Gated by `autoE2ETest` (no-op when `=never`).
- **Fire-once per session** — `e2eRun` is set when the gate fires (and when an actual muggle E2E run is observed), so it nudges at most once and never after a real E2E run.
- Reviewers: this is the most intrusive guardrail (acts on Stop). Recommend monitoring spurious-fire rate before considering any hard-block behavior.

## Verification

- `vitest run` → **263 passed (23 files)**.
- Smoke-tested: record passing tests → Stop fires the E2E directive once → second Stop dedupes to `{}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)