### PR TITLE
[UNIT-ONLY] Local runs inherit test case cloud url as remoteUrl

### DIFF
--- a/packages/mcps/src/mcp/local/services/action-script-builders.ts
+++ b/packages/mcps/src/mcp/local/services/action-script-builders.ts
@@ -62,6 +62,10 @@ export function buildGenerationActionScript(params: {
       actionScriptId: params.localTestScriptId,
       workflowRunId: params.runId,
       url: params.localUrl,
+      // The studio executes against `url` (localhost) but uploads `productionUrl`
+      // as the run's remoteUrl. Without it the studio falls back to the localhost
+      // url, so the run record shows localhost where the test case's cloud url belongs.
+      productionUrl: params.testCase.url,
       // Tags the run as locally executed so the studio skips its own cloud
       // ActionScript/TestScript write — the /local-run/upload path is the
       // single writer for local runs (avoids duplicate Firestore docs).
@@ -132,6 +136,11 @@ export function buildReplayActionScript(params: {
       testCaseId: params.testScript.testCaseId,
       testScriptId: params.testScript.id,
       workflowRunId: params.runId,
+      // The studio executes against the rewritten localhost steps but uploads
+      // `productionUrl` as the run's remoteUrl. Without it the studio falls back
+      // to the localhost url, so the run record shows localhost where the test
+      // script's cloud url belongs.
+      productionUrl: params.testScript.url,
       // Tags the run as locally executed so the studio skips its own cloud
       // ActionScript write — replay's cloud record is owned by the upload path
       // (avoids duplicate Firestore docs).

--- a/packages/mcps/src/test/local-action-script-builders.test.ts
+++ b/packages/mcps/src/test/local-action-script-builders.test.ts
@@ -20,6 +20,7 @@ function makeTestCase(): TestCaseDetails {
     precondition: "",
     instructions: "",
     expectedResult: "Dashboard shown",
+    url: "https://staging.example.com",
   } as unknown as TestCaseDetails;
 }
 
@@ -59,6 +60,14 @@ describe("buildGenerationActionScript", () => {
   it("leaves sharedTestMemoryId empty (resolved server-side, never the projectId)", () => {
     expect(actionParams(script).sharedTestMemoryId).toBe("");
   });
+
+  it("carries the cloud url as productionUrl so the run's remoteUrl is not localhost", () => {
+    expect(actionParams(script).productionUrl).toBe("https://staging.example.com");
+  });
+
+  it("keeps localUrl on actionParams.url, not the cloud url", () => {
+    expect(actionParams(script).url).toBe("http://localhost:3999");
+  });
 });
 
 describe("buildReplayActionScript", () => {
@@ -80,5 +89,13 @@ describe("buildReplayActionScript", () => {
 
   it("leaves sharedTestMemoryId empty (resolved server-side, never the projectId)", () => {
     expect(actionParams(script).sharedTestMemoryId).toBe("");
+  });
+
+  it("carries the cloud url as productionUrl so the run's remoteUrl is not localhost", () => {
+    expect(actionParams(script).productionUrl).toBe("https://staging.example.com");
+  });
+
+  it("runs the script against localUrl, not the cloud url", () => {
+    expect(script.url).toBe("http://localhost:3999");
   });
 });


### PR DESCRIPTION
## Goal
A local test run must record the test case's cloud/remote URL as the run's `remoteUrl`, not the localhost URL it executes against.

## Acceptance Criteria
- Local generation: action-script `actionParams` carries `productionUrl === testCase.url` (cloud URL).
- Local replay: action-script `actionParams` carries `productionUrl === testScript.url` (cloud URL).
- The localhost URL stays on `url`/`localUrl`; the studio uploads `productionUrl` as the run's `remoteUrl`.

## Changes
`buildGenerationActionScript` / `buildReplayActionScript` (`packages/mcps/src/mcp/local/services/action-script-builders.ts`) handed the studio `actionParams` with only the localhost `url` and no `productionUrl`. The studio's upload builder (`muggle-ai-teaching-service` `run_mode_router._buildLocalRunUploadRequest`) reads `actionParams.productionUrl ?? script.url`, so it fell back to the localhost url and recorded **localhost as the run's `remoteUrl`** — the dashboard then showed `http://localhost:3999` where the test case's cloud url (`https://staging.muggle-ai.com/...`) belongs.

This carries `productionUrl` (`testCase.url` / `testScript.url`) on both builders so the studio uploads the cloud url as `remoteUrl` while still executing against localhost. The local run-result storage already stored the correct `productionUrl`; only the action script handed to the studio dropped it. The teaching-service `?? script.url` fallback stays as backward-compat for runs predating the field — no teaching-service change required.

Unit tests added: `productionUrl` is present and equals the source url for both builders, and `localUrl` stays on the execution url.

## Validation
unit-only — `packages/mcps` builder suite 10/10 green (2 new `productionUrl` assertions, TDD red→green). Change is internal MCP builder logic with no web-app surface, so E2E is SKIPPED. (Full mcps suite has one unrelated pre-existing snapshot failure in `tool-registry-pagination.test.ts` on `origin/master`, untouched by this diff.)
