### PR TITLE
fix(muggle-test-prepare): resolve dev-server host from the recorded last-host

### DIFF
--- a/plugin/skills/muggle-test-prepare/SKILL.md
+++ b/plugin/skills/muggle-test-prepare/SKILL.md
@@ -62,6 +62,7 @@ Gates run per [`preference-gates/README.md`](../muggle-preferences/preference-ga
 |------------|-------|
 | `autoRebase` | [rebase-check](./steps/rebase-check.md) — rebase onto `origin/<default>` before starting dev servers |
 | `reusePreparePlan` | [reuse-plan](./steps/reuse-plan.md) — reuse the saved prepare plan for this stack, or rediscover |
+| `autoSelectLocalHost` | [check-running](./steps/check-running.md) — reuse the recorded dev-server URL silently, or confirm it each run |
 
 ## Workflow
 
@@ -111,6 +112,8 @@ After a test run, the caller can re-invoke for cleanup or leave services running
 
 ## Guardrails
 
+- **Never invent or default a host/port** — the dev-server URL is a recorded value, not a guess. Resolve it from `<repo>/.muggle-ai/last-host.json` (the [`autoSelectLocalHost`](../muggle-preferences/preference-gates/autoSelectLocalHost.md) cache) before probing ports; a framework default like `:3000` is never a fallback. See [check-running](./steps/check-running.md).
+- **No silent auto-selection without a gate** — when no preference authorizes a silent choice (host, restart, kill), confirm with the user. A gate set to `always` is the only license to skip the question; absent that, ask.
 - **Verify first, offer to start second** — check what's already running before proposing to start anything.
 - **The user may prefer to start services themselves** — always offer that option.
 - **Never start a process the user didn't approve.**

--- a/plugin/skills/muggle-test-prepare/steps/check-running.md
+++ b/plugin/skills/muggle-test-prepare/steps/check-running.md
@@ -1,5 +1,18 @@
 # Check what's already running
 
+## Resolve the target host first
+
+The dev-server URL the tests will hit is a **recorded value, not a guess** — resolve it before probing anything.
+
+1. Read the cached host with `muggle-local-last-host-get`. It reads `<cwd>/.muggle-ai/last-host.json`; a worktree usually has **no cache of its own**, so when the worktree returns nothing, pass the **main** working-tree root as `cwd` — `git rev-parse --git-common-dir`, then its parent directory.
+2. Apply the [`autoSelectLocalHost`](../../muggle-preferences/preference-gates/autoSelectLocalHost.md) gate (read its value from the `Muggle Test Preferences` session-context line; absent → `ask`):
+   - `always` **and** a cache exists → use it silently: `Using saved local URL {lastHost}`.
+   - otherwise (`ask` / `never`, or no cache) → **confirm before using any host.** Run the gate's Picker 1 with `{lastHost}` (cached URL, omitted when absent) and `{suggestedHost}` (a port you actually detect listening). Never auto-pick, and never fall back to a framework default like `:3000`; if nothing is cached or detected, ask the user to type the URL.
+
+The resolved host fixes the **expected** dev-server port for the detection below — probe that port; don't infer the target from whichever port happens to be listening.
+
+## Detect listening services
+
 Run port detection and (when an app declares a backend URL) backend-health probe per [`../../_shared/dev-server-readiness.md`](../../_shared/dev-server-readiness.md). Cross-reference hits against selected service directories.
 
 > "**backend-api** is already listening on port 3001 (PID 54321) — looks good."


### PR DESCRIPTION
## Summary
muggle-test-prepare never consulted the recorded dev-server host (`<repo>/.muggle-ai/last-host.json`). `check-running` only probed live ports and could let the caller assume a host — which is how a prepare run ended up targeting a fabricated `:3000` (CRA default) instead of the repo's registered `localhost:3999`, bouncing the Auth0 login.

This makes host selection a recorded value, not a guess:
- **`check-running` resolves the host first** via `muggle-local-last-host-get`, falling back to the **main working-tree root** when the cwd is a worktree (worktrees carry no cache of their own).
- **Confirmation is enforced when no gate authorizes silent reuse.** Only `autoSelectLocalHost = always` skips the question; `ask`/`never`/unset → confirm via the gate's picker. A framework default like `:3000` is never a fallback.
- Adds `autoSelectLocalHost` to the prepare preferences table (prepare didn't reference the gate at all) and two guardrails: *never invent a host/port* and *no silent auto-selection without a gate*.

## Test plan
- RED: reproduced live — a prepare run guessed `:3000`, never read `last-host.json`, didn't confirm.
- GREEN: a fresh agent following the updated `check-running` against a worktree scenario correctly (a) read the cache from the main repo root via `git rev-parse --git-common-dir`, (b) confirmed the host because the gate was unset, (c) rejected `:3000` as a fallback, (d) routed the held port through the existing "port already held" confirm flow.
- Source-only change; `dist/` is gitignored and regenerated by `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)