### PR TITLE
feat(mcp): lane-aware test-script-list (local-lane fetch for replay)

### DIFF
--- a/packages/mcps/src/mcp/e2e/contracts/index.ts
+++ b/packages/mcps/src/mcp/e2e/contracts/index.ts
@@ -367,6 +367,7 @@ export const TestCaseUpdateInputSchema = z.object({
 export const TestScriptListInputSchema = z.object({
   projectId: IdSchema.describe("Project ID (UUID) to list test scripts for"),
   testCaseId: IdSchema.optional().describe("Optional test case ID (UUID) to filter scripts by"),
+  runEnvironmentType: RunEnvironmentInputSchema,
 }).merge(PaginationInputSchema);
 
 export const TestScriptGetInputSchema = z.object({

--- a/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
+++ b/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
@@ -452,7 +452,7 @@ const testScriptTools: IQaToolDefinition[] = [
   {
     name: "muggle-remote-test-script-list",
     description:
-      "List test scripts for a project, optionally filtered by test case. Returns up to 10 items per page by default (max 100). Response includes pagination metadata (totalCount, totalPages, hasMore) — check `hasMore` to decide whether to fetch additional pages.",
+      "List test scripts for a project, optionally filtered by test case and by environment lane. Returns up to 10 items per page by default (max 100). Response includes pagination metadata (totalCount, totalPages, hasMore) — check `hasMore` to decide whether to fetch additional pages. Pass runEnvironmentType: 'local' to fetch the local-lane (localhost) script for a local replay, or 'remote' for the deployed script.",
     inputSchema: schemas.TestScriptListInputSchema,
     mapToUpstream: (input) => {
       const data = input as z.infer<typeof schemas.TestScriptListInputSchema>;
@@ -462,6 +462,7 @@ const testScriptTools: IQaToolDefinition[] = [
         queryParams: {
           projectId: data.projectId,
           testCaseId: data.testCaseId,
+          type: data.runEnvironmentType,
           page: data.page,
           pageSize: data.pageSize,
           sortBy: data.sortBy,

--- a/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
+++ b/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
@@ -462,7 +462,7 @@ const testScriptTools: IQaToolDefinition[] = [
         queryParams: {
           projectId: data.projectId,
           testCaseId: data.testCaseId,
-          type: data.runEnvironmentType,
+          runEnvironmentType: data.runEnvironmentType,
           page: data.page,
           pageSize: data.pageSize,
           sortBy: data.sortBy,

--- a/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
+++ b/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
@@ -452,7 +452,7 @@ const testScriptTools: IQaToolDefinition[] = [
   {
     name: "muggle-remote-test-script-list",
     description:
-      "List test scripts for a project, optionally filtered by test case and by environment lane. Returns up to 10 items per page by default (max 100). Response includes pagination metadata (totalCount, totalPages, hasMore) — check `hasMore` to decide whether to fetch additional pages. Pass runEnvironmentType: 'local' to fetch the local-lane (localhost) script for a local replay, or 'remote' for the deployed script.",
+      "List test scripts for a project, optionally filtered by test case and by environment lane. Returns up to 10 items per page by default (max 100). Response includes pagination metadata (totalCount, totalPages, hasMore) — check `hasMore` to decide whether to fetch additional pages.",
     inputSchema: schemas.TestScriptListInputSchema,
     mapToUpstream: (input) => {
       const data = input as z.infer<typeof schemas.TestScriptListInputSchema>;

--- a/packages/mcps/src/test/run-environment-lane.test.ts
+++ b/packages/mcps/src/test/run-environment-lane.test.ts
@@ -158,3 +158,23 @@ describe("muggle-remote-workflow-start-test-script-generation lane forwarding", 
     expect(call.body as Record<string, unknown>).not.toHaveProperty("runEnvironmentType");
   });
 });
+
+describe("muggle-remote-test-script-list lane forwarding", () => {
+  it("forwards runEnvironmentType as the runEnvironmentType query param when provided", () => {
+    const tool = getQaToolByName("muggle-remote-test-script-list")!;
+    const call = tool.mapToUpstream({
+      projectId: PROJECT_ID,
+      testCaseId: TEST_CASE_ID,
+      runEnvironmentType: RunEnvironment.Local,
+    });
+    expect((call.queryParams as Record<string, unknown>).runEnvironmentType).toBe(
+      RunEnvironment.Local,
+    );
+  });
+
+  it("leaves the runEnvironmentType query param undefined when not provided", () => {
+    const tool = getQaToolByName("muggle-remote-test-script-list")!;
+    const call = tool.mapToUpstream({ projectId: PROJECT_ID, testCaseId: TEST_CASE_ID });
+    expect((call.queryParams as Record<string, unknown>).runEnvironmentType).toBeUndefined();
+  });
+});

--- a/plugin/skills/_shared/dev-loop/run.md
+++ b/plugin/skills/_shared/dev-loop/run.md
@@ -23,7 +23,7 @@ One local browser exists, so **execution is sequential** — one test case at a 
 Per test case, branch on `mode`:
 
 **Replay**
-1. `muggle-remote-test-script-get` (latest replayable script) → note `actionScriptId`.
+1. `muggle-remote-test-script-get` (latest replayable script — the lane-scoped one the caller resolved during classification per [`../failure-mode-handling.md`](../failure-mode-handling.md) §A) → note `actionScriptId`.
 2. `muggle-remote-action-script-get` with that id → full `actionScript` (see [`action-script.md`](action-script.md)).
 3. `muggle-local-execute-replay` with `testScript`, `actionScript`, `localUrl`, `cwd`, `showUi`, `freshSession` (see [`fresh-session.md`](fresh-session.md)), `timeoutMs` (see [`timeouts.md`](timeouts.md)).
 

--- a/plugin/skills/_shared/failure-mode-handling.md
+++ b/plugin/skills/_shared/failure-mode-handling.md
@@ -61,7 +61,7 @@ Run during change analysis, **per impacted test case**. Picks the initial execut
 
 - The change summary from `git diff` (file paths + diff content).
 - The test case (title, description, instructions, last passing run timestamp).
-- Existing test scripts for that test case from `muggle-remote-test-script-list`.
+- Existing test scripts for that test case from `muggle-remote-test-script-list`, scoped to the run's lane: pass `runEnvironmentType: "local"` in Local mode (Step 7A), `"remote"` in Remote mode (Step 7B). The lane is fixed at runtime — it selects the versioned runSettings the cloud resolves — so a local run keys replay-vs-regen off the localhost-lane script and a remote run off the deployed-lane script, never the other lane's.
 
 ### Rules (fire in order; first match wins)
 

--- a/plugin/skills/do/e2e-acceptance.md
+++ b/plugin/skills/do/e2e-acceptance.md
@@ -98,7 +98,7 @@ Based on the changed files and the requirements goal, determine which test cases
 
 ### Step 4: Run the dev loop, gather screenshots
 
-For each relevant test case, run the shared loop in [`../_shared/dev-loop/run.md`](../_shared/dev-loop/run.md): `muggle-remote-test-script-list` by `testCaseId` to pick [replay vs regen](../_shared/dev-loop/run.md), [execute with `timeoutMs`](../_shared/dev-loop/timeouts.md), [fetch the result](../_shared/dev-loop/failures.md) and [interpret failures](../_shared/dev-loop/failures.md), then read the studio-published [cloud refs and per-step screenshots](../_shared/dev-loop/publish.md) off the run result.
+For each relevant test case, run the shared loop in [`../_shared/dev-loop/run.md`](../_shared/dev-loop/run.md): `muggle-remote-test-script-list` by `testCaseId` with `runEnvironmentType: "local"` (this stage runs against localhost) to pick [replay vs regen](../_shared/dev-loop/run.md), [execute with `timeoutMs`](../_shared/dev-loop/timeouts.md), [fetch the result](../_shared/dev-loop/failures.md) and [interpret failures](../_shared/dev-loop/failures.md), then read the studio-published [cloud refs and per-step screenshots](../_shared/dev-loop/publish.md) off the run result.
 
 Inputs to the loop: `mode` from the script-exists check, `localUrl`/project from Step 1.7, `cwd` = the working tree recorded in `state.md`.
 

--- a/plugin/skills/muggle-browser-task/SKILL.md
+++ b/plugin/skills/muggle-browser-task/SKILL.md
@@ -74,6 +74,7 @@ Tell the user: `Created test case: <id>`.
 Load and call `muggle-remote-test-script-list` with:
 - `projectId`: from Step 2
 - `testCaseId`: from Step 4
+- `runEnvironmentType`: `"local"` when `localUrl` (Step 1) is a loopback host (`localhost`, `127.0.0.1`, `[::1]`), else `"remote"` — replay runs locally against `localUrl`, so this resolves the script on the lane that URL belongs to.
 
 Tell the user which mutations will be applied: `Mutations: <mutations[]>` (or "no mutations" if empty).
 

--- a/plugin/skills/muggle-browser-task/SKILL.md
+++ b/plugin/skills/muggle-browser-task/SKILL.md
@@ -74,7 +74,7 @@ Tell the user: `Created test case: <id>`.
 Load and call `muggle-remote-test-script-list` with:
 - `projectId`: from Step 2
 - `testCaseId`: from Step 4
-- `runEnvironmentType`: `"local"` when `localUrl` (Step 1) is a loopback host (`localhost`, `127.0.0.1`, `[::1]`), else `"remote"` — replay runs locally against `localUrl`, so this resolves the script on the lane that URL belongs to.
+- `runEnvironmentType`: `"local"` — this skill executes in the local browser, so it resolves the local-lane script. The lane is an explicit env type, exactly as the remote flow passes `"remote"`; the target URL is just the lane's url and never decides the lane.
 
 Tell the user which mutations will be applied: `Mutations: <mutations[]>` (or "no mutations" if empty).
 

--- a/plugin/skills/muggle-test-feature-local/SKILL.md
+++ b/plugin/skills/muggle-test-feature-local/SKILL.md
@@ -136,7 +136,7 @@ Before deciding the target's script, resolve its prerequisite chain from the bac
 
 ### 5. Existing scripts vs new generation
 
-`muggle-remote-test-script-list` with `testCaseId`.
+`muggle-remote-test-script-list` with `testCaseId` and `runEnvironmentType: "local"` — this skill always replays against localhost, so resolve the local-lane script (the remote-lane script carries the deployed URL).
 
 - **If any replayable/succeeded scripts exist:** use `AskUserQuestion` to present them as clickable options. Show: name, created/updated, step count per option. Include **"Generate new script"** as the last option.
 - **If none:** go straight to generation (no need to ask replay vs generate).

--- a/plugin/skills/muggle-test/SKILL.md
+++ b/plugin/skills/muggle-test/SKILL.md
@@ -219,7 +219,7 @@ Wait for user confirmation before moving to execution.
 
 ### 6f: Classify execution mode per test case (replay vs regen)
 
-For each selected test case, decide whether the run should be a **replay** of an existing script or a fresh **regen**, using the rules in [`_shared/failure-mode-handling.md`](../_shared/failure-mode-handling.md) section A. Inputs: the change summary from Step 2, the test case body, and the result of `muggle-remote-test-script-list` for that test case (last passing timestamp + whether any replayable script exists).
+For each selected test case, decide whether the run should be a **replay** of an existing script or a fresh **regen**, using the rules in [`_shared/failure-mode-handling.md`](../_shared/failure-mode-handling.md) section A. Inputs: the change summary from Step 2, the test case body, and the result of `muggle-remote-test-script-list` for that test case (last passing timestamp + whether any replayable script exists). Scope that list call to the run's lane — `runEnvironmentType: "local"` in Local mode, `"remote"` in Remote mode (section A) — so replay reuses the script for the lane the run will execute against.
 
 Per test case, fire one `muggle-local-telemetry-event-emit` with `eventType: "pre-execution-classification"` capturing the picked mode, the rule that fired, and the matched changed-file paths.
 

--- a/plugin/skills/muggle-test/execute-remote.md
+++ b/plugin/skills/muggle-test/execute-remote.md
@@ -28,7 +28,7 @@ Branch each test case on its `mode`, then issue **all** workflow-start calls in 
 - `instructions`: From the test case
 - `expectedResult`: From the test case
 
-**Replay-mode test case** — `muggle-remote-workflow-start-test-script-replay` against the latest replayable script for that test case (resolve via `muggle-remote-test-script-list` if not already in hand from the classification step). Tag results with `mode: "replay"` so the router routes failures correctly.
+**Replay-mode test case** — `muggle-remote-workflow-start-test-script-replay` against the latest replayable script for that test case (resolve via `muggle-remote-test-script-list` with `runEnvironmentType: "remote"` if not already in hand from the classification step). Tag results with `mode: "replay"` so the router routes failures correctly.
 
 Store each returned workflow runtime ID along with its mode tag.
 


### PR DESCRIPTION
## What
1. Adds an optional `runEnvironmentType` to **`muggle-remote-test-script-list`**, mapped to the backend's `type` query filter (prompt-service #624). A local replay can now fetch the **local-lane** (`type=local`, localhost) test script instead of the remote canonical one.
2. Wires that lane param into the **skills** at every place they resolve which script to replay, so a local run reads the localhost-lane script and a remote run the deployed-lane script.

## Why (supersedes the original approach)
This PR originally added a `productionUrl` **side-by-side** with `url` in the action-script payload, feeding a studio-side runtime **origin-pin** (teaching-service #287). That was the wrong layer — the lane is fixed by runSettings and **not interchangeable**, so storing both lane URLs on one script and rewriting origins at run time is confusing and fragile. Per review, both of those changes were reverted (teaching #287 closed), and the per-lane URL now lives on **separate per-lane test scripts**:

- **prompt-service #624**: the local-run upload persists the local-lane script with the **localhost** URL via a lane-keyed get-or-create (no clobber of the remote canonical), and exposes a `type` filter on the list endpoint.
- **this PR**: the MCP list tool forwards the lane, and the skills pass it on every replay-script lookup.

## Skill wiring (read-side lane scoping)
- `_shared/failure-mode-handling.md` §A (shared replay-vs-regen classification): scope the list call to the run's lane — `local` in Mode A, `remote` in Mode B.
- `muggle-test` 6f + `execute-remote.md`, `do/e2e-acceptance.md` (local E2E), `muggle-test-feature-local`, `muggle-browser-task`: pass `runEnvironmentType` at each resolution point.
- `_shared/dev-loop/run.md`: notes the replay script is the lane-scoped one from §A.

## Result
With per-lane scripts, the existing `rewriteActionScriptUrls` becomes a benign localhost→localhost port-adaptation rather than a lane-replacing public→localhost rewrite — the agent's context is always the lane's own URL.

## Tests
`tsc --noEmit` clean. Schema change is an optional field; skill edits are markdown. CI runs the suite.

## Deploy note
Skill edits live in `plugin/skills/` — they reach users only after a plugin build/release (`@muggleai/works` npm publish). The MCP param change ships the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)