### PR TITLE
feat(pr-followup): suggest next step when a watched PR goes terminal

### DIFF
--- a/plugin/skills/do/cleanup.md
+++ b/plugin/skills/do/cleanup.md
@@ -1,14 +1,15 @@
 # Post-Merge Cleanup Stage
 
-Invoked by `/muggle-do` when the watcher forwards a PR's terminal (`merged`) state. This stage only resolves the session's workspace and **delegates** teardown to the shared procedure — it does not restate the teardown steps. Never runs while the PR is open.
+Invoked by `/muggle-do` when the watcher forwards a PR's terminal state. On `merged` it resolves the session's workspace and **delegates** teardown to the shared procedure (it does not restate the teardown steps); on `closed` (unmerged) it skips teardown. Either way it ends by suggesting the next step. Never runs while the PR is open.
 
 ## Input
 
-`$ARGUMENTS` carries the session slug as `slug=<slug>`. No PR URL, no review ids.
+`$ARGUMENTS` carries `slug=<slug>` and `state=<merged|closed>` (default `merged`). No PR URL, no review ids.
 
 ## Procedure
 
 1. Read `~/.muggle-ai/muggle-do/sessions/<slug>/`: `prs.json` (PR `repo`, `number`, observed `state`) and `state.md` (`worktreePath` if a worktree was used, and the target branch `headRefName`).
-2. Confirm `prs.json` shows the PR `merged`. If it is still open or was closed unmerged, do nothing and exit — this stage is post-merge only.
-3. Run [`../_shared/post-merge-cleanup.md`](../_shared/post-merge-cleanup.md) with `{worktreePath}` and `{branch}`. That file owns the teardown sequence **and its safety rules** — including skipping worktree-remove and local branch deletion when no worktree was used. This stage adds no teardown logic of its own.
-4. Append a cleanup line to the session's `followup.log`.
+2. If `prs.json` shows the PR still open, do nothing and exit — this stage is terminal-only.
+3. **Teardown (`merged` only).** When the PR is `merged`, run [`../_shared/post-merge-cleanup.md`](../_shared/post-merge-cleanup.md) with `{worktreePath}` and `{branch}`. That file owns the teardown sequence **and its safety rules** — including skipping worktree-remove and local branch deletion when no worktree was used. This stage adds no teardown logic of its own. On `closed`, skip teardown — the branch and any worktree stay intact.
+4. Append a cleanup line to the session's `followup.log`, recording whether teardown ran.
+5. Suggest the next step per [`next-step.md`](next-step.md), passing whether teardown ran. This is the stage's last action.

--- a/plugin/skills/do/input-routing.md
+++ b/plugin/skills/do/input-routing.md
@@ -4,7 +4,7 @@ How `/muggle-do` resolves `$ARGUMENTS` to a mode. Modes 1–3 are programmatic �
 
 1. **Address-reviews** — a `github.com/.../pull/<n>` URL **and** one or more review ids (integers ≥ 100000000) → [`address-reviews.md`](address-reviews.md).
 2. **Fix-CI** — a `github.com/.../pull/<n>` URL **and** a `fix ci` / `fix-ci` directive with failing check names (no review ids) → [`fix-ci.md`](fix-ci.md).
-3. **Post-merge cleanup** — a `cleanup` token and `slug=<slug>` (no PR URL, no review ids) → [`cleanup.md`](cleanup.md).
+3. **Post-merge cleanup** — a `cleanup` token and `slug=<slug>` (no PR URL, no review ids), optionally `state=<merged|closed>` (default `merged`) → [`cleanup.md`](cleanup.md).
 4. **Empty / `help` / `menu` / `?`** → menu + session selector.
 5. **Task automation** (perform an action on a website) → `muggle:muggle-browser-task`.
 6. **Otherwise** → forward pipeline at Stage 1.

--- a/plugin/skills/do/next-step.md
+++ b/plugin/skills/do/next-step.md
@@ -1,0 +1,18 @@
+# Next-Step Suggestion
+
+Closing step of a terminal `/muggle-do` turn (post-merge or post-close). Advances silently when the session still has a plan, stops and asks when it doesn't.
+
+## Input
+
+- `slug` — the session.
+- `teardownRan` — whether [`cleanup.md`](cleanup.md) already ran teardown (true on `merged` + `autoCleanup: always`; false on `closed` or a skipped gate).
+
+## Procedure
+
+1. Read the session plan — the current session's TodoWrite list.
+2. **Pending items remain** → do not prompt. Append `next-step: plan has <N> pending — advancing` to `followup.log` and continue to the next pending item. The user set a course; honor it.
+3. **No pending items** → stop and ask for directions with one `AskUserQuestion` selector:
+   - **Clean up now** — offer only when `teardownRan` is false (a `closed` PR, or `merged` with `autoCleanup` not `always`). Runs the shared teardown [`../_shared/post-merge-cleanup.md`](../_shared/post-merge-cleanup.md) for this slug, under its own safety rules.
+   - **Move on / next task** — start a fresh `/muggle-do` forward run, or pick another open session.
+   - **Done — stop here** — exit with no further action.
+4. Append the chosen outcome to `followup.log`.

