### PR TITLE
ci(skill-eval): post eval results to the PR + job summary

### DIFF
--- a/.github/workflows/skill-eval.yml
+++ b/.github/workflows/skill-eval.yml
@@ -24,6 +24,8 @@ concurrency:
 
 permissions:
   contents: read
+  # Post the eval results back to the PR as a sticky comment.
+  pull-requests: write
 
 jobs:
   skill-gate-eval:
@@ -176,6 +178,30 @@ jobs:
           fi
           exit "$fail"
 
+      # Post the gate results to the job summary always, and to the PR as a
+      # sticky comment on pull_request runs. `always()` so a failing gate still
+      # reports which scenario/model regressed instead of just a red check.
+      - name: Report gate results
+        if: always() && steps.scope.outputs.should_run == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          md="$(pnpm exec tsx internal/skill-gate-eval/src/report.ts "$MUGGLE_BRAIN_DIR")"
+          printf '%s\n' "$md" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            marker='<!-- muggle-skill-eval:gate -->'
+            body="$(printf '%s\n%s' "$marker" "$md")"
+            pr='${{ github.event.pull_request.number }}'
+            repo='${{ github.repository }}'
+            cid="$(gh api "repos/$repo/issues/$pr/comments" --paginate --jq "map(select(.body|startswith(\"$marker\")))|last|.id" 2>/dev/null || true)"
+            if [ -n "${cid:-}" ] && [ "$cid" != "null" ]; then
+              gh api -X PATCH "repos/$repo/issues/comments/$cid" -f body="$body" >/dev/null
+            else
+              gh api -X POST "repos/$repo/issues/$pr/comments" -f body="$body" >/dev/null
+            fi
+          fi
+
   skill-routing-eval:
     runs-on: ubuntu-latest
     timeout-minutes: 180
@@ -285,4 +311,33 @@ jobs:
           else
             python internal/skill-routing-eval/run.py \
               --all --runs "$ROUTING_RUNS" --repo-root "$CLEAN_CWD" --fail-under 0.95
+          fi
+
+      # Post the routing report (reports/run/combined.md) to the job summary and,
+      # on a PR, a sticky comment. `always()` so a flaked/failed sweep still
+      # reports rather than leaving a bare red check.
+      - name: Report routing results
+        if: always() && steps.scope.outputs.should_run == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          f="internal/skill-routing-eval/reports/run/combined.md"
+          if [ -f "$f" ]; then
+            md="$(printf '### 🧭 Skill routing eval\n\n%s' "$(head -c 60000 "$f")")"
+          else
+            md="$(printf '### 🧭 Skill routing eval\n\n_No routing report produced — the run failed before writing combined.md (often the MCP-disconnect / subscription-limit flake; re-run)._')"
+          fi
+          printf '%s\n' "$md" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            marker='<!-- muggle-skill-eval:routing -->'
+            body="$(printf '%s\n%s' "$marker" "$md")"
+            pr='${{ github.event.pull_request.number }}'
+            repo='${{ github.repository }}'
+            cid="$(gh api "repos/$repo/issues/$pr/comments" --paginate --jq "map(select(.body|startswith(\"$marker\")))|last|.id" 2>/dev/null || true)"
+            if [ -n "${cid:-}" ] && [ "$cid" != "null" ]; then
+              gh api -X PATCH "repos/$repo/issues/comments/$cid" -f body="$body" >/dev/null
+            else
+              gh api -X POST "repos/$repo/issues/$pr/comments" -f body="$body" >/dev/null
+            fi
           fi

--- a/internal/skill-gate-eval/src/report.ts
+++ b/internal/skill-gate-eval/src/report.ts
@@ -1,0 +1,71 @@
+/**
+ * Emit a markdown summary of the skill-gate-eval results.json files so CI can
+ * drop it into the job summary and a PR comment. Reads every
+ * `<gate>/results.json` under `<brain-dir>/eval/skill-gate-eval/`.
+ *
+ * Usage: tsx internal/skill-gate-eval/src/report.ts [brain-dir]
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import type { ScenarioReport } from "./types.js";
+
+interface GateResult {
+  gate: string;
+  skill: string;
+  model: string;
+  runsPerScenario: number;
+  scenarios: ScenarioReport[];
+}
+
+const brainDir = process.argv[2] ?? process.env.MUGGLE_BRAIN_DIR ?? "../muggle-ai-brain";
+const gateDir = path.resolve(brainDir, "eval", "skill-gate-eval");
+
+const files = fs.existsSync(gateDir)
+  ? fs
+      .readdirSync(gateDir)
+      .map((d) => path.join(gateDir, d, "results.json"))
+      .filter((f) => fs.existsSync(f))
+      .sort()
+  : [];
+
+if (files.length === 0) {
+  process.stdout.write("### 🚪 Skill gate eval\n\n_No results.json found._\n");
+  process.exit(0);
+}
+
+const rows: string[] = [
+  "### 🚪 Skill gate eval",
+  "",
+  "| Gate | Skill | Model | Scenarios | Status |",
+  "| :--- | :--- | :--- | :---: | :---: |",
+];
+const details: string[] = [];
+
+for (const f of files) {
+  const r = JSON.parse(fs.readFileSync(f, "utf8")) as GateResult;
+  const passed = r.scenarios.filter((s) => s.passed).length;
+  const ok = r.scenarios.length > 0 && r.scenarios.every((s) => s.passed);
+  rows.push(
+    `| \`${r.gate}\` | \`${r.skill}\` | \`${r.model}\` | ${passed}/${r.scenarios.length} | ${ok ? "✅" : "❌"} |`,
+  );
+  for (const s of r.scenarios) {
+    const reasons = s.passed ? "" : ` — ${s.failureReasons.join("; ")}`;
+    details.push(
+      `- ${s.passed ? "✓" : "✗"} \`${r.gate}\`/${s.name}: ${s.passes}/${s.runs} (${(s.passRate * 100).toFixed(0)}%)${reasons}`,
+    );
+  }
+}
+
+const out = [
+  ...rows,
+  "",
+  "<details><summary>Per-scenario detail</summary>",
+  "",
+  ...details,
+  "</details>",
+  "",
+].join("\n");
+
+process.stdout.write(out + "\n");


### PR DESCRIPTION
## What

Makes the skill evals **report their results on the PR**, not just flip a check red/green.

- **Gate eval** — new `internal/skill-gate-eval/src/report.ts` renders the per-gate `results.json` into a markdown table (gate / skill / **model** / scenarios passed / status) + a collapsible per-scenario breakdown with pass rates and failure reasons.
- **Routing eval** — posts `reports/run/combined.md` (truncated to fit a comment).
- Both write to the **job summary** (every run) and a **sticky PR comment** (on `pull_request`), under `always()` so a failed/flaked eval still shows *which* scenario/skill/model regressed.
- Adds `pull-requests: write`.

## Why

You asked whether eval results get posted to the PR — they didn't. This wires that up so reviewers see the numbers inline (including which model each skill ran on, now that the harness is tier-aware).

## Note

This PR touches the gate harness, so its own CI runs the gate eval and will post the results comment **to this PR** — a live demonstration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)