### PR TITLE
Local runs: tag executionSource so the studio skips its duplicate cloud ActionScript write

### DIFF
--- a/packages/mcps/src/mcp/local/services/action-script-builders.ts
+++ b/packages/mcps/src/mcp/local/services/action-script-builders.ts
@@ -1,0 +1,152 @@
+/**
+ * Pure builders for the local action-script payload handed to the electron-app
+ * studio. Kept free of config/logger/cloud imports so the build logic stays
+ * unit-testable in isolation.
+ */
+
+import type { TestCaseDetails, TestScriptDetails } from "../contracts/project-schemas.js";
+import { rewriteActionScriptUrls } from "./replay-url-rewrite.js";
+
+/**
+ * Get a required string from an object field.
+ */
+function getRequiredStringField(params: {
+  source: Record<string, unknown>;
+  fieldName: string;
+  sourceLabel: string;
+}): string {
+  const value = params.source[params.fieldName];
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(
+      `Missing required field '${params.fieldName}' in ${params.sourceLabel}. ` +
+        "Please pass the full object from the corresponding muggle-remote-* get tool.",
+    );
+  }
+  return value;
+}
+
+/**
+ * Build a local action script for test generation (explore mode).
+ */
+export function buildGenerationActionScript(params: {
+  testCase: TestCaseDetails;
+  localUrl: string;
+  runId: string;
+  localTestScriptId: string;
+  ownerUserId: string;
+}): Record<string, unknown> {
+  const testCaseRecord = params.testCase as unknown as Record<string, unknown>;
+  const projectId = getRequiredStringField({
+    source: testCaseRecord,
+    fieldName: "projectId",
+    sourceLabel: "testCase",
+  });
+  const useCaseId = getRequiredStringField({
+    source: testCaseRecord,
+    fieldName: "useCaseId",
+    sourceLabel: "testCase",
+  });
+
+  return {
+    actionScriptId: params.localTestScriptId,
+    actionScriptName: `Local Generation ${params.testCase.title}`,
+    actionType: "UserDefined",
+    actionParams: {
+      type: "Test Script Generation Workflow",
+      name: `Local Generation ${params.testCase.title}`,
+      ownerId: params.ownerUserId,
+      projectId: projectId,
+      useCaseId: useCaseId,
+      testCaseId: params.testCase.id,
+      testScriptId: params.localTestScriptId,
+      actionScriptId: params.localTestScriptId,
+      workflowRunId: params.runId,
+      url: params.localUrl,
+      // Tags the run as locally executed so the studio skips its own cloud
+      // ActionScript/TestScript write — the /local-run/upload path is the
+      // single writer for local runs (avoids duplicate Firestore docs).
+      executionSource: "local",
+      // A non-empty id lets the studio persist run summaries + feedback to the
+      // project's SharedTestMemory; an empty id makes the memory writer skip.
+      sharedTestMemoryId: projectId,
+    },
+    goal: params.testCase.goal,
+    url: params.localUrl,
+    description: params.testCase.title,
+    precondition: params.testCase.precondition ?? "",
+    instructions: params.testCase.instructions ?? "",
+    expectedResult: params.testCase.expectedResult,
+    steps: [],
+    ownerId: params.ownerUserId,
+    createdAt: Date.now(),
+    isRemoteScript: false,
+    status: "active",
+  };
+}
+
+/**
+ * Build a local action script for test replay (engine mode).
+ * @param params.testScript - Test script metadata (from muggle-remote-test-script-get).
+ * @param params.actionScript - Action script steps (from muggle-remote-action-script-get).
+ * @param params.localUrl - Local URL to test against.
+ * @param params.runId - Run ID for this execution.
+ * @param params.ownerUserId - Owner user ID.
+ */
+export function buildReplayActionScript(params: {
+  testScript: TestScriptDetails;
+  actionScript: unknown[];
+  localUrl: string;
+  runId: string;
+  ownerUserId: string;
+}): Record<string, unknown> {
+  const testScriptRecord = params.testScript as unknown as Record<string, unknown>;
+  const projectId = getRequiredStringField({
+    source: testScriptRecord,
+    fieldName: "projectId",
+    sourceLabel: "testScript",
+  });
+  const useCaseId = getRequiredStringField({
+    source: testScriptRecord,
+    fieldName: "useCaseId",
+    sourceLabel: "testScript",
+  });
+
+  const rewrittenActionScript = rewriteActionScriptUrls({
+    actionScript: params.actionScript,
+    originalUrl: params.testScript.url,
+    localUrl: params.localUrl,
+  });
+
+  return {
+    actionScriptId: params.testScript.actionScriptId,
+    actionScriptName: params.testScript.name,
+    actionType: "UserDefined",
+    actionParams: {
+      type: "Test Script Replay Workflow",
+      name: params.testScript.name,
+      ownerId: params.ownerUserId,
+      projectId: projectId,
+      useCaseId: useCaseId,
+      testCaseId: params.testScript.testCaseId,
+      testScriptId: params.testScript.id,
+      workflowRunId: params.runId,
+      // Tags the run as locally executed so the studio skips its own cloud
+      // ActionScript write — replay's cloud record is owned by the upload path
+      // (avoids duplicate Firestore docs).
+      executionSource: "local",
+      // A non-empty id lets the studio persist run summaries + feedback to the
+      // project's SharedTestMemory; an empty id makes the memory writer skip.
+      sharedTestMemoryId: projectId,
+    },
+    goal: params.testScript.name,
+    url: params.localUrl,
+    description: params.testScript.name,
+    precondition: "",
+    expectedResult: "Replay completes without critical failures.",
+    steps: rewrittenActionScript,
+    ownerId: params.ownerUserId,
+    createdAt: Date.now(),
+    isRemoteScript: true,
+    status: "active",
+  };
+}

