### PR TITLE
ci: enforce skill evals (gate + routing) as blocking PR checks

### DIFF
--- a/.github/workflows/skill-eval.yml
+++ b/.github/workflows/skill-eval.yml
@@ -34,6 +34,15 @@ jobs:
       GATE_RUNS: ${{ inputs.gate_runs || '10' }}
       MUGGLE_BRAIN_DIR: ${{ github.workspace }}/muggle-ai-brain
     steps:
+      # Fail fast with a clear reason if setup is incomplete, rather than a
+      # cryptic git-auth error deep in the scenario-repo checkout.
+      - name: Require secrets
+        env:
+          BRAIN_REPO_TOKEN: ${{ secrets.BRAIN_REPO_TOKEN }}
+        run: |
+          : "${ANTHROPIC_API_KEY:?set the ANTHROPIC_API_KEY repo secret to run skill evals}"
+          : "${BRAIN_REPO_TOKEN:?set the BRAIN_REPO_TOKEN repo secret (read access to multiplex-ai/muggle-ai-brain)}"
+
       - name: Checkout works
         uses: actions/checkout@v6
 
@@ -92,7 +101,7 @@ jobs:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       ROUTING_RUNS: ${{ inputs.routing_runs || '3' }}
       CLAUDE_CONFIG_DIR: ${{ github.workspace }}/.cc-config
-      CLEAN_CWD: ${{ runner.temp }}/clean-cwd
+      CLEAN_CWD: ${{ github.workspace }}/.clean-cwd
     steps:
       - name: Checkout works
         uses: actions/checkout@v6

