### PR TITLE
fix(muggle-pr-followup): thread-state dispatch baseline (not review-id watermark)

### DIFF
--- a/plugin/skills/_shared/github-cli-recipes.md
+++ b/plugin/skills/_shared/github-cli-recipes.md
@@ -9,10 +9,10 @@ Skills assume a working `gh auth status`. Auth errors surface verbatim from `gh`
 | Recipe | Use case |
 | :----- | :------- |
 | [`pr-metadata`](github-cli-recipes/pr-metadata.md) | Snapshot PR state, head SHA, branch — watcher + bootstrap. |
-| [`submitted-reviews`](github-cli-recipes/submitted-reviews.md) | Fetch reviews past a cursor — watcher's poll. |
+| [`submitted-reviews`](github-cli-recipes/submitted-reviews.md) | Fetch a review by id / watcher's body-only-review check. |
 | [`pr-checks`](github-cli-recipes/pr-checks.md) | Check-run rollup for the head SHA — watcher's CI poll. |
 | [`line-comments-for-review`](github-cli-recipes/line-comments-for-review.md) | Pull a review's line comments — `/muggle-do` per-comment routing. |
-| [`unresolved-threads`](github-cli-recipes/unresolved-threads.md) | GraphQL fetch of unresolved comment threads — resolve-reminder. |
+| [`unresolved-threads`](github-cli-recipes/unresolved-threads.md) | GraphQL unresolved-thread state — watcher's dispatch trigger + resolve-reminder. |
 | [`reply-line-comment`](github-cli-recipes/reply-line-comment.md) | POST a threaded reply on a line comment. |
 | [`top-level-comment`](github-cli-recipes/top-level-comment.md) | POST a top-level PR comment — resolve-reminder + overflow. |
 | [`push-to-branch`](github-cli-recipes/push-to-branch.md) | Push + capture new SHA after address-reviews work. |

--- a/plugin/skills/_shared/github-cli-recipes/submitted-reviews.md
+++ b/plugin/skills/_shared/github-cli-recipes/submitted-reviews.md
@@ -1,16 +1,24 @@
-# Submitted reviews past a cursor
+# Submitted reviews
 
-For the watcher's poll and the address-reviews fetch.
+Two consumers (this recipe links to neither — it is a shared primitive):
+
+- the watcher's **body-only-review** check — a submitted review carrying a summary body but **no** line comments. Line-comment threads are dispatched from live thread state, not here.
+- the address-reviews fetch of a **specific** review id.
 
 ```bash
 gh api repos/<owner>/<repo>/pulls/<n>/reviews --paginate
 ```
 
-Filter client-side:
+Common filter:
 
 - `submitted_at != null` (skip PENDING drafts)
-- `id > last_seen.reviewId`
-- `id` not in `last_seen.escalated_review_ids`
 - `user.login` in the resolved allow-list
 - `state` in `{CHANGES_REQUESTED, COMMENTED}`, OR `APPROVED` with a non-empty body or at least one line comment
