### PR TITLE
feat(gitlab): Phase 1 — recognize GitLab MRs and open them via glab

### DIFF
--- a/plugin/skills/_shared/detect-vcs.md
+++ b/plugin/skills/_shared/detect-vcs.md
@@ -1,0 +1,28 @@
+# Detect VCS provider
+
+Resolve a single provider token — `github` or `gitlab` — before a caller picks its recipe set. GitHub uses `gh`; GitLab uses `glab`. Auth errors from either surface verbatim.
+
+## Resolution order
+
+1. **From a URL argument**, if one was passed:
+   - `github.com/<owner>/<repo>/pull/<n>` → `github`.
+   - `<host>/<group>/<project>/-/merge_requests/<iid>` → `gitlab`. The `/-/merge_requests/` segment is the tell, on any host.
+
+2. **From the repo**, when no URL — parse the origin remote:
+
+   ```bash
+   git remote get-url origin
+   ```
+
+   - Host `github.com` → `github`.
+   - Host `gitlab.com`, **or** any other host where `glab auth status` succeeds → `gitlab`.
+
+## GitLab wrinkles
+
+- **Nested namespaces.** The path between host and `/-/` can be `group/subgroup/project`, any depth. Do not assume two segments — split on `/-/`, the project path is everything before it.
+- **The `/-/` segment** separates the project path from the resource (`/-/merge_requests/<iid>`). GitHub has no equivalent; its `/pull/<n>` sits directly under `<owner>/<repo>`.
+- **Self-hosted hosts.** GitLab is not just `gitlab.com` — `git.acme.com`, `gitlab.internal`, etc. Resolve the host from the remote and confirm it against `glab`'s configured host (`GITLAB_HOST`, or `glab auth status`'s active host). A remote host that matches `glab`'s host → `gitlab`, even when unknown to this doc.
+
+## Output
+
+The bare token `github` or `gitlab` — nothing else.

--- a/plugin/skills/_shared/gitlab-cli-recipes.md
+++ b/plugin/skills/_shared/gitlab-cli-recipes.md
@@ -1,0 +1,24 @@
+# GitLab CLI Recipes
+
+Reusable `glab` / `git` snippets used by `muggle-pr-followup` (watcher + bootstrap) and `/muggle-do` (address-reviews + open-prs), mirroring the `gh` set for GitLab merge requests. Each recipe is one file — load only what you need.
+
+Skills assume a working `glab auth status`. Auth errors surface verbatim from `glab`.
+
+The project ref `:id` is `<group>/<project>` — URL-encode it for `glab api` (`mygroup/myproj` → `mygroup%2Fmyproj`). `:iid` is the MR's per-project internal id (the `!123` number), not the global id.
+
+## Index
+
+| Recipe | Use case |
+| :----- | :------- |
+| [`mr-metadata`](gitlab-cli-recipes/mr-metadata.md) | Snapshot MR state, head SHA, branch, conflict + out-of-date detection — watcher + bootstrap. |
+| [`mr-pipeline`](gitlab-cli-recipes/mr-pipeline.md) | Pipeline-job rollup for the head SHA — watcher's CI poll. |
+| [`mr-discussions`](gitlab-cli-recipes/mr-discussions.md) | Fetch incoming notes/discussions — watcher's feedback poll. |
+| [`unresolved-discussions`](gitlab-cli-recipes/unresolved-discussions.md) | Unresolved-discussion state — watcher's dispatch trigger + resolve-reminder. |
+| [`reply-discussion`](gitlab-cli-recipes/reply-discussion.md) | POST a threaded reply on a discussion. |
+| [`mr-note`](gitlab-cli-recipes/mr-note.md) | POST a top-level MR note — resolve-reminder + overflow. |
+| [`resolve-discussion`](gitlab-cli-recipes/resolve-discussion.md) | Mark a discussion thread resolved. |
+| [`mr-edit`](gitlab-cli-recipes/mr-edit.md) | Refresh title or description when address-reviews mode flips state. |
+| [`mr-create`](gitlab-cli-recipes/mr-create.md) | Open an MR + capture its URL for handoff. |
+| [`loop-user-identity`](gitlab-cli-recipes/loop-user-identity.md) | Resolve the GitLab username of the loop user. |
+| [`push-to-branch`](github-cli-recipes/push-to-branch.md) | Push + capture new SHA after address-reviews work (provider-agnostic). |
+| [`verify-working-tree`](github-cli-recipes/verify-working-tree.md) | Three checks bootstrap runs before seeding state (provider-agnostic). |