--- a/.github/workflows/skill-eval.yml
+++ b/.github/workflows/skill-eval.yml
@@ -1,0 +1,180 @@
+name: Skill Evals
+
+# Blocking on every PR to master: the gate eval (behavioral preference-gate
+# contract) and the routing eval (skill descriptions route the right queries).
+# Both are LLM-driven, so the per-PR routing run is scoped to the skills the PR
+# touches; the full 391-query routing sweep runs nightly and on demand.
+on:
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+    inputs:
+      gate_runs:
+        description: "skill-gate-eval: runs per scenario"
+        default: "10"
+      routing_runs:
+        description: "skill-routing-eval: runs per query"
+        default: "3"
+
+concurrency:
+  group: skill-eval-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  skill-gate-eval:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      GATE_RUNS: ${{ inputs.gate_runs || '10' }}
+      MUGGLE_BRAIN_DIR: ${{ github.workspace }}/muggle-ai-brain
+    steps:
+      - name: Checkout works
+        uses: actions/checkout@v6
+
+      # Scenario data lives in a separate private repo; needs a token with read
+      # access to multiplex-ai/muggle-ai-brain (the default GITHUB_TOKEN cannot
+      # read other private repos).
+      - name: Checkout scenario data (muggle-ai-brain)
+        uses: actions/checkout@v6
+        with:
+          repository: multiplex-ai/muggle-ai-brain
+          token: ${{ secrets.BRAIN_REPO_TOKEN }}
+          path: muggle-ai-brain
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run skill-gate evals (every gate in the scenario repo)
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          fail=0
+          ran=0
+          for scenarios in "$MUGGLE_BRAIN_DIR"/eval/skill-gate-eval/*/scenarios.json; do
+            gate="$(basename "$(dirname "$scenarios")")"
+            skill="$(node -e "process.stdout.write(require(process.argv[1]).skill)" "$scenarios")"
+            echo "::group::gate=$gate skill=$skill runs=$GATE_RUNS"
+            if pnpm exec tsx internal/skill-gate-eval/src/run.ts \
+                 --gate "$gate" --skill "$skill" --runs "$GATE_RUNS" \
+                 --brain-dir "$MUGGLE_BRAIN_DIR"; then
+              echo "PASS $gate"
+            else
+              echo "FAIL $gate"
+              fail=1
+            fi
+            ran=$((ran + 1))
+            echo "::endgroup::"
+          done
+          if [ "$ran" -eq 0 ]; then
+            echo "No scenarios.json found under $MUGGLE_BRAIN_DIR/eval/skill-gate-eval" >&2
+            exit 1
+          fi
+          exit "$fail"
+
+  skill-routing-eval:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      ROUTING_RUNS: ${{ inputs.routing_runs || '3' }}
+      CLAUDE_CONFIG_DIR: ${{ github.workspace }}/.cc-config
+      CLEAN_CWD: ${{ runner.temp }}/clean-cwd
+    steps:
+      - name: Checkout works
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      # On a PR, only the touched skills are evaluated (full sweep is nightly).
+      # When no skill description changed, the job has nothing to gate and the
+      # remaining steps are skipped — the required check still goes green.
+      - name: Determine scope
+        id: scope
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "skills=" >> "$GITHUB_OUTPUT"
+            echo "Full routing sweep (event: ${{ github.event_name }})"
+            exit 0
+          fi
+          git fetch --no-tags origin "${{ github.base_ref }}"
+          changed="$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- 'plugin/skills/*/SKILL.md' \
+            | awk -F/ '{print $3}' | sort -u | paste -sd, -)"
+          if [ -z "$changed" ]; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "No plugin/skills/*/SKILL.md changed — routing eval not required."
+          else
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "skills=$changed" >> "$GITHUB_OUTPUT"
+            echo "Changed skills: $changed"
+          fi
+
+      - name: Setup Node.js
+        if: steps.scope.outputs.should_run == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Setup Python
+        if: steps.scope.outputs.should_run == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Claude Code CLI
+        if: steps.scope.outputs.should_run == 'true'
+        run: npm install -g @anthropic-ai/claude-code
+
+      # Install the plugin from THIS checkout (not GitHub master) so the eval
+      # tests the PR's skill descriptions. Fresh CLAUDE_CONFIG_DIR + a clean cwd
+      # keep the repo's own .claude settings/skills from competing.
+      - name: Install muggle plugin from this checkout
+        if: steps.scope.outputs.should_run == 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p "$CLAUDE_CONFIG_DIR" "$CLEAN_CWD"
+          claude plugin marketplace add "$GITHUB_WORKSPACE"
+          claude plugin install muggleai@muggle-works
+          claude plugin list
+          claude plugin list | grep -Fq "muggleai@muggle-works" \
+            || { echo "muggle plugin failed to install/enable" >&2; exit 1; }
+
+      - name: Preflight — confirm the plugin actually routes
+        if: steps.scope.outputs.should_run == 'true'
+        run: |
+          set -euo pipefail
+          route="$(python internal/skill-routing-eval/router_eval.py \
+            --probe 'test my changes before I open the PR' --repo-root "$CLEAN_CWD")"
+          echo "preflight route=$route"
+          case "$route" in
+            muggle*) echo "plugin loaded; routing works" ;;
+            *) echo "Preflight failed: expected a muggle* route, got '$route'. Plugin not loaded or auth missing." >&2; exit 1 ;;
+          esac
+
+      - name: Run routing eval
+        if: steps.scope.outputs.should_run == 'true'
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            python internal/skill-routing-eval/run.py \
+              --skills "${{ steps.scope.outputs.skills }}" \
+              --runs "$ROUTING_RUNS" --repo-root "$CLEAN_CWD" --fail-under 1.0
+          else
+            python internal/skill-routing-eval/run.py \
+              --all --runs "$ROUTING_RUNS" --repo-root "$CLEAN_CWD" --fail-under 0.95
+          fi

--- a/internal/skill-gate-eval/README.md
+++ b/internal/skill-gate-eval/README.md
@@ -54,4 +54,14 @@ A scenario passes if it succeeds on ≥ 99% of runs (per the design doc).
 Layer 1 lives in `src/test/skills/` and runs via vitest on every
 commit. Layer 2 is multi-turn agent sessions — slow, costs API
 tokens, nondeterministic. Keeping it out of the vitest tree avoids
-accidental CI runs. Promote to CI only after the suite stabilizes.
+running it on every unit-test commit; it runs instead as its own
+blocking workflow — see CI below.
+
+## CI (blocking)
+
+`.github/workflows/skill-eval.yml` runs every gate found under
+`$MUGGLE_BRAIN_DIR/eval/skill-gate-eval/*/scenarios.json` on each PR to
+`master` (`--runs 10`, each scenario must hold ≥99%), plus nightly and on
+`workflow_dispatch`. It checks out `muggle-ai-brain` for the scenarios, so
+CI needs two repo secrets: `ANTHROPIC_API_KEY` and `BRAIN_REPO_TOKEN`
+(read access to the scenario repo).

