### PR TITLE
fix(skills): tighten muggle-browser-task triggering (Opus 4.8 re-validation)

### DIFF
--- a/internal/skill-routing-eval/reports/optimization-log.md
+++ b/internal/skill-routing-eval/reports/optimization-log.md
@@ -26,6 +26,14 @@ Each entry: the genuine routing miss from the baseline, the description change, 
 
 **Re-run (8/8):** failing query → `muggle-test-prepare` 3/3; all 4 other prepare positives pass; `muggle-test` ("validate before PR", "test on staging") and `muggle-test-feature-local` ("checkout on localhost") siblings unaffected.
 
+## muggle-browser-task (Opus 4.8 re-validation)
+
+**Baseline miss (runs=3):** 20/25 — "log into X and do Y" action requests (AWS IAM, Slack message, Stripe refund, prod checkout, …) routed to `none`; the model attempts or declines the task itself instead of invoking the skill. Original description was the thinnest real skill (322 ch) and named neither the user's verbs nor the failure mode.
+
+**Change:** pushier, concrete framing — transactional verbs (submit the form, place the order, refund the charge, file the ticket, publish a post) and sites (Stripe, Jira, Shopify, AWS console, WordPress, LinkedIn), plus an explicit "reach for this rather than declining or doing it by hand." Chat framing ("Slack", "send a message") was deliberately dropped: it collided with the negative "ping the team on slack to review my PR".
+
+**Re-run (runs=3, browser-task + 48 negatives):** browser-task **24/25**, negatives **48/48** clean. Triggering here is high-variance (21–25/25 across four near-identical runs — the dispositional floor for action skills), so the gain is real but modest; the one remaining miss (a Slack-channel message) is a deliberate trade to keep negatives clean. Full analysis in [`opus-4-8-revalidation.md`](opus-4-8-revalidation.md).
+
 ---
 
 # Verified-clean entrances (no change needed)

--- a/internal/skill-routing-eval/reports/opus-4-8-revalidation.md
+++ b/internal/skill-routing-eval/reports/opus-4-8-revalidation.md
@@ -1,0 +1,42 @@
+# Opus 4.8 re-validation
+
+Re-ran the routing eval against `claude-opus-4-8` (the prior baseline in `final.md` was on opus-4-6) across all 14 auto-trigger skills. The family still routes correctly; one description was improved and one harness bug fixed.
+
+## Method
+
+`run.py` routes via the *installed* plugin cache. Master's auto-trigger descriptions are byte-identical to installed 5.0.4 for all 14 eval skills (only `muggle-do` differs, and it is explicit-only / out of scope), so the triage measured master directly. Description edits were validated by syncing the working-tree `SKILL.md` into the cache and re-running.
+
+## Triage (runs=1, full set)
+
+374/391 = **95.7%**. Negatives **48/48** — no muggle skill over-triggered. All 17 misses were under-triggers.
+
+runs=1 is noisy, so every flagged skill was re-confirmed at runs=3 (majority vote):
+
+| skill | runs=1 | runs=3 | verdict |
+|---|---|---|---|
+| muggle-browser-task | 17/25 | **20/25** | genuine systematic gap → fixed below |
+| muggle-repair | 21/24 | **24/24** | runs=1 "→status" misses were noise; no change |
+| muggle-feedback | 21/24 | **23/24** | runs=1 "→systematic-debugging" misses were noise; no change |
+| muggle-status | 24/24 | 24/24 | clean |
+| muggle | 22/24 | — | `/muggle`→none (noise) + one deliberately-ambiguous query; no change |
+| muggle-pr-followup | 23/24 | — | one loss to `muggle-do`; well above its documented best-effort ceiling (the `loop` collision); no change |
+
+The other eight skills were 100% at runs=1 (pr-visual-walkthrough, preferences, test, test-feature-local, test-import, test-prepare, regenerate-missing, upgrade).
+
+## The one fix: muggle-browser-task
+
+"Log into X and do Y" action requests routed to `none` — the model attempts or declines the task itself instead of invoking the skill. The original description was the thinnest of the real skills (322 ch) and named neither the user's verbs nor the model's failure mode.
+
+**Triggering here is high-variance.** Across four runs of near-identical pushier wording, recall swung 21–25/25 — these queries sit exactly on the model's invoke-or-act-directly boundary, so the number is noise-dominated (the dispositional floor for do-the-task skills; wording is a weak lever at this margin). The mean still beats the 20/25 baseline, so a pushier, more concrete description helps — it just cannot stably pin 25/25.
+
+Precision is the real constraint: listing "Slack" / "send a message" as triggers collided with the negative "ping the team on slack to review my PR" (a PR-coordination ask), which over-fired browser-task — more disruptive than an under-trigger. The shipped wording leads with transactional verbs and sites (submit the form, place the order, refund the charge, file the ticket, publish a post; Stripe, Jira, Shopify, the AWS console, WordPress, LinkedIn), pushes against declining, and drops the chat framing.
+
+**Result (runs=3, browser-task + 48 negatives):** browser-task **24/25** (was 20/25), negatives **48/48** clean. The single remaining miss — a Slack-channel message — is a deliberate trade to keep negatives clean; explicit `/mbt` remains the reliable path for that case.
+
+## Harness fix
+
+`run.py`'s `REPO_ROOT = HERE.parents[2]` resolved to the repo's *parent*, so the documented `run.py --all --sync-cache` (no explicit `--repo-root`) silently synced 0 descriptions and tested the installed copy instead of the edit. Corrected to `parents[1]`.
+
+## Net
+
+14/14 skills route correctly; negatives 48/48 clean. One description improved (browser-task 80%→96%), one harness bug fixed. The "wording is a weak lever for action/test skills" finding holds — browser-task is the only description that moved, and only modestly.