-- **Not a loop echo.** `POST /pulls/<n>/comments/<id>/replies` creates an implicit review whose comments all have `in_reply_to_id` set. Fetch each candidate review's comments via `gh api repos/<owner>/<repo>/pulls/<n>/reviews/<id>/comments` and drop the review **only if every comment is a reply (`in_reply_to_id != null`) and carries the loop marker `<!-- muggle-do:bot -->`** (see [`../pr-followup-helpers/loop-signature.md`](../pr-followup-helpers/loop-signature.md)). A reply-only wrapper with any comment **lacking** the marker is a human follow-up — keep it; the round addresses it. Matching the marker, not structure, is what skips the loop's own replies (posted under the author's identity in single-account workflows) without dropping genuine follow-ups.
+
+The **watcher's body-only check** adds:
+
+- the review has **no line comments** — `gh api repos/<owner>/<repo>/pulls/<n>/reviews/<id>/comments` returns `[]`. A review with line comments is dispatched from thread state, not here.
+- `id > last_seen.lastBodyReviewId`
+- `id` not in `last_seen.escalated_review_ids`
+
+A reply posted by the loop surfaces as an implicit review, but it always carries the reply as a line comment, so it can never be body-only — the body-only filter excludes it structurally, no marker check needed. Thread-level echo protection is intrinsic to the marker rule in [`unresolved-threads.md`](unresolved-threads.md).

--- a/plugin/skills/_shared/github-cli-recipes/unresolved-threads.md
+++ b/plugin/skills/_shared/github-cli-recipes/unresolved-threads.md
@@ -1,6 +1,6 @@
 # Unresolved comment threads
 
-For the resolve-reminder stage. GraphQL only — REST does not expose `isResolved`.
+For the watcher's dispatch trigger and the resolve-reminder stage. GraphQL only — REST does not expose `isResolved`/`isOutdated`.
 
 ```bash
 gh api graphql -F owner=<owner> -F name=<repo> -F number=<n> -f query='
@@ -11,9 +11,11 @@ query($owner: String!, $name: String!, $number: Int!) {
         nodes {
           id
           isResolved
+          isOutdated
           comments(first: 100) {
             nodes {
               databaseId
+              pullRequestReview { databaseId }
               author { login }
               body
               createdAt
@@ -29,7 +31,9 @@ query($owner: String!, $name: String!, $number: Int!) {
 Filter client-side to `isResolved == false`. Walk each thread's comments in `createdAt` order and classify by the loop marker (see [`../pr-followup-helpers/loop-signature.md`](../pr-followup-helpers/loop-signature.md)), not by `author.login` — the login is ambiguous under a shared account:
 
 - **Addressed, awaiting resolve** — the **newest** comment carries the loop marker `<!-- muggle-do:bot -->`. The loop has replied and nothing newer is waiting. → resolve-reminder.
-- **Unaddressed human comment** — the newest comment lacks the marker and is newer than the thread's newest loop-marked comment (or the thread has no loop comment yet). → actionable: the round should address it.
+- **Unaddressed human comment** — the newest comment lacks the marker and is newer than the thread's newest loop-marked comment (or the thread has no loop comment yet). → actionable: the round should address it. The **watcher's dispatch trigger** additionally requires `isOutdated == false` — a thread whose anchored line has since changed is skipped, since re-surfacing a stale anchor risks answering a concern the change already mooted. The resolve-reminder stage ignores `isOutdated`.
 - **Not addressed** — indeterminate (e.g. no comments).
+
+Each comment exposes its owning review as `pullRequestReview.databaseId` — the watcher collects this from an actionable thread's newest comment to build its dispatch list.
 
 A loop comment also cites a `<short-sha>` from `last_seen.pushed_shas[]` in its body, which tells *which* push addressed the thread.

--- a/plugin/skills/_shared/pr-followup-helpers/classify.md
+++ b/plugin/skills/_shared/pr-followup-helpers/classify.md
@@ -10,7 +10,7 @@ A review is a **self-loop** iff **every** line comment under it is a reply (`in_
 
 If any comment in a reply-only wrapper **lacks** the marker, it is a **human follow-up** on an existing thread — not a self-loop. It carries reviewer intent; treat it as actionable and address it in this round (the caller's unresolved-thread sweep picks up the thread context).
 
-Self-loops bypass the actionable/ambiguous decision entirely. Action: advance the cursor silently. No push, no reply, no resolve-reminder, no escalation, no entry in `escalated_review_ids`. Telemetry: emit one `cycle` event with `outcome: "self-loop-skip"`.
+Self-loops bypass the actionable/ambiguous decision entirely. Action: skip silently — a body-only echo folds its id into `lastBodyReviewId`; a line-comment echo already drops out of the actionable set via the marker. No push, no reply, no resolve-reminder, no escalation, no entry in `escalated_review_ids`. Telemetry: emit one `cycle` event with `outcome: "self-loop-skip"`.
 
 Only reviews that survive the self-loop check proceed to classify below.
 
@@ -51,7 +51,7 @@ Reply shape (all replies for one review reference the same SHA):
 | 1 comment: "won't this break the prod migration we did last week?" | Implicit change request gated on knowledge the loop can't access |
 | Mixed: 2 concrete directives + 1 "rethink the whole approach" | The "rethink" subverts the others; escalate to confirm scope |
 
-Escalate per the caller's procedure (add the review id to the cursor's escalated set, emit one terminal message, pause the PR).
+Escalate per the caller's procedure (add the review id to `escalated_review_ids`, emit one terminal message, pause the PR).
 
 ## Borderline rule
 

--- a/plugin/skills/_shared/pr-followup-helpers/echo-skip.md
+++ b/plugin/skills/_shared/pr-followup-helpers/echo-skip.md
@@ -1,16 +1,10 @@
-# Reply-echo skip
+# Echo protection (intrinsic under thread-state)
 
-When `/muggle-do` posts a threaded reply to a review comment, GitHub surfaces that reply as a **new submitted review** under the same account. Left unchecked, the next watcher tick reads that review as fresh feedback and dispatches another cycle — which posts another reply, which becomes another review. The loop never converges.
+When `/muggle-do` posts a threaded reply to a review comment, GitHub surfaces that reply as a **new submitted review** under the same account, and the reply becomes the newest comment in its thread. The watcher must never read that as fresh feedback, or it replies to itself forever.
 
-## Rule
+Under the thread-state dispatch trigger this is **intrinsic** — there is no "advance past the echo" step to get wrong:
 
-A submitted review is an **echo** when **every** comment in it carries the loop marker `<!-- muggle-do:bot -->` (see [`loop-signature.md`](loop-signature.md)). An echo is the loop's own reply wearing a review's clothing, never human intent.
+- **Line-comment threads.** A thread is actionable only when its newest comment lacks the loop marker `<!-- muggle-do:bot -->` (see [`loop-signature.md`](loop-signature.md)). After the loop replies, the newest comment is the loop's own and carries the marker, so the thread drops out of the actionable set on its own.
+- **Body-only reviews.** A loop reply always carries a line comment, so it is never body-only; the body-only check (no line comments, `id > lastBodyReviewId` — see [`../github-cli-recipes/submitted-reviews.md`](../github-cli-recipes/submitted-reviews.md)) excludes echoes structurally.
 
-On an echo review, the watcher must:
-
-1. Advance `last_seen.reviewId` past the echo's id (so it is not seen again), and
-2. **Skip it** — never dispatch `/muggle-do` for it.
-
-## Detection
-
-Classify by the marker, never by `author.login` — under a shared account the loop posts as the PR author, so the login cannot tell echo from human. Fetch the review's comments; if the set is non-empty and every comment body contains `<!-- muggle-do:bot -->`, it is an echo. A review with at least one marker-less comment is human feedback and must be processed normally.
+Classify by the marker, never by `author.login` — under a shared account the loop posts as the PR author, so the login cannot tell echo from human.

--- a/plugin/skills/_shared/pr-followup-helpers/reply-routing.md
+++ b/plugin/skills/_shared/pr-followup-helpers/reply-routing.md
@@ -37,4 +37,4 @@ fix(ci): lint — remove unused import
 
 - Never post a top-level comment in reply to a line-level comment. It loses thread context.
 - Never `gh pr review --comment` for replies — that endpoint is for *new* reviews.
-- Never reply twice to the same comment. The cursor in `last_seen.json` is the only re-entry guard; advance it after every reply.
+- Never reply twice to the same comment. The loop marker on each posted reply is the re-entry guard — a thread whose newest comment is loop-marked is no longer actionable, so the next round won't re-reply.

--- a/plugin/skills/_shared/telemetry-events/pr-followup-tick.md
+++ b/plugin/skills/_shared/telemetry-events/pr-followup-tick.md
@@ -9,7 +9,7 @@ One per watcher iteration (idle or not).
   "session_slug": "<slug>",
   "repo": "<owner>/<repo>",
   "pr_number": <int>,
-  "reviews_seen": <int>,
+  "actionable_threads": <int>,
   "dispatched_review_ids": [<int>, ...],
   "checks_red": <int>,
   "dispatched_ci_fix": true | false,
@@ -19,9 +19,9 @@ One per watcher iteration (idle or not).
 }
 ```
 
-- `reviews_seen`: count of new submitted reviews past the cursor, **after** filtering by the escalated set.
-- `dispatched_review_ids`: review ids handed to `/muggle-do`. Empty when idle.
+- `actionable_threads`: count of actionable items this tick — unresolved, non-outdated threads whose newest comment is unmarked, plus body-only reviews past `lastBodyReviewId` — **after** filtering by the escalated set.
+- `dispatched_review_ids`: owning review ids handed to `/muggle-do`. Empty when idle.
 - `checks_red`: count of failing checks on the head SHA. `0` when reviews were dispatched (reviews preempt the CI poll) or CI was green/pending.
 - `dispatched_ci_fix`: true when this tick dispatched `/muggle-do` with a fix-ci directive.
 - `terminal`: true when this tick observed the PR merged or closed and wrote `result.md`.
-- `idle`: true when no reviews were dispatched this tick.
+- `idle`: true when nothing was dispatched this tick.

--- a/plugin/skills/do/address-reviews.md
+++ b/plugin/skills/do/address-reviews.md
@@ -13,16 +13,16 @@ The entry procedure for `/muggle-do`'s **address-reviews** mode — invoked by t
 `$ARGUMENTS` carries:
 - PR URL: `<owner>/<repo>#<n>` derivable from the URL.
 - Session slug: `<slug>`.
