### PR TITLE
feat(gitlab): Phase 2 — watcher + dev-cycle parity for GitLab MRs

### DIFF
--- a/plugin/skills/do/address-reviews.md
+++ b/plugin/skills/do/address-reviews.md
@@ -33,7 +33,9 @@ Before assembling work, rebase onto the latest default branch so the cycle addre
 
 ### Step 1 — Assemble the work set
 
-Two sources, combined into one batch (dedupe by comment id):
+Resolve the provider per [`../_shared/detect-vcs.md`](../_shared/detect-vcs.md), then assemble.
+
+**`github`** — two sources, combined into one batch (dedupe by comment id):
 
 **(a) The dispatched reviews.** For each review id in the input:
 
@@ -43,6 +45,8 @@ Two sources, combined into one batch (dedupe by comment id):
 **(b) Unaddressed comments on every unresolved thread.** Fetch unresolved threads per [`../_shared/github-cli-recipes/unresolved-threads.md`](../_shared/github-cli-recipes/unresolved-threads.md). For each thread classified **unaddressed human comment** — newest comment lacks the loop marker `<!-- muggle-do:bot -->` ([`loop-signature.md`](../_shared/pr-followup-helpers/loop-signature.md)) and post-dates the loop's last marked reply — add it to the batch — unresolved thread state, not any review-id watermark, is the authority here. This is how a human thread follow-up (a marker-less reply) gets addressed. **Exclude** comments whose review id is in `last_seen.escalated_review_ids` — paused awaiting the user, not re-work.
 
 Group (a) and (b) into one combined batch.
+
+**`gitlab`** — single source (no review-id watermark; discussion state is the sole authority). Fetch unresolved discussions per [`../_shared/gitlab-cli-recipes/unresolved-discussions.md`](../_shared/gitlab-cli-recipes/unresolved-discussions.md) (drop to [`../_shared/gitlab-cli-recipes/mr-discussions.md`](../_shared/gitlab-cli-recipes/mr-discussions.md) for raw notes where classification needs them). The input ids are discussion ids; the batch is every discussion classified **unaddressed human comment** — newest note lacks the marker and post-dates the loop's last marked note. **Exclude** discussions whose id is in `last_seen.escalated_review_ids`. A discussion is the unit of work in place of GitHub's review + line-comment pair.
 
 ### Step 2 — Classify each review
 
