### PR TITLE
fix(muggle-test): make the account-switch login knob reachable and honest

### DIFF
--- a/packages/mcps/src/mcp/local/services/auth-service.ts
+++ b/packages/mcps/src/mcp/local/services/auth-service.ts
@@ -133,11 +133,20 @@ export class AuthService {
     let browserUrl = data.verification_uri_complete;
 
     if (options?.forceNewSession) {
+      // A stale local token would otherwise mask the account switch; pollDeviceCode()
+      // rewrites it with the new identity once authorization completes.
+      this.logout();
+
+      // The device flow has no prompt=select_account, so unless the Auth0 browser
+      // session is cleared first the verification page silently reuses the live SSO
+      // session. returnTo MUST be in the app's Auth0 Allowed Logout URLs — otherwise
+      // Auth0 renders a generic error page and the session is left intact, so the
+      // caller must finish login in a fresh/incognito browser instead.
       const logoutUrl = new URL(`https://${domain}/v2/logout`);
       logoutUrl.searchParams.set("client_id", clientId);
       logoutUrl.searchParams.set("returnTo", data.verification_uri_complete);
       browserUrl = logoutUrl.toString();
-      logger.info("Force new session: opening logout-redirect URL", {
+      logger.info("Force new session: cleared local token, opening logout-redirect URL", {
         logoutUrl: browserUrl,
       });
     }
@@ -624,8 +633,8 @@ export class AuthService {
     const expiresAt = new Date(storedAuth.expiresAt);
     const isStrictlyExpired = now >= expiresAt;
 
-    // If not strictly expired, return the token
-    // (we'll still try to refresh in the buffer zone, but won't fail if refresh fails)
+    // In the buffer zone we still attempt a proactive refresh, but a failure there
+    // is non-fatal — the unexpired token is returned as-is.
     if (!isStrictlyExpired && !this.isAccessTokenExpired()) {
       return storedAuth.accessToken;
     }

--- a/plugin/skills/muggle-test/SKILL.md
+++ b/plugin/skills/muggle-test/SKILL.md
@@ -113,13 +113,15 @@ If no changes detected (clean tree), tell the user and ask what they want to tes
 
 ## Step 3: Authenticate
 
-1. Call `muggle-remote-auth-status`
-2. If **authenticated and not expired** → gate `autoLogin` (per `preference-gates/README.md`):
-   - `always` → reuse saved session.
+1. Call `muggle-remote-auth-status`. Three states: **valid** (`authenticated: true`), **expired** (`authenticated: false` + `isExpired: true`, `email` still present), **absent** (`authenticated: false`, no `email`).
+2. **Valid OR expired** (any stored identity) → gate `autoLogin` (per `preference-gates/README.md`). An expired token is NOT a reason to silently re-login the same account — surface the switch choice:
+   - `always` → reuse if valid; if expired, re-login the **same** account (`muggle-remote-auth-login`, then `muggle-remote-auth-poll`).
    - `never` → `muggle-remote-auth-login` with `forceNewSession: true`, then `muggle-remote-auth-poll`.
    - `ask` → run Picker 1 from `preference-gates/autoLogin.md` via `AskUserQuestion`; map the answer back to one of the actions above.
-3. If **not authenticated or expired** → call `muggle-remote-auth-login`
-4. If login pending → call `muggle-remote-auth-poll`
+3. **Absent** (no stored identity) → `muggle-remote-auth-login` directly, then `muggle-remote-auth-poll`.
+4. If login pending → call `muggle-remote-auth-poll`.
+
+**Account-switch caveat (`never` / "Switch account").** The device flow has no `prompt=select_account`; switching relies on `forceNewSession` first clearing the Auth0 session via `/v2/logout?returnTo=<device-activation URL>`. That redirect only works if the activation URL is in the app's Auth0 *Allowed Logout URLs* — otherwise the browser shows an Auth0 error page and the session is silently reused. If that happens, tell the user to complete login in a **fresh incognito window** (no live SSO session) so Auth0 presents an account login.
 
 If auth fails repeatedly, suggest: `muggle logout && muggle login` from terminal.
 


### PR DESCRIPTION
## Problem
"Switch account" in the `/muggle-test` auth flow was effectively non-functional:

1. **Knob unreachable on expired tokens.** SKILL.md Step 3 only ran the `autoLogin` picker (which offers *"Switch account / sign in fresh"*) when the token was **valid**. On an **expired** token it silently re-logged-in the same account — so the knob never appeared exactly when a user wants to switch.
2. **`forceNewSession` can't force an account chooser.** The Auth0 **device flow has no `prompt=select_account`**. Switching relies on `forceNewSession` first clearing the Auth0 browser session via `/v2/logout?returnTo=<device-activation URL>`. That redirect 500s with a generic Auth0 "Oops" page unless the activation URL is in the app's **Allowed Logout URLs** — so the session was silently reused and the same identity re-authenticated.

## Changes (code)
- **`plugin/skills/muggle-test/SKILL.md` Step 3** — any stored identity (valid **or** expired) now routes through the `autoLogin` gate, so the switch-account knob is reachable on expired tokens; only a fully absent session logs in directly. Documents the `forceNewSession`/Allowed-Logout-URLs caveat + incognito fallback.
- **`auth-service.ts` `forceNewSession`** — also clears the **local** stored token (a stale local identity could mask the switch), and documents the Auth0 dependency in-code.

## Required config (separate, not in this PR)
The functional unblocker is an **Auth0 dashboard** change on the production CLI/MCP application (Client ID `UgG5UjoyLksxMciWWKqVpwfWrJ4rFvtT`, tenant `muggleai.us.auth0.com`): add `https://login.muggle-ai.com/activate` to **Allowed Logout URLs**. *(Applied manually.)*

## Verification
- `tsc --noEmit` on `packages/mcps` — clean.
- no-bloat hook — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)