### PR TITLE
feat(preferences): max-automation defaults at init + gate-key reconciliation + enforced footer

### DIFF
--- a/internal/skill-gate-eval/README.md
+++ b/internal/skill-gate-eval/README.md
@@ -26,16 +26,19 @@ back to the same place.
 
 ## Running
 
-Layer 2 is run **manually** until the suite is stable. From the
-muggle-ai-works repo root:
+Layer 2 is **ad-hoc**, never wired to CI — trigger it by hand when you
+want it. From the muggle-ai-works repo root, via the `test:gates:behavioral`
+script (forward args after `--`):
 
 ```bash
 MUGGLE_BRAIN_DIR=../muggle-ai-brain \
-  pnpm tsx internal/skill-gate-eval/src/run.ts \
+  pnpm test:gates:behavioral -- \
     --gate showElectronBrowser \
     --skill muggle-test-feature-local \
     --runs 10
 ```
+
+(equivalently `pnpm tsx internal/skill-gate-eval/src/run.ts …`)
 
 **Auth:** the harness drives `@anthropic-ai/claude-agent-sdk`'s `query()`, which uses your **Claude Code login session** by default — no API key needed when you're logged in. Set `ANTHROPIC_API_KEY` (prefix the command) only where there's no login session, e.g. headless CI.
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "lint:check": "eslint .",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:gates:behavioral": "tsx internal/skill-gate-eval/src/run.ts"
   },
   "muggleConfig": {
     "electronAppVersion": "1.4.0",

--- a/packages/mcps/src/shared/preferences-constants.ts
+++ b/packages/mcps/src/shared/preferences-constants.ts
@@ -18,25 +18,36 @@ export const PREFERENCES_PROJECT_DIR_NAME = ".muggle-ai";
 /** Current schema version. */
 export const PREFERENCES_VERSION = 1;
 
-/** Default preferences — every knob set to "ask". */
+/**
+ * Default preferences — max automation out of the box. Every knob defaults
+ * to its proceed-without-asking value. Two deliberate exceptions:
+ * `showElectronBrowser` stays visible so a new user sees their first run, and
+ * `verboseOutput` stays quiet (it's UX noise, not automation).
+ * `defaultExecutionMode` resolves to `local` rather than re-prompting.
+ */
 export const DEFAULT_PREFERENCES: IPreferences = {
-  [PreferenceKey.AutoLogin]: PreferenceValue.Ask,
-  [PreferenceKey.AutoSelectProject]: PreferenceValue.Ask,
-  [PreferenceKey.AutoSelectLocalHost]: PreferenceValue.Ask,
-  [PreferenceKey.ShowElectronBrowser]: PreferenceValue.Ask,
-  [PreferenceKey.OpenTestResultsAfterRun]: PreferenceValue.Ask,
-  [PreferenceKey.DefaultExecutionMode]: PreferenceValue.Ask,
-  [PreferenceKey.SuggestRelatedUseCases]: PreferenceValue.Ask,
-  [PreferenceKey.SuggestRelatedTestCases]: PreferenceValue.Ask,
-  [PreferenceKey.AutoDetectChanges]: PreferenceValue.Ask,
-  [PreferenceKey.PostPRVisualWalkthrough]: PreferenceValue.Ask,
-  [PreferenceKey.AutoCreatePR]: PreferenceValue.Ask,
-  [PreferenceKey.CheckForUpdates]: PreferenceValue.Ask,
-  [PreferenceKey.VerboseOutput]: PreferenceValue.Ask,
-  [PreferenceKey.AutoUseWorktree]: PreferenceValue.Ask,
-  [PreferenceKey.AutoRebase]: PreferenceValue.Ask,
-  [PreferenceKey.AutoCleanup]: PreferenceValue.Ask,
+  [PreferenceKey.AutoLogin]: PreferenceValue.Always,
+  [PreferenceKey.AutoSelectProject]: PreferenceValue.Always,
+  [PreferenceKey.AutoSelectLocalHost]: PreferenceValue.Always,
+  [PreferenceKey.ShowElectronBrowser]: PreferenceValue.Always,
+  [PreferenceKey.OpenTestResultsAfterRun]: PreferenceValue.Always,
+  [PreferenceKey.DefaultExecutionMode]: PreferenceValue.Local,
+  [PreferenceKey.SuggestRelatedUseCases]: PreferenceValue.Always,
+  [PreferenceKey.SuggestRelatedTestCases]: PreferenceValue.Always,
+  [PreferenceKey.AutoDetectChanges]: PreferenceValue.Always,
+  [PreferenceKey.PostPRVisualWalkthrough]: PreferenceValue.Always,
+  [PreferenceKey.AutoCreatePR]: PreferenceValue.Always,
+  [PreferenceKey.CheckForUpdates]: PreferenceValue.Always,
+  [PreferenceKey.VerboseOutput]: PreferenceValue.Never,
+  [PreferenceKey.AutoUseWorktree]: PreferenceValue.Always,
+  [PreferenceKey.AutoRebase]: PreferenceValue.Always,
+  [PreferenceKey.AutoCleanup]: PreferenceValue.Always,
   [PreferenceKey.AutoE2ETest]: PreferenceValue.Always,
+  [PreferenceKey.AutoResolveConflicts]: PreferenceValue.Always,
+  [PreferenceKey.AutoReuseValidationContext]: PreferenceValue.Always,
+  [PreferenceKey.AutoRouteBuildToMuggleDo]: PreferenceValue.Always,
+  [PreferenceKey.AutoWatchPR]: PreferenceValue.Always,
+  [PreferenceKey.ReusePreparePlan]: PreferenceValue.Always,
 };
 
 const ALWAYS_ASK_NEVER = [
@@ -79,6 +90,11 @@ export const PREFERENCE_ALLOWED_VALUES: Record<PreferenceKey, readonly Preferenc
   [PreferenceKey.AutoRebase]: ALWAYS_ASK_NEVER,
   [PreferenceKey.AutoCleanup]: ALWAYS_ASK_NEVER,
   [PreferenceKey.AutoE2ETest]: ALWAYS_ASK,
+  [PreferenceKey.AutoResolveConflicts]: ALWAYS_ASK_NEVER,
+  [PreferenceKey.AutoReuseValidationContext]: ALWAYS_ASK_NEVER,
+  [PreferenceKey.AutoRouteBuildToMuggleDo]: ALWAYS_ASK_NEVER,
+  [PreferenceKey.AutoWatchPR]: ALWAYS_ASK_NEVER,
+  [PreferenceKey.ReusePreparePlan]: ALWAYS_ASK_NEVER,
 };
 
 /** Human-readable schema for each preference — used in setup wizard and validation. */
@@ -133,5 +149,20 @@ export const PREFERENCES_SCHEMA: Record<PreferenceKey, IPreferenceSchemaEntry> =
   },
   [PreferenceKey.AutoE2ETest]: {
     description: "Run Stage 6 (E2E acceptance) at the end of every /muggle-do cycle (default always — running E2E is the point of muggle-do; never is not an option)",
+  },
+  [PreferenceKey.AutoResolveConflicts]: {
+    description: "When a rebase onto the default branch hits conflicts, resolve them autonomously behind a verify-or-rollback gate instead of aborting and escalating",
+  },
+  [PreferenceKey.AutoReuseValidationContext]: {
+    description: "When a prior session left an E2E validation context for this working tree, reuse it instead of re-asking the validation questions",
+  },
+  [PreferenceKey.AutoRouteBuildToMuggleDo]: {
+    description: "When a prompt looks like a build/implement/fix request, route it through the /muggle-do pipeline (requirements → build → impact → tests → E2E → PR → watcher)",
+  },
+  [PreferenceKey.AutoWatchPR]: {
+    description: "After a test run opens a PR, start a muggle-pr-followup watcher that polls for new reviews and hands them to /muggle-do",
+  },
+  [PreferenceKey.ReusePreparePlan]: {
+    description: "Reuse the saved prepare plan for this stack (skip discovery, jump to check-running + smoke-test) instead of rediscovering from scratch",
   },
 };

