### PR TITLE
feat(guardrails): build-intent → muggle-do front-door router

### DIFF
--- a/plugin/hooks/README.md
+++ b/plugin/hooks/README.md
@@ -23,3 +23,4 @@ Each guardrail is a thin bash wrapper in `../scripts/` registered in `hooks.json
 | :--------- | :------ | :-------- | :--------- | :----------- |
 | `PostToolUse` (Bash) | `guardrail-pr-opened.sh` | a `gh pr create`/`gh pr ready` just succeeded | `autoWatchPR` | start a `muggle-pr-followup` watcher on the new PR |
 | `Stop` | `guardrail-e2e-gate.sh` | unit tests passed this session and no E2E ran yet (recorded by `guardrail-record-tests.sh`) | `autoE2ETest` | run change-driven E2E via `muggle-test` before finishing |
+| `UserPromptSubmit` | `guardrail-build-router.sh` | a build/implement/fix request (first one this session) | `autoRouteBuildToMuggleDo` | route the work through `muggle-do` (build delegated to superpowers) |

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -39,6 +39,17 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/guardrail-build-router.sh\"",
+            "async": false
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugin/scripts/ensure-electron-app.sh
+++ b/plugin/scripts/ensure-electron-app.sh
@@ -109,7 +109,7 @@ if [ -f "$prefs_global_file" ]; then
         postPRVisualWalkthrough:'ask', autoCreatePR:'ask',
         checkForUpdates:'ask', verboseOutput:'ask',
         autoUseWorktree:'ask', autoRebase:'ask', autoCleanup:'ask',
-        autoE2ETest:'always'
+        autoE2ETest:'always', autoRouteBuildToMuggleDo:'ask'
       };
       const cwd = process.env.CLAUDE_CWD || process.env.CURSOR_CWD || process.cwd();
       const pPath = require('path').join(cwd, '.muggle-ai', 'preferences.json');

--- a/plugin/scripts/guardrail-build-router.sh
+++ b/plugin/scripts/guardrail-build-router.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Front-door router (UserPromptSubmit). On the first build/implement/fix prompt
+# of a session, offers to route the work through /muggle-do (build delegated to
+# superpowers), gated by autoRouteBuildToMuggleDo. Fires once per session.
+# Degrades to {} so it never blocks a turn.
+root="${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-}}"
+node "${root}/scripts/guardrails.mjs" build-router 2>/dev/null || printf '{}'

--- a/plugin/scripts/guardrails.mjs
+++ b/plugin/scripts/guardrails.mjs
@@ -62,6 +62,16 @@ function shouldRunE2E(state) {
   return state.unitTestsGreen === true && state.e2eRun !== true;
 }
 
+// src/guardrails/detectBuildIntent.ts
+var BUILD = /\b(implement|build|add|create|write|fix|refactor|wire up|hook up|make (a|the|it)|change the)\b/i;
+var QUESTION = /^\s*(why|what|how|when|where|who|is|are|does|do|can you (explain|tell)|explain)\b/i;
+function detectBuildIntent(prompt) {
+  const p = (prompt ?? "").trim();
+  if (!p || p.startsWith("/")) return false;
+  if (QUESTION.test(p)) return false;
+  return BUILD.test(p);
+}
+
 // src/guardrails/emit.ts
 function envelope(eventName, context, host2) {
   if (!context) return "{}";
@@ -115,9 +125,19 @@ function e2eGate() {
   const ctx = `Unit tests passed this session and no E2E acceptance run has happened yet. Per the autoE2ETest preference (default: always), run change-driven E2E now via /muggle:muggle-test before finishing. If autoE2ETest=never, skip.`;
   return envelope("Stop", ctx, host);
 }
+function buildRouter() {
+  if (!detectBuildIntent(input.prompt ?? "")) return "{}";
+  const state = readState(sessionId);
+  if (state.buildIntentRouted) return "{}";
+  state.buildIntentRouted = true;
+  writeState(state);
+  const ctx = `This looks like a build/implement/fix request. Per the autoRouteBuildToMuggleDo preference, route it through /muggle-do \u2014 which runs requirements \u2192 build (delegated to superpowers' design\u2192plan\u2192review) \u2192 impact \u2192 unit tests \u2192 E2E \u2192 PR \u2192 watcher. If autoRouteBuildToMuggleDo=always, enter that flow; if =ask, offer it; if =never, proceed normally.`;
+  return envelope("UserPromptSubmit", ctx, host);
+}
 var handlers = {
   "pr-opened": prOpened,
   "record-tests": recordTests,
-  "e2e-gate": e2eGate
+  "e2e-gate": e2eGate,
+  "build-router": buildRouter
 };
 process.stdout.write((handlers[sub] ?? (() => "{}"))());

