### PR TITLE
fix(guardrails): E2E gate never fired — detect E2E via MCP tool, not Bash text

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "5.2.0"
+      "version": "5.3.0"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "5.2.0"
+      "version": "5.3.0"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@muggleai/works",
   "mcpName": "io.github.multiplex-ai/muggle",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
   "type": "module",
   "main": "dist/index.js",
@@ -43,14 +43,14 @@
     "test:gates:behavioral": "tsx internal/skill-gate-eval/src/run.ts"
   },
   "muggleConfig": {
-    "electronAppVersion": "1.4.3",
+    "electronAppVersion": "1.5.1",
     "downloadBaseUrl": "https://github.com/multiplex-ai/muggle-ai-works/releases/download",
     "runtimeTargetDefault": "dev",
     "checksums": {
-      "darwin-arm64": "c89902e5003614cdb3a00aa12a3774d07f63d3a6450282ea86530bc46969eb55",
-      "darwin-x64": "093742c15e7439cf62ddb22a42c7d5cc8c482140c9a981cd06c4f58eb7a48cd4",
-      "linux-x64": "adb4d707ce122c3826260a26176ba2ee10bf14f376eed3455a1b0e2202ac4f3f",
-      "win32-x64": "d1abae146be3378884c74fc2c2f9d7a272e86695b5ae04fdbea200586ea3bfd2"
+      "darwin-arm64": "70649bed80b3ae407893728abd426e32c54eeda03fde7856e530bb6f67e359cd",
+      "darwin-x64": "26a2176c0c926a6f20a4af99e4bc7362e8365ad260c3ca42d18bb1f6cf1b29d5",
+      "linux-x64": "69f33e49c6baa017604ffd49a4f4db2eba90260375c4fb5918326843c51d7bdd",
+      "win32-x64": "559d02c0e80860dec3ed5c82e8e1d3d4aa2c4dea4f73a2c62c149ad4bd6131d0"
     }
   },
   "dependencies": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/scripts/guardrails.mjs
+++ b/plugin/scripts/guardrails.mjs
@@ -43,7 +43,7 @@ ${input2.tool_response?.output ?? ""}`;
 // src/guardrails/testsGreen.ts
 var TEST_CMD = /\b(pnpm|npm|yarn)\s+(run\s+)?test\b|\b(jest|vitest|pytest)\b|\bgo\s+test\b|\bcargo\s+test\b/;
 var FAIL = /\b\d+\s+failed\b|\bFAIL\b|✗/;
-var E2E_RUN = /\bmuggle\b[^\n]*\b(execute|test)\b/i;
+var E2E_TOOL = /muggle.*(execute|test-generation|replay)/i;
 function isTestCommand(cmd) {
   return TEST_CMD.test(cmd);
 }
@@ -54,9 +54,7 @@ ${input2.tool_response?.stderr ?? ""}`;
   return !FAIL.test(out);
 }
 function isE2ERun(input2) {
-  const cmd = input2.tool_input?.command ?? "";
-  const tool = input2.tool_name ?? "";
-  return E2E_RUN.test(cmd) || /muggle.*(execute|test-generation|replay)/i.test(tool);
+  return E2E_TOOL.test(input2.tool_name ?? "");
 }
 
 // src/guardrails/shouldRunE2E.ts

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "5.2.0",
+  "version": "5.3.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"

--- a/src/guardrails/testsGreen.ts
+++ b/src/guardrails/testsGreen.ts
@@ -2,7 +2,14 @@ import type { HookInput } from "./types.js";
 
 const TEST_CMD = /\b(pnpm|npm|yarn)\s+(run\s+)?test\b|\b(jest|vitest|pytest)\b|\bgo\s+test\b|\bcargo\s+test\b/;
 const FAIL = /\b\d+\s+failed\b|\bFAIL\b|✗/;
