### PR TITLE
ci: authenticate skill evals with Claude subscription (not API key)

### DIFF
--- a/.github/workflows/skill-eval.yml
+++ b/.github/workflows/skill-eval.yml
@@ -30,7 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      # Subscription auth, not a pay-per-use API key. Generate with
+      # `claude setup-token` and store as the CLAUDE_CODE_OAUTH_TOKEN secret.
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       GATE_RUNS: ${{ inputs.gate_runs || '10' }}
       MUGGLE_BRAIN_DIR: ${{ github.workspace }}/muggle-ai-brain
     steps:
@@ -40,7 +42,7 @@ jobs:
         env:
           BRAIN_REPO_TOKEN: ${{ secrets.BRAIN_REPO_TOKEN }}
         run: |
-          : "${ANTHROPIC_API_KEY:?set the ANTHROPIC_API_KEY repo secret to run skill evals}"
+          : "${CLAUDE_CODE_OAUTH_TOKEN:?set the CLAUDE_CODE_OAUTH_TOKEN repo secret (run \`claude setup-token\`) to run skill evals}"
           : "${BRAIN_REPO_TOKEN:?set the BRAIN_REPO_TOKEN repo secret (read access to multiplex-ai/muggle-ai-brain)}"
 
       - name: Checkout works
@@ -77,7 +79,9 @@ jobs:
             gate="$(basename "$(dirname "$scenarios")")"
             skill="$(node -e "process.stdout.write(require(process.argv[1]).skill)" "$scenarios")"
             echo "::group::gate=$gate skill=$skill runs=$GATE_RUNS"
-            if pnpm exec tsx internal/skill-gate-eval/src/run.ts \
+            # Keep a stray API key from outranking the subscription token (it would bill the API).
+          unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN
+          if pnpm exec tsx internal/skill-gate-eval/src/run.ts \
                  --gate "$gate" --skill "$skill" --runs "$GATE_RUNS" \
                  --brain-dir "$MUGGLE_BRAIN_DIR"; then
               echo "PASS $gate"
@@ -98,7 +102,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 180
     env:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      # Subscription auth, not a pay-per-use API key (see skill-gate-eval above).
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       ROUTING_RUNS: ${{ inputs.routing_runs || '3' }}
       CLAUDE_CONFIG_DIR: ${{ github.workspace }}/.cc-config
       CLEAN_CWD: ${{ github.workspace }}/.clean-cwd
@@ -167,6 +172,7 @@ jobs:
         if: steps.scope.outputs.should_run == 'true'
         run: |
           set -euo pipefail
+          unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN
           route="$(python internal/skill-routing-eval/router_eval.py \
             --probe 'test my changes before I open the PR' --repo-root "$CLEAN_CWD")"
           echo "preflight route=$route"
@@ -179,6 +185,7 @@ jobs:
         if: steps.scope.outputs.should_run == 'true'
         run: |
           set -euo pipefail
+          unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             python internal/skill-routing-eval/run.py \
               --skills "${{ steps.scope.outputs.skills }}" \

--- a/.github/workflows/skill-eval.yml
+++ b/.github/workflows/skill-eval.yml
@@ -35,6 +35,9 @@ jobs:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       GATE_RUNS: ${{ inputs.gate_runs || '10' }}
       MUGGLE_BRAIN_DIR: ${{ github.workspace }}/muggle-ai-brain
+      # Fresh, writable config dir for the headless Claude Code CLI (same as
+      # skill-routing-eval) — avoids first-run state in an unwritable HOME.
+      CLAUDE_CONFIG_DIR: ${{ github.workspace }}/.cc-config
     steps:
       # Fail fast with a clear reason if setup is incomplete, rather than a
       # cryptic git-auth error deep in the scenario-repo checkout.
@@ -85,6 +88,7 @@ jobs:
           # The SDK can't find its bundled native binary on the runner; point it
           # at the globally-installed CLI instead.
           export CLAUDE_CODE_EXECUTABLE="$(command -v claude)"