@@ -93,7 +97,7 @@ Invoke [`open-prs/update.md`](open-prs/update.md) (pass the PR URL + slug + exis
 
 #### 4f. Post per-comment inline replies
 
-Invoke [`per-comment-replies.md`](per-comment-replies.md) with the actionable reviews and the new SHA. One reply per comment, in its own thread, describing what was done for it.
+Invoke [`per-comment-replies.md`](per-comment-replies.md) with the actionable reviews (`gitlab`: discussions) and the new SHA. One reply per comment, in its own thread, describing what was done for it; on `gitlab` the same step also resolves each fully-addressed discussion.
 
 (The resolve-reminder runs once per round in Step 5.5 below — not only after a push — so a round that pushed nothing still nudges addressed-but-unresolved threads.)
 
@@ -109,7 +113,7 @@ Invoke [`resolve-reminder.md`](resolve-reminder.md) once, regardless of whether 
 
 ### Step 6 — Respawn the watcher
 
-Refresh PR state per [`../_shared/github-cli-recipes/pr-metadata.md`](../_shared/github-cli-recipes/pr-metadata.md). If the PR is now merged or closed:
+Refresh PR state with the provider resolved in Step 1 — `github` per [`../_shared/github-cli-recipes/pr-metadata.md`](../_shared/github-cli-recipes/pr-metadata.md), `gitlab` per [`../_shared/gitlab-cli-recipes/mr-metadata.md`](../_shared/gitlab-cli-recipes/mr-metadata.md) (`state == merged`/`closed`, lowercase). If the PR is now merged or closed:
 
 1. Write `result.md` per [`../muggle-pr-followup/state-schemas.md`](../muggle-pr-followup/state-schemas.md#resultmd).
 2. Do **not** respawn the watcher.

--- a/plugin/skills/do/fix-ci.md
+++ b/plugin/skills/do/fix-ci.md
@@ -10,7 +10,7 @@ Resolve red CI on a PR's head — lint/format, typecheck, and failing unit tests
 
 ## Input
 
-`$ARGUMENTS` carries a `github.com/.../pull/<n>` URL, `slug=<slug>`, and the failing check names (no review ids). Parse all three.
+`$ARGUMENTS` carries a PR/MR URL (`github.com/.../pull/<n>` or `<host>/<group>/<project>/-/merge_requests/<iid>`), `slug=<slug>`, and the failing check names (no review ids). Parse all three. The names are GitHub check-runs or — when the URL resolves `gitlab` per [`../_shared/detect-vcs.md`](../_shared/detect-vcs.md) — the failed pipeline-job names the watcher read off [`../_shared/gitlab-cli-recipes/mr-pipeline.md`](../_shared/gitlab-cli-recipes/mr-pipeline.md); the fix cycle below is identical for either.
 
 ## Inputs from disk
 

--- a/plugin/skills/do/per-comment-replies.md
+++ b/plugin/skills/do/per-comment-replies.md
@@ -2,13 +2,15 @@
 
 A `/muggle-do` step invoked from [`address-reviews.md`](address-reviews.md) (Step 4f) after the push has succeeded. Posts one inline nested reply on each line comment from the actionable reviews, describing what was done for that comment and referencing the new SHA.
 
-This is **not** a top-level "summary reply on the review." Each comment thread gets its own reply, in context, via GitHub's `/comments/{id}/replies` endpoint.
+This is **not** a top-level "summary reply on the review." Each comment thread gets its own reply, in context — on `github` via the `/comments/{id}/replies` endpoint, on `gitlab` via a threaded note on the discussion.
 
 ## Inputs
 
-- `actionable_reviews` — the list of reviews classified actionable in `address-reviews.md` Step 2.
+- `actionable_reviews` — the list of reviews classified actionable in `address-reviews.md` Step 2. On `gitlab`, these are the actionable **discussions** (no review envelope) — read each as a thread of notes.
 - `new_sha` — the SHA `open-prs/update.md` just pushed.
-- The PR's owner, repo, number.
+- The PR's owner, repo, number. On `gitlab`, the project ref and MR iid.
+
+Resolve the provider once per [`../_shared/detect-vcs.md`](../_shared/detect-vcs.md).
 
 ## Procedure
 
@@ -23,14 +25,18 @@ If a comment has no associated change in either source (e.g. the comment was a q
 
 ### Step 2 — Post one reply per comment
 
-For each comment id with a description:
+For each comment id with a description, post the reply with the resolved provider:
 
-```bash
-gh api --method POST \
-  -H "Accept: application/vnd.github+json" \
-  repos/<owner>/<repo>/pulls/<n>/comments/<comment-id>/replies \
-  -f body="<reply-body>"
-```
+- **`github`** — nested reply on the line comment:
+
+  ```bash
+  gh api --method POST \
+    -H "Accept: application/vnd.github+json" \
+    repos/<owner>/<repo>/pulls/<n>/comments/<comment-id>/replies \
+    -f body="<reply-body>"
+  ```
+
+- **`gitlab`** — one threaded note per actionable discussion per [`../_shared/gitlab-cli-recipes/reply-discussion.md`](../_shared/gitlab-cli-recipes/reply-discussion.md) (the discussion id stands in for the comment id), then resolve each fully-addressed thread per [`../_shared/gitlab-cli-recipes/resolve-discussion.md`](../_shared/gitlab-cli-recipes/resolve-discussion.md). The loop-marked reply is the addressed signal; the resolve is GitLab's equivalent of a reviewer closing the thread, which the loop can do directly. Resolving folds the discussion out of the next tick's actionable set, so no separate resolve-reminder nudge is needed for it.
 
 Reply body uses the template in [`../muggle-pr-followup/output-templates/inline-reply.md`](../muggle-pr-followup/output-templates/inline-reply.md):
 
@@ -43,7 +49,10 @@ Addressed in <short-sha>: <one-line summary of the change made for THIS comment>
 
 `<short-sha>` is the first 7 chars of `new_sha`; the body must contain that substring so the resolve-reminder stage knows which push addressed the thread. The trailing signature block is mandatory — its `<!-- muggle-do:bot -->` marker is what identifies the reply as loop-authored (see [`../_shared/pr-followup-helpers/loop-signature.md`](../_shared/pr-followup-helpers/loop-signature.md)).
 
-### Step 3 — Handle review-body-only comments
+### Step 3 — Handle review-body-only comments (GitHub only)
+
+GitLab has no review envelope — every note belongs to a discussion handled in Step 2 — so this step is GitHub-only.
+
 
 If an actionable review has a non-empty `body` and **zero** line comments, GitHub has no `/replies` endpoint for the review body itself (the API has been inconsistent on this and the only reliable path is a top-level PR comment that references the review). Use the *top-level reference* form:
 
@@ -63,5 +72,5 @@ Posted per [`../_shared/github-cli-recipes/top-level-comment.md`](../_shared/git
 
 ## Invariants
 
-- One reply per line comment. No per-review summary reply anywhere.
+- One reply per line comment (`gitlab`: per discussion). No per-review summary reply anywhere.
 - Every reply body contains the new SHA's 7-char prefix (which push addressed it) and ends with the loop signature block — the `<!-- muggle-do:bot -->` marker, not the author login, is what identifies loop-authored comments.

--- a/plugin/skills/do/resolve-reminder.md
+++ b/plugin/skills/do/resolve-reminder.md
@@ -14,21 +14,23 @@ This stage does not print a turn preamble — it runs inside `/muggle-do`'s addr
 
 ## Inputs
 
-- The current PR (URL, owner, repo, number) from the session's `prs.json`.
+- The current PR (URL, owner, repo, number) from the session's `prs.json`. On `gitlab`, the project ref and MR iid.
 - `last_seen.pushed_shas[]` from `last_seen.json` — the list of every SHA `/muggle-do` has pushed for this PR.
-- The loop user's GitHub login (cached in `state.md` under `Loop user:` — re-resolve per [`../_shared/github-cli-recipes/loop-user-identity.md`](../_shared/github-cli-recipes/loop-user-identity.md) if missing).
+- The loop user's login (cached in `state.md` under `Loop user:`) — re-resolve when missing, `github` per [`../_shared/github-cli-recipes/loop-user-identity.md`](../_shared/github-cli-recipes/loop-user-identity.md), `gitlab` per [`../_shared/gitlab-cli-recipes/loop-user-identity.md`](../_shared/gitlab-cli-recipes/loop-user-identity.md).
+
+Resolve the provider once per [`../_shared/detect-vcs.md`](../_shared/detect-vcs.md).
 
 ## Procedure
 
 ### Step 1 — Fetch unresolved comment threads
 
-Per [`../_shared/github-cli-recipes/unresolved-threads.md`](../_shared/github-cli-recipes/unresolved-threads.md). Filter client-side to `isResolved == false`. Each thread carries its line comments with `author.login`, `body`, and `databaseId`.
+`github` per [`../_shared/github-cli-recipes/unresolved-threads.md`](../_shared/github-cli-recipes/unresolved-threads.md) (filter client-side to `isResolved == false`; each thread carries its line comments with `author.login`, `body`, `databaseId`); `gitlab` per [`../_shared/gitlab-cli-recipes/unresolved-discussions.md`](../_shared/gitlab-cli-recipes/unresolved-discussions.md) (each discussion carries its `notes[]` and `id`).
 
 If the API call fails, log the error to `followup.log` and skip the stage. Do not surface a user-facing error — the resolve reminder is a nice-to-have, not load-bearing. The reply summaries on the threads themselves still happen.
 
 ### Step 2 — Classify each thread
 
-Per [`../_shared/github-cli-recipes/unresolved-threads.md`](../_shared/github-cli-recipes/unresolved-threads.md): walk each thread's comments in `createdAt` order and classify by the loop marker `<!-- muggle-do:bot -->` ([`../_shared/pr-followup-helpers/loop-signature.md`](../_shared/pr-followup-helpers/loop-signature.md)), not by `author.login`:
+Walk each thread's comments (`gitlab`: notes) in chronological order and classify by the loop marker `<!-- muggle-do:bot -->` ([`../_shared/pr-followup-helpers/loop-signature.md`](../_shared/pr-followup-helpers/loop-signature.md)), not by `author.login` — `github` per [`../_shared/github-cli-recipes/unresolved-threads.md`](../_shared/github-cli-recipes/unresolved-threads.md), `gitlab` per [`../_shared/gitlab-cli-recipes/unresolved-discussions.md`](../_shared/gitlab-cli-recipes/unresolved-discussions.md):
 
 - **Addressed, awaiting resolve** — the **newest** comment carries the marker. The loop replied and nothing newer is waiting. These feed the reminder.
 - **Unaddressed human comment** — the newest comment lacks the marker and post-dates the loop's last marked reply (or there is no loop reply yet). The address-reviews round handles these as work (Step 1 sweep), not the reminder.
@@ -42,7 +44,7 @@ Collect the thread `databaseId` of every thread classified **addressed, awaiting
 
 ### Step 4 — Post the top-level reminder comment
 
-If the resolve-reminder list is non-empty, post **one** top-level PR comment using the template in [`../muggle-pr-followup/output-templates/resolve-reminder.md`](../muggle-pr-followup/output-templates/resolve-reminder.md) per [`../_shared/github-cli-recipes/top-level-comment.md`](../_shared/github-cli-recipes/top-level-comment.md). The comment carries the loop signature, so a later round's scan won't read it back as a human comment.
+If the resolve-reminder list is non-empty, post **one** top-level comment using the template in [`../muggle-pr-followup/output-templates/resolve-reminder.md`](../muggle-pr-followup/output-templates/resolve-reminder.md) — `github` per [`../_shared/github-cli-recipes/top-level-comment.md`](../_shared/github-cli-recipes/top-level-comment.md), `gitlab` per [`../_shared/gitlab-cli-recipes/mr-note.md`](../_shared/gitlab-cli-recipes/mr-note.md). The comment carries the loop signature, so a later round's scan won't read it back as a human comment.
 
 If the list is empty, post **nothing**. Still emit telemetry so the stage's run is observable.
 
@@ -59,7 +61,7 @@ Emit one event per [`../_shared/telemetry-events/muggle-do-resolve-reminder.md`]
 
 This stage is best-effort. Any failure is logged to `followup.log` and silently skipped — the reviewer still gets the per-comment inline replies (the canonical signal that work was done), and the cycle continues to respawn the watcher.
 
-The one exception: do not silently swallow a `gh pr comment` failure if Step 4 ran. The comment is a user-visible artifact; if it fails, surface the underlying `gh` error to the user so they know the reminder didn't post.
+The one exception: do not silently swallow a Step 4 post failure (`gh pr comment` / `glab mr note`) if Step 4 ran. The comment is a user-visible artifact; if it fails, surface the underlying CLI error to the user so they know the reminder didn't post.
 
 ## Invariants
 

--- a/plugin/skills/muggle-pr-followup/contract.md
+++ b/plugin/skills/muggle-pr-followup/contract.md
@@ -50,24 +50,28 @@ If `state` is `MERGED` or `CLOSED`:
 
 ### Step 3 — Compute the actionable set from live thread state
 
-The watcher's dispatch trigger is **derived from current GitHub state**, not a stored review-id cursor — see the [thread-state baseline design](../../../../muggle-ai-brain/architecture/2026-06-06-pr-followup-thread-state-baseline-design.md). Two sources, unioned:
+The watcher's dispatch trigger is **derived from current provider state**, not a stored review-id cursor — see the [thread-state baseline design](../../../../muggle-ai-brain/architecture/2026-06-06-pr-followup-thread-state-baseline-design.md). Resolve the provider per [`../_shared/detect-vcs.md`](../_shared/detect-vcs.md), then:
 
-**(a) Actionable threads.** Fetch unresolved review threads per [`../_shared/github-cli-recipes/unresolved-threads.md`](../_shared/github-cli-recipes/unresolved-threads.md). A thread is **actionable** when `isResolved == false` **and** `isOutdated == false` **and** its newest comment lacks the loop marker `<!-- muggle-do:bot -->` — classify by the marker, never `author.login` (see [`../_shared/pr-followup-helpers/loop-signature.md`](../_shared/pr-followup-helpers/loop-signature.md)). The marker rule makes echo intrinsic: once the loop has replied, the thread's newest comment is the loop's own, so the thread is no longer actionable — no cursor to advance, no self-recursion (see [`../_shared/pr-followup-helpers/echo-skip.md`](../_shared/pr-followup-helpers/echo-skip.md)).
+- **`github`** — two sources, unioned:
 
-**(b) Actionable body-only reviews.** A body-only review — a submitted `CHANGES_REQUESTED`/`COMMENTED` review with no line comments — has no thread to derive state from, so it keeps a narrow watermark. Fetch submitted reviews per [`../_shared/github-cli-recipes/submitted-reviews.md`](../_shared/github-cli-recipes/submitted-reviews.md); a body-only review is actionable when `id > last_seen.lastBodyReviewId` **and** `id ∉ last_seen.escalated_review_ids`.
+  **(a) Actionable threads.** Fetch unresolved review threads per [`../_shared/github-cli-recipes/unresolved-threads.md`](../_shared/github-cli-recipes/unresolved-threads.md). A thread is **actionable** when `isResolved == false` **and** `isOutdated == false` **and** its newest comment lacks the loop marker `<!-- muggle-do:bot -->` — classify by the marker, never `author.login` (see [`../_shared/pr-followup-helpers/loop-signature.md`](../_shared/pr-followup-helpers/loop-signature.md)). The marker rule makes echo intrinsic: once the loop has replied, the thread's newest comment is the loop's own, so the thread is no longer actionable — no cursor to advance, no self-recursion (see [`../_shared/pr-followup-helpers/echo-skip.md`](../_shared/pr-followup-helpers/echo-skip.md)).
 
-Collect the **owning review ids** for dispatch: for each actionable thread, the owning review of its newest comment (`pullRequestReview.databaseId` from the query); plus every actionable body-only review id. The dedup'd union is the dispatch list.
+  **(b) Actionable body-only reviews — GitHub only.** A body-only review — a submitted `CHANGES_REQUESTED`/`COMMENTED` review with no line comments — has no thread to derive state from, so it keeps a narrow watermark. GitLab has no review envelope (feedback is always a discussion note), so this sub-branch is GitHub-only and has no GitLab analogue. Fetch submitted reviews per [`../_shared/github-cli-recipes/submitted-reviews.md`](../_shared/github-cli-recipes/submitted-reviews.md); a body-only review is actionable when `id > last_seen.lastBodyReviewId` **and** `id ∉ last_seen.escalated_review_ids`.
+
+  Collect the **owning review ids** for dispatch: for each actionable thread, the owning review of its newest comment (`pullRequestReview.databaseId` from the query); plus every actionable body-only review id. The dedup'd union is the dispatch list.
+
+- **`gitlab`** — single source. Fetch unresolved discussions per [`../_shared/gitlab-cli-recipes/unresolved-discussions.md`](../_shared/gitlab-cli-recipes/unresolved-discussions.md) (drop to [`../_shared/gitlab-cli-recipes/mr-discussions.md`](../_shared/gitlab-cli-recipes/mr-discussions.md) for the raw notes if a thread's classification needs them). A discussion is **actionable** when it is unresolved **and** its newest note lacks the loop marker `<!-- muggle-do:bot -->` — same marker classification, never `author.username`. There is no body-only watermark: discussion state is the sole authority. The dispatch list is the **discussion ids** of the actionable discussions.
 
 ### Step 4 — If the actionable set is non-empty → dispatch (reviews preempt CI)
 
-The watcher does **not** classify. Classification, batching, replying, escalation, and cycle execution all live in `/muggle-do`. The watcher hands over the owning review ids and exits — `/muggle-do`'s address-reviews re-derives the unresolved threads itself (its authority), so the watcher only needs to decide *that* there is work, not enumerate it exhaustively.
+The watcher does **not** classify. Classification, batching, replying, escalation, and cycle execution all live in `/muggle-do`. The watcher hands over the dispatch ids from Step 3 (GitHub: owning review ids; GitLab: discussion ids) and exits — `/muggle-do`'s address-reviews re-derives the unresolved threads itself (its authority), so the watcher only needs to decide *that* there is work, not enumerate it exhaustively.
 
 1. Reset `last_seen.idle_tick_count` to 0.
 2. **Stop this watcher (single-thread).** Cancel its cron so no tick fires while the dev cycle runs: `CronList`, find the job whose command ends with `/muggle:muggle-pr-followup <slug> <n>` (exact two-arg match), `CronDelete` it. `/muggle-do` respawns the watcher when the cycle finishes — exactly one cron ever, and no tick overlaps a running cycle.
 3. Dispatch `/muggle-do` with an *address-reviews* directive carrying:
    - PR URL (from `prs.json[0].url`)
    - Session slug (from the invocation arguments)
-   - The owning review ids from Step 3, as a space-separated list
+   - The dispatch ids from Step 3 (GitHub owning review ids / GitLab discussion ids), as a space-separated list
 
    Exact phrasing belongs to `/muggle-do`'s intent-routing. A reasonable shape is:
    ```
@@ -82,7 +86,7 @@ The watcher does **not** classify. Classification, batching, replying, escalatio
 A merge-ready branch is **current with its base** — neither conflicting nor behind. From the Step 1 metadata, the branch needs a rebase when either:
 
 - `mergeable == CONFLICTING` (corroborated by `mergeStateStatus == DIRTY`) — conflicts with the base, **or**
-- `behind_by > 0` — out of date with the base. Read this from the `compare` call (commit ancestry), **never** from `mergeStateStatus == BEHIND`: GitHub masks `BEHIND` behind `DIRTY`/`BLOCKED` and only surfaces it under "require branches up to date" protection, so a stale PR that is also awaiting review or has a red required check reports `BLOCKED` — and its staleness would go unseen. See [`../_shared/github-cli-recipes/pr-metadata.md`](../_shared/github-cli-recipes/pr-metadata.md#behind-by-out-of-date-detection).
+- `behind_by > 0` — out of date with the base. Read this from the `compare` call (commit ancestry), **never** from `mergeStateStatus == BEHIND`: GitHub masks `BEHIND` behind `DIRTY`/`BLOCKED` and only surfaces it under "require branches up to date" protection, so a stale PR that is also awaiting review or has a red required check reports `BLOCKED` — and its staleness would go unseen. See [`../_shared/github-cli-recipes/pr-metadata.md`](../_shared/github-cli-recipes/pr-metadata.md#behind-by-out-of-date-detection). On `gitlab`, the same behind-by comes from the compare in [`../_shared/gitlab-cli-recipes/mr-metadata.md`](../_shared/gitlab-cli-recipes/mr-metadata.md#behind-by-out-of-date-detection) (commit ancestry, not `detailed_merge_status`); conflict is `detailed_merge_status` in `{broken_status, conflict}`.
 
 This trigger is **independent of approval and CI state**: an out-of-date branch is rebased whether or not it has been reviewed, approved, or has green checks. The watcher acts on staleness directly — it never waits for an approval to surface it.
 
@@ -102,7 +106,7 @@ Otherwise — `behind_by == 0` and not conflicting (`mergeable == UNKNOWN` is fi
 
 ### Step 6 — No actionable feedback, branch current → poll CI for the head SHA
 
-Fetch the check-run rollup for `prs.json[0].head_sha` per [`../_shared/github-cli-recipes/pr-checks.md`](../_shared/github-cli-recipes/pr-checks.md), then:
+Fetch the CI rollup for `prs.json[0].head_sha`, provider resolved as in Step 3 — `github` → the check-run rollup per [`../_shared/github-cli-recipes/pr-checks.md`](../_shared/github-cli-recipes/pr-checks.md); `gitlab` → the pipeline-job rollup per [`../_shared/gitlab-cli-recipes/mr-pipeline.md`](../_shared/gitlab-cli-recipes/mr-pipeline.md) (failed/running/success jobs fold into the same red/pending/green buckets). Then, on the bucket:
 
 - **Any check still pending** (`bucket == "pending"`) → idle (wait for checks to settle).
 - **All checks green / skipped, or no checks** → idle (green path).


### PR DESCRIPTION
## Goal
Phase 2 of GitLab support: make the **muggle-pr-followup** watcher and **muggle-do** dev cycle work end-to-end on a GitLab MR exactly like a GitHub PR. Builds on Phase 1 (#271, merged) which added provider detection + MR creation/recognition.

## Acceptance Criteria
- Watcher tick polls GitLab MR **discussions** (marker-aware) for the actionable set and **pipeline** status for CI; rebase trigger works via the MR compare.
- address-reviews assembles from discussions, replies one loop-marked note per discussion and resolves fully-addressed threads, nudges via MR note, refreshes via MR metadata.
- fix-ci feeds a failed GitLab pipeline into the same fix cycle.
- GitHub paths unchanged; one-way dependency rule honored.

## Changes
Provider-branch (resolved once via `_shared/detect-vcs.md`) added to 5 skill files; `github` paths byte-stable, `gitlab` reuses the Phase-1 `gitlab-cli-recipes/` (no new recipe):
- `muggle-pr-followup/contract.md` — Step 3 actionable discussions (body-only `lastBodyReviewId` watermark marked **GitHub-only** — GitLab has no review envelope), Step 5 behind-by via `mr-metadata` compare (not `detailed_merge_status`), Step 6 CI via `mr-pipeline` buckets.
- `do/address-reviews.md` — Step 1 assemble from discussions (no review-id watermark), Step 4f resolve fully-addressed, Step 6 refresh via `mr-metadata`.
- `do/per-comment-replies.md` — `reply-discussion` + `resolve-discussion`; body-only step marked GitHub-only.
- `do/resolve-reminder.md` — loop-user via `loop-user-identity`, fetch/classify via `unresolved-discussions`, nudge via `mr-note`.
- `do/fix-ci.md` — failed GitLab pipeline-jobs via `mr-pipeline` into the identical fix cycle.

## Validation
unit-only (vitest **24 files / 271 tests pass**, 0 fail; `tsc --noEmit` 0; no `.ts` changed → eslint N/A). No web UI in this repo → no browser E2E. Markdown-only skill edits, so no new TS unit surface; the Phase-1 `prOpened` guardrail is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)