### PR TITLE
fix(muggle-test-feature-local): make showElectronBrowser=always reliably omit showUi

### DIFF
--- a/plugin/skills/muggle-test-feature-local/SKILL.md
+++ b/plugin/skills/muggle-test-feature-local/SKILL.md
@@ -151,12 +151,12 @@ Caller glue: `mode` is the path chosen in §5; `localUrl` from §4; `cwd` = the 
 
 Resolve the `showElectronBrowser` gate **first**, then call `muggle-local-execute-test-generation` or `muggle-local-execute-replay`. **Do not** ask the user to re-approve the Electron launch itself — choosing this skill is the approval. That run-approval suppression does **not** extend to the gate below: when `showElectronBrowser=ask` you must still fire its picker.
 
-Gate `showElectronBrowser` (per `preference-gates/README.md`). Reuse the choice within a session.
-- `always` → omit `showUi` (the browser shows by default).
-- `never` → pass `showUi: false`.
+Gate `showElectronBrowser` (per `preference-gates/README.md`). Reuse the choice within a session. The runner shows the browser by default, so treat `showUi` as a **hide switch** — include it only to turn the browser off:
+- `always` (show it) → **omit `showUi` entirely** — no `showUi` key in the call. Passing `showUi: false` here is a bug: it hides the browser the user wanted to watch.
+- `never` (hide it) → pass `showUi: false`.
 - `ask` → you **must** call `AskUserQuestion` (Picker 1 from `preference-gates/showElectronBrowser.md`) **before** the execute call, then map the answer to the `always`/`never` action above. Do not decide for the user.
 
-`showUi` is only ever omitted or `false` — never pass `showUi: true`.
+So the execute call carries **no `showUi` key** for `always`, or `showUi: false` for `never` — never `showUi: true`.
 
 ### 8. Open the run on the dashboard (`viewUrl` gated by `openTestResultsAfterRun`)
 


### PR DESCRIPTION
## What

Tightens `muggle-test-feature-local`'s `showElectronBrowser` gate so `always` reliably **omits** `showUi`.

## Why

The gate eval flaked at **90%** on `always-omits-showUi`: ~1 in 10 runs the model passed `showUi: false` on `always` instead of omitting it — which *inverts* the gate (hides the browser the user asked to watch). The `show=omit` / `hide=false` mapping is the trap.

The fix reframes `showUi` as a **hide-switch** (runner shows by default; include it only to turn the browser off) and explicitly calls out `showUi: false` on `always` as a bug.

## Evidence

Re-ran all three `showElectronBrowser` scenarios ×12 on sonnet (the skill's tier) against the patched SKILL.md:

| Scenario | Before | After |
|---|---|---|
| `always-omits-showUi` | 90% | **12/12 = 100%** |
| `never-passes-showUi-false` | 100% | 12/12 = 100% |
| `ask-fires-picker1` | 100% | 12/12 = 100% |

This PR touches a SKILL.md body, so its own gate eval re-runs the suite as a final check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)