--- a/plugin/skills/_shared/gitlab-cli-recipes/loop-user-identity.md
+++ b/plugin/skills/_shared/gitlab-cli-recipes/loop-user-identity.md
@@ -1,0 +1,9 @@
+# Identify the loop user
+
+The GitLab identity that owns the authenticated `glab` token. Resolve-reminder thread classification and reply attribution need this.
+
+```bash
+glab api user --jq '.username'
+```
+
+Cache in `state.md` under `Loop user:`; re-resolve only when missing.

--- a/plugin/skills/_shared/gitlab-cli-recipes/mr-create.md
+++ b/plugin/skills/_shared/gitlab-cli-recipes/mr-create.md
@@ -1,0 +1,11 @@
+# Open a merge request
+
+For `open-prs`. Push the branch first (see [`../github-cli-recipes/push-to-branch.md`](../github-cli-recipes/push-to-branch.md)), then open the MR.
+
+```bash
+glab mr create -R <group>/<project> \
+  --source-branch <branch> --target-branch <base> \
+  --title "<title>" --description "$(cat <file>)"
+```
+
+`glab` prints the created MR's URL on success — capture stdout and store the URL for handoff (the watcher seeds from it, the user gets the link).

--- a/plugin/skills/_shared/gitlab-cli-recipes/mr-discussions.md
+++ b/plugin/skills/_shared/gitlab-cli-recipes/mr-discussions.md
@@ -1,0 +1,18 @@
+# MR discussions
+
+Incoming feedback for the watcher's poll and the address-reviews fetch. GitLab has **no review envelope** — there is no submitted-review object grouping a summary body with line comments. Feedback arrives as individual notes, each belonging to a discussion (a thread). This recipe is the `submitted-reviews` analogue.
+
+```bash
+glab api projects/:id/merge_requests/:iid/discussions --paginate
+```
+
+Each discussion has `id` and a `notes[]` array; each note has `id`, `author.username`, `body`, `created_at`, `system` (a `true` flag marks GitLab's own activity entries — skip them).
+
+Common filter:
+
+- `system == false` (skip "added 2 commits", "changed the description", etc.)
+- `author.username` in the resolved allow-list
+
+Cursor: track the highest note/discussion `id` seen in `last_seen`; a note whose `id` exceeds it is new this tick. (GitLab ids are monotonic, so id ordering is reliable where `created_at` ties.)
+
+Loop-echo skip: a note the loop itself posted carries the `<!-- muggle-do:bot -->` marker in its `body`. Classify by that marker per note, never by `author.username` alone — under a shared account the login is ambiguous. A marked note is the loop's own and must never re-trigger a cycle; an unmarked note from an allow-listed author is actionable.

--- a/plugin/skills/_shared/gitlab-cli-recipes/mr-edit.md
+++ b/plugin/skills/_shared/gitlab-cli-recipes/mr-edit.md
@@ -1,0 +1,8 @@
+# Refresh the MR title or description
+
+For `open-prs/update.md` when E2E state flips (passing↔failing) or validation strategy changes. GitLab calls the body the **description**.
+
+```bash
+glab mr update <iid> -R <group>/<project> --title "<new-title>"
+glab mr update <iid> -R <group>/<project> --description "$(cat <file>)"
+```

--- a/plugin/skills/_shared/gitlab-cli-recipes/mr-metadata.md
+++ b/plugin/skills/_shared/gitlab-cli-recipes/mr-metadata.md
@@ -1,0 +1,22 @@
+# MR metadata snapshot
+
+Fetch the fields the watcher and bootstrap need.
+
+```bash
+glab mr view <iid> -R <group>/<project> -F json
+```
+
+- `state` is one of `opened`, `merged`, `closed`, `locked` (lowercase — unlike GitHub's uppercase).
+- `sha` is the current head SHA — store as `head_sha` in `prs.json`.
+- `source_branch` is the branch — must match the working tree's branch in bootstrap. `target_branch` is the base.
+- conflict comes from `detailed_merge_status`, not a `mergeable` + `mergeStateStatus` pair. The watcher's **conflict** signal is `detailed_merge_status == "broken_status"` or `"conflict"`. `"checking"`/`"unchecked"` means GitLab is still computing — treat as not-conflicting this tick.
+
+## Behind-by (out-of-date detection)
+
+`detailed_merge_status == "need_rebase"` reports a behind branch only when the project enforces "fast-forward merge"; otherwise it stays `mergeable` while behind. Detect out-of-date straight from commit ancestry instead — independent of merge-method config:
+
+```bash
+glab api projects/:id/repository/compare?from=<target_branch>&to=<head_sha> --jq '.commits | length'
+```
+
+GitLab's compare lists only the commits `to` is ahead by, so flip the direction: compare `from=<head_sha>&to=<target_branch>` and a non-empty `.commits` ⇒ the base has commits the head lacks ⇒ out of date. Empty ⇒ current with base.

--- a/plugin/skills/_shared/gitlab-cli-recipes/mr-note.md
+++ b/plugin/skills/_shared/gitlab-cli-recipes/mr-note.md
@@ -1,0 +1,7 @@
+# Top-level MR note
+
+For the resolve-reminder stage and any non-threaded notice.
+
+```bash
+glab mr note <iid> -R <group>/<project> -m "<text>"
+```

--- a/plugin/skills/_shared/gitlab-cli-recipes/mr-pipeline.md
+++ b/plugin/skills/_shared/gitlab-cli-recipes/mr-pipeline.md
@@ -1,0 +1,27 @@
+# MR pipeline rollup
+
+Fetch the CI state for an MR's head — what the watcher polls to detect red CI. GitLab runs **one** pipeline of jobs per commit, not independent check-runs, so the rollup is over that pipeline's jobs.
+
+```bash
+glab ci status -R <group>/<project> -b <source_branch>
+```
+
+Or straight from the API for the latest pipeline and its jobs:
+
+```bash
+glab api projects/:id/merge_requests/:iid/pipelines --jq '.[0].id'
+glab api projects/:id/pipelines/<pipeline-id>/jobs --paginate
+```
+
+Each job:
+
+- `name` — the job's name (e.g. `lint`, `test`, `build`).
+- `status` — one of `success` / `failed` / `running` / `pending` / `created` / `canceled` / `skipped` / `manual`.
+
+Classify for the watcher:
+
+- **red** — any job `failed`. Candidate for fix-ci.
+- **pending** — no job `failed`, but any job `running` / `pending` / `created`. Pipeline hasn't settled → idle.
+- **green** — every job `success` / `skipped` / `manual` / `canceled`, or no jobs at all.
+
+The fix-ci dispatch carries the `name`s of the `failed` jobs.

--- a/plugin/skills/_shared/gitlab-cli-recipes/reply-discussion.md
+++ b/plugin/skills/_shared/gitlab-cli-recipes/reply-discussion.md
@@ -1,0 +1,9 @@
+# Reply to a discussion (threaded)
+
+Used by `/muggle-do` per-comment inline replies. A threaded reply is a new note appended to an existing discussion.
+
+```bash
+glab api --method POST \
+  projects/:id/merge_requests/:iid/discussions/<discussion-id>/notes \
+  -f body="<reply-text>"
+```

--- a/plugin/skills/_shared/gitlab-cli-recipes/resolve-discussion.md
+++ b/plugin/skills/_shared/gitlab-cli-recipes/resolve-discussion.md
@@ -1,0 +1,10 @@
+# Resolve a discussion thread
+
+Mark a thread resolved once the loop's reply has addressed it — the resolve-reminder stage's action.
+
+```bash
+glab api --method PUT \
+  "projects/:id/merge_requests/:iid/discussions/<discussion-id>?resolved=true"
+```
+
+Resolves every resolvable note in the thread at once. Only resolvable (diff/line) threads accept this; a non-resolvable discussion returns an error.

--- a/plugin/skills/_shared/gitlab-cli-recipes/unresolved-discussions.md
+++ b/plugin/skills/_shared/gitlab-cli-recipes/unresolved-discussions.md
@@ -1,0 +1,18 @@
+# Unresolved discussions
+
+For the watcher's dispatch trigger and the resolve-reminder stage. REST exposes resolution directly — no GraphQL needed, unlike GitHub.
+
+```bash
+glab api projects/:id/merge_requests/:iid/discussions --paginate \
+  --jq '[.[] | select(.notes[0].resolvable == true) | select(any(.notes[]; .resolved == false))]'
+```
+
+A discussion is resolvable when its notes carry `resolvable == true` (diff/line threads are; the MR description and system notes are not). A thread is **unresolved** when any of its notes has `resolved == false`.
+
+Walk each unresolved thread's `notes[]` in `created_at` order and classify by the loop marker (see [`../pr-followup-helpers/loop-signature.md`](../pr-followup-helpers/loop-signature.md)), not by `author.username` — the login is ambiguous under a shared account:
+
+- **Addressed, awaiting resolve** — the **newest** note carries `<!-- muggle-do:bot -->`. The loop has replied and nothing newer waits. → resolve-reminder.
+- **Unaddressed human comment** — the newest note lacks the marker and is newer than the thread's newest loop-marked note (or the thread has none yet). → actionable: the round should address it.
+- **Not addressed** — indeterminate (e.g. no notes).
+
+Each thread carries its `id` (the `discussion_id`) — the watcher collects this from an actionable thread to build its dispatch list and to target the resolve call later.

--- a/plugin/skills/do/input-routing.md
+++ b/plugin/skills/do/input-routing.md
@@ -1,10 +1,10 @@
 # Input routing
 
-How `/muggle-do` resolves `$ARGUMENTS` to a mode. Modes 1–4 are programmatic — dispatched by the watcher — so never ask on those. Inspect in order:
+How `/muggle-do` resolves `$ARGUMENTS` to a mode. Modes 1–4 are programmatic — dispatched by the watcher — so never ask on those. A change-URL in modes 1–3 is either a GitHub PR (`github.com/.../pull/<n>`) or a GitLab MR (`<host>/.../-/merge_requests/<iid>`); provider is resolved via [`../_shared/detect-vcs.md`](../_shared/detect-vcs.md). Inspect in order:
 
-1. **Address-reviews** — a `github.com/.../pull/<n>` URL **and** one or more review ids (integers ≥ 100000000) → [`address-reviews.md`](address-reviews.md).
-2. **Fix-CI** — a `github.com/.../pull/<n>` URL **and** a `fix ci` / `fix-ci` directive with failing check names (no review ids) → [`fix-ci.md`](fix-ci.md).
-3. **Rebase** — a `github.com/.../pull/<n>` URL **and** a `rebase` directive (or legacy `resolve conflicts` / `resolve-conflicts`; no review ids, no check names) → [`resolve-conflicts.md`](resolve-conflicts.md). Rebases the branch onto its base whether it's merely behind or actually conflicting.
+1. **Address-reviews** — a PR/MR URL **and** an address-reviews directive carrying review/discussion ids → [`address-reviews.md`](address-reviews.md). On GitHub these ids are integers ≥ 100000000; that magnitude is GitHub-specific lore, **not** a portable test. Under GitLab, tell this apart from other directives by the directive keyword plus the presence of discussion ids, never by id size.
+2. **Fix-CI** — a PR/MR URL **and** a `fix ci` / `fix-ci` directive with failing check names (no review/discussion ids) → [`fix-ci.md`](fix-ci.md).
+3. **Rebase** — a PR/MR URL **and** a `rebase` directive (or legacy `resolve conflicts` / `resolve-conflicts`; no review/discussion ids, no check names) → [`resolve-conflicts.md`](resolve-conflicts.md). Rebases the branch onto its base whether it's merely behind or actually conflicting.
 4. **Post-merge cleanup** — a `cleanup` token and `slug=<slug>` (no PR URL, no review ids), optionally `state=<merged|closed>` (default `merged`) → [`cleanup.md`](cleanup.md).
 5. **Empty / `help` / `menu` / `?`** → menu + session selector.
 6. **Task automation** (perform an action on a website) → `muggle:muggle-browser-task`.

--- a/plugin/skills/do/open-prs/forward.md
+++ b/plugin/skills/do/open-prs/forward.md
@@ -32,7 +32,9 @@ Forward pipeline's Stage 7. Invoked by `/muggle-do` after stages 1–6 of a fres
    - `## Validation` — one line: link to E2E report, `unit-only`, or `skip — <reason>`.
    - **Walkthrough block** — only when an E2E report exists. Fire [`postPRVisualWalkthrough`](../../muggle-preferences/preference-gates/postPRVisualWalkthrough.md); on skip, omit this block. Otherwise invoke [`../../muggle-pr-visual-walkthrough/SKILL.md`](../../muggle-pr-visual-walkthrough/SKILL.md) Mode B and embed the returned `body` verbatim. No report → skip the block.
 
-4. **Create:** `gh pr create --title "..." --body "..." --head <branch>`. Capture the PR URL and number.
+4. **Create:** resolve the provider per [`../../_shared/detect-vcs.md`](../../_shared/detect-vcs.md).
+   - `github` → `gh pr create --title "..." --body "..." --head <branch>`. Capture the PR URL and number.
+   - `gitlab` → open the change via [`../../_shared/gitlab-cli-recipes/mr-create.md`](../../_shared/gitlab-cli-recipes/mr-create.md): `glab mr create --source-branch <branch> --target-branch <base> --title "..." --description "..."`. Capture the MR URL and iid.
 
 5. **Overflow comment:** if the walkthrough skill returned a non-null `comment`, post it once per [`../../_shared/github-cli-recipes/top-level-comment.md`](../../_shared/github-cli-recipes/top-level-comment.md). Never post when `comment` is `null`.
 

--- a/plugin/skills/do/open-prs/forward.md
+++ b/plugin/skills/do/open-prs/forward.md
@@ -1,6 +1,6 @@
 # Open PR — forward mode
 
-Forward pipeline's Stage 7. Invoked by `/muggle-do` after stages 1–6 of a fresh feature. Creates the PR via `gh pr create`, seeds session state, dispatches the first watcher.
+Forward pipeline's Stage 7. Invoked by `/muggle-do` after stages 1–6 of a fresh feature. Opens the change — a PR on GitHub (`gh pr create`) or an MR on GitLab (`glab mr create`), provider resolved in Step 4 — then seeds session state and dispatches the first watcher.
 
 ## Turn preamble
 
@@ -36,7 +36,7 @@ Forward pipeline's Stage 7. Invoked by `/muggle-do` after stages 1–6 of a fres
    - `github` → `gh pr create --title "..." --body "..." --head <branch>`. Capture the PR URL and number.
    - `gitlab` → open the change via [`../../_shared/gitlab-cli-recipes/mr-create.md`](../../_shared/gitlab-cli-recipes/mr-create.md): `glab mr create --source-branch <branch> --target-branch <base> --title "..." --description "..."`. Capture the MR URL and iid.
 
-5. **Overflow comment:** if the walkthrough skill returned a non-null `comment`, post it once per [`../../_shared/github-cli-recipes/top-level-comment.md`](../../_shared/github-cli-recipes/top-level-comment.md). Never post when `comment` is `null`.
+5. **Overflow comment:** if the walkthrough skill returned a non-null `comment`, post it once using the provider resolved in Step 4 — `github` per [`../../_shared/github-cli-recipes/top-level-comment.md`](../../_shared/github-cli-recipes/top-level-comment.md), `gitlab` per [`../../_shared/gitlab-cli-recipes/mr-note.md`](../../_shared/gitlab-cli-recipes/mr-note.md). Never post when `comment` is `null`.
 
 ## Stage 8 handoff
 

--- a/plugin/skills/do/open-prs/update.md
+++ b/plugin/skills/do/open-prs/update.md
@@ -20,6 +20,8 @@ Does **not** create a PR, seed session state, or dispatch a watcher (`/muggle-do
 
 Skip `autoCreatePR` (it gates creation, not update). The PR's title is left intact unless state changed in Step 3.
 
+Resolve the provider once per [`../../_shared/detect-vcs.md`](../../_shared/detect-vcs.md). Wherever Steps 3–4 below edit title/description: `github` uses `gh pr edit` per [`../../_shared/github-cli-recipes/pr-edit.md`](../../_shared/github-cli-recipes/pr-edit.md); `gitlab` uses `glab mr update --title --description` per [`../../_shared/gitlab-cli-recipes/mr-edit.md`](../../_shared/gitlab-cli-recipes/mr-edit.md).
+
 1. **Push:** per [`../../_shared/github-cli-recipes/push-to-branch.md`](../../_shared/github-cli-recipes/push-to-branch.md). Capture the new SHA.
 
 2. **Append new SHA** to `last_seen.json[<key>].pushed_shas` (the resolve-reminder stage uses this to recognize threads addressed by the loop). Set `last_seen.last_pushed_sha` to the new SHA too.

--- a/plugin/skills/muggle-pr-followup/state-schemas.md
+++ b/plugin/skills/muggle-pr-followup/state-schemas.md
@@ -16,6 +16,7 @@ A list of one entry. (Historical: the file is an array for forward-compat with t
 [
   {
     "repo": "<owner>/<repo>",
+    "provider": "github" | "gitlab",
     "number": <int>,
     "url": "https://github.com/<owner>/<repo>/pull/<number>",
     "head_sha": "<40-char-hex-sha>",
@@ -24,6 +25,8 @@ A list of one entry. (Historical: the file is an array for forward-compat with t
 ]
 ```
 
+- `provider` selects the recipe set (`gh` vs `glab`). Absent ⇒ `github` — existing slots predate the field and stay GitHub.
+- Under GitLab, `number` holds the MR `iid` (per-project, not the global MR id); `head_sha` is unchanged. GitLab's `opened` normalizes to `open`; `merged` and `closed` already align.
 - `state` is the **observed** state from the last `gh pr view`. The watcher refreshes it each tick.
 - Terminal states (`merged`, `closed`) are sticky — once set, the watcher writes `result.md` and exits without rescheduling.
 
@@ -48,7 +51,7 @@ Keyed by `"<owner>/<repo>#<n>"`. One key per PR in the slot.
 }
 ```
 
-- `lastBodyReviewId`: narrow watermark for **body-only** reviews (a submitted review carrying no line comments). The watcher dispatches a body-only review only when `id > lastBodyReviewId`. Line-comment threads do **not** use it — they are dispatched from live thread state (unresolved + not outdated + newest comment unmarked by the loop), so there is no cursor that can pin past them. Bootstrap sets it to the highest existing submitted review id with `--forward-only`, else `0`.
+- `lastBodyReviewId`: narrow watermark for **body-only** reviews (a submitted review carrying no line comments). The watcher dispatches a body-only review only when `id > lastBodyReviewId`. Line-comment threads do **not** use it — they are dispatched from live thread state (unresolved + not outdated + newest comment unmarked by the loop), so there is no cursor that can pin past them. Bootstrap sets it to the highest existing submitted review id with `--forward-only`, else `0`. The cursor keeps its name under GitLab, where it holds the highest note / discussion id.
 - `last_pushed_sha`: most recent SHA `/muggle-do` pushed in this PR's life; `null` until the first push.
 - `idle_tick_count`: incremented each tick whose actionable set is empty. Reset to 0 on any tick that dispatches `/muggle-do`. Diagnostic only — does not gate behavior.
 - `cycles_completed`: incremented each time `/muggle-do` completes an address-reviews invocation (regardless of actionable/ambiguous/mixed).

--- a/src/guardrails/prOpened.ts
+++ b/src/guardrails/prOpened.ts
@@ -1,13 +1,15 @@
 import type { HookInput } from "./types.js";
 
 const PR_URL = /https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/\d+/;
+const MR_URL = /https?:\/\/[^/\s]+\/[^\s]+\/-\/merge_requests\/\d+/;
 const CREATE_CMD = /\bgh\s+pr\s+(create|ready)\b/;
+const MR_CREATE_CMD = /\bglab\s+mr\s+create\b|\bglab\s+mr\s+update\b.*--ready\b/;
 
 export function detectPrOpened(input: HookInput): string | null {
   if (input.tool_name !== "Bash") return null;
   const cmd = input.tool_input?.command ?? "";
-  if (!CREATE_CMD.test(cmd)) return null;
+  if (!CREATE_CMD.test(cmd) && !MR_CREATE_CMD.test(cmd)) return null;
   const out = `${input.tool_response?.stdout ?? ""}\n${input.tool_response?.output ?? ""}`;
-  const m = out.match(PR_URL);
+  const m = out.match(PR_URL) ?? out.match(MR_URL);
   return m ? m[0] : null;
 }

--- a/src/test/guardrails/prOpened.test.ts
+++ b/src/test/guardrails/prOpened.test.ts
@@ -42,6 +42,36 @@ describe("detectPrOpened", () => {
     ).toBe("https://github.com/o/r/pull/19");
   });
 
+  it("extracts the MR url from a successful glab mr create", () => {
+    expect(
+      detectPrOpened({
+        tool_name: "Bash",
+        tool_input: { command: "glab mr create --title x --description y" },
+        tool_response: { stdout: "https://gitlab.com/group/subgroup/proj/-/merge_requests/42\n" },
+      }),
+    ).toBe("https://gitlab.com/group/subgroup/proj/-/merge_requests/42");
+  });
+
+  it("extracts the MR url from a self-hosted GitLab host", () => {
+    expect(
+      detectPrOpened({
+        tool_name: "Bash",
+        tool_input: { command: "glab mr create --fill" },
+        tool_response: { stdout: "https://gitlab.example.com/team/app/-/merge_requests/7\n" },
+      }),
+    ).toBe("https://gitlab.example.com/team/app/-/merge_requests/7");
+  });
+
+  it("ignores non-MR-create glab calls", () => {
+    expect(
+      detectPrOpened({
+        tool_name: "Bash",
+        tool_input: { command: "glab mr view 42" },
+        tool_response: { stdout: "https://gitlab.com/o/r/-/merge_requests/42" },
+      }),
+    ).toBeNull();
+  });
+
   it("ignores non-Bash tools", () => {
     expect(
       detectPrOpened({


### PR DESCRIPTION
Phase 1 of GitLab support for the muggle-* skills — design: [muggle-ai-brain#95](https://github.com/multiplex-ai/muggle-ai-brain/pull/95) (merged).

Adds GitLab merge-request support via **parallel `glab` recipes** selected by a provider token. GitHub paths are byte-for-byte unchanged and `provider` defaults to `github`, so existing sessions keep working.

## What's in this slice
- **`_shared/detect-vcs.md`** — resolve `github | gitlab` from a URL arg or the `origin` remote; handles nested namespaces, the `/-/merge_requests/` segment, and self-hosted hosts.
- **`_shared/gitlab-cli-recipes/`** (+ index) — `glab` analogues of the 11 `gh` recipes: `mr-metadata`, `mr-pipeline` (jobs, not check-runs), `mr-discussions` (no review envelope), `unresolved-discussions`, `reply-`/`resolve-discussion`, `mr-note`, `mr-edit`, `mr-create`, `loop-user-identity`. `push-to-branch`/`verify-working-tree` are reused, not duplicated.
- **`do/input-routing.md`** — modes 1–3 accept a PR or MR URL; the "review id ≥ 1e8" disambiguator is flagged GitHub-specific.
- **`do/open-prs/{forward,update}.md`** — provider branch to `glab mr create` / `glab mr update`.
- **`muggle-pr-followup/state-schemas.md`** — `provider` discriminator (absent ⇒ github; `number` holds the MR `iid` under GitLab).
- **`src/guardrails/prOpened.ts`** (+ test) — detect GitLab MR URLs and `glab mr create`.

## Validation
- `vitest run` — **274/274 pass** (24 files), including all prior GitHub guardrail cases plus new GitLab cases (nested namespace, self-hosted host).
- `tsc --noEmit` exit 0; eslint on changed TS exit 0.
- No E2E: this repo has no web UI and there are no user-facing surface changes.

## Not in this slice (follow-ups)
- Phase 2: watcher parity (discussions/pipeline polling, address-reviews + fix-ci GitLab branches).
- Phase 3: visual-walkthrough posting via `glab`, image-proxy verification.
- The GitHub-side "extract inlined `gh` commands into recipes" refactor noted in the design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
