### PR TITLE
fix(muggle-pr-followup): detect out-of-date by behind_by, not mergeStateStatus==BEHIND

### DIFF
--- a/plugin/skills/_shared/github-cli-recipes.md
+++ b/plugin/skills/_shared/github-cli-recipes.md
@@ -8,7 +8,7 @@ Skills assume a working `gh auth status`. Auth errors surface verbatim from `gh`
 
 | Recipe | Use case |
 | :----- | :------- |
-| [`pr-metadata`](github-cli-recipes/pr-metadata.md) | Snapshot PR state, head SHA, branch — watcher + bootstrap. |
+| [`pr-metadata`](github-cli-recipes/pr-metadata.md) | Snapshot PR state, head SHA, branch, conflict + `behind_by` out-of-date detection — watcher + bootstrap. |
 | [`submitted-reviews`](github-cli-recipes/submitted-reviews.md) | Fetch a review by id / watcher's body-only-review check. |
 | [`pr-checks`](github-cli-recipes/pr-checks.md) | Check-run rollup for the head SHA — watcher's CI poll. |
 | [`line-comments-for-review`](github-cli-recipes/line-comments-for-review.md) | Pull a review's line comments — `/muggle-do` per-comment routing. |

--- a/plugin/skills/_shared/github-cli-recipes/pr-metadata.md
+++ b/plugin/skills/_shared/github-cli-recipes/pr-metadata.md
@@ -1,6 +1,6 @@
 # PR metadata snapshot
 
-Fetch the fields the watcher and bootstrap need in one call.
+Fetch the fields the watcher and bootstrap need.
 
 ```bash
 gh pr view <pr-number> --repo <owner>/<repo> \
@@ -10,4 +10,16 @@ gh pr view <pr-number> --repo <owner>/<repo> \
 - `state` is one of `OPEN`, `MERGED`, `CLOSED`.
 - `headRefOid` is the current head SHA — store as `head_sha` in `prs.json`.
 - `headRefName` is the branch — must match the working tree's branch in bootstrap.
-- `mergeable` is `MERGEABLE`, `CONFLICTING`, or `UNKNOWN` (GitHub still computing — treat as current this tick). `mergeStateStatus` carries the finer state: `DIRTY` = conflicts with base, `BEHIND` = out of date with base (no conflict), `CLEAN`/`BLOCKED`/`UNSTABLE`/`HAS_HOOKS` = current. The watcher dispatches a rebase on `CONFLICTING`/`DIRTY` **or** `BEHIND` — keeping the branch current with its base, a merge-ready gap no review or CI signal would surface.
+- `mergeable` is `MERGEABLE`, `CONFLICTING`, or `UNKNOWN` (GitHub still computing — treat as not-conflicting this tick). The watcher's **conflict** signal is `mergeable == CONFLICTING` (corroborated by `mergeStateStatus == DIRTY`).
+
+## Behind-by (out-of-date detection)
+
+`mergeStateStatus == BEHIND` is **not** a reliable out-of-date signal. GitHub collapses merge state into one value with precedence — `DIRTY` (conflict) and `BLOCKED` (missing required review, pending/failing required check) outrank `BEHIND` and mask it, and `BEHIND` surfaces *at all* only when the base enforces "require branches up to date." So a PR that is genuinely behind **and** awaiting review reports `BLOCKED`; `BEHIND` never shows, and its staleness goes unseen.
+
+Detect out-of-date straight from commit ancestry instead — independent of merge-state precedence, review state, and branch protection:
+
+```bash
+gh api repos/<owner>/<repo>/compare/<baseRefName>...<head_sha> --jq '.behind_by'
+```
+
+`behind_by > 0` ⇒ the head is missing that many base commits ⇒ out of date. `0` ⇒ current with base. (`ahead_by` counts the head's own commits — ignore it.) This is the watcher's out-of-date trigger; it is exact even while `mergeable == UNKNOWN`.

--- a/plugin/skills/_shared/telemetry-events/pr-followup-tick.md
+++ b/plugin/skills/_shared/telemetry-events/pr-followup-tick.md
@@ -23,7 +23,7 @@ One per watcher iteration (idle or not).
 
 - `actionable_threads`: count of actionable items this tick — unresolved, non-outdated threads whose newest comment is unmarked, plus body-only reviews past `lastBodyReviewId` — **after** filtering by the escalated set.
 - `dispatched_review_ids`: owning review ids handed to `/muggle-do`. Empty when idle.
-- `rebase_needed`: true when the branch is behind (`BEHIND`) or conflicting (`DIRTY`/`CONFLICTING`) with its base. `false` when reviews were dispatched (reviews preempt the mergeability check).
+- `rebase_needed`: true when the branch is behind its base (`behind_by > 0`) or conflicting (`mergeable == CONFLICTING`). `false` when reviews were dispatched (reviews preempt the mergeability check).
 - `dispatched_rebase`: true when this tick dispatched `/muggle-do` with a rebase directive.
 - `checks_red`: count of failing checks on the head SHA. `0` when reviews or a rebase were dispatched (both preempt the CI poll) or CI was green/pending.
 - `dispatched_ci_fix`: true when this tick dispatched `/muggle-do` with a fix-ci directive.

--- a/plugin/skills/muggle-pr-followup/contract.md
+++ b/plugin/skills/muggle-pr-followup/contract.md
@@ -31,7 +31,7 @@ If `prs.json[0].state` on disk is already `merged` or `closed`, this slot was fi
 
 ### Step 1 — Refresh PR state
 
-Per [`../_shared/github-cli-recipes/pr-metadata.md`](../_shared/github-cli-recipes/pr-metadata.md). Update `prs.json[0].head_sha` and `prs.json[0].state` from the response; keep `mergeable` / `mergeStateStatus` from the same call for Step 5.
+Per [`../_shared/github-cli-recipes/pr-metadata.md`](../_shared/github-cli-recipes/pr-metadata.md). Update `prs.json[0].head_sha` and `prs.json[0].state` from the response; keep `mergeable` (conflict signal) for Step 5, and run the recipe's `compare` call to capture `behind_by` (out-of-date signal) for Step 5.
 
 ### Step 2 — Termination check
 
@@ -79,10 +79,12 @@ The watcher does **not** classify. Classification, batching, replying, escalatio
 
 ### Step 5 — No actionable feedback → keep the branch rebased on its base
 
-A merge-ready branch is **current with its base** — neither conflicting nor behind. Read `mergeable` / `mergeStateStatus` from the Step 1 metadata; the branch needs a rebase when either:
+A merge-ready branch is **current with its base** — neither conflicting nor behind. From the Step 1 metadata, the branch needs a rebase when either:
 
-- `mergeable == CONFLICTING` or `mergeStateStatus == DIRTY` — conflicts with the base, **or**
-- `mergeStateStatus == BEHIND` — out of date with the base, no conflict. An unrebased branch never becomes merge-ready on its own, and is merge-blocked wherever the base requires up-to-date branches.
+- `mergeable == CONFLICTING` (corroborated by `mergeStateStatus == DIRTY`) — conflicts with the base, **or**
+- `behind_by > 0` — out of date with the base. Read this from the `compare` call (commit ancestry), **never** from `mergeStateStatus == BEHIND`: GitHub masks `BEHIND` behind `DIRTY`/`BLOCKED` and only surfaces it under "require branches up to date" protection, so a stale PR that is also awaiting review or has a red required check reports `BLOCKED` — and its staleness would go unseen. See [`../_shared/github-cli-recipes/pr-metadata.md`](../_shared/github-cli-recipes/pr-metadata.md#behind-by-out-of-date-detection).
+
+This trigger is **independent of approval and CI state**: an out-of-date branch is rebased whether or not it has been reviewed, approved, or has green checks. The watcher acts on staleness directly — it never waits for an approval to surface it.
 
 If a rebase is due **and** `conflict_resolve_attempts[head_sha] < 2` **and** `head_sha` ∉ `conflict_escalated_shas` → dispatch and exit:
 
@@ -96,7 +98,7 @@ If a rebase is due **and** `conflict_resolve_attempts[head_sha] < 2` **and** `he
   4. Append a dispatching line to `followup.log`; emit a `tick` event with `rebase_needed: true`, `dispatched_rebase: true`.
   5. Exit. The dev cycle owns the PR; its respawn restarts the watcher, whose next tick re-checks the branch against its base on the new head — the rebase is its own verify loop, bounded by the per-SHA attempt budget.
 