-const E2E_RUN = /\bmuggle\b[^\n]*\b(execute|test)\b/i;
+
+// A real acceptance run reaches the hook only as a muggle execute/replay MCP
+// tool call — there is no `muggle test`/`muggle replay` CLI. Match the tool name,
+// never the Bash command text: in a repo named "muggle", commits, PR titles and
+// greps say "muggle … test" constantly, so a command-text match flips e2eRun=true
+// before any run happens and disarms the Stop gate (even the unit-test command,
+// `cd …/muggle-ai-works && npm test`, both armed and disarmed it in one call).
+const E2E_TOOL = /muggle.*(execute|test-generation|replay)/i;
 
 export function isTestCommand(cmd: string): boolean {
   return TEST_CMD.test(cmd);
@@ -15,7 +22,5 @@ export function testsPassed(input: HookInput): boolean {
 }
 
 export function isE2ERun(input: HookInput): boolean {
-  const cmd = input.tool_input?.command ?? "";
-  const tool = input.tool_name ?? "";
-  return E2E_RUN.test(cmd) || /muggle.*(execute|test-generation|replay)/i.test(tool);
+  return E2E_TOOL.test(input.tool_name ?? "");
 }

--- a/src/test/guardrails/testsGreen.test.ts
+++ b/src/test/guardrails/testsGreen.test.ts
@@ -17,9 +17,21 @@ describe("testsGreen", () => {
     expect(testsPassed({ tool_response: { stdout: "" } })).toBe(false);
   });
 
-  it("detects a muggle E2E run", () => {
-    expect(isE2ERun({ tool_input: { command: "muggle test --local" } })).toBe(true);
+  it("counts a muggle execute/replay MCP tool call as an E2E run", () => {
+    expect(isE2ERun({ tool_name: "muggle-local-execute-replay" })).toBe(true);
     expect(isE2ERun({ tool_name: "muggle-local-execute-test-generation" })).toBe(true);
-    expect(isE2ERun({ tool_input: { command: "pnpm test" } })).toBe(false);
+    expect(
+      isE2ERun({ tool_name: "mcp__plugin_muggle_muggle__muggle-remote-workflow-start-test-script-replay" }),
+    ).toBe(true);
+  });
+
+  it("never counts a Bash command as an E2E run, even one naming muggle + test", () => {
+    const bash = (command: string) => isE2ERun({ tool_name: "Bash", tool_input: { command } });
+    expect(bash("git commit -m 'feat: muggle e2e test gate'")).toBe(false);
+    expect(bash("gh pr create --title 'muggle lane-aware test-script-list'")).toBe(false);
+    expect(bash("grep -rn muggle src/test/")).toBe(false);
+    expect(bash("cd /c/Users/x/muggle-ai-works && npm test")).toBe(false);
+    expect(bash("muggle test --local")).toBe(false);
+    expect(bash("pnpm test")).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

The hard-enforce E2E Stop gate (#280) **never fired once in 483 recorded sessions** — it armed 0 times and blocked 0 times. E2E got silently skipped.

`shouldRunE2E` enforces only when `unitTestsGreen === true && e2eRun !== true`. The `e2eRun` flag is set by `isE2ERun`, whose Bash branch was wildly over-broad:

```js
E2E_RUN = /\bmuggle\b[^\n]*\b(execute|test)\b/i   // tested against the COMMAND string
```

`record-tests` runs on **every Bash PostToolUse**, so in a repo literally named *muggle*, ordinary commands flipped `e2eRun=true` before any acceptance run:

- `git commit -m "…muggle…test…"`
- `gh pr create --title "muggle … test-script-list"`
- `grep -rn muggle src/test/`
- `cd …/muggle-ai-works && npm test` — the unit-test command **armed and disarmed the gate in the same call**

By the time the Stop hook evaluated, `e2eRun` was already true → `shouldRunE2E` false → gate stood down.

### Evidence (`~/.muggle-ai/guardrails/`, 483 sessions)

| Metric | Count |
| --- | --- |
| Sessions where the gate could ever fire (`unit green & e2e≠true`) | **0** |
| Sessions where the Stop hook ever blocked (`e2eBlockCount` set) | **0** |
| `e2eRun=true` with **no unit tests at all** | 17 |
| muggle-ai-brain docs PR (no app, E2E impossible) with `e2eRun=true` | proof |

## Fix

There is no `muggle test`/`muggle replay` CLI — the CLI surface is `build-pr-section`, `doctor`, `login`, `serve`, `status`, etc. A real acceptance run reaches the hook **only as a `muggle …execute/replay` MCP tool call**, which the `record-tests` matcher (`mcp__.*muggle.*(execute|replay)`) already scopes. So `isE2ERun` now keys on the **tool name alone** and ignores Bash command text — the only un-spoofable signal.

The re-arm reset (a fresh unit pass clears `e2eRun`) already existed and is unchanged.

## Verification

- Unit: new regression cases prove `git commit`/`gh pr create`/`grep`/`cd …/muggle-ai-works && npm test`/`muggle test --local` all return `isE2ERun=false`, while `muggle-local-execute-replay` / `…-test-script-replay` MCP tools return true. `387/387` tests pass, typecheck clean.
- Behavioral (piped real payloads through the rebuilt `guardrails.mjs`):
  1. `npm test` in a muggle path → arms gate (`unitTestsGreen=true`, `e2eRun=false`)
  2. `git commit` naming muggle+test → `e2eRun` stays false
  3. Stop → gate **BLOCKS** (`decision:"block"`) ✅ first time it ever fired
  4. MCP replay tool → `e2eRun=true` → gate releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