+          mkdir -p "$CLAUDE_CONFIG_DIR"
           fail=0
           ran=0
           for scenarios in "$MUGGLE_BRAIN_DIR"/eval/skill-gate-eval/*/scenarios.json; do

--- a/.github/workflows/skill-eval.yml
+++ b/.github/workflows/skill-eval.yml
@@ -69,19 +69,29 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # The gate harness drives @anthropic-ai/claude-agent-sdk's query(), which
+      # needs the Claude Code CLI; the SDK's bundled native binary isn't usable
+      # on the runner. Install it (as skill-routing-eval does) and let the run
+      # step point the SDK at it. Auth stays on the subscription token.
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
       - name: Run skill-gate evals (every gate in the scenario repo)
         run: |
           set -euo pipefail
           shopt -s nullglob
+          # Keep a stray API key from outranking the subscription token (it would bill the API).
+          unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN
+          # The SDK can't find its bundled native binary on the runner; point it
+          # at the globally-installed CLI instead.
+          export CLAUDE_CODE_EXECUTABLE="$(command -v claude)"
           fail=0
           ran=0
           for scenarios in "$MUGGLE_BRAIN_DIR"/eval/skill-gate-eval/*/scenarios.json; do
             gate="$(basename "$(dirname "$scenarios")")"
             skill="$(node -e "process.stdout.write(require(process.argv[1]).skill)" "$scenarios")"
             echo "::group::gate=$gate skill=$skill runs=$GATE_RUNS"
-            # Keep a stray API key from outranking the subscription token (it would bill the API).
-          unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN
-          if pnpm exec tsx internal/skill-gate-eval/src/run.ts \
+            if pnpm exec tsx internal/skill-gate-eval/src/run.ts \
                  --gate "$gate" --skill "$skill" --runs "$GATE_RUNS" \
                  --brain-dir "$MUGGLE_BRAIN_DIR"; then
               echo "PASS $gate"

--- a/.github/workflows/skill-eval.yml
+++ b/.github/workflows/skill-eval.yml
@@ -79,6 +79,25 @@ jobs:
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code
 
+      # Prove the subscription token authenticates before the agent-SDK harness
+      # runs, via the same `claude -p` path skill-routing-eval relies on. A
+      # rejected CLAUDE_CODE_OAUTH_TOKEN and an SDK/harness fault otherwise both
+      # surface only as the SDK's opaque "process exited with code 1"; this
+      # separates them and fails fast with an actionable message.
+      - name: Preflight — confirm subscription auth
+        run: |
+          set -euo pipefail
+          unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN
+          mkdir -p "$CLAUDE_CONFIG_DIR"
+          if out="$(claude -p 'Respond with exactly: OK' --max-turns 1 2>&1)"; then
+            echo "auth preflight ok"
+          else
+            echo "::error::Subscription auth preflight failed — CLAUDE_CODE_OAUTH_TOKEN is rejected. Regenerate with \`claude setup-token\` and re-set the secret (no trailing newline)." >&2
+            echo "claude output:" >&2
+            echo "$out" >&2
+            exit 1
+          fi
+
       - name: Run skill-gate evals (every gate in the scenario repo)
         run: |
           set -euo pipefail

--- a/internal/skill-gate-eval/README.md
+++ b/internal/skill-gate-eval/README.md
@@ -40,7 +40,7 @@ MUGGLE_BRAIN_DIR=../muggle-ai-brain \
 
 (equivalently `pnpm tsx internal/skill-gate-eval/src/run.ts …`)
 
-**Auth:** the harness drives `@anthropic-ai/claude-agent-sdk`'s `query()`, which uses your **Claude Code login session** by default — no API key needed when you're logged in. Set `ANTHROPIC_API_KEY` (prefix the command) only where there's no login session, e.g. headless CI.
+**Auth:** the harness drives `@anthropic-ai/claude-agent-sdk`'s `query()`, which uses your **Claude Code login session** by default — no API key needed when you're logged in. In headless CI, authenticate with your subscription: run `claude setup-token` once and set `CLAUDE_CODE_OAUTH_TOKEN` (not a pay-per-use API key).
 
 The harness loads
 `$MUGGLE_BRAIN_DIR/eval/skill-gate-eval/showElectronBrowser/scenarios.json`,