--- a/plugin/skills/do/build.md
+++ b/plugin/skills/do/build.md
@@ -29,6 +29,10 @@ For each affected repo:
 
    The body explains *why* when the why is non-obvious. The diff already says *what*.
 
+## Delegation
+
+For a non-trivial change — multiple files, real design surface, or anything you would otherwise brainstorm before coding — run the implementation through superpowers' design → plan → subagent-driven build, then return to this stage's Output. That is a runtime hand-off (an action), not a doc dependency; do not encode superpowers' internals here. Routing a build request into this pipeline (the `autoRouteBuildToMuggleDo` front-door guardrail) exists to combine superpowers' design rigor with this pipeline's impact analysis, E2E, PR, and watcher — neither delivers both alone.
+
 ## Output
 
 Per repo:

--- a/plugin/skills/muggle-do/SKILL.md
+++ b/plugin/skills/muggle-do/SKILL.md
@@ -63,6 +63,7 @@ When invoked with the directive (PR URL + slug + review ids), routes to [`../do/
 | :--------- | :--- |
 | `autoE2ETest` | Stage 6 — run E2E every cycle (default `always`), or fold into pre-flight |
 | `autoResolveConflicts` | On rebase conflict — resolve autonomously behind a verify-or-rollback gate (opt-in), or abort + escalate (default `never`) |
+| `autoRouteBuildToMuggleDo` | Front-door guardrail — route build/implement/fix requests through this pipeline (build delegated to superpowers); fired by the UserPromptSubmit guardrail, default `ask` |
 
 `autoUseWorktree`, `autoRebase`, `autoResolveConflicts`, `autoCreatePR`, `autoCleanup` fire from per-stage files.
 

--- a/plugin/skills/muggle-preferences/preference-gates/autoRouteBuildToMuggleDo.md
+++ b/plugin/skills/muggle-preferences/preference-gates/autoRouteBuildToMuggleDo.md
@@ -1,0 +1,13 @@
+# `autoRouteBuildToMuggleDo`
+
+When the user asks to build, implement, or fix something, controls whether the front-door guardrail routes the work through `/muggle-do` — the orchestrator that runs requirements → build (delegated to superpowers' design→plan→review) → impact → unit tests → E2E → PR → watcher — or lets the request proceed however the model would otherwise handle it. Fires once per session, on the first build-intent prompt (UserPromptSubmit guardrail).
+
+**Picker 1** — header `Route to muggle-do?`, question `"This looks like a build request — run it through /muggle-do (E2E + PR + watcher, build delegated to superpowers)?"`
+- `Route it` — `Enter the /muggle-do pipeline.` → `always`
+- `Ask me next time` — `Decide per request.` → `ask`
+- `No — proceed normally` — `Handle it without /muggle-do.` → `never`
+
+**Silent action**
+- `always` → `Routing build requests through /muggle-do`
+- `ask` → `Asking about routing to muggle-do`
+- `never` → `Not routing to muggle-do`

--- a/src/guardrails/cli.ts
+++ b/src/guardrails/cli.ts
@@ -3,6 +3,7 @@ import { readState, writeState, markPrHandled } from "./sessionState.js";
 import { detectPrOpened } from "./prOpened.js";
 import { isTestCommand, testsPassed, isE2ERun } from "./testsGreen.js";
 import { shouldRunE2E } from "./shouldRunE2E.js";
+import { detectBuildIntent } from "./detectBuildIntent.js";
 import { envelope, type Host } from "./emit.js";
 import type { HookInput } from "./types.js";
 
@@ -60,9 +61,24 @@ function e2eGate(): string {
   return envelope("Stop", ctx, host);
 }
 
+function buildRouter(): string {
+  if (!detectBuildIntent(input.prompt ?? "")) return "{}";
+  const state = readState(sessionId);
+  if (state.buildIntentRouted) return "{}";
+  state.buildIntentRouted = true;
+  writeState(state);
+  const ctx =
+    `This looks like a build/implement/fix request. Per the autoRouteBuildToMuggleDo preference, ` +
+    `route it through /muggle-do — which runs requirements → build (delegated to superpowers' ` +
+    `design→plan→review) → impact → unit tests → E2E → PR → watcher. ` +
+    `If autoRouteBuildToMuggleDo=always, enter that flow; if =ask, offer it; if =never, proceed normally.`;
+  return envelope("UserPromptSubmit", ctx, host);
+}
+
 const handlers: Record<string, () => string> = {
   "pr-opened": prOpened,
   "record-tests": recordTests,
   "e2e-gate": e2eGate,
+  "build-router": buildRouter,
 };
 process.stdout.write((handlers[sub] ?? (() => "{}"))());

--- a/src/guardrails/detectBuildIntent.ts
+++ b/src/guardrails/detectBuildIntent.ts
@@ -1,0 +1,9 @@
+const BUILD = /\b(implement|build|add|create|write|fix|refactor|wire up|hook up|make (a|the|it)|change the)\b/i;
+const QUESTION = /^\s*(why|what|how|when|where|who|is|are|does|do|can you (explain|tell)|explain)\b/i;
+
+export function detectBuildIntent(prompt: string): boolean {
+  const p = (prompt ?? "").trim();
+  if (!p || p.startsWith("/")) return false;
+  if (QUESTION.test(p)) return false;
+  return BUILD.test(p);
+}

--- a/src/test/guardrails/detectBuildIntent.test.ts
+++ b/src/test/guardrails/detectBuildIntent.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { detectBuildIntent } from "../../guardrails/detectBuildIntent";
+
+describe("detectBuildIntent", () => {
+  it("matches build/implement/fix asks", () => {
+    expect(detectBuildIntent("implement a dark-mode toggle")).toBe(true);
+    expect(detectBuildIntent("can you build the export feature")).toBe(true);
+    expect(detectBuildIntent("fix the null crash in the parser")).toBe(true);
+    expect(detectBuildIntent("add a retry to the upload")).toBe(true);
+  });
+  it("ignores questions and non-build asks", () => {
+    expect(detectBuildIntent("why does the failed job have no screenshots?")).toBe(false);
+    expect(detectBuildIntent("what is next")).toBe(false);
+    expect(detectBuildIntent("explain how auth works")).toBe(false);
+  });
+  it("ignores slash commands (already routed)", () => {
+    expect(detectBuildIntent("/muggle-do address reviews 1 on https://github.com/o/r/pull/2")).toBe(false);
+  });
+});


### PR DESCRIPTION
Third guardrail (design: `muggle-ai-brain` PR #76). On the **first build/implement/fix prompt** of a session, offers to route the work through `/muggle-do` — whose build stage **delegates to superpowers' design→plan→review** — so a build request gets design rigor **and** impact analysis / E2E / PR / watcher, regardless of entry point. Resolves the design's weak-point 6 (auto-routing no longer costs design quality).

**Stacked on #244** (which is stacked on #243). Merge #243 → #244 → this.

## What's here

- `detectBuildIntent.ts` — conservative classifier; guards questions and slash commands.
- `cli.ts` `build-router` (UserPromptSubmit) — fires once per session.
- New preference **`autoRouteBuildToMuggleDo`**: gate file + `ensure-electron-app.sh` default `ask` + muggle-do SKILL Preferences row. The Layer-1 gate-lint validates it.
- `do/build.md` — Delegation note (runtime hand-off to superpowers; internals not encoded — one-way rule).
- `guardrail-build-router.sh` + UserPromptSubmit hook; degrades to `{}`.

## Default is `ask`, not `always` — eval gate pending

The user chose an auto-route intervention level, but the Layer-2 eval that would justify an `always` default — *does the injected `additionalContext` reliably steer the model into muggle-do against superpowers' always-on gate?* — needs `ANTHROPIC_API_KEY` + the brain scenario harness and isn't runnable in this environment. Per the plan's documented go/no-go, the default ships as **`ask`** (offer, not silent route). Flipping to `always` once the eval passes is a one-line change in `ensure-electron-app.sh`.

## Verification

- `vitest run` → **269 passed (24 files)** incl. gate-lint for the new preference.
- Smoke-tested: build prompt → directive once → second build prompt dedupes → question prompt `{}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)