### PR TITLE
chore(release): @muggleai/works 5.3.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "5.3.0"
+      "version": "5.3.1"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "5.3.0"
+      "version": "5.3.1"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@muggleai/works",
   "mcpName": "io.github.multiplex-ai/muggle",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
   "type": "module",
   "main": "dist/index.js",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "5.3.0",
+  "version": "5.3.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "5.3.0",
+      "version": "5.3.1",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
Patch release shipping the E2E gate fix (#282).

`isE2ERun` now keys on the `muggle …execute/replay` MCP tool name instead of false-matching ordinary Bash commands (`git commit`, `gh pr create`, `grep`, `cd …/muggle-ai-works && npm test`). The hard-enforce Stop gate from #280 — which **never fired once in 483 recorded sessions** — now arms and blocks when an E2E run is owed.

- Version: 5.3.0 → **5.3.1** (synced across all 5 manifests via `sync:versions`)
- Electron: unchanged (1.5.1)
- Verify: `lint:check` (0 errors), `typecheck`, `test` (387/387), `build`, `verify:plugin`, `verify:contracts`, `verify:electron-release-checksums` all pass

Squash-merge, then dispatch `publish-works-to-npm.yml --field version=5.3.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
