### PR TITLE
chore(release): @muggleai/works 5.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "5.0.4"
+      "version": "5.1.0"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "5.0.4"
+      "version": "5.1.0"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@muggleai/works",
   "mcpName": "io.github.multiplex-ai/muggle",
-  "version": "5.0.4",
+  "version": "5.1.0",
   "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
   "type": "module",
   "main": "dist/index.js",
@@ -42,14 +42,14 @@
     "test:watch": "vitest"
   },
   "muggleConfig": {
-    "electronAppVersion": "1.2.3",
+    "electronAppVersion": "1.4.0",
     "downloadBaseUrl": "https://github.com/multiplex-ai/muggle-ai-works/releases/download",
     "runtimeTargetDefault": "dev",
     "checksums": {
-      "darwin-arm64": "f46cfc5f052021f13de7d7721276d58863b958ec717631e98b97b7cd3d0fe4fa",
-      "darwin-x64": "e2254373a0bb3fffa46b236629c5d54a611ab05e138104a98f6f60a5d1280805",
-      "linux-x64": "ff5698fdbc1d65f436b75d860ebe50ee7171c7726565fa0ab2149a6f1cde4d13",
-      "win32-x64": "35ffa7af1767e802c7670c85205ea11961cb5583aa5dc30947d142eb7c734ff5"
+      "darwin-arm64": "9dd7ac0a378a1d5db908a102aec4f596741e943572a7d55b08e2a62f336981bc",
+      "darwin-x64": "70c9c6df21e03ad1529682e6cf8150ddfef306e1019e4b3bd2a4e7d025a98d64",
+      "linux-x64": "14ee27b3c22988bf72f13f3734e1594dcbb0fb94f699d5ad789ea8cf452dc7a1",
+      "win32-x64": "9e059917ba4605527b47d23b43bd78438cf59e7df38c4c9698f6b9487ed64a97"
     }
   },
   "dependencies": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "5.0.4",
+  "version": "5.1.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "5.0.4",
+  "version": "5.1.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/scripts/guardrails.mjs
+++ b/plugin/scripts/guardrails.mjs
@@ -27,14 +27,16 @@ function markPrHandled(sessionId2, prUrl, dirOverride) {
 
 // src/guardrails/prOpened.ts
 var PR_URL = /https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/\d+/;
+var MR_URL = /https?:\/\/[^/\s]+\/[^\s]+\/-\/merge_requests\/\d+/;
 var CREATE_CMD = /\bgh\s+pr\s+(create|ready)\b/;
+var MR_CREATE_CMD = /\bglab\s+mr\s+create\b|\bglab\s+mr\s+update\b.*--ready\b/;
 function detectPrOpened(input2) {
   if (input2.tool_name !== "Bash") return null;
   const cmd = input2.tool_input?.command ?? "";
-  if (!CREATE_CMD.test(cmd)) return null;
+  if (!CREATE_CMD.test(cmd) && !MR_CREATE_CMD.test(cmd)) return null;
   const out = `${input2.tool_response?.stdout ?? ""}
 ${input2.tool_response?.output ?? ""}`;
-  const m = out.match(PR_URL);
+  const m = out.match(PR_URL) ?? out.match(MR_URL);
   return m ? m[0] : null;
 }
 

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "5.0.4",
+  "version": "5.1.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "5.0.4",
+      "version": "5.1.0",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
## Release 5.1.0

Minor bump **5.0.4 → 5.1.0**. Baseline = max(npm 5.0.4, master 5.0.4); `feat` work with no breaking changes → minor.

### Shipping (since 5.0.4 / #266)

| PR | Change |
| :- | :----- |
| #271, #274 | **feat(gitlab):** GitLab MR support — Phase 1 (recognize + open via `glab`) + Phase 2 (watcher + dev-cycle parity) |
| #275 | refactor(skills): consolidate VCS recipes under `_shared/vcs/` |
| #267 | refactor(local): works drops publish, reads studio-published cloud refs |
| #272 | fix(skills): tighten muggle-browser-task triggering |
| #270 | fix(muggle-do): honor `postPRVisualWalkthrough` gate in open-prs |
| #269 | fix(pr-followup): make E2E validation optional in URL-bootstrap |
| #263 | refactor(muggle-test): router + per-path execution files |
| #268 | chore(skills): broaden muggle-do auto-trigger description |
| #264 | local runs: tag `executionSource` so studio skips duplicate cloud write |

### Electron

Bumped `electronAppVersion` **1.2.3 → 1.4.0** + all four `muggleConfig.checksums`, verified against the `electron-app-v1.4.0` release artifacts.

### Manifests

Synced by `sync:versions` (not hand-edited): both `marketplace.json`, both `plugin.json`, `server.json`, `plugin/scripts/guardrails.mjs`.

### Verification

- `lint:check` 0 errors · `typecheck` clean · `test` 24 files / 271 pass
- `build` ok · `verify:plugin` pass · `verify:contracts` pass · `verify:electron-release-checksums` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)