@@ -63,5 +63,5 @@ blocking workflow — see CI below.
 `$MUGGLE_BRAIN_DIR/eval/skill-gate-eval/*/scenarios.json` on each PR to
 `master` (`--runs 10`, each scenario must hold ≥99%), plus nightly and on
 `workflow_dispatch`. It checks out `muggle-ai-brain` for the scenarios, so
-CI needs two repo secrets: `ANTHROPIC_API_KEY` and `BRAIN_REPO_TOKEN`
-(read access to the scenario repo).
+CI needs two repo secrets: `CLAUDE_CODE_OAUTH_TOKEN` (subscription auth, from
+`claude setup-token`) and `BRAIN_REPO_TOKEN` (read access to the scenario repo).

--- a/internal/skill-gate-eval/src/harness.ts
+++ b/internal/skill-gate-eval/src/harness.ts
@@ -215,6 +215,9 @@ export async function runScenarioOnce(
       ...(process.env.CLAUDE_CODE_EXECUTABLE
         ? { pathToClaudeCodeExecutable: process.env.CLAUDE_CODE_EXECUTABLE }
         : {}),
+      // Surface the CLI's own stderr — otherwise an auth/launch failure only
+      // shows as "Claude Code process exited with code 1".
+      stderr: (data: string) => process.stderr.write(data),
     },
   });
 

--- a/internal/skill-gate-eval/src/harness.ts
+++ b/internal/skill-gate-eval/src/harness.ts
@@ -209,6 +209,12 @@ export async function runScenarioOnce(
       maxTurns: opts.maxTurns ?? DEFAULT_MAX_TURNS,
       // Disable everything except our mock MCP namespace + AskUserQuestion.
       tools: ["AskUserQuestion"],
+      // In CI the SDK's bundled native binary isn't present; the workflow sets
+      // CLAUDE_CODE_EXECUTABLE to the globally-installed CLI. Unset locally, so
+      // the SDK falls back to its default resolution.
+      ...(process.env.CLAUDE_CODE_EXECUTABLE
+        ? { pathToClaudeCodeExecutable: process.env.CLAUDE_CODE_EXECUTABLE }
+        : {}),
     },
   });
 

--- a/internal/skill-gate-eval/src/harness.ts
+++ b/internal/skill-gate-eval/src/harness.ts
@@ -221,9 +221,30 @@ export async function runScenarioOnce(
     },
   });
 