--- a/packages/mcps/src/mcp/local/services/action-script-builders.ts
+++ b/packages/mcps/src/mcp/local/services/action-script-builders.ts
@@ -66,9 +66,10 @@ export function buildGenerationActionScript(params: {
       // ActionScript/TestScript write — the /local-run/upload path is the
       // single writer for local runs (avoids duplicate Firestore docs).
       executionSource: "local",
-      // A non-empty id lets the studio persist run summaries + feedback to the
-      // project's SharedTestMemory; an empty id makes the memory writer skip.
-      sharedTestMemoryId: projectId,
+      // Resolved server-side (a UUID get-or-created per project, 1-1 with
+      // projectId but NOT equal to it). The MCP has no client-side source for
+      // it, so leave it empty here; STM-on-local needs a backend resolver.
+      sharedTestMemoryId: "",
     },
     goal: params.testCase.goal,
     url: params.localUrl,
@@ -134,9 +135,10 @@ export function buildReplayActionScript(params: {
       // ActionScript write — replay's cloud record is owned by the upload path
       // (avoids duplicate Firestore docs).
       executionSource: "local",
-      // A non-empty id lets the studio persist run summaries + feedback to the
-      // project's SharedTestMemory; an empty id makes the memory writer skip.
-      sharedTestMemoryId: projectId,
+      // Resolved server-side (a UUID get-or-created per project, 1-1 with
+      // projectId but NOT equal to it). The MCP has no client-side source for
+      // it, so leave it empty here; STM-on-local needs a backend resolver.
+      sharedTestMemoryId: "",
     },
     goal: params.testScript.name,
     url: params.localUrl,

--- a/packages/mcps/src/mcp/local/services/execution-service.ts
+++ b/packages/mcps/src/mcp/local/services/execution-service.ts
@@ -23,8 +23,11 @@ import {
 import { getLogger } from "../../../shared/logger.js";
 import type { TestCaseDetails, TestScriptDetails } from "../contracts/project-schemas.js";
 import { getAuthService, getRunResultStorageService, getStorageService } from "./index.js";
+import {
+  buildGenerationActionScript,
+  buildReplayActionScript,
+} from "./action-script-builders.js";
 import { acquireLocalExecutionLock } from "./local-execution-lock.js";
-import { rewriteActionScriptUrls } from "./replay-url-rewrite.js";
 import type { ILocalExecutionContext } from "./run-result-storage-service.js";
 import type { RunResultStatus } from "./run-result-storage-service.js";
 
@@ -434,138 +437,6 @@ function getElectronAppPathOrThrow(): string {
   errorLines.push("Or set ELECTRON_APP_PATH to the path of the MuggleAI executable.");
 
   throw new Error(errorLines.join("\n"));
-}
-
-/**
- * Get a required string from an object field.
- */
-function getRequiredStringField(params: {
-  source: Record<string, unknown>;
-  fieldName: string;
-  sourceLabel: string;
-}): string {
-  const value = params.source[params.fieldName];
-  if (typeof value !== "string" || value.trim() === "") {
-    throw new Error(
-      `Missing required field '${params.fieldName}' in ${params.sourceLabel}. ` +
-        "Please pass the full object from the corresponding muggle-remote-* get tool.",
-    );
-  }
-  return value;
-}
-
-/**
- * Build a local action script for test generation (explore mode).
- */
-function buildGenerationActionScript(params: {
-  testCase: TestCaseDetails;
-  localUrl: string;
-  runId: string;
-  localTestScriptId: string;
-  ownerUserId: string;
-}): Record<string, unknown> {
-  const testCaseRecord = params.testCase as unknown as Record<string, unknown>;
-  const projectId = getRequiredStringField({
-    source: testCaseRecord,
-    fieldName: "projectId",
-    sourceLabel: "testCase",
-  });
-  const useCaseId = getRequiredStringField({
-    source: testCaseRecord,
-    fieldName: "useCaseId",
-    sourceLabel: "testCase",
-  });
-
-  return {
-    actionScriptId: params.localTestScriptId,
-    actionScriptName: `Local Generation ${params.testCase.title}`,
-    actionType: "UserDefined",
-    actionParams: {
-      type: "Test Script Generation Workflow",
-      name: `Local Generation ${params.testCase.title}`,
-      ownerId: params.ownerUserId,
-      projectId: projectId,
-      useCaseId: useCaseId,
-      testCaseId: params.testCase.id,
-      testScriptId: params.localTestScriptId,
-      actionScriptId: params.localTestScriptId,
-      workflowRunId: params.runId,
-      url: params.localUrl,
-      sharedTestMemoryId: "",
-    },
-    goal: params.testCase.goal,
-    url: params.localUrl,
-    description: params.testCase.title,
-    precondition: params.testCase.precondition ?? "",
-    instructions: params.testCase.instructions ?? "",
-    expectedResult: params.testCase.expectedResult,
-    steps: [],
-    ownerId: params.ownerUserId,
-    createdAt: Date.now(),
-    isRemoteScript: false,
-    status: "active",
-  };
-}
-
-/**
- * Build a local action script for test replay (engine mode).
- * @param params.testScript - Test script metadata (from muggle-remote-test-script-get).
- * @param params.actionScript - Action script steps (from muggle-remote-action-script-get).
- * @param params.localUrl - Local URL to test against.
- * @param params.runId - Run ID for this execution.
- * @param params.ownerUserId - Owner user ID.
- */
-function buildReplayActionScript(params: {
-  testScript: TestScriptDetails;
-  actionScript: unknown[];
-  localUrl: string;
-  runId: string;
-  ownerUserId: string;
-}): Record<string, unknown> {
-  const testScriptRecord = params.testScript as unknown as Record<string, unknown>;
-  const projectId = getRequiredStringField({
-    source: testScriptRecord,
-    fieldName: "projectId",
-    sourceLabel: "testScript",
-  });
-  const useCaseId = getRequiredStringField({
-    source: testScriptRecord,
-    fieldName: "useCaseId",
-    sourceLabel: "testScript",
-  });
-
-  const rewrittenActionScript = rewriteActionScriptUrls({
-    actionScript: params.actionScript,
-    originalUrl: params.testScript.url,
-    localUrl: params.localUrl,
-  });
-
-  return {
-    actionScriptId: params.testScript.actionScriptId,
-    actionScriptName: params.testScript.name,
-    actionType: "UserDefined",
-    actionParams: {
-      type: "Test Script Replay Workflow",
-      name: params.testScript.name,
-      ownerId: params.ownerUserId,
-      projectId: projectId,
-      useCaseId: useCaseId,
-      testCaseId: params.testScript.testCaseId,
-      testScriptId: params.testScript.id,
-      workflowRunId: params.runId,
-      sharedTestMemoryId: "",
-    },
-    goal: params.testScript.name,
-    url: params.localUrl,
-    description: params.testScript.name,
-    precondition: "",
-    expectedResult: "Replay completes without critical failures.",
-    steps: rewrittenActionScript,
-    ownerId: params.ownerUserId,
-    createdAt: Date.now(),
-    isRemoteScript: true,
-    status: "active",
-  };
 }
 
 /**

--- a/packages/mcps/src/test/local-action-script-builders.test.ts
+++ b/packages/mcps/src/test/local-action-script-builders.test.ts
@@ -52,8 +52,8 @@ describe("buildGenerationActionScript", () => {
     expect(actionParams(script).executionSource).toBe("local");
   });
 
-  it("sets sharedTestMemoryId to the project id (not empty)", () => {
-    expect(actionParams(script).sharedTestMemoryId).toBe(PROJECT_ID);
+  it("leaves sharedTestMemoryId empty (resolved server-side, never the projectId)", () => {
+    expect(actionParams(script).sharedTestMemoryId).toBe("");
   });
 });
 
@@ -70,7 +70,7 @@ describe("buildReplayActionScript", () => {
     expect(actionParams(script).executionSource).toBe("local");
   });
 
-  it("sets sharedTestMemoryId to the project id (not empty)", () => {
-    expect(actionParams(script).sharedTestMemoryId).toBe(PROJECT_ID);
+  it("leaves sharedTestMemoryId empty (resolved server-side, never the projectId)", () => {
+    expect(actionParams(script).sharedTestMemoryId).toBe("");
   });
 });

--- a/packages/mcps/src/test/local-action-script-builders.test.ts
+++ b/packages/mcps/src/test/local-action-script-builders.test.ts
@@ -1,0 +1,76 @@
+/** Tests for local action-script builders: executionSource tag + SharedTestMemory id. */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildGenerationActionScript,
+  buildReplayActionScript,
+} from "../mcp/local/services/action-script-builders.js";
+import type { TestCaseDetails, TestScriptDetails } from "../mcp/local/contracts/project-schemas.js";
+
+const PROJECT_ID = "proj-123";
+
+function makeTestCase(): TestCaseDetails {
+  return {
+    id: "tc-1",
+    projectId: PROJECT_ID,
+    useCaseId: "uc-1",
+    title: "Login with valid creds",
+    goal: "User can log in",
+    precondition: "",
+    instructions: "",
+    expectedResult: "Dashboard shown",
+  } as unknown as TestCaseDetails;
+}
+
+function makeTestScript(): TestScriptDetails {
+  return {
+    id: "ts-1",
+    actionScriptId: "as-1",
+    testCaseId: "tc-1",
+    projectId: PROJECT_ID,
+    useCaseId: "uc-1",
+    name: "Login replay",
+    url: "https://staging.example.com",
+  } as unknown as TestScriptDetails;
+}
+
+function actionParams(script: Record<string, unknown>): Record<string, unknown> {
+  return script.actionParams as Record<string, unknown>;
+}
+
+describe("buildGenerationActionScript", () => {
+  const script = buildGenerationActionScript({
+    testCase: makeTestCase(),
+    localUrl: "http://localhost:3999",
+    runId: "run-1",
+    localTestScriptId: "lts-1",
+    ownerUserId: "user-1",
+  });
+
+  it("tags the run as locally executed", () => {
+    expect(actionParams(script).executionSource).toBe("local");
+  });
+
+  it("sets sharedTestMemoryId to the project id (not empty)", () => {
+    expect(actionParams(script).sharedTestMemoryId).toBe(PROJECT_ID);
+  });
+});
+
+describe("buildReplayActionScript", () => {
+  const script = buildReplayActionScript({
+    testScript: makeTestScript(),
+    actionScript: [],
+    localUrl: "http://localhost:3999",
+    runId: "run-2",
+    ownerUserId: "user-1",
+  });
+
+  it("tags the run as locally executed", () => {
+    expect(actionParams(script).executionSource).toBe("local");
+  });
+
+  it("sets sharedTestMemoryId to the project id (not empty)", () => {
+    expect(actionParams(script).sharedTestMemoryId).toBe(PROJECT_ID);
+  });
+});


### PR DESCRIPTION
## What

In `execution-service.ts` both local action-script builders (extracted into a config-free `action-script-builders.ts`, unit-tested) now tag `actionParams.executionSource = "local"`. The studio reads that tag and skips its own cloud `ActionScript`/`TestScript` write, leaving the `/local-run/upload` path as the single writer (the studio-side gate ships in **muggle-ai-teaching-service #275**).

## Why

A normal local run writes **two** `ActionScript` Firestore docs — the studio's own (orphaned) and the MCP `/local-run/upload` doc (the one feedback + canonical `testScriptId` resolve to). Dashboard lists by `testCaseId`, so the dup is user-visible. `executionSource` is the discriminator that lets the studio skip its write. It's inert until the teaching-service binary ships, so this PR is safe to merge on its own.

## Correction (was in an earlier commit)

An earlier commit also set `sharedTestMemoryId = projectId` to enable SharedTestMemory on local runs. **That was wrong and has been reverted.** The canonical `sharedTestMemoryId` is a backend-minted **UUID**, get-or-created per project (1-1 with `projectId` but **not equal** — `IExplorationRequest.ts`; `shared_test_memory_dao.ts:84` mints `randomUUID()`), and it is **not present on any record the MCP fetches**. Using `projectId` leaned on the studio load-path's projectId keying — a latent inconsistency, not the source of truth. Both builders are back to `sharedTestMemoryId: ""`.

**STM-on-local is deferred:** doing it correctly needs a backend resolver (get-or-create STM by `projectId`, returning the UUID) that the MCP calls at run-start. Tracked separately.

## Verification

- `tsc --noEmit` clean
- `vitest run` — full mcps suite **153 passed** (incl. `local-action-script-builders.test.ts`: asserts `executionSource: "local"` and `sharedTestMemoryId: ""` for both builders)
- `tsup` build success

🤖 Generated with [Claude Code](https://claude.com/claude-code)