### PR TITLE
docs(skill-gate-eval): clarify the eval uses the login session, not a required API key

### DIFF
--- a/internal/skill-gate-eval/README.md
+++ b/internal/skill-gate-eval/README.md
@@ -30,13 +30,14 @@ Layer 2 is run **manually** until the suite is stable. From the
 muggle-ai-works repo root:
 
 ```bash
-ANTHROPIC_API_KEY=... \
-  MUGGLE_BRAIN_DIR=../muggle-ai-brain \
+MUGGLE_BRAIN_DIR=../muggle-ai-brain \
   pnpm tsx internal/skill-gate-eval/src/run.ts \
     --gate showElectronBrowser \
     --skill muggle-test-feature-local \
     --runs 10
 ```
+
+**Auth:** the harness drives `@anthropic-ai/claude-agent-sdk`'s `query()`, which uses your **Claude Code login session** by default — no API key needed when you're logged in. Set `ANTHROPIC_API_KEY` (prefix the command) only where there's no login session, e.g. headless CI.
 
 The harness loads
 `$MUGGLE_BRAIN_DIR/eval/skill-gate-eval/showElectronBrowser/scenarios.json`,


### PR DESCRIPTION
The README's Running example prefixed the command with `ANTHROPIC_API_KEY=...`, which reads as if a raw key is required. It isn't — the harness drives `@anthropic-ai/claude-agent-sdk`'s `query()`, which authenticates via the **Claude Code login session** by default. (Confirmed by running the `showElectronBrowser` eval with no key set.)

- Drop `ANTHROPIC_API_KEY=...` from the primary command.
- Add an **Auth** note: login session is used by default; set the key only where there's no login session (headless CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)