-  // Drain the stream so the SDK actually runs the agent to completion.
-  for await (const msg of stream) {
-    if (onMessage) onMessage(msg);
+  // Drain the stream so the SDK actually runs the agent to completion. Capture
+  // the terminal `result` message: on an auth/launch failure the real reason
+  // rides this stdout message (e.g. an is_error subtype), which the SDK then
+  // collapses into an opaque "process exited with code 1" throw. Surfacing it
+  // is the difference between "a token 401" and "an SDK fault" in the CI log.
+  let lastResult: unknown = null;
+  try {
+    for await (const msg of stream) {
+      if (onMessage) onMessage(msg);
+      if ((msg as { type?: unknown }).type === "result") lastResult = msg;
+    }
+  } catch (err) {
+    if (lastResult !== null) {
+      process.stderr.write(
+        `[skill-gate-eval] final SDK message before failure: ${JSON.stringify(lastResult)}\n`,
+      );
+    }
+    throw err;
+  }
+
+  if ((lastResult as { is_error?: unknown } | null)?.is_error) {
+    process.stderr.write(
+      `[skill-gate-eval] SDK returned an error result: ${JSON.stringify(lastResult)}\n`,
+    );
   }
 
   return verdict(opts.scenario, mcpCalls, askQuestions, gateQuestionFired);

--- a/internal/skill-routing-eval/README.md
+++ b/internal/skill-routing-eval/README.md
@@ -46,7 +46,7 @@ the skills the PR changed; the full set runs nightly and on `workflow_dispatch`.
 - `--fail-under F` — exit non-zero if accuracy < F, or if a chunk stays 0% (suspected disconnect, unverified). Default `0.0` keeps dev runs informational. CI uses `1.0` on PRs (changed skills must route perfectly) and `0.95` for the nightly full sweep.
 - `router_eval.py --probe "<query>"` — route one query and print the result; CI uses it to fail fast when the plugin didn't load.
 
-CI installs the plugin from the PR checkout (`claude plugin marketplace add "$GITHUB_WORKSPACE"`), so it tests the PR's descriptions rather than master — no `--sync-cache` needed. Requires the `ANTHROPIC_API_KEY` repo secret.
+CI installs the plugin from the PR checkout (`claude plugin marketplace add "$GITHUB_WORKSPACE"`), so it tests the PR's descriptions rather than master — no `--sync-cache` needed. Requires the `CLAUDE_CODE_OAUTH_TOKEN` repo secret (subscription auth from `claude setup-token`, not a pay-per-use API key).
 
 ## Optimization loop (per skill)
 

--- a/internal/skill-routing-eval/reports/run/chunk_muggle-status.in.json
+++ b/internal/skill-routing-eval/reports/run/chunk_muggle-status.in.json
@@ -1,0 +1,122 @@
+[
+  {
+    "query": "muggle status",
+    "expected_skill": "muggle-status",
+    "note": "Explicit canonical trigger \u2014 bare status command."
+  },
+  {
+    "query": "Can you run muggle status for me real quick?",
+    "expected_skill": "muggle-status",
+    "note": "Explicit status request, casual phrasing."
+  },
+  {
+    "query": "Is my Muggle install healthy right now?",
+    "expected_skill": "muggle-status",
+    "note": "Direct health-check intent."
+  },
+  {
+    "query": "Check whether the Muggle MCP is connected properly.",
+    "expected_skill": "muggle-status",
+    "note": "MCP connection health check."
+  },
+  {
+    "query": "Is my muggle auth still valid or did my login expire?",
+    "expected_skill": "muggle-status",
+    "note": "Auth/login validity check."
+  },
+  {
+    "query": "I want to make sure muggle is set up correctly before I start testing.",
+    "expected_skill": "muggle-status",
+    "note": "\"Is it set up right\" verification intent."
+  },
+  {
+    "query": "Give me a full health report on my Muggle Test setup.",
+    "expected_skill": "muggle-status",
+    "note": "Health report = diagnose/report, status."
+  },
+  {
+    "query": "Are the muggle MCP tools actually loading? Want to confirm they're live.",
+    "expected_skill": "muggle-status",
+    "note": "MCP health, confirm not fix."
+  },
+  {
+    "query": "Did my Muggle session token expire? Check my auth please.",
+    "expected_skill": "muggle-status",
+    "note": "Auth validity diagnose."
+  },
+  {
+    "query": "Verify that everything in my muggle environment is wired up right.",
+    "expected_skill": "muggle-status",
+    "note": "Setup correctness check."
+  },
+  {
+    "query": "Can you confirm Muggle is talking to the backend okay?",
+    "expected_skill": "muggle-status",
+    "note": "Connectivity/health confirmation."
+  },
+  {
+    "query": "What's the current state of my muggle installation \u2014 all green?",
+    "expected_skill": "muggle-status",
+    "note": "Status report phrasing."
+  },
+  {
+    "query": "I just installed muggle. Can you check it's configured properly?",
+    "expected_skill": "muggle-status",
+    "note": "Post-install setup verification."
+  },
+  {
+    "query": "Run a quick diagnostic on muggle and tell me if anything looks off.",
+    "expected_skill": "muggle-status",
+    "note": "Diagnose-only intent, report findings."
+  },
+  {
+    "query": "Is the muggle MCP server reachable from here? Just checking.",
+    "expected_skill": "muggle-status",
+    "note": "MCP reachability check, diagnose."
+  },
+  {
+    "query": "muggle's been acting up today \u2014 can you take a look and tell me what's wrong?",
+    "expected_skill": "muggle-status",
+    "note": "HARD near-boundary: ambiguous \"acting up\" + diagnose intent, leans status (diagnose before fix)."
+  },
+  {
+    "query": "Muggle isn't responding when I try to run tests. Is something broken with it?",
+    "expected_skill": "muggle-status",
+    "note": "HARD near-boundary: \"is something broken?\" is diagnose, not \"fix it\" \u2192 status."
+  },
+  {
+    "query": "The MCP keeps timing out \u2014 can you figure out if it's a muggle health issue?",
+    "expected_skill": "muggle-status",
+    "note": "HARD near-boundary: investigate cause vs repair; intent is diagnose \u2192 status."
+  },
+  {
+    "query": "I think my muggle login might be busted. Can you check before I do anything?",
+    "expected_skill": "muggle-status",
+    "note": "HARD near-boundary: suspects breakage but asks to CHECK first \u2192 status."
+  },
+  {
+    "query": "Muggle commands are failing silently. Is it me or is the install unhealthy?",
+    "expected_skill": "muggle-status",
+    "note": "HARD near-boundary: \"is the install unhealthy?\" diagnose framing \u2192 status."
+  },
+  {
+    "query": "Something feels off with muggle \u2014 diagnose it for me, don't fix anything yet.",
+    "expected_skill": "muggle-status",
+    "note": "HARD near-boundary: explicit diagnose-only, defer fixing \u2192 status."
+  },
+  {
+    "query": "Before I report a bug, can you tell me if my muggle auth and MCP are healthy?",
+    "expected_skill": "muggle-status",
+    "note": "Health check of auth + MCP, report intent."
+  },
+  {
+    "query": "Why does muggle keep saying it can't connect? Check its status for me.",
+    "expected_skill": "muggle-status",
+    "note": "Connectivity symptom + explicit status check."
+  },
+  {
+    "query": "Quick sanity check \u2014 is muggle good to go or is there a problem with the setup?",
+    "expected_skill": "muggle-status",
+    "note": "Sanity/health check, diagnose whether setup is okay."
+  }
+]

--- a/internal/skill-routing-eval/reports/run/chunk_muggle-status.json
+++ b/internal/skill-routing-eval/reports/run/chunk_muggle-status.json
@@ -1,0 +1,250 @@
+{
+  "model": "default",
+  "runs_per_query": 1,
+  "total": 24,
+  "passed": 23,
+  "failed": 1,
+  "accuracy": 0.9583,
+  "results": [
+    {
+      "query": "muggle status",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Explicit canonical trigger \u2014 bare status command."
+    },
+    {
+      "query": "Can you run muggle status for me real quick?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Explicit status request, casual phrasing."
+    },
+    {
+      "query": "Is my Muggle install healthy right now?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Direct health-check intent."
+    },
+    {
+      "query": "Check whether the Muggle MCP is connected properly.",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "MCP connection health check."
+    },
+    {
+      "query": "Is my muggle auth still valid or did my login expire?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Auth/login validity check."
+    },
+    {
+      "query": "I want to make sure muggle is set up correctly before I start testing.",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "\"Is it set up right\" verification intent."
+    },
+    {
+      "query": "Give me a full health report on my Muggle Test setup.",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Health report = diagnose/report, status."
+    },
+    {
+      "query": "Are the muggle MCP tools actually loading? Want to confirm they're live.",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "MCP health, confirm not fix."
+    },
+    {
+      "query": "Did my Muggle session token expire? Check my auth please.",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Auth validity diagnose."
+    },
+    {
+      "query": "Verify that everything in my muggle environment is wired up right.",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Setup correctness check."
+    },
+    {
+      "query": "Can you confirm Muggle is talking to the backend okay?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Connectivity/health confirmation."
+    },
+    {
+      "query": "What's the current state of my muggle installation \u2014 all green?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Status report phrasing."
+    },
+    {
+      "query": "I just installed muggle. Can you check it's configured properly?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Post-install setup verification."
+    },
+    {
+      "query": "Run a quick diagnostic on muggle and tell me if anything looks off.",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Diagnose-only intent, report findings."
+    },
+    {
+      "query": "Is the muggle MCP server reachable from here? Just checking.",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "none"
+      ],
+      "majority": "none",
+      "pass": false,
+      "note": "MCP reachability check, diagnose."
+    },
+    {
+      "query": "muggle's been acting up today \u2014 can you take a look and tell me what's wrong?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "HARD near-boundary: ambiguous \"acting up\" + diagnose intent, leans status (diagnose before fix)."
+    },
+    {
+      "query": "Muggle isn't responding when I try to run tests. Is something broken with it?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "HARD near-boundary: \"is something broken?\" is diagnose, not \"fix it\" \u2192 status."
+    },
+    {
+      "query": "The MCP keeps timing out \u2014 can you figure out if it's a muggle health issue?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "HARD near-boundary: investigate cause vs repair; intent is diagnose \u2192 status."
+    },
+    {
+      "query": "I think my muggle login might be busted. Can you check before I do anything?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "HARD near-boundary: suspects breakage but asks to CHECK first \u2192 status."
+    },
+    {
+      "query": "Muggle commands are failing silently. Is it me or is the install unhealthy?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "HARD near-boundary: \"is the install unhealthy?\" diagnose framing \u2192 status."
+    },
+    {
+      "query": "Something feels off with muggle \u2014 diagnose it for me, don't fix anything yet.",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "HARD near-boundary: explicit diagnose-only, defer fixing \u2192 status."
+    },
+    {
+      "query": "Before I report a bug, can you tell me if my muggle auth and MCP are healthy?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Health check of auth + MCP, report intent."
+    },
+    {
+      "query": "Why does muggle keep saying it can't connect? Check its status for me.",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Connectivity symptom + explicit status check."
+    },
+    {
+      "query": "Quick sanity check \u2014 is muggle good to go or is there a problem with the setup?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Sanity/health check, diagnose whether setup is okay."
+    }
+  ]
+}