--- a/packages/mcps/src/shared/preferences-types.ts
+++ b/packages/mcps/src/shared/preferences-types.ts
@@ -40,6 +40,16 @@ export enum PreferenceKey {
   AutoCleanup = "autoCleanup",
   /** Run Stage 6 (E2E acceptance) at the end of every /muggle-do cycle. */
   AutoE2ETest = "autoE2ETest",
+  /** Resolve rebase conflicts autonomously (verify-or-rollback) instead of escalating. */
+  AutoResolveConflicts = "autoResolveConflicts",
+  /** Reuse a prior session's E2E validation context instead of re-asking. */
+  AutoReuseValidationContext = "autoReuseValidationContext",
+  /** Route build/implement/fix requests through the /muggle-do pipeline. */
+  AutoRouteBuildToMuggleDo = "autoRouteBuildToMuggleDo",
+  /** After a test run opens a PR, start a muggle-pr-followup watcher on it. */
+  AutoWatchPR = "autoWatchPR",
+  /** Reuse the saved prepare plan for this stack instead of rediscovering. */
+  ReusePreparePlan = "reusePreparePlan",
 }
 
 /**

--- a/packages/mcps/src/test/preferences.test.ts
+++ b/packages/mcps/src/test/preferences.test.ts
@@ -32,9 +32,9 @@ import {
 } from "../shared/preferences.js";
 
 describe("PreferenceKey enum", () => {
-  it("has exactly 17 keys", () => {
+  it("has exactly 22 keys", () => {
     const keys = Object.values(PreferenceKey);
-    expect(keys).toHaveLength(17);
+    expect(keys).toHaveLength(22);
   });
 
   it("contains all expected keys", () => {
@@ -55,6 +55,11 @@ describe("PreferenceKey enum", () => {
     expect(PreferenceKey.AutoRebase).toBe("autoRebase");
     expect(PreferenceKey.AutoCleanup).toBe("autoCleanup");
     expect(PreferenceKey.AutoE2ETest).toBe("autoE2ETest");
+    expect(PreferenceKey.AutoResolveConflicts).toBe("autoResolveConflicts");
+    expect(PreferenceKey.AutoReuseValidationContext).toBe("autoReuseValidationContext");
+    expect(PreferenceKey.AutoRouteBuildToMuggleDo).toBe("autoRouteBuildToMuggleDo");
+    expect(PreferenceKey.AutoWatchPR).toBe("autoWatchPR");
+    expect(PreferenceKey.ReusePreparePlan).toBe("reusePreparePlan");
   });
 });
 
@@ -103,10 +108,15 @@ describe("DEFAULT_PREFERENCES", () => {
     }
   });
 
-  it("defaults every key to ask except autoE2ETest (always)", () => {
+  it("defaults to max automation (always) except defaultExecutionMode (local) and verboseOutput (never)", () => {
     for (const [key, value] of Object.entries(DEFAULT_PREFERENCES)) {
-      const expected = key === "autoE2ETest" ? PreferenceValue.Always : PreferenceValue.Ask;
-      expect(value).toBe(expected);
+      const expected =
+        key === PreferenceKey.DefaultExecutionMode
+          ? PreferenceValue.Local
+          : key === PreferenceKey.VerboseOutput
+            ? PreferenceValue.Never
+            : PreferenceValue.Always;
+      expect(value, `DEFAULT_PREFERENCES.${key}`).toBe(expected);
     }
   });
 });
@@ -169,11 +179,11 @@ describe("PreferencesService", () => {
       const filePath = path.join(globalDir, "preferences.json");
       fs.writeFileSync(filePath, JSON.stringify({
         version: 1,
-        preferences: { autoLogin: "always" },
+        preferences: { autoLogin: "never" },
       }));
       const prefs = readGlobalPreferences(globalDir);
-      expect(prefs.autoLogin).toBe("always");
-      expect(prefs.autoSelectProject).toBe("ask");
+      expect(prefs.autoLogin).toBe("never"); // saved value overrides the default
+      expect(prefs.autoSelectProject).toBe("always"); // unsaved key falls back to default
     });
   });
 
@@ -199,7 +209,7 @@ describe("PreferencesService", () => {
     it("merges global + project, project wins", () => {
       fs.writeFileSync(
         path.join(globalDir, "preferences.json"),
-        JSON.stringify({ version: 1, preferences: { autoLogin: "always", verboseOutput: "never" } }),
+        JSON.stringify({ version: 1, preferences: { autoLogin: "always", verboseOutput: "always" } }),
       );
       const overrideDir = path.join(projectDir, ".muggle-ai");
       fs.mkdirSync(overrideDir, { recursive: true });
@@ -209,9 +219,9 @@ describe("PreferencesService", () => {
       );
 
       const resolved = resolvePreferences(globalDir, projectDir);
-      expect(resolved.autoLogin).toBe("never");
-      expect(resolved.verboseOutput).toBe("never");
-      expect(resolved.checkForUpdates).toBe("ask");
+      expect(resolved.autoLogin).toBe("never"); // project overrides global
+      expect(resolved.verboseOutput).toBe("always"); // global override (non-default) survives
+      expect(resolved.checkForUpdates).toBe("always"); // unset everywhere → default
     });
   });
 
@@ -289,8 +299,9 @@ describe("PreferencesService", () => {
   describe("formatPreferencesOneLiner", () => {
     it("formats all preferences into a compact string", () => {
       const result = formatPreferencesOneLiner(DEFAULT_PREFERENCES);
-      expect(result).toContain("autoLogin=ask");
-      expect(result).toContain("verboseOutput=ask");
+      expect(result).toContain("autoLogin=always");
+      expect(result).toContain("verboseOutput=never");
+      expect(result).toContain("defaultExecutionMode=local");
     });
   });
 });

--- a/plugin/skills/muggle-preferences/preference-gates/README.md
+++ b/plugin/skills/muggle-preferences/preference-gates/README.md
@@ -16,16 +16,19 @@ which uses `local` / `remote` / `ask`).
 
 ## Gate behavior
 
-- `always` → take the pro-action, then print silent footer.
-- `never` → take the skip-action, then print silent footer.
+- `always` → take the pro-action, then **always** print the silent footer.
+- `never` → take the skip-action, then **always** print the silent footer.
 - `ask` (or absent) → run Picker 1 (per-key file) → Picker 2 (below).
 
 `defaultExecutionMode` uses `local`/`remote` instead of `always`/`never`.
 
-## Silent footer (whenever pickers are skipped)
+## Silent footer (mandatory whenever a prompt is skipped)
 
-The user must always be told **what happened**, **why it was silent**, and
-**how to change it**. Two lines:
+Whenever a gate resolves to a non-`ask` value and skips its picker, the footer
+below is **required** — every gate, every time, no exceptions. It tells the
+user **what happened**, **why it was silent**, and **how to change it**. The
+`preference-gates-lint` test enforces that this contract exists; omitting the
+footer when a gate fires is a bug. Two lines:
 
 ```
 ✓ <silent action from per-key file>

--- a/src/test/skills/preference-gates-lint.test.ts
+++ b/src/test/skills/preference-gates-lint.test.ts
@@ -10,6 +10,14 @@ import { describe, it, expect } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+// Import the leaf modules, not the package barrel: the barrel has import-time
+// side effects (config/logger) that need the root package.json's muggleConfig
+// and throw when pulled into this test. These two modules are side-effect-free.
+import { PreferenceKey } from "../../../packages/mcps/src/shared/preferences-types.js";
+import {
+  DEFAULT_PREFERENCES,
+  PREFERENCE_ALLOWED_VALUES,
+} from "../../../packages/mcps/src/shared/preferences-constants.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, "../../..");
@@ -169,6 +177,61 @@ describe("preference-gate contract lint", () => {
           allReferencedGates.has(key),
           `preference-gates/${key}.md is gated but no skill's Preferences table references it`,
         ).toBe(true);
+      });
+    }
+  });
+
+  describe("code/contract parity: PreferenceKey enum === gate files", () => {
+    const enumKeys = new Set<string>(Object.values(PreferenceKey));
+    const fileKeys = new Set(gateFiles);
+    for (const key of enumKeys) {
+      it(`PreferenceKey.${key} has a gate file`, () => {
+        expect(
+          fileKeys.has(key),
+          `PreferenceKey "${key}" has no preference-gates/${key}.md — add the gate file`,
+        ).toBe(true);
+      });
+    }
+    for (const key of fileKeys) {
+      it(`${key}.md has a PreferenceKey entry`, () => {
+        expect(
+          enumKeys.has(key),
+          `preference-gates/${key}.md has no PreferenceKey entry — the gate is unsettable and unseeded`,
+        ).toBe(true);
+      });
+    }
+  });
+
+  describe("defaults sanity: every key has a default in its allowed set", () => {
+    for (const key of Object.values(PreferenceKey)) {
+      it(`${key} default is present and allowed`, () => {
+        const def = (DEFAULT_PREFERENCES as Record<string, string>)[key];
+        expect(def, `DEFAULT_PREFERENCES is missing ${key}`).toBeDefined();
+        const allowed = (
+          PREFERENCE_ALLOWED_VALUES as Record<string, readonly string[]>
+        )[key];
+        expect(
+          allowed.includes(def),
+          `DEFAULT_PREFERENCES.${key} = "${def}" is not in allowed {${allowed.join(",")}}`,
+        ).toBe(true);
+      });
+    }
+  });
+
+  describe("footer contract: the canonical silent footer is mandated", () => {
+    const readme = fs.readFileSync(path.join(GATES_DIR, "README.md"), "utf8");
+    it("README declares the footer required on every skipped prompt", () => {
+      expect(/Skipped the prompt/.test(readme)).toBe(true);
+      expect(/`\/muggle-preferences <key>`/.test(readme)).toBe(true);
+      expect(/required|mandatory/i.test(readme)).toBe(true);
+    });
+    for (const [key, contract] of gateContracts) {
+      if (contract.ungated) continue;
+      it(`${key}.md declares a Silent action the footer can render`, () => {
+        expect(
+          contract.silentActionValues.size,
+          `${key}.md has no Silent action — a skipped ${key} gate would have no footer text`,
+        ).toBeGreaterThan(0);
       });
     }
   });


### PR DESCRIPTION
## What

Three coupled changes to the preference/gate system.

### 1. Max-automation defaults at init
A fresh install now seeds **max automation** instead of `ask`. `DEFAULT_PREFERENCES` sets every knob to `always`, with two deliberate exceptions:
- `defaultExecutionMode = local` — pick a concrete mode rather than re-prompting.
- `verboseOutput = never` — it's UX noise, not automation.

`showElectronBrowser` stays `always` (visible) so a new user sees their first run.

> ⚠️ **Behavior change for new installs only.** Existing installs are untouched: `setup` seeds `preferences.json` only when it's absent, and reads fill only missing keys. No migration runs against an existing file.

### 2. Reconcile the 17↔22 key drift
Five gates had a contract file (`preference-gates/*.md`) but **no code key**, so they were unsettable and unseeded: `autoResolveConflicts`, `autoReuseValidationContext`, `autoRouteBuildToMuggleDo`, `autoWatchPR`, `reusePreparePlan`. All five are fired by skills (`do/`, `muggle-test`, `muggle-test-prepare`, `muggle-pr-followup`). They're now added to `PreferenceKey`, `DEFAULT_PREFERENCES` (→ `always`), `PREFERENCE_ALLOWED_VALUES`, and `PREFERENCES_SCHEMA`. The MCP set-tool enum already derives from `PreferenceKey`, so it picks them up automatically. **Code enum == 22 gate files == seeded defaults.**

### 3. Enforce the footer + extend the lint
- The silent gate footer (value + change command, on every skipped prompt) is now **mandatory and canonical** in the gate contract README.
- `preference-gates-lint.test.ts` (runs in CI via `pnpm test`) gains three checks: **enum↔gate-file parity** (closes the drift that was previously invisible to the lint), **default sanity** (every key has a default within its allowed set), and **footer-contract presence**.
- The behavioral eval stays **ad-hoc** via a new `pnpm test:gates:behavioral` script — deliberately **not** wired to CI.

## Verification
- `pnpm test` (root, 359) ✓ · gate-lint (168) ✓ · workspace tests (mcp 154, workflows 4) ✓
- `pnpm typecheck` ✓ · `pnpm lint:check` ✓ (0 errors) · `pnpm build` ✓ · `verify:plugin` ✓ · `verify:contracts` ✓
- Default-seeding is unit-covered (`readGlobalPreferences` returns `DEFAULT_PREFERENCES` when no file exists; `setup.test.ts` writes them).

## Out of scope
Gate semantics, new gates, picker-flow refactor, wiring the behavioral eval to CI.