### PR TITLE
feat(guardrails): hard-enforce E2E run + CLI-rendered PR reports

### DIFF
--- a/plugin/hooks/README.md
+++ b/plugin/hooks/README.md
@@ -9,18 +9,29 @@ Condition-triggered hooks that make Muggle Test's high-value handoffs fire path-
 - **Claude Code layer** — the agent runtime that fires these hooks. A guardrail is a Claude-Code-layer trigger, nothing more.
 - **Muggle Test layer** — the product (muggle-do, muggle-test, the watcher). This is what a guardrail *invokes*.
 
-A guardrail injects an advisory directive (`additionalContext`); the model then runs the Muggle Test flow. The guardrail never reimplements the flow.
+A guardrail steers the model toward a Muggle Test flow; it never reimplements the flow.
 
-Design rationale: `muggle-ai-brain/architecture/2026-06-02-harness-pipeline-integration-design.md`.
+Design rationale: `muggle-ai-brain/architecture/2026-06-02-harness-pipeline-integration-design.md` (original advisory design; the E2E gate and report gate below now enforce rather than advise).
+
+## Advise vs enforce
+
+A guardrail emits one of two strengths:
+
+- **Advise** — `additionalContext` (PostToolUse/UserPromptSubmit) or a plain Stop message. A soft nudge the model can ignore.
+- **Enforce** — a `Stop` `decision: "block"` that refuses to end the turn, or a `PreToolUse` `permissionDecision: "deny"` that refuses a tool call. The model cannot proceed until the condition is met.
+
+Enforcement is reserved for the handoffs that were being skipped: the E2E acceptance run and posting a deterministically-rendered report. Each enforcing gate carries an escape so it can't trap a turn — the E2E gate releases to advisory after `MAX_E2E_BLOCKS` (3) blocks; the report gate only denies a body it can positively see is a hand-written report and fails open otherwise.
 
 ## Mechanism
 
-Each guardrail is a thin bash wrapper in `../scripts/` registered in `hooks.json`. The wrapper pipes the event payload (stdin JSON) to the bundled `../scripts/guardrails.mjs <subcommand>`, which holds the decision logic (built from `src/guardrails/`, vitest-covered). Per-session state in `~/.muggle-ai/guardrails/<session_id>.json` makes each guardrail fire once. Any failure degrades to `{}` — a guardrail must never block a turn.
+Each guardrail is a thin bash wrapper in `../scripts/` registered in `hooks.json`. The wrapper pipes the event payload (stdin JSON) to the bundled `../scripts/guardrails.mjs <subcommand>`, which holds the decision logic (built from `src/guardrails/`, vitest-covered). Per-session state in `~/.muggle-ai/guardrails/<session_id>.json` tracks what fired. Any *failure* degrades to `{}` (allow) — a gate blocks only by an explicit, tested decision, never by accident.
 
 ## Guardrails
 
-| Hook event | Wrapper | Condition | Preference | Flow invoked |
-| :--------- | :------ | :-------- | :--------- | :----------- |
-| `PostToolUse` (Bash) | `guardrail-pr-opened.sh` | a `gh pr create`/`gh pr ready` just succeeded | `autoWatchPR` | start a `muggle-pr-followup` watcher on the new PR |
-| `Stop` | `guardrail-e2e-gate.sh` | unit tests passed this session and no E2E ran yet (recorded by `guardrail-record-tests.sh`) | `autoE2ETest` | run change-driven E2E via `muggle-test` before finishing |
-| `UserPromptSubmit` | `guardrail-build-router.sh` | a build/implement/fix request (first one this session) | `autoRouteBuildToMuggleDo` | route the work through `muggle-do` (build delegated to superpowers) |
+| Hook event | Wrapper | Strength | Condition | Preference | Effect |
+| :--------- | :------ | :------- | :-------- | :--------- | :----- |
+| `PostToolUse` (Bash) | `guardrail-pr-opened.sh` | advise | a `gh pr create`/`gh pr ready` just succeeded | `autoWatchPR` | start a `muggle-pr-followup` watcher on the new PR |
+| `PostToolUse` (Bash + muggle execute/replay MCP tools) | `guardrail-record-tests.sh` | record | a unit-test command passed, or an E2E run happened | — | set `unitTestsGreen` / `e2eRun` session state |
+| `PreToolUse` (Bash) | `guardrail-report-format.sh` | **enforce** | a `gh pr comment\|create\|edit` body reads like an E2E report but lacks the `build-pr-section` sentinel | — | **deny** — render via `muggle build-pr-section` instead |
+| `Stop` | `guardrail-e2e-gate.sh` | **enforce** | unit tests passed this session and no E2E ran yet | `autoE2ETest` | **block** the turn until E2E runs via `muggle-test` (releases after 3 blocks) |
+| `UserPromptSubmit` | `guardrail-build-router.sh` | advise | a build/implement/fix request (first one this session) | `autoRouteBuildToMuggleDo` | route the work through `muggle-do` (build delegated to superpowers) |

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -12,6 +12,18 @@
         ]
       }
     ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/guardrail-report-format.sh\"",
+            "async": false
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Bash",
@@ -21,6 +33,16 @@
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/guardrail-pr-opened.sh\"",
             "async": false
           },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/guardrail-record-tests.sh\"",