--- a/internal/skill-routing-eval/reports/run/combined.json
+++ b/internal/skill-routing-eval/reports/run/combined.json
@@ -1,0 +1,246 @@
+{
+  "model": "claude (run.py)",
+  "runs_per_query": 1,
+  "results": [
+    {
+      "query": "muggle status",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Explicit canonical trigger \u2014 bare status command."
+    },
+    {
+      "query": "Can you run muggle status for me real quick?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Explicit status request, casual phrasing."
+    },
+    {
+      "query": "Is my Muggle install healthy right now?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Direct health-check intent."
+    },
+    {
+      "query": "Check whether the Muggle MCP is connected properly.",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "MCP connection health check."
+    },
+    {
+      "query": "Is my muggle auth still valid or did my login expire?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Auth/login validity check."
+    },
+    {
+      "query": "I want to make sure muggle is set up correctly before I start testing.",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "\"Is it set up right\" verification intent."
+    },
+    {
+      "query": "Give me a full health report on my Muggle Test setup.",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Health report = diagnose/report, status."
+    },
+    {
+      "query": "Are the muggle MCP tools actually loading? Want to confirm they're live.",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "MCP health, confirm not fix."
+    },
+    {
+      "query": "Did my Muggle session token expire? Check my auth please.",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Auth validity diagnose."
+    },
+    {
+      "query": "Verify that everything in my muggle environment is wired up right.",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Setup correctness check."
+    },
+    {
+      "query": "Can you confirm Muggle is talking to the backend okay?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Connectivity/health confirmation."
+    },
+    {
+      "query": "What's the current state of my muggle installation \u2014 all green?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Status report phrasing."
+    },
+    {
+      "query": "I just installed muggle. Can you check it's configured properly?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Post-install setup verification."
+    },
+    {
+      "query": "Run a quick diagnostic on muggle and tell me if anything looks off.",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Diagnose-only intent, report findings."
+    },
+    {
+      "query": "Is the muggle MCP server reachable from here? Just checking.",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "none"
+      ],
+      "majority": "none",
+      "pass": false,
+      "note": "MCP reachability check, diagnose."
+    },
+    {
+      "query": "muggle's been acting up today \u2014 can you take a look and tell me what's wrong?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "HARD near-boundary: ambiguous \"acting up\" + diagnose intent, leans status (diagnose before fix)."
+    },
+    {
+      "query": "Muggle isn't responding when I try to run tests. Is something broken with it?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "HARD near-boundary: \"is something broken?\" is diagnose, not \"fix it\" \u2192 status."
+    },
+    {
+      "query": "The MCP keeps timing out \u2014 can you figure out if it's a muggle health issue?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "HARD near-boundary: investigate cause vs repair; intent is diagnose \u2192 status."
+    },
+    {
+      "query": "I think my muggle login might be busted. Can you check before I do anything?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "HARD near-boundary: suspects breakage but asks to CHECK first \u2192 status."
+    },
+    {
+      "query": "Muggle commands are failing silently. Is it me or is the install unhealthy?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "HARD near-boundary: \"is the install unhealthy?\" diagnose framing \u2192 status."
+    },
+    {
+      "query": "Something feels off with muggle \u2014 diagnose it for me, don't fix anything yet.",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "HARD near-boundary: explicit diagnose-only, defer fixing \u2192 status."
+    },
+    {
+      "query": "Before I report a bug, can you tell me if my muggle auth and MCP are healthy?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Health check of auth + MCP, report intent."
+    },
+    {
+      "query": "Why does muggle keep saying it can't connect? Check its status for me.",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Connectivity symptom + explicit status check."
+    },
+    {
+      "query": "Quick sanity check \u2014 is muggle good to go or is there a problem with the setup?",
+      "expected_skill": "muggle-status",
+      "fired": [
+        "muggle-status"
+      ],
+      "majority": "muggle-status",
+      "pass": true,
+      "note": "Sanity/health check, diagnose whether setup is okay."
+    }
+  ]
+}