--- a/plugin/skills/do/open-prs/forward.md
+++ b/plugin/skills/do/open-prs/forward.md
@@ -78,3 +78,5 @@ Append one short reminder tied to the gate value:
 - `always` → `Once merged, I'll run the cleanup sequence automatically.`
 - `never` → omit.
 - `ask` / absent → `Once merged, I'll check with you about cleanup.`
+
+Regardless of the gate, also append: `Once it's merged or closed, I'll move to the next plan item — or ask where to go next if there's no plan.`

--- a/plugin/skills/muggle-pr-followup/SKILL.md
+++ b/plugin/skills/muggle-pr-followup/SKILL.md
@@ -7,7 +7,7 @@ description: Use this skill when the user wants a pull request's incoming review
 
 > Telemetry first step: see [`../_shared/telemetry-emit.md`](../_shared/telemetry-emit.md). Use `skillName: "muggle-pr-followup"`.
 
-A watcher that babysits one open PR's review thread and CI. Polls for new submitted reviews and check-run state; when review feedback lands or CI goes red, hands the work to `/muggle-do` and exits. On merge, it hands off post-merge cleanup to `/muggle-do` the same way. `/muggle-do` is the executor — it classifies the reviews or fixes the failing checks, pushes, replies per comment, and respawns the watcher.
+A watcher that babysits one open PR's review thread and CI. Polls for new submitted reviews and check-run state; when review feedback lands or CI goes red, hands the work to `/muggle-do` and exits. On merge or close, it hands the terminal wrap-up to `/muggle-do` the same way — teardown when merged, then a next-step suggestion. `/muggle-do` is the executor — it classifies the reviews or fixes the failing checks, pushes, replies per comment, and respawns the watcher.
 
 **The watcher is a dumb pipe.** It does not classify reviews, iterate cycles, post replies, or escalate. All of that lives in `/muggle-do`. See [stage-8 design](../../../../muggle-ai-brain/architecture/2026-05-08-muggle-do-pr-comment-loop-design.md) for the rationale.
 

--- a/plugin/skills/muggle-pr-followup/contract.md
+++ b/plugin/skills/muggle-pr-followup/contract.md
@@ -34,13 +34,13 @@ Per [`../_shared/github-cli-recipes/pr-metadata.md`](../_shared/github-cli-recip
 If `state` is `MERGED` or `CLOSED`:
 
 1. Finalize the slot per [`finalize.md`](finalize.md) — mark terminal, write `result.md`, log + telemetry, unschedule this watcher's cron.
-2. **If `MERGED`**, hand off post-merge cleanup as the last action of the turn (skip on `CLOSED` — unmerged, leave the branch and any worktree intact):
+2. Hand off the terminal wrap-up as the last action of the turn — for both `MERGED` and `CLOSED`:
 
    ```
-   /muggle-do post-merge cleanup slug=<slug>
+   /muggle-do post-merge cleanup slug=<slug> state=<merged|closed>
    ```
 
-   `/muggle-do` owns the worktree/branch knowledge and honors the `autoCleanup` gate. This is a runtime dispatch, not a doc dependency on `/muggle-do` — see the one-way rule in [`../CLAUDE.md`](../CLAUDE.md).
+   `/muggle-do` owns the worktree/branch knowledge: it runs teardown only on `merged` (honoring the `autoCleanup` gate — `closed` is unmerged, so the branch and any worktree stay intact), then suggests the next step. This is a runtime dispatch, not a doc dependency on `/muggle-do` — see the one-way rule in [`../CLAUDE.md`](../CLAUDE.md).
 3. Exit. The watcher has unscheduled itself; no future ticks fire for this PR.
 
 


### PR DESCRIPTION
## What

When a watched PR goes terminal, PR-followup now suggests the next step instead of cleaning up silently (merged) or doing nothing (closed).

- The watcher dispatches the wrap-up on **both** `MERGED` and `CLOSED` (was merged-only), passing `state=<merged|closed>`.
- `/muggle-do` runs teardown on `merged` only (existing `autoCleanup` gate), then runs the next-step decision.
- **Next step:** read the session's TodoWrite plan — pending items remain → advance silently; no plan → `AskUserQuestion` selector (**Clean up now / Move on / Done**).

This encodes the rule: skip the prompt while the plan still has items; stop for directions only when the plan is empty — covering both closed and merged.

## Files

- `do/next-step.md` *(new)* — the plan-check + selector
- `do/cleanup.md` — teardown stays `merged`-only; `closed` skips teardown; both paths end by calling next-step
- `do/input-routing.md` — cleanup mode accepts the optional `state=` param
- `muggle-pr-followup/contract.md` — fire the wrap-up on `closed` too + pass state
- `muggle-pr-followup/SKILL.md`, `do/open-prs/forward.md` — description + pre-flight reminder

## Notes

- The watcher stays a silent dumb pipe; all prompting lives in `/muggle-do`. One-way skill deps and the cleanup routing token are intact.
- Docs-only (skill procedure files); takes effect after the plugin is rebuilt/released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