-- List of review ids: one or more integers.
+- Owning review ids: one or more integers (the reviews whose actionable threads or body-only feedback the watcher flagged).
 
-Exact phrasing comes from the watcher's dispatch (see [`../muggle-pr-followup/contract.md`](../muggle-pr-followup/contract.md#step-5-if-one-or-more-new-reviews-dispatch)). Parse all three out of the directive text.
+Exact phrasing comes from the watcher's dispatch (see [`../muggle-pr-followup/contract.md`](../muggle-pr-followup/contract.md)). Parse all three out of the directive text.
 
 ## Inputs from disk
 
 Read from `~/.muggle-ai/muggle-do/sessions/<slug>/`:
 
 - `prs.json` — to locate the PR's local checkout path (the `repo` field maps to a configured local repo) and capture `head_sha_before`.
-- `last_seen.json` — for `pushed_shas[]` (used by the resolve-reminder stage) and to update the cursor.
+- `last_seen.json` — for `pushed_shas[]` (used by the resolve-reminder stage) and to update `lastBodyReviewId`.
 - `state.md` — for the cached `loop_user` login (used by resolve-reminder thread classification).
 
 ## Procedure
@@ -37,10 +37,10 @@ Two sources, combined into one batch (dedupe by comment id):
 
 **(a) The dispatched reviews.** For each review id in the input:
 
-- Fetch reviews per [`../_shared/github-cli-recipes/submitted-reviews.md`](../_shared/github-cli-recipes/submitted-reviews.md) (cursor 0; filter to the specific id).
+- Fetch reviews per [`../_shared/github-cli-recipes/submitted-reviews.md`](../_shared/github-cli-recipes/submitted-reviews.md) (no watermark; filter to the specific id).
 - Fetch its line comments per [`../_shared/github-cli-recipes/line-comments-for-review.md`](../_shared/github-cli-recipes/line-comments-for-review.md).
 
-**(b) Unaddressed comments on every unresolved thread.** Fetch unresolved threads per [`../_shared/github-cli-recipes/unresolved-threads.md`](../_shared/github-cli-recipes/unresolved-threads.md). For each thread classified **unaddressed human comment** — newest comment lacks the loop marker `<!-- muggle-do:bot -->` ([`loop-signature.md`](../_shared/pr-followup-helpers/loop-signature.md)) and post-dates the loop's last marked reply — add it to the batch, even if its review predates the cursor. This is how a human thread follow-up (a marker-less reply) gets addressed. **Exclude** comments whose review id is in `last_seen.escalated_review_ids` — paused awaiting the user, not re-work.
+**(b) Unaddressed comments on every unresolved thread.** Fetch unresolved threads per [`../_shared/github-cli-recipes/unresolved-threads.md`](../_shared/github-cli-recipes/unresolved-threads.md). For each thread classified **unaddressed human comment** — newest comment lacks the loop marker `<!-- muggle-do:bot -->` ([`loop-signature.md`](../_shared/pr-followup-helpers/loop-signature.md)) and post-dates the loop's last marked reply — add it to the batch — unresolved thread state, not any review-id watermark, is the authority here. This is how a human thread follow-up (a marker-less reply) gets addressed. **Exclude** comments whose review id is in `last_seen.escalated_review_ids` — paused awaiting the user, not re-work.
 
 Group (a) and (b) into one combined batch.
 