--- a/internal/skill-routing-eval/README.md
+++ b/internal/skill-routing-eval/README.md
@@ -37,6 +37,17 @@ python internal/skill-routing-eval/router_eval.py --eval-set <set.json> --repo-r
 python internal/skill-routing-eval/analyze.py report --in <report.json> --out <report.md>
 ```
 
+## CI (blocking)
+
+`.github/workflows/skill-eval.yml` runs this on every PR to `master`, scoped to
+the skills the PR changed; the full set runs nightly and on `workflow_dispatch`.
+
+- `--skills a,b` — run a subset (CI derives it from the PR's changed `plugin/skills/*/SKILL.md`).
+- `--fail-under F` — exit non-zero if accuracy < F, or if a chunk stays 0% (suspected disconnect, unverified). Default `0.0` keeps dev runs informational. CI uses `1.0` on PRs (changed skills must route perfectly) and `0.95` for the nightly full sweep.
+- `router_eval.py --probe "<query>"` — route one query and print the result; CI uses it to fail fast when the plugin didn't load.
+
+CI installs the plugin from the PR checkout (`claude plugin marketplace add "$GITHUB_WORKSPACE"`), so it tests the PR's descriptions rather than master — no `--sync-cache` needed. Requires the `ANTHROPIC_API_KEY` repo secret.
+
 ## Optimization loop (per skill)
 
 1. Run the router eval; `analyze.py report` surfaces each skill's recall and the confusion pairs.

--- a/internal/skill-routing-eval/router_eval.py
+++ b/internal/skill-routing-eval/router_eval.py
@@ -88,15 +88,22 @@ def detect_route(query: str, repo_root: str, timeout: int, model: str | None) ->
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--eval-set", required=True)
-    ap.add_argument("--repo-root", required=True)
+    ap.add_argument("--eval-set")
+    ap.add_argument("--repo-root", default=".")
     ap.add_argument("--model", default=None)
     ap.add_argument("--runs", type=int, default=3)
     ap.add_argument("--workers", type=int, default=6)
     ap.add_argument("--timeout", type=int, default=120)
-    ap.add_argument("--out", required=True)
+    ap.add_argument("--out")
     ap.add_argument("--limit", type=int, default=0)
+    ap.add_argument("--probe", help="route a single query, print the detected skill, and exit (CI preflight)")
     args = ap.parse_args()
+
+    if args.probe:
+        print(detect_route(args.probe, args.repo_root, args.timeout, args.model))
+        return
+    if not args.eval_set or not args.out:
+        ap.error("--eval-set and --out are required unless --probe is given")
 
     eval_set = json.loads(Path(args.eval_set).read_text(encoding="utf-8"))
     if args.limit:

--- a/internal/skill-routing-eval/run.py
+++ b/internal/skill-routing-eval/run.py
@@ -86,12 +86,16 @@ def main():
     g = ap.add_mutually_exclusive_group()
     g.add_argument("--all", action="store_true", help="run every skill chunk (default)")
     g.add_argument("--skill", help="run only this expected_skill chunk")
+    g.add_argument("--skills", help="comma-separated subset of expected_skills to run (e.g. the skills changed in a PR)")
     ap.add_argument("--runs", type=int, default=3)
     ap.add_argument("--workers", type=int, default=3, help="keep low — high concurrency trips the MCP disconnect")
     ap.add_argument("--timeout", type=int, default=200)
     ap.add_argument("--out-dir", default=str(HERE / "reports" / "run"))
     ap.add_argument("--repo-root", default=str(REPO_ROOT))
     ap.add_argument("--sync-cache", action="store_true", help="copy working-tree descriptions into the installed plugin cache first")
+    # CI gate: exit non-zero when accuracy < threshold or a chunk stays 0% (suspected disconnect).
+    # Default 0.0 leaves dev runs informational, never failing the process.
+    ap.add_argument("--fail-under", type=float, default=0.0, help="CI gate: exit 1 if overall accuracy is below this, or if any chunk is flagged suspected-disconnect")
     args = ap.parse_args()
 
     repo_root = Path(args.repo_root).resolve()
@@ -111,7 +115,12 @@ def main():
     for item in eval_set:
         by_skill[item.get("expected_skill", NONE)].append(item)
 
-    skills = [args.skill] if args.skill else sorted(by_skill)
+    if args.skill:
+        skills = [args.skill]
+    elif args.skills:
+        skills = [s.strip() for s in args.skills.split(",") if s.strip()]
+    else:
+        skills = sorted(by_skill)
     all_results = []
     flagged = []
 
@@ -141,11 +150,23 @@ def main():
     def ok(r):
         # mirror analyze.py's rule: negatives pass when no muggle skill fires
         return (not r["majority"].startswith("muggle")) if r["expected_skill"] == NONE else (r["majority"] == r["expected_skill"])
+    total = len(all_results)
     passed = sum(1 for r in all_results if ok(r))
-    print(f"\nDone. {passed}/{len(all_results)} = {passed/len(all_results):.1%}", file=sys.stderr)
+    accuracy = passed / total if total else 1.0
+    print(f"\nDone. {passed}/{total} = {accuracy:.1%}", file=sys.stderr)
     if flagged:
         print(f"Suspected-disconnect (unverified): {', '.join(flagged)}", file=sys.stderr)
     print(f"Report: {md_path}", file=sys.stderr)
+
+    if args.fail_under > 0.0:
+        reasons = []
+        if flagged:
+            reasons.append(f"{len(flagged)} chunk(s) flagged suspected-disconnect (re-run to clear): {', '.join(flagged)}")
+        if accuracy < args.fail_under:
+            reasons.append(f"accuracy {accuracy:.1%} below --fail-under {args.fail_under:.0%}")
+        if reasons:
+            print("GATE FAILED: " + "; ".join(reasons), file=sys.stderr)
+            sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Wires both skill-eval suites into CI as **blocking checks on every PR to `master`** (the requested enforcement), via a new `.github/workflows/skill-eval.yml`. Also runs nightly (full) and on `workflow_dispatch`.

## Jobs

**`skill-gate-eval`** — runs every gate under `muggle-ai-brain/eval/skill-gate-eval/*/scenarios.json` (`--runs 10`, each scenario must hold ≥99%). Checks out the scenario repo and tests the PR's `plugin/skills` working tree directly via the agent SDK.

**`skill-routing-eval`** — LLM routing eval is 391 queries × 3 runs, impractical to run in full on every PR, so:
- **PR**: scoped to the skills whose `plugin/skills/*/SKILL.md` changed (`run.py --skills <changed> --fail-under 1.0`). No skill changed → job skips its work and the required check still goes green.
- **Nightly / dispatch**: full sweep (`--all --fail-under 0.95`; the docs note the full sweep flakes via intermittent MCP disconnects, which `run.py` already re-runs and flags).

Installs the plugin from the PR checkout (`claude plugin marketplace add "$GITHUB_WORKSPACE"`) so it tests the PR's descriptions, not master, and **preflights** that the plugin actually routes a known query before running — so an unloaded plugin fails loudly instead of silently passing everything as `none`.

## Script changes
- `run.py`: `--skills` (subset) and `--fail-under` (exit non-zero on accuracy miss or an unverified suspected-disconnect chunk; default `0.0` keeps dev runs informational).
- `router_eval.py`: `--probe "<query>"` routes one query and prints the result (reuses `detect_route`).

## Required to actually enforce (manual, admin/secrets — I can't do these)
1. Add repo secrets: **`ANTHROPIC_API_KEY`**, and **`BRAIN_REPO_TOKEN`** (read access to `multiplex-ai/muggle-ai-brain` — the default `GITHUB_TOKEN` can't read another private repo).
2. Mark **`skill-gate-eval`** and **`skill-routing-eval`** as required status checks on the `master` branch protection rule (this is the switch that blocks merges).

## Verified locally
Both scripts parse + new flags work; plugin install-from-local-checkout populates the cache with the PR's skills; YAML valid; changed-skills diff/awk pipeline and scenario-skill extraction produce correct output. Not run end-to-end (needs the API-key secret + cross-repo checkout — exercises on first CI run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)