--- a/internal/skill-routing-eval/reports/run/combined.md
+++ b/internal/skill-routing-eval/reports/run/combined.md
@@ -1,0 +1,20 @@
+# Router eval report
+
+- model: `claude (run.py)`  runs/query: 1
+- overall accuracy (muggle-routing): **23/24 = 95.8%**
+- negative-class rule: a query labeled `none` passes when no `muggle*` skill fires; an appropriate non-muggle skill (debugging, review, brainstorming) winning is correct.
+
+## Per-skill recall (positive queries)
+
+| skill | correct | total | recall | stolen by (majority when wrong) |
+|---|---|---|---|---|
+| muggle-status | 23 | 24 | 96%  ⚠ | none×1 |
+
+## Negative class (must not fire a muggle skill)
+
+- 0/0 clean (no muggle skill fired).
+- No muggle skill over-triggered on any near-miss. ✔
+
+## Genuine misses
+
+- expected `muggle-status` got `none` — Is the muggle MCP server reachable from here? Just checking.  (fired: {'none': 1})


### PR DESCRIPTION
Follow-up to #284. Switches both eval jobs from a pay-per-use `ANTHROPIC_API_KEY` to **Claude subscription auth** via `CLAUDE_CODE_OAUTH_TOKEN`.

## Changes
- `skill-gate-eval` + `skill-routing-eval` now read `CLAUDE_CODE_OAUTH_TOKEN` (from `claude setup-token`) instead of `ANTHROPIC_API_KEY`.
- The gate job's "Require secrets" check and both READMEs updated accordingly.
- **Billing guard:** `ANTHROPIC_API_KEY` outranks the OAuth token in Claude's auth precedence, so every `claude`/SDK invocation `unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN` first — a stray org-level API key can't silently flip runs to API billing.

## Setup (replaces the old API-key step)
1. Run `claude setup-token` locally (one-time, ~1-year token) and add the output as repo secret **`CLAUDE_CODE_OAUTH_TOKEN`**.
2. Add **`BRAIN_REPO_TOKEN`** (read access to `multiplex-ai/muggle-ai-brain`) — unchanged.
3. Mark both jobs as required status checks.

## Note / to verify on first run
The Claude CLI (`claude -p`, routing eval) honors `CLAUDE_CODE_OAUTH_TOKEN` directly. The agent SDK (`@anthropic-ai/claude-agent-sdk`, gate eval) shares Claude Code's auth chain and should too, but this isn't explicitly documented — the first CI run with the token confirms it. Runs draw on the subscription's rate limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)