--- a/internal/skill-routing-eval/run.py
+++ b/internal/skill-routing-eval/run.py
@@ -28,7 +28,7 @@ import sys
 from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
-REPO_ROOT = HERE.parents[2]  # internal/skill-routing-eval -> repo root
+REPO_ROOT = HERE.parents[1]  # internal/skill-routing-eval -> repo root
 EVAL_SET = HERE / "eval-set.json"
 ROUTER = HERE / "router_eval.py"
 ANALYZE = HERE / "analyze.py"

--- a/plugin/skills/muggle-browser-task/SKILL.md
+++ b/plugin/skills/muggle-browser-task/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: muggle-browser-task
-description: Run a browser automation task on a website using natural language. Finds or creates the Muggle Test project, use case, test case, and script, then executes locally via the electron app. Use when the user wants to perform an action on a website (post, fill a form, click through a flow) rather than implement a code change.
+description: "Perform a real action on a website or web app from a plain-English instruction — log in and do the thing: submit a form, create or update a record, place an order, refund a charge, file a ticket, publish a post, click through and complete a multi-step flow (Stripe, Jira, Shopify, the AWS console, WordPress, LinkedIn, an admin dashboard). Use whenever the user wants something actually done in a web UI ('log into X and …', 'submit the form', 'create the ticket', 'refund the charge', 'place the order', 'update the listing'); Muggle drives a real browser to do it, so reach for this rather than declining or doing it by hand. Boundary: this performs the action (operating a site's own UI), not migrating personal data between consumer apps; to verify a flow works instead, use muggle-test-feature-local."
 ---
 
 # Muggle Test Task Runner


### PR DESCRIPTION
## What

Re-ran the `internal/skill-routing-eval` router eval against **claude-opus-4-8** (the prior baseline in `reports/final.md` was on opus-4-6) across all 14 auto-trigger skills. The family still routes correctly; this PR ships the one genuine fix plus a harness bug fix.

## Eval result

- **Triage (runs=1, 391 queries):** 374/391 = 95.7%; negatives **48/48** (no over-triggering).
- **runs=3 confirmation** of every flagged skill — most runs=1 misses were noise:
  - `muggle-repair` 24/24, `muggle-feedback` 23/24, `muggle-status` 24/24 → **no change** (a speculative repair edit was reverted).
  - `muggle-browser-task` **20/25** → the one genuine systematic gap.

## The fix: muggle-browser-task

"Log into X and do Y" action requests were routing to `none` — the model attempts or declines the task itself instead of invoking the skill. The original description (322 ch, thinnest real skill) named neither the user's verbs nor the failure mode.

New description leads with concrete transactional verbs + sites and pushes against declining. The `Slack`/`send a message` framing was deliberately dropped because it over-fired on the negative *"ping the team on slack to review my PR"*.

**runs=3 (browser-task + 48 negatives):** browser-task **24/25** (was 20/25), negatives **48/48** clean.

Triggering here is high-variance (recall swung 21–25/25 across four near-identical runs — the dispositional floor for action skills), so the gain is real but modest; the single remaining miss (a Slack-channel message) is a deliberate trade to keep negatives clean. Explicit `/mbt` remains the reliable path for that case.

## Harness fix

`run.py`'s `REPO_ROOT` resolved to the repo's *parent* (`parents[2]`), so the documented `run.py --all --sync-cache` silently synced 0 descriptions and tested the installed copy instead of the edit. Corrected to `parents[1]`.

## Files

- `plugin/skills/muggle-browser-task/SKILL.md` — description only (body unchanged).
- `internal/skill-routing-eval/run.py` — REPO_ROOT fix.
- `internal/skill-routing-eval/reports/opus-4-8-revalidation.md` — new report.
- `internal/skill-routing-eval/reports/optimization-log.md` — browser-task entry.

`dist/` is gitignored and rebuilt from source, so no built artifact is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)