### PR TITLE
test(skill-gate-eval): evaluate each skill on its declared model

### DIFF
--- a/internal/skill-gate-eval/src/constants.ts
+++ b/internal/skill-gate-eval/src/constants.ts
@@ -4,5 +4,13 @@ export const ASK_QUESTION_TOOL = "AskUserQuestion";
 /** Per-scenario pass-rate floor below which we treat the gate as misfiring. */
 export const PASS_THRESHOLD = 0.99;
 
-/** Default eval target until the suite is stable enough to add others. */
+/** Default eval target — used when a skill leaves `model:` unset (inherits the session model). */
 export const DEFAULT_MODEL = "claude-sonnet-4-6";
+
+/** Map `/model`-style aliases (as used in SKILL.md `model:`) to concrete model ids. */
+export const MODEL_ALIASES: Record<string, string> = {
+  haiku: "claude-haiku-4-5-20251001",
+  sonnet: "claude-sonnet-4-6",
+  opus: "claude-opus-4-8",
+  fable: "claude-fable-5",
+};

--- a/internal/skill-gate-eval/src/mock-mcp.ts
+++ b/internal/skill-gate-eval/src/mock-mcp.ts
@@ -63,6 +63,19 @@ export function buildMockMcpServer(fixtures: Fixtures): MockServerHandle {
         async () => jsonResult({ ok: true }),
       ),
       tool(
+        "muggle-local-check-status",
+        "MCP server / local status (mock).",
+        PERMISSIVE_SHAPE,
+        async () =>
+          jsonResult(
+            fixtures.checkStatus ?? {
+              ok: true,
+              authenticated: true,
+              email: "tester@example.com",
+            },
+          ),
+      ),
+      tool(
         "muggle-remote-auth-status",
         "Auth status (mock).",
         PERMISSIVE_SHAPE,

--- a/internal/skill-gate-eval/src/run.ts
+++ b/internal/skill-gate-eval/src/run.ts
@@ -17,7 +17,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-import { DEFAULT_MODEL, PASS_THRESHOLD } from "./constants.js";
+import { DEFAULT_MODEL, MODEL_ALIASES, PASS_THRESHOLD } from "./constants.js";
 import { runScenarioOnce } from "./harness.js";
 import { loadScenarioFile } from "./scenario.js";
 import type { CliArgs, RunVerdict, ScenarioReport } from "./types.js";
@@ -25,6 +25,27 @@ import type { CliArgs, RunVerdict, ScenarioReport } from "./types.js";
 interface RunCliArgs extends CliArgs {
   scenarioFilter?: string;
   verbose: boolean;
+}
+
+/** Resolve a `/model`-style value (alias or full id) to a model id; `inherit`/empty falls back. */
+function resolveModel(raw: string | undefined, fallback: string): string {
+  if (!raw || raw === "inherit") return fallback;
+  return MODEL_ALIASES[raw] ?? raw;
+}
+
+/**
+ * Read a skill's `model:` frontmatter so the eval runs it on the same model
+ * production would. Returns undefined when the skill leaves `model:` unset
+ * (it inherits the session model — represented here by DEFAULT_MODEL).
+ */
+function frontmatterModel(skillsDir: string, skill: string): string | undefined {
+  const p = path.resolve(skillsDir, skill, "SKILL.md");
+  if (!fs.existsSync(p)) return undefined;
+  const body = fs.readFileSync(p, "utf8");
+  const fm = body.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!fm) return undefined;
+  const m = fm[1].match(/^model:[ \t]*(.+?)[ \t]*$/m);
+  return m ? m[1].trim() : undefined;
 }
 
 function parseArgs(argv: string[]): RunCliArgs {
@@ -45,13 +66,20 @@ function parseArgs(argv: string[]): RunCliArgs {
   if (!out.gate || !out.skill) {
     throw new Error("Required: --gate <key> --skill <name>");
   }
+  const skillsDir = out["skills-dir"] ?? "plugin/skills";
+  // Precedence: explicit --model > the skill's declared `model:` > DEFAULT_MODEL.
+  // Honoring the frontmatter means the eval exercises the skill on the same
+  // model it runs on in production (e.g. a haiku-tier skill is tested on haiku).
+  const model = out.model
+    ? resolveModel(out.model, DEFAULT_MODEL)
+    : resolveModel(frontmatterModel(skillsDir, out.skill), DEFAULT_MODEL);
   return {
     gate: out.gate,
     skill: out.skill,
     runs: parseInt(out.runs ?? "10", 10),
     brainDir: out["brain-dir"] ?? process.env.MUGGLE_BRAIN_DIR ?? "../muggle-ai-brain",
-    skillsDir: out["skills-dir"] ?? "plugin/skills",
-    model: out.model ?? DEFAULT_MODEL,
+    skillsDir: skillsDir,
+    model: model,
     scenarioFilter: out.scenario,
     verbose: flags.has("verbose"),
   };
@@ -59,6 +87,8 @@ function parseArgs(argv: string[]): RunCliArgs {
 
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
+  // eslint-disable-next-line no-console
+  console.error(`[skill-gate-eval] ${args.gate} on ${args.skill} — model=${args.model} runs=${args.runs}`);
   const scenarioFilePath = path.resolve(
     args.brainDir,
     "eval",


### PR DESCRIPTION
## What

Makes the gate eval exercise a skill on the **model it actually runs on** in production, and unblocks gate scenarios for status-style skills.

- **Honor `model:` frontmatter.** The harness pinned `DEFAULT_MODEL` for every skill, so it never measured the effect of a skill's declared model. `run.ts` now resolves the model with precedence `--model` > the skill's SKILL.md `model:` > default, mapping aliases (`haiku`/`sonnet`/`opus`/`fable`) to ids. A startup line logs the resolved model.
- **Mock `muggle-local-check-status`.** `muggle-status` (and any skill that probes local status) would otherwise hit a denied tool and derail before reaching its gate.

## Why

We just retiered the muggle skills onto cheaper models (haiku/sonnet) in a separate PR. To validate that the cheaper tiers don't degrade gate behavior, the eval has to run each skill on its declared tier — which this enables.

## Evidence

With a new `checkForUpdates → muggle-status` scenario (muggle-ai-brain), `muggle-status` on **haiku** matched **opus** exactly — 8/8 = 100% on all three scenarios (always-silent, never-silent, ask-fires-picker). No degradation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)