### PR TITLE
fix(mcp): explain Smart App Control block instead of bare "spawn UNKNOWN"

### DIFF
--- a/packages/mcps/src/mcp/local/services/execution-service.ts
+++ b/packages/mcps/src/mcp/local/services/execution-service.ts
@@ -28,6 +28,7 @@ import {
   buildReplayActionScript,
 } from "./action-script-builders.js";
 import { acquireLocalExecutionLock } from "./local-execution-lock.js";
+import { describeElectronSpawnFailure } from "./spawn-failure-message.js";
 import type { ILocalExecutionContext } from "./run-result-storage-service.js";
 import type { RunResultStatus } from "./run-result-storage-service.js";
 
@@ -594,7 +595,12 @@ async function executeElectronAppAsync(params: {
     child.on("error", (error) => {
       finalize({
         ok: false,
-        payload: new Error(`Failed to start electron-app: ${error.message}`),
+        payload: new Error(
+          describeElectronSpawnFailure({
+            error: error as NodeJS.ErrnoException,
+            electronAppPath: electronAppPath,
+          }),
+        ),
       });
     });
 

--- a/packages/mcps/src/mcp/local/services/spawn-failure-message.ts
+++ b/packages/mcps/src/mcp/local/services/spawn-failure-message.ts
@@ -1,0 +1,31 @@
+// Node surfaces a Windows Application Control block (Smart App Control / WDAC refusing to
+// launch the unsigned binary) as a bare `spawn UNKNOWN` with no stderr — undiagnosable
+// unless we translate it into the cause and the way out.
+export function describeElectronSpawnFailure(params: {
+  error: NodeJS.ErrnoException;
+  electronAppPath: string;
+  platform?: NodeJS.Platform;
+}): string {
+  const base = `Failed to start electron-app: ${params.error.message}`;
+  const platform = params.platform ?? process.platform;
+  const blockedByAppControl =
+    platform === "win32" && (params.error.code === "UNKNOWN" || params.error.code === "EPERM");
+  if (!blockedByAppControl) {
+    return base;
+  }
+  return [
+    base,
+    "",
+    "This is almost certainly Windows Smart App Control (or a WDAC policy) blocking the",
+    "Muggle desktop app because it is not yet code-signed: the OS refuses to launch the",
+    "binary before it starts, so there is no output and the run fails in 0ms.",
+    "",
+    `  Binary: ${params.electronAppPath}`,
+    "  Confirm: launch the binary directly, or check Event Viewer > Applications and Services",
+    '  Logs > Microsoft > Windows > CodeIntegrity (events 3033/3077) for "An Application',
+    '  Control policy has blocked this file."',
+    "",
+    "  To run Muggle now: Settings > Privacy & security > Windows Security > App & browser",
+    "  control > Smart App Control > Off. A signed build that passes Smart App Control is on the way.",
+  ].join("\n");
+}

--- a/packages/mcps/src/test/spawn-failure-message.test.ts
+++ b/packages/mcps/src/test/spawn-failure-message.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { describeElectronSpawnFailure } from "../mcp/local/services/spawn-failure-message.js";
+
+const spawnUnknown = Object.assign(new Error("spawn UNKNOWN"), {
+  code: "UNKNOWN",
+}) as NodeJS.ErrnoException;
+
+describe("describeElectronSpawnFailure", () => {
+  it("explains the Smart App Control block on a Windows spawn UNKNOWN", () => {
+    const message = describeElectronSpawnFailure({
+      error: spawnUnknown,
+      electronAppPath: "C:/Users/me/.muggle-ai/electron-app/1.5.1/MuggleAI.exe",
+      platform: "win32",
+    });
+    expect(message).toContain("spawn UNKNOWN");
+    expect(message).toContain("Smart App Control");
+    expect(message).toContain("MuggleAI.exe");
+    expect(message).toContain("Smart App Control > Off");
+  });
+
+  it("treats EPERM on Windows as the same block", () => {
+    const message = describeElectronSpawnFailure({
+      error: Object.assign(new Error("spawn EPERM"), { code: "EPERM" }) as NodeJS.ErrnoException,
+      electronAppPath: "C:/x/MuggleAI.exe",
+      platform: "win32",
+    });
+    expect(message).toContain("Smart App Control");
+  });
+
+  it("returns only the base message for unrelated Windows errors", () => {
+    const message = describeElectronSpawnFailure({
+      error: Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" }) as NodeJS.ErrnoException,
+      electronAppPath: "C:/x/MuggleAI.exe",
+      platform: "win32",
+    });
+    expect(message).toBe("Failed to start electron-app: spawn ENOENT");
+    expect(message).not.toContain("Smart App Control");
+  });
+
+  it("does not blame App Control on non-Windows platforms", () => {
+    const message = describeElectronSpawnFailure({
+      error: spawnUnknown,
+      electronAppPath: "/x/MuggleAI",
+      platform: "linux",
+    });
+    expect(message).toBe("Failed to start electron-app: spawn UNKNOWN");
+  });
+});


### PR DESCRIPTION
## Problem

On Windows boxes with **Smart App Control** in enforce mode (or a WDAC policy), the OS blocks the unsigned `MuggleAI.exe` *before the process starts*. Node surfaces this only as:

```
Status: failed   Duration: 0ms   Error: spawn UNKNOWN
```

No stderr, no exit code — undiagnosable from the message. (Smart App Control auto-promotes itself from Evaluation to Enforce on clean Win11 installs with no user action, so this is starting to hit a growing subset of users.)

## Fix

Translate the specific spawn failure (`win32` + `UNKNOWN`/`EPERM`) into the actual cause and the way out, instead of the bare Node message:

```
Failed to start electron-app: spawn UNKNOWN

This is almost certainly Windows Smart App Control (or a WDAC policy) blocking the
Muggle desktop app because it is not yet code-signed: the OS refuses to launch the
binary before it starts, so there is no output and the run fails in 0ms.

  Binary: C:\Users\...\.muggle-ai\electron-app\1.5.1\MuggleAI.exe
  Confirm: launch the binary directly, or check Event Viewer > ... > CodeIntegrity
  (events 3033/3077) for "An Application Control policy has blocked this file."

  To run Muggle now: Settings > Privacy & security > Windows Security > App & browser
  control > Smart App Control > Off. A signed build that passes Smart App Control is on the way.
```

- Extracted to a pure helper `describeElectronSpawnFailure` (platform injectable) — `packages/mcps/src/mcp/local/services/spawn-failure-message.ts`.
- Wired into the spawn `error` handler in `execution-service.ts`.
- Non-block errors (e.g. `ENOENT`) and non-Windows platforms keep the original message.

## Scope / safety

UX-only — it changes the **error string** on a spawn failure, nothing about how the app launches or runs. The real cure is code-signing the binary (Azure Trusted Signing, separate teaching-service work); this makes the interim failure self-explanatory instead of cryptic.

## Verification

- `tsc --noEmit` (mcps) — clean
- `vitest run spawn-failure-message.test.ts` — 4/4 (win UNKNOWN, win EPERM, win ENOENT→base, linux→base)
- `eslint` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
