### PR TITLE
chore(claude): self-bootstrap muggleai plugin for fresh clones

### DIFF
--- a/.claude/hooks/ensure-muggle-plugin.sh
+++ b/.claude/hooks/ensure-muggle-plugin.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Best-effort install of the muggle-ai-works marketplace plugin at project scope.
+# Used for ephemeral environments (e.g. Claude web) where ~/.claude/plugins/ does not persist.
+# Desktop users with extraKnownMarketplaces + enabledPlugins in settings.json get the same
+# plugin via trust prompts; this hook makes the first session self-contained when needed.
+
+readonly MARKETPLACE_NAME="muggle-works"
+readonly PLUGIN_SPEC="muggleai@${MARKETPLACE_NAME}"
+readonly MARKETPLACE_REPO="multiplex-ai/muggle-ai-works"
+
+if ! command -v claude >/dev/null 2>&1; then
+  exit 0
+fi
+
+if claude plugin list 2>/dev/null | grep -Fq "${PLUGIN_SPEC}"; then
+  exit 0
+fi
+
+claude plugin marketplace add "${MARKETPLACE_REPO}" --scope project >/dev/null 2>&1 || true
+claude plugin install "${PLUGIN_SPEC}" --scope project >/dev/null 2>&1 || true

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,28 @@
+{
+  "extraKnownMarketplaces": {
+    "muggle-works": {
+      "autoUpdate": true,
+      "source": {
+        "source": "github",
+        "repo": "multiplex-ai/muggle-ai-works"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "muggleai@muggle-works": true
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR}/.claude/hooks/ensure-muggle-plugin.sh\"",
+            "async": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ coverage/
 
 # muggle-do / pr-followup session state (runtime, never committed)
 .muggle-do/
+
+# Claude Code per-user local settings (settings.json is shared; .local is machine-specific)
+.claude/settings.local.json


### PR DESCRIPTION
## What

Adds a project-scoped `.claude/settings.json` so any clone of this repo — including ephemeral **Claude web** sessions — auto-loads the `muggleai@muggle-works` plugin, making the `/muggle:*` commands callable with **zero manual setup**.

- `extraKnownMarketplaces.muggle-works` → registers this repo as the plugin marketplace.
- `enabledPlugins."muggleai@muggle-works": true` → enables the plugin on clone (subject to the usual trust prompt).
- `SessionStart` hook `.claude/hooks/ensure-muggle-plugin.sh` → **fallback** installer for environments where `~/.claude/plugins/` doesn't persist (e.g. Claude web). It **no-ops** when the `claude` CLI is absent or the plugin is already installed, and is `async` so it never blocks session start.
- `.gitignore`: ignore `.claude/settings.local.json` so per-user local settings (permission allow-lists, worktree mode) can never be committed.

## Why

Today the plugin only loads where a user has manually run `/plugin install muggleai@muggle-works` or has it in their global `~/.claude`. A fresh web clone has neither, so `/muggle:*` commands aren't available until set up by hand. Committing the declarative settings makes a fresh clone self-contained.

## Contributor impact

- The declarative `extraKnownMarketplaces` + `enabledPlugins` follow the existing `.claude/skills/` convention already tracked in this repo.
- The `SessionStart` hook shells out to `bash`. It's guarded (`command -v claude`, already-installed check) and `async`, so on a machine without `bash`/`claude` on PATH it's a non-blocking no-op. Flagging this explicitly for review — if the team prefers **settings.json only (no hook)**, drop the hook commit and keep the rest.

## Verification

- No secrets in the diff (scanned).
- Only three files touched: `.claude/settings.json` (new), `.claude/hooks/ensure-muggle-plugin.sh` (new), `.gitignore` (+1 ignore rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)