-Branch current with its base (`CLEAN` / `BLOCKED` / `UNSTABLE` / `HAS_HOOKS`), `mergeable == UNKNOWN` (GitHub still computing — treat as current this tick), or budget spent (`conflict_resolve_attempts[head_sha] >= 2` or `head_sha` ∈ `conflict_escalated_shas`) → fall through to CI.
+Otherwise — `behind_by == 0` and not conflicting (`mergeable == UNKNOWN` is fine here: `behind_by` is exact while GitHub is still computing conflict state, so a stale branch still triggers), or budget spent (`conflict_resolve_attempts[head_sha] >= 2` or `head_sha` ∈ `conflict_escalated_shas`) → fall through to CI.
 
 ### Step 6 — No actionable feedback, branch current → poll CI for the head SHA
 


### PR DESCRIPTION
## The bug

5.0.3 (#261) made the watcher rebase a behind branch — but it keyed the trigger on `mergeStateStatus == BEHIND`. That's an **unreliable** out-of-date signal:

- GitHub collapses merge state into **one** value with precedence. `DIRTY` (conflict) and `BLOCKED` (missing required review, pending/failing required check) **outrank and mask** `BEHIND`.
- `BEHIND` surfaces *at all* only when the base enforces "require branches up to date".

So a PR that is genuinely behind master **and** awaiting review reports `BLOCKED` — the watcher sees no `BEHIND` and **never rebases it**. It would only rebase after approval flipped `BLOCKED`→`BEHIND` (and only if the repo requires up-to-date branches). That read as a deliberate "rebase only after approval" policy, but there's no such logic in the contract — it was a blind spot.

Proof, on a real PR (`muggle-ai-ui#283`): `mergeStateStatus: BLOCKED`, `reviewDecision: REVIEW_REQUIRED`, yet the compare API says `behind_by: 0, ahead_by: 6` — the branch is actually **up to date**. `mergeStateStatus` told us nothing about staleness; `behind_by` told us the truth.

## The fix

Detect out-of-date straight from commit ancestry, independent of merge-state precedence, review state, and branch protection:

```
gh api repos/{owner}/{repo}/compare/{base}...{head} --jq .behind_by
```

The watcher (`contract.md` Step 5) now dispatches a rebase on **`behind_by > 0`** OR `mergeable == CONFLICTING` — **independent of approval and CI state**. A branch that falls behind its base is rebased immediately, whether or not it's been reviewed or its checks are green.

Touches: `contract.md` Step 1 (capture `behind_by`) + Step 5 (trigger), `pr-metadata.md` recipe (compare call + why `BEHIND` is unreliable), recipes TOC, tick-telemetry doc. Docs-only skill markdown; `dist/` regenerated at release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)