@@ -101,7 +101,7 @@ Invoke [`per-comment-replies.md`](per-comment-replies.md) with the actionable re
 
 - `last_seen.cycles_completed` += 1
 - `last_seen.last_pushed_sha` = the new head SHA (update.md already wrote this; verify)
-- `last_seen.reviewId` = max(input review ids ∪ last_seen.reviewId)
+- `last_seen.lastBodyReviewId` = max(body-only input review ids ∪ last_seen.lastBodyReviewId) — line-comment threads need no watermark; they fall out of the actionable set once the per-comment reply carries the loop marker.
 
 ### Step 5.5 — Resolve-reminder (runs every round)
 
@@ -145,5 +145,5 @@ Do **not** push, do **not** post replies, do **not** run resolve-reminder. The c
 ## Invariants
 
 - One `/muggle-do` invocation = at most one push and one resolve-reminder, regardless of how many reviews are in the batch.
-- Every input review id ends up in either the cursor (handled) or `escalated_review_ids` (skipped) — never both, never neither.
+- Every input review id ends up either handled (its thread answered with a loop-marked reply, or — for a body-only review — folded into `lastBodyReviewId`) or in `escalated_review_ids` (skipped) — never both, never neither.
 - The watcher is respawned exactly when the PR is still open at the end of the cycle.