+            "async": false
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__.*muggle.*(execute|replay)",
+        "hooks": [
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/guardrail-record-tests.sh\"",

--- a/plugin/scripts/guardrail-report-format.sh
+++ b/plugin/scripts/guardrail-report-format.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Report-format gate (PreToolUse, Bash). Denies a `gh pr comment|create|edit`
+# whose body reads like a hand-written E2E report — one that lacks the
+# build-pr-section sentinel — so every posted walkthrough goes through the
+# deterministic renderer. Degrades to {} so it never blocks an unrelated command.
+root="${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-}}"
+node "${root}/scripts/guardrails.mjs" report-gate 2>/dev/null || printf '{}'

--- a/plugin/scripts/guardrails.mjs
+++ b/plugin/scripts/guardrails.mjs
@@ -66,9 +66,9 @@ function shouldRunE2E(state) {
 }
 function e2eGateDecision(state, maxBlocks = MAX_E2E_BLOCKS) {
   const blockCount = state.e2eBlockCount ?? 0;
-  if (!shouldRunE2E(state)) return { action: "none", blockCount };
-  if (blockCount >= maxBlocks) return { action: "release", blockCount };
-  return { action: "block", blockCount: blockCount + 1 };
+  if (!shouldRunE2E(state)) return { action: "none" /* None */, blockCount };
+  if (blockCount >= maxBlocks) return { action: "release" /* Release */, blockCount };
+  return { action: "block" /* Block */, blockCount: blockCount + 1 };
 }
 
 // src/guardrails/detectBuildIntent.ts
@@ -200,7 +200,7 @@ function recordTests() {
 function e2eGate() {
   const state = readState(sessionId);
   const decision = e2eGateDecision(state);
-  if (decision.action === "none" || decision.action === "release") return "{}";
+  if (decision.action === "none" /* None */ || decision.action === "release" /* Release */) return "{}";
   state.e2eBlockCount = decision.blockCount;
   writeState(state);
   const reason = `Do not end the turn yet. Unit tests passed this session but no E2E acceptance run has happened. Per the autoE2ETest preference (default: always), run change-driven E2E now via /muggle:muggle-test, then finish. If E2E genuinely cannot run here (no app, services down, no PR), say so explicitly to the user \u2014 this gate releases after ${MAX_E2E_BLOCKS} attempts.`;

--- a/plugin/scripts/guardrails.mjs
+++ b/plugin/scripts/guardrails.mjs
@@ -64,6 +64,16 @@ var MAX_E2E_BLOCKS = 3;
 function shouldRunE2E(state) {
   return state.unitTestsGreen === true && state.e2eRun !== true;
 }
+function applyRecordedRun(state, run) {
+  let next = state;
+  if (run.unitTestPassed) {
+    next = { ...next, unitTestsGreen: true, e2eRun: false, e2eBlockCount: 0 };
+  }
+  if (run.e2eRan) {
+    next = { ...next, e2eRun: true };
+  }
+  return next;
+}
 function e2eGateDecision(state, maxBlocks = MAX_E2E_BLOCKS) {
   const blockCount = state.e2eBlockCount ?? 0;
   if (!shouldRunE2E(state)) return { action: "none" /* None */, blockCount };
@@ -185,16 +195,11 @@ Per the autoWatchPR preference, a muggle-pr-followup watcher should handle its i
 function recordTests() {
   const cmd = input.tool_input?.command ?? "";
   const state = readState(sessionId);
-  let changed = false;
-  if (isTestCommand(cmd) && testsPassed(input)) {
-    state.unitTestsGreen = true;
-    changed = true;
-  }
-  if (isE2ERun(input)) {
-    state.e2eRun = true;
-    changed = true;
-  }
-  if (changed) writeState(state);
+  const next = applyRecordedRun(state, {
+    unitTestPassed: isTestCommand(cmd) && testsPassed(input),
+    e2eRan: isE2ERun(input)
+  });
+  if (next !== state) writeState(next);
   return "{}";
 }
 function e2eGate() {

--- a/plugin/scripts/guardrails.mjs
+++ b/plugin/scripts/guardrails.mjs
@@ -1,5 +1,5 @@
 import { readFileSync, existsSync, mkdirSync, writeFileSync } from 'fs';
-import { join } from 'path';
+import { isAbsolute, resolve, join } from 'path';
 import { homedir } from 'os';
 
 // src/guardrails/cli.ts
@@ -60,8 +60,15 @@ function isE2ERun(input2) {
 }
 
 // src/guardrails/shouldRunE2E.ts
+var MAX_E2E_BLOCKS = 3;
 function shouldRunE2E(state) {
   return state.unitTestsGreen === true && state.e2eRun !== true;
+}
+function e2eGateDecision(state, maxBlocks = MAX_E2E_BLOCKS) {
+  const blockCount = state.e2eBlockCount ?? 0;
+  if (!shouldRunE2E(state)) return { action: "none", blockCount };
+  if (blockCount >= maxBlocks) return { action: "release", blockCount };
+  return { action: "block", blockCount: blockCount + 1 };
 }
 
 // src/guardrails/detectBuildIntent.ts
@@ -74,6 +81,60 @@ function detectBuildIntent(prompt) {
   if (QUESTION.test(p)) return false;
   return BUILD.test(p) || DEVCYCLE.test(p);
 }
+var REPORT_SENTINEL = "muggle-pr-section";
+var PR_POST_CMD = /\bgh\s+pr\s+(comment|create|edit)\b/;
+var defaultReader = (path, cwd) => {
+  try {
+    const abs = isAbsolute(path) ? path : resolve(cwd ?? process.cwd(), path);
+    if (!existsSync(abs)) return null;
+    return readFileSync(abs, "utf-8");
+  } catch {
+    return null;
+  }
+};
+function unquote(s) {
+  const t = s.trim();
+  if (t.startsWith('"') && t.endsWith('"') || t.startsWith("'") && t.endsWith("'")) {
+    return t.slice(1, -1);
+  }
+  return t;
+}
+function looksLikeE2EReport(text) {
+  const t = text.toLowerCase();
+  const statusEmojis = (text.match(/[✅❌⚠]/gu) ?? []).length;
+  const tally = /\b\d+\s+(tests?\s+)?passed\b/.test(t) && /\b\d+\s+(tests?\s+)?(failed|inconclusive)\b/.test(t);
+  const slashTally = /\bpassed\b\s*[/|]\s*\d*\s*(tests?\s*)?\bfailed\b/.test(t) || /\bfailed\b\s*[/|]\s*\d*\s*(tests?\s*)?\bpassed\b/.test(t);
+  const resultsStructure = /acceptance results/.test(t) || tally || slashTally || statusEmojis >= 2;
+  const muggleContext = /\bmuggle\b/.test(t) || /muggle-ai\.com/.test(t) || /\be2e\b/.test(t) || /\bacceptance\b/.test(t);
+  return resultsStructure && muggleContext;
+}
+function collectInspectableText(cmd, cwd, read) {
+  let text = cmd;
+  for (const m of cmd.matchAll(/--body-file[=\s]+("[^"]+"|'[^']+'|\S+)/g)) {
+    const p = unquote(m[1]);
+    if (p && p !== "-") {
+      const c = read(p, cwd);
+      if (c) text += "\n" + c;
+    }
+  }
+  for (const m of cmd.matchAll(/jq\b[^|]*?("[^"]+\.json"|'[^']+\.json'|\S+\.json)/g)) {
+    const c = read(unquote(m[1]), cwd);
+    if (c) text += "\n" + c;
+  }
+  return text;
+}
+function evaluateReportPost(input2, read = defaultReader) {
+  if (input2.tool_name !== "Bash") return { deny: false };
+  const cmd = input2.tool_input?.command ?? "";
+  if (!PR_POST_CMD.test(cmd)) return { deny: false };
+  const text = collectInspectableText(cmd, input2.cwd, read);
+  if (text.includes(REPORT_SENTINEL)) return { deny: false };
+  if (!looksLikeE2EReport(text)) return { deny: false };
+  return {
+    deny: true,
+    reason: "Blocked: this looks like a hand-written E2E test report. Muggle requires the deterministic renderer \u2014 build the run's E2eReport JSON and pipe it through `muggle build-pr-section` (or invoke /muggle:muggle-pr-visual-walkthrough), then post that output. Never hand-write the walkthrough markdown."
+  };
+}
 
 // src/guardrails/emit.ts
 function envelope(eventName, context, host2) {
@@ -81,6 +142,22 @@ function envelope(eventName, context, host2) {
   if (host2 === "cursor") return JSON.stringify({ additional_context: context });
   return JSON.stringify({
     hookSpecificOutput: { hookEventName: eventName, additionalContext: context }
+  });
+}
+function blockStop(reason, host2) {
+  if (!reason) return "{}";
+  if (host2 === "cursor") return JSON.stringify({ additional_context: reason });
+  return JSON.stringify({ decision: "block", reason });
+}
+function denyTool(reason, host2) {
+  if (!reason) return "{}";
+  if (host2 === "cursor") return JSON.stringify({ additional_context: reason });
+  return JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: reason
+    }
   });
 }
 
@@ -122,11 +199,17 @@ function recordTests() {
 }
 function e2eGate() {
   const state = readState(sessionId);
-  if (!shouldRunE2E(state)) return "{}";
-  state.e2eRun = true;
+  const decision = e2eGateDecision(state);
+  if (decision.action === "none" || decision.action === "release") return "{}";
+  state.e2eBlockCount = decision.blockCount;
   writeState(state);
-  const ctx = `Unit tests passed this session and no E2E acceptance run has happened yet. Per the autoE2ETest preference (default: always), run change-driven E2E now via /muggle:muggle-test before finishing. If autoE2ETest=never, skip.`;
-  return envelope("Stop", ctx, host);
+  const reason = `Do not end the turn yet. Unit tests passed this session but no E2E acceptance run has happened. Per the autoE2ETest preference (default: always), run change-driven E2E now via /muggle:muggle-test, then finish. If E2E genuinely cannot run here (no app, services down, no PR), say so explicitly to the user \u2014 this gate releases after ${MAX_E2E_BLOCKS} attempts.`;
+  return blockStop(reason, host);
+}
+function reportGate() {
+  const result = evaluateReportPost(input);
+  if (!result.deny || !result.reason) return "{}";
+  return denyTool(result.reason, host);
 }
 function buildRouter() {
   if (!detectBuildIntent(input.prompt ?? "")) return "{}";
@@ -141,6 +224,7 @@ var handlers = {
   "pr-opened": prOpened,
   "record-tests": recordTests,
   "e2e-gate": e2eGate,
+  "report-gate": reportGate,
   "build-router": buildRouter
 };
 process.stdout.write((handlers[sub] ?? (() => "{}"))());

--- a/src/cli/build-pr-section.ts
+++ b/src/cli/build-pr-section.ts
@@ -14,6 +14,17 @@ import { resolveGsScreenshotUrls } from "./pr-section/resolve-urls.js";
 /** Default UTF-8 byte budget for the PR description. */
 export const DEFAULT_MAX_BODY_BYTES = 60_000;
 
+/**
+ * Invisible marker prepended to every rendered section. GitHub hides HTML
+ * comments, so reviewers never see it — but the report-format guardrail
+ * (src/guardrails/reportGate.ts) reads it to tell a CLI-rendered walkthrough
+ * apart from a hand-written one and block the latter.
+ */
+export const REPORT_SECTION_SENTINEL = "<!-- muggle-pr-section:v1 -->";
+
+const withSentinel = <T extends string | null>(s: T): T =>
+  (s ? (`${REPORT_SECTION_SENTINEL}\n${s}` as T) : s);
+
 interface IRunOptions {
   stdin: NodeJS.ReadableStream;
   stdoutWrite: (s: string) => boolean;
@@ -68,8 +79,11 @@ export async function runBuildPrSection (opts: IRunOptions): Promise<number> {
     return 1;
   }
   const resolvedReport = await resolveGsScreenshotUrls(report, { stderrWrite: opts.stderrWrite });
-  const result = buildPrSection(resolvedReport, { maxBodyBytes: opts.maxBodyBytes });
-  opts.stdoutWrite(JSON.stringify({ body: result.body, comment: result.comment }));
+  const sentinelCost = Buffer.byteLength(`${REPORT_SECTION_SENTINEL}\n`, "utf-8");
+  const result = buildPrSection(resolvedReport, { maxBodyBytes: opts.maxBodyBytes - sentinelCost });
+  opts.stdoutWrite(
+    JSON.stringify({ body: withSentinel(result.body), comment: withSentinel(result.comment) }),
+  );
   return 0;
 }
 

--- a/src/guardrails/cli.ts
+++ b/src/guardrails/cli.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "fs";
 import { readState, writeState, markPrHandled } from "./sessionState.js";
 import { detectPrOpened } from "./prOpened.js";
 import { isTestCommand, testsPassed, isE2ERun } from "./testsGreen.js";
-import { e2eGateDecision, E2eGateAction, MAX_E2E_BLOCKS } from "./shouldRunE2E.js";
+import { e2eGateDecision, E2eGateAction, MAX_E2E_BLOCKS, applyRecordedRun } from "./shouldRunE2E.js";
 import { detectBuildIntent } from "./detectBuildIntent.js";
 import { evaluateReportPost } from "./reportGate.js";
 import { envelope, blockStop, denyTool, type Host } from "./emit.js";
@@ -37,16 +37,11 @@ function prOpened(): string {
 function recordTests(): string {
   const cmd = input.tool_input?.command ?? "";
   const state = readState(sessionId);
-  let changed = false;
-  if (isTestCommand(cmd) && testsPassed(input)) {
-    state.unitTestsGreen = true;
-    changed = true;
-  }
-  if (isE2ERun(input)) {
-    state.e2eRun = true;
-    changed = true;
-  }
-  if (changed) writeState(state);
+  const next = applyRecordedRun(state, {
+    unitTestPassed: isTestCommand(cmd) && testsPassed(input),
+    e2eRan: isE2ERun(input),
+  });
+  if (next !== state) writeState(next);
   return "{}";
 }
 

--- a/src/guardrails/cli.ts
+++ b/src/guardrails/cli.ts
@@ -2,9 +2,10 @@ import { readFileSync } from "fs";
 import { readState, writeState, markPrHandled } from "./sessionState.js";
 import { detectPrOpened } from "./prOpened.js";
 import { isTestCommand, testsPassed, isE2ERun } from "./testsGreen.js";
-import { shouldRunE2E } from "./shouldRunE2E.js";
+import { e2eGateDecision, MAX_E2E_BLOCKS } from "./shouldRunE2E.js";
 import { detectBuildIntent } from "./detectBuildIntent.js";
-import { envelope, type Host } from "./emit.js";
+import { evaluateReportPost } from "./reportGate.js";
+import { envelope, blockStop, denyTool, type Host } from "./emit.js";
 import type { HookInput } from "./types.js";
 
 function readStdin(): HookInput {
@@ -51,14 +52,22 @@ function recordTests(): string {
 
 function e2eGate(): string {
   const state = readState(sessionId);
-  if (!shouldRunE2E(state)) return "{}";
-  state.e2eRun = true;
+  const decision = e2eGateDecision(state);
+  if (decision.action === "none" || decision.action === "release") return "{}";
+  state.e2eBlockCount = decision.blockCount;
   writeState(state);
-  const ctx =
-    `Unit tests passed this session and no E2E acceptance run has happened yet. ` +
-    `Per the autoE2ETest preference (default: always), run change-driven E2E now via /muggle:muggle-test ` +
-    `before finishing. If autoE2ETest=never, skip.`;
-  return envelope("Stop", ctx, host);
+  const reason =
+    `Do not end the turn yet. Unit tests passed this session but no E2E acceptance run has happened. ` +
+    `Per the autoE2ETest preference (default: always), run change-driven E2E now via /muggle:muggle-test, ` +
+    `then finish. If E2E genuinely cannot run here (no app, services down, no PR), say so explicitly to the ` +
+    `user — this gate releases after ${MAX_E2E_BLOCKS} attempts.`;
+  return blockStop(reason, host);
+}
+
+function reportGate(): string {
+  const result = evaluateReportPost(input);
+  if (!result.deny || !result.reason) return "{}";
+  return denyTool(result.reason, host);
 }
 
 function buildRouter(): string {
@@ -79,6 +88,7 @@ const handlers: Record<string, () => string> = {
   "pr-opened": prOpened,
   "record-tests": recordTests,
   "e2e-gate": e2eGate,
+  "report-gate": reportGate,
   "build-router": buildRouter,
 };
 process.stdout.write((handlers[sub] ?? (() => "{}"))());

--- a/src/guardrails/cli.ts
+++ b/src/guardrails/cli.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "fs";
 import { readState, writeState, markPrHandled } from "./sessionState.js";
 import { detectPrOpened } from "./prOpened.js";
 import { isTestCommand, testsPassed, isE2ERun } from "./testsGreen.js";
-import { e2eGateDecision, MAX_E2E_BLOCKS } from "./shouldRunE2E.js";
+import { e2eGateDecision, E2eGateAction, MAX_E2E_BLOCKS } from "./shouldRunE2E.js";
 import { detectBuildIntent } from "./detectBuildIntent.js";
 import { evaluateReportPost } from "./reportGate.js";
 import { envelope, blockStop, denyTool, type Host } from "./emit.js";
@@ -53,7 +53,7 @@ function recordTests(): string {
 function e2eGate(): string {
   const state = readState(sessionId);
   const decision = e2eGateDecision(state);
-  if (decision.action === "none" || decision.action === "release") return "{}";
+  if (decision.action === E2eGateAction.None || decision.action === E2eGateAction.Release) return "{}";
   state.e2eBlockCount = decision.blockCount;
   writeState(state);
   const reason =

--- a/src/guardrails/emit.ts
+++ b/src/guardrails/emit.ts
@@ -7,3 +7,26 @@ export function envelope(eventName: string, context: string, host: Host): string
     hookSpecificOutput: { hookEventName: eventName, additionalContext: context },
   });
 }
+
+// Stop hook: refuse to end the turn. Claude honours `decision: "block"` and feeds
+// `reason` back to the model as the instruction to keep going. Cursor has no block
+// primitive, so it degrades to an advisory the model can still ignore.
+export function blockStop(reason: string, host: Host): string {
+  if (!reason) return "{}";
+  if (host === "cursor") return JSON.stringify({ additional_context: reason });
+  return JSON.stringify({ decision: "block", reason: reason });
+}
+
+// PreToolUse hook: refuse a tool call before it runs. Claude honours
+// `permissionDecision: "deny"`; cursor degrades to an advisory.
+export function denyTool(reason: string, host: Host): string {
+  if (!reason) return "{}";
+  if (host === "cursor") return JSON.stringify({ additional_context: reason });
+  return JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: reason,
+    },
+  });
+}

--- a/src/guardrails/reportGate.ts
+++ b/src/guardrails/reportGate.ts
@@ -1,0 +1,97 @@
+import { readFileSync, existsSync } from "fs";
+import { isAbsolute, resolve } from "path";
+import type { HookInput } from "./types.js";
+
+// Substring present in every `muggle build-pr-section` rendering (see
+// src/cli/build-pr-section.ts). Kept as a version-agnostic substring so the gate
+// keeps recognising sanctioned output across `:v1` → `:v2` bumps.
+export const REPORT_SENTINEL = "muggle-pr-section";
+
+const PR_POST_CMD = /\bgh\s+pr\s+(comment|create|edit)\b/;
+
+export interface ReportGateResult {
+  deny: boolean;
+  reason?: string;
+}
+
+export type FileReader = (path: string, cwd?: string) => string | null;
+
+const defaultReader: FileReader = (path, cwd) => {
+  try {
+    const abs = isAbsolute(path) ? path : resolve(cwd ?? process.cwd(), path);
+    if (!existsSync(abs)) return null;
+    return readFileSync(abs, "utf-8");
+  } catch {
+    return null;
+  }
+};
+
+function unquote(s: string): string {
+  const t = s.trim();
+  if ((t.startsWith('"') && t.endsWith('"')) || (t.startsWith("'") && t.endsWith("'"))) {
+    return t.slice(1, -1);
+  }
+  return t;
+}
+
+// Does this text read like a rendered E2E acceptance report (vs an ordinary PR
+// comment or a PR description that merely mentions E2E work)? Require a results
+// *structure* — the walkthrough's heading, a pass/fail tally, or a per-test
+// status list — AND a Muggle/E2E context. Keying on structure (not just the
+// words "e2e"/"muggle") keeps plain comments and feature PR descriptions clear.
+export function looksLikeE2EReport(text: string): boolean {
+  const t = text.toLowerCase();
+  const statusEmojis = (text.match(/[✅❌⚠]/gu) ?? []).length;
+  const tally =
+    /\b\d+\s+(tests?\s+)?passed\b/.test(t) &&
+    /\b\d+\s+(tests?\s+)?(failed|inconclusive)\b/.test(t);
+  const slashTally =
+    /\bpassed\b\s*[/|]\s*\d*\s*(tests?\s*)?\bfailed\b/.test(t) ||
+    /\bfailed\b\s*[/|]\s*\d*\s*(tests?\s*)?\bpassed\b/.test(t);
+  const resultsStructure =
+    /acceptance results/.test(t) || tally || slashTally || statusEmojis >= 2;
+  const muggleContext =
+    /\bmuggle\b/.test(t) || /muggle-ai\.com/.test(t) || /\be2e\b/.test(t) || /\bacceptance\b/.test(t);
+  return resultsStructure && muggleContext;
+}
+
+// Everything the gate can read of what a `gh pr` command will post: the command
+// string itself (covers inline `--body`, `-b`, echo/heredoc/printf bodies) plus
+// any readable `--body-file <path>` and any `.json` a `jq` pipe reads (the
+// sanctioned build-pr-section artifact, whose {body,comment} carry the sentinel).
+function collectInspectableText(cmd: string, cwd: string | undefined, read: FileReader): string {
+  let text = cmd;
+  for (const m of cmd.matchAll(/--body-file[=\s]+("[^"]+"|'[^']+'|\S+)/g)) {
+    const p = unquote(m[1]);
+    if (p && p !== "-") {
+      const c = read(p, cwd);
+      if (c) text += "\n" + c;
+    }
+  }
+  for (const m of cmd.matchAll(/jq\b[^|]*?("[^"]+\.json"|'[^']+\.json'|\S+\.json)/g)) {
+    const c = read(unquote(m[1]), cwd);
+    if (c) text += "\n" + c;
+  }
+  return text;
+}
+
+// Gate a `gh pr comment|create|edit`. Deny only when the body the gate can
+// actually see reads like an E2E report yet lacks the sentinel — i.e. a
+// hand-written report. The sanctioned `jq … | gh … --body-file -` path either
+// surfaces the sentinel (via the jq'd artifact) or is un-inspectable; both
+// fail open, so legitimate posts are never blocked.
+export function evaluateReportPost(input: HookInput, read: FileReader = defaultReader): ReportGateResult {
+  if (input.tool_name !== "Bash") return { deny: false };
+  const cmd = input.tool_input?.command ?? "";
+  if (!PR_POST_CMD.test(cmd)) return { deny: false };
+  const text = collectInspectableText(cmd, input.cwd, read);
+  if (text.includes(REPORT_SENTINEL)) return { deny: false };
+  if (!looksLikeE2EReport(text)) return { deny: false };
+  return {
+    deny: true,
+    reason:
+      "Blocked: this looks like a hand-written E2E test report. Muggle requires the deterministic " +
+      "renderer — build the run's E2eReport JSON and pipe it through `muggle build-pr-section` (or invoke " +
+      "/muggle:muggle-pr-visual-walkthrough), then post that output. Never hand-write the walkthrough markdown.",
+  };
+}

--- a/src/guardrails/shouldRunE2E.ts
+++ b/src/guardrails/shouldRunE2E.ts
@@ -1,5 +1,30 @@
 import type { GuardrailState } from "./types.js";
 
+export const MAX_E2E_BLOCKS = 3;
+
 export function shouldRunE2E(state: GuardrailState): boolean {
   return state.unitTestsGreen === true && state.e2eRun !== true;
+}
+
+export type E2eGateAction = "block" | "release" | "none";
+
+export interface E2eGateDecision {
+  action: E2eGateAction;
+  blockCount: number;
+}
+
+// Decide what the Stop hook does when the turn is about to end.
+//
+// - `none`   — no E2E owed (tests weren't green, or a real E2E run was recorded).
+// - `block`  — force the turn to continue so E2E runs; increments blockCount.
+// - `release`— blocked MAX_E2E_BLOCKS times already; stop nagging and allow the
+//              turn to end so a genuinely un-runnable E2E can't trap the session.
+export function e2eGateDecision(
+  state: GuardrailState,
+  maxBlocks: number = MAX_E2E_BLOCKS,
+): E2eGateDecision {
+  const blockCount = state.e2eBlockCount ?? 0;
+  if (!shouldRunE2E(state)) return { action: "none", blockCount: blockCount };
+  if (blockCount >= maxBlocks) return { action: "release", blockCount: blockCount };
+  return { action: "block", blockCount: blockCount + 1 };
 }

--- a/src/guardrails/shouldRunE2E.ts
+++ b/src/guardrails/shouldRunE2E.ts
@@ -6,6 +6,30 @@ export function shouldRunE2E(state: GuardrailState): boolean {
   return state.unitTestsGreen === true && state.e2eRun !== true;
 }
 
+export interface RecordedRun {
+  unitTestPassed?: boolean;
+  e2eRan?: boolean;
+}
+
+// Fold a recorded test run into the gate state, returning the same reference
+// when nothing was recorded so the caller can skip a redundant write.
+//
+// A fresh unit-test pass re-arms the latch — it clears `e2eRun` and the block
+// counter so the gate fires again after the *latest* green unit run. Without
+// the reset the first E2E of a long-lived session keeps the gate satisfied for
+// every later round, so a watcher addressing a second round of review comments
+// would change code, go unit-green, and end the turn with no fresh E2E.
+export function applyRecordedRun(state: GuardrailState, run: RecordedRun): GuardrailState {
+  let next = state;
+  if (run.unitTestPassed) {
+    next = { ...next, unitTestsGreen: true, e2eRun: false, e2eBlockCount: 0 };
+  }
+  if (run.e2eRan) {
+    next = { ...next, e2eRun: true };
+  }
+  return next;
+}
+
 export enum E2eGateAction {
   Block = "block",
   Release = "release",

--- a/src/guardrails/shouldRunE2E.ts
+++ b/src/guardrails/shouldRunE2E.ts
@@ -6,7 +6,11 @@ export function shouldRunE2E(state: GuardrailState): boolean {
   return state.unitTestsGreen === true && state.e2eRun !== true;
 }
 
-export type E2eGateAction = "block" | "release" | "none";
+export enum E2eGateAction {
+  Block = "block",
+  Release = "release",
+  None = "none",
+}
 
 export interface E2eGateDecision {
   action: E2eGateAction;
@@ -15,16 +19,16 @@ export interface E2eGateDecision {
 
 // Decide what the Stop hook does when the turn is about to end.
 //
-// - `none`   — no E2E owed (tests weren't green, or a real E2E run was recorded).
-// - `block`  — force the turn to continue so E2E runs; increments blockCount.
-// - `release`— blocked MAX_E2E_BLOCKS times already; stop nagging and allow the
+// - `None`   — no E2E owed (tests weren't green, or a real E2E run was recorded).
+// - `Block`  — force the turn to continue so E2E runs; increments blockCount.
+// - `Release`— blocked MAX_E2E_BLOCKS times already; stop nagging and allow the
 //              turn to end so a genuinely un-runnable E2E can't trap the session.
 export function e2eGateDecision(
   state: GuardrailState,
   maxBlocks: number = MAX_E2E_BLOCKS,
 ): E2eGateDecision {
   const blockCount = state.e2eBlockCount ?? 0;
-  if (!shouldRunE2E(state)) return { action: "none", blockCount: blockCount };
-  if (blockCount >= maxBlocks) return { action: "release", blockCount: blockCount };
-  return { action: "block", blockCount: blockCount + 1 };
+  if (!shouldRunE2E(state)) return { action: E2eGateAction.None, blockCount: blockCount };
+  if (blockCount >= maxBlocks) return { action: E2eGateAction.Release, blockCount: blockCount };
+  return { action: E2eGateAction.Block, blockCount: blockCount + 1 };
 }

--- a/src/guardrails/types.ts
+++ b/src/guardrails/types.ts
@@ -3,6 +3,7 @@ export interface GuardrailState {
   prsHandled: string[];
   unitTestsGreen?: boolean;
   e2eRun?: boolean;
+  e2eBlockCount?: number;
   buildIntentRouted?: boolean;
 }
 

--- a/src/test/cli/build-pr-section-command.test.ts
+++ b/src/test/cli/build-pr-section-command.test.ts
@@ -94,6 +94,7 @@ describe("buildPrSectionCommand", () => {
     const written = stdoutSpy.mock.calls.map((c) => String(c[0])).join("");
     const parsed = JSON.parse(written);
     expect(parsed.body).toContain("E2E Acceptance Results");
+    expect(parsed.body.startsWith("<!-- muggle-pr-section:v1 -->\n")).toBe(true);
   });
 
   it("sets a nonzero exit code when the report is invalid", async () => {

--- a/src/test/guardrails/emit.test.ts
+++ b/src/test/guardrails/emit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { envelope } from "../../guardrails/emit";
+import { envelope, blockStop, denyTool } from "../../guardrails/emit";
 
 describe("envelope", () => {
   it("wraps context as Claude hookSpecificOutput", () => {
@@ -15,5 +15,37 @@ describe("envelope", () => {
 
   it("emits an empty object when context is empty", () => {
     expect(envelope("PostToolUse", "", "claude")).toBe("{}");
+  });
+});
+
+describe("blockStop", () => {
+  it("emits a Claude Stop block decision", () => {
+    const out = JSON.parse(blockStop("run E2E first", "claude"));
+    expect(out.decision).toBe("block");
+    expect(out.reason).toBe("run E2E first");
+  });
+  it("degrades to a Cursor advisory (no block primitive)", () => {
+    const out = JSON.parse(blockStop("run E2E first", "cursor"));
+    expect(out.decision).toBeUndefined();
+    expect(out.additional_context).toBe("run E2E first");
+  });
+  it("emits an empty object when reason is empty", () => {
+    expect(blockStop("", "claude")).toBe("{}");
+  });
+});
+
+describe("denyTool", () => {
+  it("emits a Claude PreToolUse deny", () => {
+    const out = JSON.parse(denyTool("use the CLI", "claude"));
+    expect(out.hookSpecificOutput.hookEventName).toBe("PreToolUse");
+    expect(out.hookSpecificOutput.permissionDecision).toBe("deny");
+    expect(out.hookSpecificOutput.permissionDecisionReason).toBe("use the CLI");
+  });
+  it("degrades to a Cursor advisory", () => {
+    const out = JSON.parse(denyTool("use the CLI", "cursor"));
+    expect(out.additional_context).toBe("use the CLI");
+  });
+  it("emits an empty object when reason is empty", () => {
+    expect(denyTool("", "claude")).toBe("{}");
   });
 });

--- a/src/test/guardrails/reportGate.test.ts
+++ b/src/test/guardrails/reportGate.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { looksLikeE2EReport, evaluateReportPost, type FileReader } from "../../guardrails/reportGate";
+import type { HookInput } from "../../guardrails/types";
+
+const bash = (command: string, cwd?: string): HookInput => ({
+  tool_name: "Bash",
+  tool_input: { command: command },
+  cwd: cwd,
+});
+
+const noFiles: FileReader = () => null;
+
+describe("looksLikeE2EReport", () => {
+  it("flags a structured acceptance report", () => {
+    expect(looksLikeE2EReport("## E2E Acceptance Results\n3 passed / 1 failed")).toBe(true);
+    expect(looksLikeE2EReport("muggle run:\n3 tests passed, 1 failed")).toBe(true);
+    expect(looksLikeE2EReport("E2E:\n- ✅ login\n- ❌ checkout")).toBe(true);
+  });
+  it("ignores ordinary PR comments", () => {
+    expect(looksLikeE2EReport("Rebased on main and fixed the lint error.")).toBe(false);
+    expect(looksLikeE2EReport("LGTM, merging once CI is green")).toBe(false);
+  });
+  it("ignores a vague claim with no results structure", () => {
+    expect(looksLikeE2EReport("ran the muggle e2e suite, all good")).toBe(false);
+  });
+  it("ignores a feature PR description that merely mentions E2E", () => {
+    expect(
+      looksLikeE2EReport("## Summary\nAdds the E2E enforcement gate for muggle. All unit tests passed."),
+    ).toBe(false);
+  });
+});
+
+describe("evaluateReportPost", () => {
+  it("ignores non-Bash tools and non-PR commands", () => {
+    expect(evaluateReportPost({ tool_name: "Edit" }, noFiles).deny).toBe(false);
+    expect(evaluateReportPost(bash("npm test"), noFiles).deny).toBe(false);
+  });
+
+  it("allows ordinary PR comments", () => {
+    expect(evaluateReportPost(bash('gh pr comment 5 --body "rebased, ready for review"'), noFiles).deny).toBe(false);
+  });
+
+  it("denies a hand-written E2E report posted inline", () => {
+    const r = evaluateReportPost(
+      bash('gh pr comment 5 --body "## E2E Acceptance Results\n2 passed / 1 failed via muggle"'),
+      noFiles,
+    );
+    expect(r.deny).toBe(true);
+    expect(r.reason).toMatch(/build-pr-section/);
+  });
+
+  it("allows an inline body carrying the sentinel", () => {
+    expect(
+      evaluateReportPost(
+        bash('gh pr comment 5 --body "<!-- muggle-pr-section:v1 -->\n## E2E Acceptance Results\n2 passed / 1 failed"'),
+        noFiles,
+      ).deny,
+    ).toBe(false);
+  });
+
+  it("reads --body-file and denies a hand-written report file", () => {
+    const read: FileReader = (p) => (p === "report.md" ? "## E2E Acceptance Results\nmuggle: 1 failed" : null);
+    expect(evaluateReportPost(bash("gh pr comment 5 --body-file report.md"), read).deny).toBe(true);
+  });
+
+  it("reads --body-file and allows a CLI-rendered report file", () => {
+    const read: FileReader = (p) =>
+      p === "report.md" ? "<!-- muggle-pr-section:v1 -->\n## E2E Acceptance Results\nmuggle: 1 failed" : null;
+    expect(evaluateReportPost(bash("gh pr comment 5 --body-file report.md"), read).deny).toBe(false);
+  });
+
+  it("allows the sanctioned jq-from-artifact pipe via the artifact sentinel", () => {
+    const artifact = JSON.stringify({
+      body: "<!-- muggle-pr-section:v1 -->\n## E2E Acceptance Results\nmuggle: 2 passed",
+      comment: "",
+    });
+    const read: FileReader = (p) => (p === "/tmp/out.json" ? artifact : null);
+    const cmd = "jq -r '.body' /tmp/out.json | gh pr comment 5 --body-file -";
+    expect(evaluateReportPost(bash(cmd), read).deny).toBe(false);
+  });
+
+  it("does not deny an un-inspectable stdin pipe (fails open)", () => {
+    // The body comes from a shell var the gate can't see — must not block.
+    const cmd = 'printf "%s" "$REPORT" | gh pr comment 5 --body-file -';
+    expect(evaluateReportPost(bash(cmd), noFiles).deny).toBe(false);
+  });
+
+  it("denies a hand-written report piped via echo (body is in the command)", () => {
+    const cmd = 'echo "## E2E Acceptance Results - muggle 1 failed" | gh pr comment 5 --body-file -';
+    expect(evaluateReportPost(bash(cmd), noFiles).deny).toBe(true);
+  });
+});

--- a/src/test/guardrails/shouldRunE2E.test.ts
+++ b/src/test/guardrails/shouldRunE2E.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { shouldRunE2E, e2eGateDecision, MAX_E2E_BLOCKS } from "../../guardrails/shouldRunE2E";
+import { shouldRunE2E, e2eGateDecision, E2eGateAction, MAX_E2E_BLOCKS } from "../../guardrails/shouldRunE2E";
 
 describe("shouldRunE2E", () => {
   it("fires when tests green and no e2e yet", () => {
@@ -17,22 +17,22 @@ describe("e2eGateDecision", () => {
   const green = { sessionId: "s", prsHandled: [], unitTestsGreen: true };
 
   it("does nothing when no E2E is owed", () => {
-    expect(e2eGateDecision({ ...green, e2eRun: true }).action).toBe("none");
-    expect(e2eGateDecision({ sessionId: "s", prsHandled: [] }).action).toBe("none");
+    expect(e2eGateDecision({ ...green, e2eRun: true }).action).toBe(E2eGateAction.None);
+    expect(e2eGateDecision({ sessionId: "s", prsHandled: [] }).action).toBe(E2eGateAction.None);
   });
 
   it("blocks and increments the count on the first owed stop", () => {
-    expect(e2eGateDecision(green)).toEqual({ action: "block", blockCount: 1 });
-    expect(e2eGateDecision({ ...green, e2eBlockCount: 2 })).toEqual({ action: "block", blockCount: 3 });
+    expect(e2eGateDecision(green)).toEqual({ action: E2eGateAction.Block, blockCount: 1 });
+    expect(e2eGateDecision({ ...green, e2eBlockCount: 2 })).toEqual({ action: E2eGateAction.Block, blockCount: 3 });
   });
 
   it("releases once it has blocked MAX_E2E_BLOCKS times", () => {
     const d = e2eGateDecision({ ...green, e2eBlockCount: MAX_E2E_BLOCKS });
-    expect(d.action).toBe("release");
+    expect(d.action).toBe(E2eGateAction.Release);
     expect(d.blockCount).toBe(MAX_E2E_BLOCKS);
   });
 
   it("a recorded E2E run wins even after blocks", () => {
-    expect(e2eGateDecision({ ...green, e2eRun: true, e2eBlockCount: 2 }).action).toBe("none");
+    expect(e2eGateDecision({ ...green, e2eRun: true, e2eBlockCount: 2 }).action).toBe(E2eGateAction.None);
   });
 });

--- a/src/test/guardrails/shouldRunE2E.test.ts
+++ b/src/test/guardrails/shouldRunE2E.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { shouldRunE2E, e2eGateDecision, E2eGateAction, MAX_E2E_BLOCKS } from "../../guardrails/shouldRunE2E";
+import { shouldRunE2E, e2eGateDecision, E2eGateAction, MAX_E2E_BLOCKS, applyRecordedRun } from "../../guardrails/shouldRunE2E";
 
 describe("shouldRunE2E", () => {
   it("fires when tests green and no e2e yet", () => {
@@ -34,5 +34,35 @@ describe("e2eGateDecision", () => {
 
   it("a recorded E2E run wins even after blocks", () => {
     expect(e2eGateDecision({ ...green, e2eRun: true, e2eBlockCount: 2 }).action).toBe(E2eGateAction.None);
+  });
+});
+
+describe("applyRecordedRun", () => {
+  const base = { sessionId: "s", prsHandled: [] };
+
+  it("a unit-test pass marks tests green and arms the gate", () => {
+    const next = applyRecordedRun(base, { unitTestPassed: true });
+    expect(next.unitTestsGreen).toBe(true);
+    expect(shouldRunE2E(next)).toBe(true);
+  });
+
+  it("an E2E run satisfies the gate", () => {
+    const next = applyRecordedRun({ ...base, unitTestsGreen: true }, { e2eRan: true });
+    expect(next.e2eRun).toBe(true);
+    expect(shouldRunE2E(next)).toBe(false);
+  });
+
+  it("re-arms across rounds: a fresh unit pass after a prior E2E re-requires E2E", () => {
+    const afterRound1 = { ...base, unitTestsGreen: true, e2eRun: true, e2eBlockCount: 2 };
+    expect(shouldRunE2E(afterRound1)).toBe(false);
+
+    const afterRound2Unit = applyRecordedRun(afterRound1, { unitTestPassed: true });
+    expect(afterRound2Unit.e2eRun).toBe(false);
+    expect(afterRound2Unit.e2eBlockCount).toBe(0);
+    expect(shouldRunE2E(afterRound2Unit)).toBe(true);
+  });
+
+  it("returns the same reference when nothing was recorded", () => {
+    expect(applyRecordedRun(base, { unitTestPassed: false, e2eRan: false })).toBe(base);
   });
 });

--- a/src/test/guardrails/shouldRunE2E.test.ts
+++ b/src/test/guardrails/shouldRunE2E.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { shouldRunE2E } from "../../guardrails/shouldRunE2E";
+import { shouldRunE2E, e2eGateDecision, MAX_E2E_BLOCKS } from "../../guardrails/shouldRunE2E";
 
 describe("shouldRunE2E", () => {
   it("fires when tests green and no e2e yet", () => {
@@ -10,5 +10,29 @@ describe("shouldRunE2E", () => {
   });
   it("does not fire if tests never went green", () => {
     expect(shouldRunE2E({ sessionId: "s", prsHandled: [], unitTestsGreen: false })).toBe(false);
+  });
+});
+
+describe("e2eGateDecision", () => {
+  const green = { sessionId: "s", prsHandled: [], unitTestsGreen: true };
+
+  it("does nothing when no E2E is owed", () => {
+    expect(e2eGateDecision({ ...green, e2eRun: true }).action).toBe("none");
+    expect(e2eGateDecision({ sessionId: "s", prsHandled: [] }).action).toBe("none");
+  });
+
+  it("blocks and increments the count on the first owed stop", () => {
+    expect(e2eGateDecision(green)).toEqual({ action: "block", blockCount: 1 });
+    expect(e2eGateDecision({ ...green, e2eBlockCount: 2 })).toEqual({ action: "block", blockCount: 3 });
+  });
+
+  it("releases once it has blocked MAX_E2E_BLOCKS times", () => {
+    const d = e2eGateDecision({ ...green, e2eBlockCount: MAX_E2E_BLOCKS });
+    expect(d.action).toBe("release");
+    expect(d.blockCount).toBe(MAX_E2E_BLOCKS);
+  });
+
+  it("a recorded E2E run wins even after blocks", () => {
+    expect(e2eGateDecision({ ...green, e2eRun: true, e2eBlockCount: 2 }).action).toBe("none");
   });
 });


### PR DESCRIPTION
## Problem

The E2E acceptance gate and the PR walkthrough were **advisory only**. The model could (and did) skip the E2E run and hand-write freeform "test reports" that bypass the deterministic `muggle build-pr-section` renderer. The Stop gate even set `e2eRun=true` the moment it *reminded* — so it fired once, lied that E2E had run, and never re-armed.

## What changed

**E2E run — now enforced (`Stop` → `decision: block`)**
- The gate refuses to end the turn until a real E2E run is recorded, instead of an ignorable `additionalContext` nudge.
- Removed the self-marking lie: `e2eRun` is set **only** when an actual run is detected (`guardrail-record-tests`).
- Escape hatch: releases to advisory after `MAX_E2E_BLOCKS` (3) blocks so a genuinely un-runnable E2E (no app/services/PR) can't trap the turn.
- E2E runs driven by the **muggle execute/replay MCP tools** are now recorded too (new `PostToolUse` matcher), not just Bash `muggle …` — otherwise the block could never be satisfied.

**Report formatting — now enforced (`PreToolUse` → `permissionDecision: deny`)**
- `muggle build-pr-section` prepends an invisible sentinel (`<!-- muggle-pr-section:v1 -->`) to `body` and `comment`.
- New `guardrail-report-format` denies a `gh pr comment|create|edit` whose body **reads like an E2E results report** (acceptance-results heading / pass-fail tally / per-test status list + Muggle/E2E context) but **lacks the sentinel**.
- Fails **open** on anything it can't positively read as a hand-written report: the sanctioned `jq -r '.body' … | gh … --body-file -` path (sentinel surfaced via the artifact), ordinary comments, and feature PR descriptions that merely mention E2E all pass.

Cursor has no block/deny primitive, so both gates degrade to advisories there.

## Tunable knob for review
`looksLikeE2EReport` (src/guardrails/reportGate.ts) is the precision/recall dial — it keys on report *structure*, not just the words "e2e"/"muggle", to avoid flagging normal PR descriptions. Worth a look if you want it tighter or looser.

## Verification
- `vitest run` — **382 passing** (25 files), incl. new `reportGate` + extended `emit`/`shouldRunE2E` suites.
- `tsc --noEmit` clean; eslint clean on changed files.
- Bundled `guardrails.mjs` smoke-tested end-to-end: report-gate denies a hand-written report / allows sentinel + ordinary comments; E2E gate blocks 3× then releases, and a recorded MCP E2E run satisfies it.

Docs: `plugin/hooks/README.md` updated with an **advise vs enforce** section and a strength column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)