### PR TITLE
fix(muggle-do): honor postPRVisualWalkthrough gate in open-prs

### DIFF
--- a/plugin/skills/do/open-prs/forward.md
+++ b/plugin/skills/do/open-prs/forward.md
@@ -30,7 +30,7 @@ Forward pipeline's Stage 7. Invoked by `/muggle-do` after stages 1–6 of a fres
    - `## Acceptance Criteria` — bulleted; omit if empty.
    - `## Changes` — summary of what changed in this repo.
    - `## Validation` — one line: link to E2E report, `unit-only`, or `skip — <reason>`.
-   - **If an E2E report exists,** invoke [`../../muggle-pr-visual-walkthrough/SKILL.md`](../../muggle-pr-visual-walkthrough/SKILL.md) Mode B to render the walkthrough block. Embed the returned `body` verbatim. If no report, skip this block entirely.
+   - **Walkthrough block** — only when an E2E report exists. Fire [`postPRVisualWalkthrough`](../../muggle-preferences/preference-gates/postPRVisualWalkthrough.md); on skip, omit this block. Otherwise invoke [`../../muggle-pr-visual-walkthrough/SKILL.md`](../../muggle-pr-visual-walkthrough/SKILL.md) Mode B and embed the returned `body` verbatim. No report → skip the block.
 
 4. **Create:** `gh pr create --title "..." --body "..." --head <branch>`. Capture the PR URL and number.
 

--- a/plugin/skills/do/open-prs/update.md
+++ b/plugin/skills/do/open-prs/update.md
@@ -32,7 +32,7 @@ Skip `autoCreatePR` (it gates creation, not update). The PR's title is left inta
 
 4. **Refresh body when validation outcome changed** — only when the `## Validation` section's content differs from what's in the body. Use the `--body-file` form in [`../../_shared/github-cli-recipes/pr-edit.md`](../../_shared/github-cli-recipes/pr-edit.md). Preserve `## Goal` and `## Acceptance Criteria` verbatim.
 
-5. **Visual walkthrough comment** — if an E2E report exists, invoke [`../../muggle-pr-visual-walkthrough/SKILL.md`](../../muggle-pr-visual-walkthrough/SKILL.md) Mode A. Always a fresh comment per cycle; do not edit prior walkthrough comments.
+5. **Visual walkthrough comment** — only when an E2E report exists. Fire [`postPRVisualWalkthrough`](../../muggle-preferences/preference-gates/postPRVisualWalkthrough.md) (PR number from `prs.json`); on skip, record `skipped (gate)` and continue. Otherwise invoke [`../../muggle-pr-visual-walkthrough/SKILL.md`](../../muggle-pr-visual-walkthrough/SKILL.md) Mode A — a fresh comment per cycle; do not edit prior walkthrough comments.
 
 6. **Overflow comment** — same rule as forward mode: post when the walkthrough skill returns non-null `comment`, via [`../../_shared/github-cli-recipes/top-level-comment.md`](../../_shared/github-cli-recipes/top-level-comment.md).
 
@@ -50,5 +50,5 @@ Return control to `/muggle-do`'s address-reviews orchestrator. The orchestrator 
 **PR updated:** URL (new SHA: `<short-sha>`)
 **Title refreshed:** yes | no
 **Body refreshed:** yes | no
-**Walkthrough comment:** posted | skipped (no report)
+**Walkthrough comment:** posted | skipped (no report) | skipped (gate)
 **Overflow comment:** posted | skipped

--- a/plugin/skills/muggle-do/SKILL.md
+++ b/plugin/skills/muggle-do/SKILL.md
@@ -65,7 +65,7 @@ When invoked with the directive (PR URL + slug + review ids), routes to [`../do/
 | `autoResolveConflicts` | On rebase conflict — resolve autonomously behind a verify-or-rollback gate (opt-in), or abort + escalate (default `never`) |
 | `autoRouteBuildToMuggleDo` | Front-door guardrail — route build/implement/fix requests through this pipeline (build delegated to superpowers); fired by the UserPromptSubmit guardrail, default `ask` |
 
-`autoUseWorktree`, `autoRebase`, `autoResolveConflicts`, `autoCreatePR`, `autoCleanup` fire from per-stage files.
+`autoUseWorktree`, `autoRebase`, `autoResolveConflicts`, `autoCreatePR`, `autoCleanup`, `postPRVisualWalkthrough` fire from per-stage files.
 
 ## Session model
 


### PR DESCRIPTION
## Gap

The `postPRVisualWalkthrough` gate exists, and `muggle-pr-visual-walkthrough/SKILL.md` states *"gating happens upstream — by the time this skill runs, the user has already approved posting (via the saved gate value or explicit pick)."* But muggle-do's `open-prs` stages **never fired it** — they posted the walkthrough whenever an E2E report existed, with no gate check.

Result: a user who set `postPRVisualWalkthrough = never` still got walkthroughs from `muggle-do`. The gate was a no-op on this path. (Surfaced while explaining why no walkthrough posted on the recent docs PRs — that was correct, *no E2E report*; but it exposed that the gate isn't consulted even when a report does exist.)

## Fix

Wire the gate in, matching the existing `autoCreatePR` fire idiom (`forward.md` Step 0) and `muggle-test` Step 9 (*"Fire [gate]. On skip → …"*):

- **`forward.md` Step 3** (new PR, Mode B body embed) — fire the gate; on skip, omit the walkthrough block.
- **`update.md` Step 5** (existing PR, Mode A comment) — fire the gate (PR number from `prs.json`); on skip, record `skipped (gate)`. Output line gains the `skipped (gate)` state.
- **`muggle-do/SKILL.md`** — add `postPRVisualWalkthrough` to the per-stage gate inventory.

## Behavior

- `always` / absent → unchanged (posts when an E2E report exists).
- `never` → now actually suppresses, as the gate promises.
- No E2E report → still skipped (unchanged).

Docs-only skill-procedure change; no reverse references (muggle-do references the gate downward, per the one-way rule). Goes live after a `@muggleai/works` release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)