--- a/plugin/skills/do/open-prs/forward.md
+++ b/plugin/skills/do/open-prs/forward.md
@@ -46,7 +46,7 @@ Write `~/.muggle-ai/muggle-do/sessions/<slug>/prs.json` per [`../../muggle-pr-fo
 [{ "repo": "owner/repo", "number": 142, "url": "...", "head_sha": "...", "state": "open" }]
 ```
 
-Seed `~/.muggle-ai/muggle-do/sessions/<slug>/last_seen.json` per [`../../muggle-pr-followup/state-schemas.md`](../../muggle-pr-followup/state-schemas.md#last_seenjson) — empty cursor shape with `pushed_shas: []`. Forward mode never has prior reviews to skip, so `reviewId: 0`.
+Seed `~/.muggle-ai/muggle-do/sessions/<slug>/last_seen.json` per [`../../muggle-pr-followup/state-schemas.md`](../../muggle-pr-followup/state-schemas.md#last_seenjson) — empty-watermark shape with `pushed_shas: []`. Forward mode never has prior reviews to skip, so `lastBodyReviewId: 0`.
 
 **Do not** seed `cycle.json` or `requirements.md`. The watcher is a dumb pipe; `/muggle-do` reads reviews off GitHub.
 

--- a/plugin/skills/muggle-pr-followup/SKILL.md
+++ b/plugin/skills/muggle-pr-followup/SKILL.md
@@ -34,7 +34,7 @@ Bootstrap accepts three optional trailing flags:
 
 - `--slug=<name>` — override the default `<repo>-pr<n>` slug
 - `--resume` — opt in to reusing an existing session slot (default is refuse on conflict)
-- `--forward-only` — pin cursor past existing reviews (skip history). Default is cursor 0, which processes prior submitted reviews on the first tick.
+- `--forward-only` — pin `lastBodyReviewId` past existing **body-only** reviews (skip history on those). Line-comment threads are always picked up from live thread state, regardless of this flag.
 
 ## Preferences
 

--- a/plugin/skills/muggle-pr-followup/auto-track.md
+++ b/plugin/skills/muggle-pr-followup/auto-track.md
@@ -51,7 +51,7 @@ For each PR URL in the track list, run the [`bootstrap.md`](bootstrap.md) proced
 - **Existing slot → skip silently** (never the slot-conflict abort); add it to the *skipped* list.
 - **`caller = "auto-track"`** in the bootstrap telemetry event.
 
-Everything else is unchanged: URL parse, metadata + terminal-PR abort, slug, cursor 0 (process prior reviews on the first tick), and the `prs.json`/`last_seen.json`/`state.md` writes minus the pre-flight block.
+Everything else is unchanged: URL parse, metadata + terminal-PR abort, slug, `lastBodyReviewId` 0 (line-comment threads are picked up live from thread state; body-only reviews from id 0), and the `prs.json`/`last_seen.json`/`state.md` writes minus the pre-flight block.
 
 ### Step 5 — Print the summary
 

--- a/plugin/skills/muggle-pr-followup/bootstrap.md
+++ b/plugin/skills/muggle-pr-followup/bootstrap.md
@@ -17,7 +17,7 @@ Bootstrap asks **one** questionnaire — the E2E validation context the loop wil
 - `<pr-url>` matches `https?://github\.com/[^/]+/[^/]+/pull/\d+` — required.
 - `--slug=<name>` overrides the default `<repo>-pr<n>` slug.
 - `--resume` opts into refreshing an existing slot instead of refusing on conflict.
-- `--forward-only` pins the cursor past existing reviews (skip history). Default is cursor 0 — the watcher will pick up prior submitted reviews on its first tick.
+- `--forward-only` pins `lastBodyReviewId` past existing **body-only** reviews (skip history on those). It does **not** affect line-comment threads — those are always picked up from live thread state. Default is `0`.
 
 ## Procedure
 
@@ -46,12 +46,14 @@ Default: `<repo>-pr<n>` (e.g. `muggle-ai-works-pr154`). Override: `--slug=<name>
 If `~/.muggle-ai/muggle-do/sessions/<slug>/` exists (including a slot just migrated above):
 
 - Without `--resume` → exit with the slot-conflict abort. Both remedies (delete + re-run, or pass `--resume`) are spelled out in the message.
-- With `--resume` → refresh `prs.json[0].head_sha` to the current `headRefOid` from Step 2; leave `last_seen.json` and the cursor untouched. If `state.md` already has a `## Pre-flight answers` block, skip to Step 8; if not (older session), run Step 6.5 to backfill it, then skip to Step 8.
+- With `--resume` → refresh `prs.json[0].head_sha` to the current `headRefOid` from Step 2; leave `last_seen.json` untouched. If `state.md` already has a `## Pre-flight answers` block, skip to Step 8; if not (older session), run Step 6.5 to backfill it, then skip to Step 8.
 
-### Step 6 — Resolve the initial cursor
+### Step 6 — Resolve the body-only watermark
 
-- **Default (no `--forward-only`):** cursor is `0`. The watcher will pick up every existing submitted review on its first tick. This matches the common case where the user opened the PR, left review comments they want addressed, and is now running bootstrap.
-- **With `--forward-only`:** fetch reviews per [`../_shared/github-cli-recipes/submitted-reviews.md`](../_shared/github-cli-recipes/submitted-reviews.md), then take `max(id)`. The watcher only acts on later submissions. Use when bootstrapping a PR with stale/already-handled prior reviews you don't want re-processed.
+Line-comment threads need no seeding — the watcher derives them from live thread state on every tick, so existing unresolved threads are picked up on the first tick regardless of this step. This step only sets `lastBodyReviewId`, the narrow watermark for body-only reviews (a submitted review with no line comments).
+
+- **Default (no `--forward-only`):** `lastBodyReviewId = 0`. The watcher picks up every existing body-only review on its first tick. Matches the common case — the user opened the PR, left feedback they want addressed, and is now bootstrapping.
+- **With `--forward-only`:** fetch reviews per [`../_shared/github-cli-recipes/submitted-reviews.md`](../_shared/github-cli-recipes/submitted-reviews.md), then take `max(id)`. Body-only reviews at or below that id are treated as already-handled. This no longer hides existing line-comment threads — those are always picked up from thread state.
 
 ### Step 6.5 — Resolve E2E validation context
 
@@ -67,7 +69,7 @@ Write under `~/.muggle-ai/muggle-do/sessions/<slug>/`:
 
 **`prs.json`** — see [`state-schemas.md`](state-schemas.md#prsjson). One entry, `state` = `"open"`, `head_sha` from Step 2's `headRefOid`.
 
-**`last_seen.json`** — see [`state-schemas.md`](state-schemas.md#last_seenjson). One key (`"<owner>/<repo>#<n>"`), `reviewId` from Step 6, `last_pushed_sha: null`, `idle_tick_count: 0`, `cycles_completed: 0`, `escalated_review_ids: []`, `pushed_shas: []`.
+**`last_seen.json`** — see [`state-schemas.md`](state-schemas.md#last_seenjson). One key (`"<owner>/<repo>#<n>"`), `lastBodyReviewId` from Step 6, `last_pushed_sha: null`, `idle_tick_count: 0`, `cycles_completed: 0`, `escalated_review_ids: []`, `pushed_shas: []`.
 
 **`state.md`** — see [`state-schemas.md`](state-schemas.md#statemd). `Bootstrapped from URL: yes`. Cache the loop-user login. Append the `## Pre-flight answers` block with the fields resolved in Step 6.5, per [`../_shared/resolve-e2e-validation-context.md`](../_shared/resolve-e2e-validation-context.md#persisted-fields).
 

--- a/plugin/skills/muggle-pr-followup/contract.md
+++ b/plugin/skills/muggle-pr-followup/contract.md
@@ -1,8 +1,8 @@
 # Watcher Per-Tick Contract
 
-The procedure for the **tick mode** of `muggle-pr-followup` — one polling iteration scoped to one PR. The watcher is a dumb pipe: it polls for new submitted reviews, CI checks, and merge-conflict state, dispatches `/muggle-do` if there's review feedback, fixable red CI, or an unmergeable branch, and exits. It does not classify, fix, resolve, amend requirements, post replies, run cycles, or escalate.
+The procedure for the **tick mode** of `muggle-pr-followup` — one polling iteration scoped to one PR. The watcher is a dumb pipe: it polls for actionable review threads, CI checks, and merge-conflict state, dispatches `/muggle-do` if there's unaddressed review feedback, fixable red CI, or an unmergeable branch, and exits. It does not classify, fix, resolve, amend requirements, post replies, run cycles, or escalate.
 
-Routing into this mode is documented in [`SKILL.md`](SKILL.md#routing). The architectural rationale lives in the brain doc `architecture/2026-05-08-muggle-do-pr-comment-loop-design.md`.
+Routing into this mode is documented in [`SKILL.md`](SKILL.md#routing). The architectural rationale lives in the brain docs `architecture/2026-05-08-muggle-do-pr-comment-loop-design.md` (the overall loop) and `architecture/2026-06-06-pr-followup-thread-state-baseline-design.md` (the thread-state dispatch trigger).
 
 ## Turn preamble
 
@@ -48,33 +48,36 @@ If `state` is `MERGED` or `CLOSED`:
 3. Exit. The watcher has unscheduled itself; no future ticks fire for this PR.
 
 
-### Step 3 — Fetch new submitted reviews
+### Step 3 — Compute the actionable set from live thread state
 
-Per [`../_shared/github-cli-recipes/submitted-reviews.md`](../_shared/github-cli-recipes/submitted-reviews.md). Exclude two kinds of review id:
+The watcher's dispatch trigger is **derived from current GitHub state**, not a stored review-id cursor — see the [thread-state baseline design](../../../../muggle-ai-brain/architecture/2026-06-06-pr-followup-thread-state-baseline-design.md). Two sources, unioned:
 
-- ids in `last_seen.escalated_review_ids` — already escalated; the watcher must not re-dispatch them.
-- **echo reviews** per [`../_shared/pr-followup-helpers/echo-skip.md`](../_shared/pr-followup-helpers/echo-skip.md) — a review whose every comment carries the loop marker is the loop's own reply, surfaced by GitHub as a new review. Advance `last_seen.reviewId` past it and skip; never dispatch, or the watcher replies to itself forever.
+**(a) Actionable threads.** Fetch unresolved review threads per [`../_shared/github-cli-recipes/unresolved-threads.md`](../_shared/github-cli-recipes/unresolved-threads.md). A thread is **actionable** when `isResolved == false` **and** `isOutdated == false` **and** its newest comment lacks the loop marker `<!-- muggle-do:bot -->` — classify by the marker, never `author.login` (see [`../_shared/pr-followup-helpers/loop-signature.md`](../_shared/pr-followup-helpers/loop-signature.md)). The marker rule makes echo intrinsic: once the loop has replied, the thread's newest comment is the loop's own, so the thread is no longer actionable — no cursor to advance, no self-recursion (see [`../_shared/pr-followup-helpers/echo-skip.md`](../_shared/pr-followup-helpers/echo-skip.md)).
 
-### Step 4 — If one or more new reviews → dispatch (reviews preempt CI)
+**(b) Actionable body-only reviews.** A body-only review — a submitted `CHANGES_REQUESTED`/`COMMENTED` review with no line comments — has no thread to derive state from, so it keeps a narrow watermark. Fetch submitted reviews per [`../_shared/github-cli-recipes/submitted-reviews.md`](../_shared/github-cli-recipes/submitted-reviews.md); a body-only review is actionable when `id > last_seen.lastBodyReviewId` **and** `id ∉ last_seen.escalated_review_ids`.
 
-The watcher does **not** classify. Classification, batching, replying, escalation, and cycle execution all live in `/muggle-do`. The watcher's job is to hand over the list of new review ids and exit.
+Collect the **owning review ids** for dispatch: for each actionable thread, the owning review of its newest comment (`pullRequestReview.databaseId` from the query); plus every actionable body-only review id. The dedup'd union is the dispatch list.
+
+### Step 4 — If the actionable set is non-empty → dispatch (reviews preempt CI)
+
+The watcher does **not** classify. Classification, batching, replying, escalation, and cycle execution all live in `/muggle-do`. The watcher hands over the owning review ids and exits — `/muggle-do`'s address-reviews re-derives the unresolved threads itself (its authority), so the watcher only needs to decide *that* there is work, not enumerate it exhaustively.
 
 1. Reset `last_seen.idle_tick_count` to 0.
 2. **Stop this watcher (single-thread).** Cancel its cron so no tick fires while the dev cycle runs: `CronList`, find the job whose command ends with `/muggle:muggle-pr-followup <slug> <n>` (exact two-arg match), `CronDelete` it. `/muggle-do` respawns the watcher when the cycle finishes — exactly one cron ever, and no tick overlaps a running cycle.
 3. Dispatch `/muggle-do` with an *address-reviews* directive carrying:
    - PR URL (from `prs.json[0].url`)
    - Session slug (from the invocation arguments)
-   - Every new review id from Step 3, as a space-separated list
+   - The owning review ids from Step 3, as a space-separated list
 
    Exact phrasing belongs to `/muggle-do`'s intent-routing. A reasonable shape is:
    ```
    /muggle-do address reviews <id1> <id2> ... on <pr-url> slug=<slug>
    ```
 4. Append a dispatching line to `followup.log` per [`output-templates/watcher-log.md`](output-templates/watcher-log.md).
-5. Emit a `tick` event with `reviews_seen: <count>`, `dispatched_review_ids: [<id>, ...]`.
-6. Exit. **Reviews preempt CI** — when reviews land, this tick dispatches address-reviews and never polls CI. The watcher is now stopped; the dev cycle owns the PR and restarts the watcher when it finishes. (The watcher also self-unschedules in Step 2, terminal.)
+5. Emit a `tick` event with `actionable_threads: <count>`, `dispatched_review_ids: [<id>, ...]`.
+6. Exit. **Reviews preempt CI** — when there is actionable feedback, this tick dispatches address-reviews and never polls CI. The watcher is now stopped; the dev cycle owns the PR and restarts the watcher when it finishes. (The watcher also self-unschedules in Step 2, terminal.)
 
-### Step 5 — No new reviews → check mergeability
+### Step 5 — No actionable feedback → check mergeability
 
 Read `mergeable` / `mergeStateStatus` from the Step 1 metadata. If `mergeable == CONFLICTING` (or `mergeStateStatus == DIRTY`), **and** `conflict_resolve_attempts[head_sha] < 2`, **and** `head_sha` ∉ `conflict_escalated_shas` → dispatch and exit:
 
@@ -89,7 +92,7 @@ Read `mergeable` / `mergeStateStatus` from the Step 1 metadata. If `mergeable ==
 
 `mergeable == MERGEABLE` / `UNKNOWN` (GitHub still computing — treat as not-conflicting this tick), or budget spent (`conflict_resolve_attempts[head_sha] >= 2` or `head_sha` ∈ `conflict_escalated_shas`) → fall through to CI.
 
-### Step 6 — No new reviews, mergeable → poll CI for the head SHA
+### Step 6 — No actionable feedback, mergeable → poll CI for the head SHA
 
 Fetch the check-run rollup for `prs.json[0].head_sha` per [`../_shared/github-cli-recipes/pr-checks.md`](../_shared/github-cli-recipes/pr-checks.md), then:
 
@@ -108,7 +111,7 @@ Fetch the check-run rollup for `prs.json[0].head_sha` per [`../_shared/github-cl
 
 ### Step 7 — Idle
 
-Any idle branch (Steps 4–6 that did not dispatch): increment `last_seen.idle_tick_count`, append an idle line to `followup.log` per [`output-templates/watcher-log.md`](output-templates/watcher-log.md), emit a `tick` event with `idle: true`, `reviews_seen: 0`, `dispatched_review_ids: []`, `conflicting: <bool>`, `dispatched_resolve_conflicts: false`, `checks_red: <count or 0>`, `dispatched_ci_fix: false`. Exit. The next tick fires in 1 min via `/loop`.
+Any idle branch (Steps 4–6 that did not dispatch): increment `last_seen.idle_tick_count`, append an idle line to `followup.log` per [`output-templates/watcher-log.md`](output-templates/watcher-log.md), emit a `tick` event with `idle: true`, `actionable_threads: 0`, `dispatched_review_ids: []`, `conflicting: <bool>`, `dispatched_resolve_conflicts: false`, `checks_red: <count or 0>`, `dispatched_ci_fix: false`. Exit. The next tick fires in 1 min via `/loop`.
 
 ## Output
 

--- a/plugin/skills/muggle-pr-followup/output-templates/bootstrap.md
+++ b/plugin/skills/muggle-pr-followup/output-templates/bootstrap.md
@@ -5,7 +5,7 @@
 ```
 Bootstrapped PR follow-up for <owner>/<repo>#<n>
   Slug:           <slug>
-  Cursor:         0 (will process <N> existing review(s) on first tick) | review #<id> (forward-only) | empty (no prior reviews)
+  Baseline:       thread-state (unresolved threads picked up live); lastBodyReviewId=0 | =<id> (forward-only)
   Working tree:   <toplevel>
   Dispatching:    /loop 1m /muggle:muggle-pr-followup <slug> <n>
 ```

--- a/plugin/skills/muggle-pr-followup/output-templates/help.md
+++ b/plugin/skills/muggle-pr-followup/output-templates/help.md
@@ -6,7 +6,7 @@ For `/muggle:muggle-pr-followup help` or `?` (no args runs **auto-track** instea
 muggle-pr-followup — watcher loop for PR review follow-ups
 
 Active loops:
-  <slug> → <owner>/<repo>#<n> (cursor @ review #<id>, <N> cycles)
+  <slug> → <owner>/<repo>#<n> (<N> cycles)
   ...
   (or "no active loops")
 

--- a/plugin/skills/muggle-pr-followup/output-templates/watcher-log.md
+++ b/plugin/skills/muggle-pr-followup/output-templates/watcher-log.md
@@ -5,13 +5,13 @@ The watcher does **not** print to the user during normal operation. It only appe
 ## Idle tick
 
 ```
-<ISO-8601> tick pr=<n> reviews_seen=0 idle
+<ISO-8601> tick pr=<n> threads=0 idle
 ```
 
 ## Dispatching tick
 
 ```
-<ISO-8601> tick pr=<n> reviews_seen=<count> dispatched=<id1>,<id2>,...
+<ISO-8601> tick pr=<n> threads=<count> dispatched=<id1>,<id2>,...
 ```
 
 ## Terminal tick

--- a/plugin/skills/muggle-pr-followup/state-schemas.md
+++ b/plugin/skills/muggle-pr-followup/state-schemas.md
@@ -34,7 +34,7 @@ Keyed by `"<owner>/<repo>#<n>"`. One key per PR in the slot.
 ```json
 {
   "<owner>/<repo>#<n>": {
-    "reviewId": <int>,
+    "lastBodyReviewId": <int>,
     "last_pushed_sha": "<sha-or-null>",
     "idle_tick_count": <int>,
     "cycles_completed": <int>,
@@ -48,11 +48,11 @@ Keyed by `"<owner>/<repo>#<n>"`. One key per PR in the slot.
 }
 ```
 
-- `reviewId`: the cursor. The watcher fetches reviews with `id > reviewId`. Bootstrap pins this to the highest existing submitted review id (or `0` if none).
+- `lastBodyReviewId`: narrow watermark for **body-only** reviews (a submitted review carrying no line comments). The watcher dispatches a body-only review only when `id > lastBodyReviewId`. Line-comment threads do **not** use it — they are dispatched from live thread state (unresolved + not outdated + newest comment unmarked by the loop), so there is no cursor that can pin past them. Bootstrap sets it to the highest existing submitted review id with `--forward-only`, else `0`.
 - `last_pushed_sha`: most recent SHA `/muggle-do` pushed in this PR's life; `null` until the first push.
-- `idle_tick_count`: incremented each tick that sees zero new reviews. Reset to 0 on any tick that dispatches `/muggle-do`. Diagnostic only — does not gate behavior.
+- `idle_tick_count`: incremented each tick whose actionable set is empty. Reset to 0 on any tick that dispatches `/muggle-do`. Diagnostic only — does not gate behavior.
 - `cycles_completed`: incremented each time `/muggle-do` completes an address-reviews invocation (regardless of actionable/ambiguous/mixed).
-- `escalated_review_ids`: review ids classified as ambiguous by `/muggle-do`. The watcher excludes these from future review fetches so the same ambiguous review is never re-dispatched.
+- `escalated_review_ids`: review ids classified as ambiguous by `/muggle-do`. The watcher excludes these from the actionable set (both body-only reviews and the threads they own) so the same ambiguous review is never re-dispatched.
 - `pushed_shas`: every SHA `/muggle-do` has pushed for this PR. Append-only. Used by the resolve-reminder stage to recognize threads addressed by the loop.
 - `ci_fix_attempts`: per-SHA count of fix-ci cycles `/muggle-do` has run. The watcher stops dispatching fix-ci for a SHA once its count reaches 3. Keyed by head SHA.
 - `ci_escalated_shas`: head SHAs whose CI the fix-ci stage gave up on (attempts exhausted or only out-of-scope checks). The watcher excludes these from CI dispatch so a hopeless SHA is never re-fixed.
@@ -94,8 +94,8 @@ The watcher does **not** read or write `state.md`. Only bootstrap, `/muggle-do`,
 Append-only line-per-tick log. One line per watcher tick, plus one line per `/muggle-do` invocation. Format is loose, but each line starts with an ISO-8601 timestamp:
 
 ```
-2026-05-20T12:34:56Z tick pr=154 reviews_seen=0 idle
-2026-05-20T12:35:56Z tick pr=154 reviews_seen=1 dispatched=4295962800
+2026-05-20T12:34:56Z tick pr=154 threads=0 idle
+2026-05-20T12:35:56Z tick pr=154 threads=1 dispatched=4295962800
 2026-05-20T12:36:14Z muggle-do cycle review_ids=[4295962800] outcome=pushed head_sha=abc1234
 ```
 
@@ -116,7 +116,7 @@ Written exactly once when the PR's watcher exits terminally (PR merged or closed
 
 ## Timeline
 
-- <ISO-8601> bootstrap (cursor pinned at <reviewId>)
+- <ISO-8601> bootstrap (lastBodyReviewId <id>; line-comment threads state-derived)
 - <ISO-8601> review <id> from <login> — actionable, pushed <sha>
 - <ISO-8601> review <id> from <login> — ambiguous, escalated
 - ...


### PR DESCRIPTION
## Problem

`muggle-pr-followup`'s watcher decides whether to dispatch `/muggle-do` from a high-water-mark on submitted-review id (`last_seen.reviewId`, "fetch reviews with `id > reviewId`"). Three structural flaws:

1. **Wrong granularity** — feedback lives in review *threads* that evolve (resolve, get new replies); a *review* is an immutable snapshot. Once a review id is below the cursor, all its line comments are "seen" forever.
2. **Baseline pins past unaddressed comments** — `--forward-only` sets the cursor to `max(reviewId)`; if that newest review *carries* an unaddressed line comment, `id > reviewId` excludes it on the first tick.
3. **Echo needs a bolt-on** — a posted reply surfaces as a new review id, so the watcher had to special-case "advance past my own echo."

Observed live on `multiplex-ai/muggle-ai-prompt-service#594`: the watcher idled ~470 ticks while a reviewer's line comment ("would existing sub expire when downgrading?") sat unanswered, because it hung under the bootstrap baseline review.

## Fix

Derive the watcher's dispatch trigger from **live thread state** instead of a stored cursor:

- **Actionable thread** = `isResolved == false` **and** `isOutdated == false` **and** its newest comment lacks the loop marker `<!-- muggle-do:bot -->` (marker, not `author.login` — shared-account safe).
- **Actionable body-only review** (a submitted review with no line comments, so no thread to derive state from) keeps a *narrow* watermark `lastBodyReviewId`.

Consequences:
- The bootstrap-baseline bug is gone — unresolved threads are picked up live, including under the newest review.
- **Echo is intrinsic** — once the loop replies, the thread's newest comment is loop-marked and drops out of the actionable set. The "advance past echo" special-case is deleted.
- A new human reply on an old thread flips it back to actionable naturally.
- `reviewId` is removed; `lastBodyReviewId` replaces it with a far narrower mandate.

The **executor** (`do/address-reviews.md`) was already thread-state-aware (Step 1b unresolved-thread sweep + `unresolved-threads` recipe + resolve-reminder); this aligns the *watcher's trigger* with it. Settled product calls: **skip outdated** threads; **do not auto-resolve** after replying (the reviewer closes).

## Changes (17 files, docs-only skill instructions)

- `muggle-pr-followup/contract.md` — Step 3 rewritten to compute the actionable set from thread state; Step 4 dispatches owning review ids; telemetry `reviews_seen`→`actionable_threads`.
- `muggle-pr-followup/{bootstrap,SKILL,state-schemas,auto-track}.md` + output templates — `reviewId`→`lastBodyReviewId`; `--forward-only` redefined (body-only only).
- `_shared/github-cli-recipes/unresolved-threads.md` — add `isOutdated` + `pullRequestReview.databaseId`; broaden to the watcher trigger.
- `_shared/github-cli-recipes/submitted-reviews.md` — reframed as by-id fetch / body-only check.
- `_shared/pr-followup-helpers/echo-skip.md` — rewritten as the intrinsic principle.
- `do/address-reviews.md` + `do/open-prs/forward.md` + `_shared` helpers/telemetry — field rename + wording.

`dist/` is gitignored and regenerated at release; no build artifact in this PR.

## Testing

- Augmented `unresolved-threads` GraphQL validated live against `#594` — `isOutdated` and `pullRequestReview.databaseId` resolve; classification computes correctly.
- Markdown link integrity checked across all changed files; one-way-dependency rule preserved (no new `_shared`/`muggle-pr-followup` → `do/` links).
- No leftover `reviewId`/`reviews_seen` in `plugin/skills`.

Design of record (separate PR to muggle-ai-brain): `architecture/2026-06-06-pr-followup-thread-state-baseline-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
