### PR TITLE
chore(release): @muggleai/works 5.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "5.3.1"
+      "version": "5.4.0"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "5.3.1"
+      "version": "5.4.0"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@muggleai/works",
   "mcpName": "io.github.multiplex-ai/muggle",
-  "version": "5.3.1",
+  "version": "5.4.0",
   "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
   "type": "module",
   "main": "dist/index.js",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "5.3.1",
+  "version": "5.4.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "5.3.1",
+  "version": "5.4.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "5.3.1",
+  "version": "5.4.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "5.3.1",
+      "version": "5.4.0",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
Release @muggleai/works 5.4.0 (minor). Baseline npm latest 5.3.3, bumped to 5.4.0.

Shipping since 5.3.1 (#283):
- Per-skill model routing: simple skills run on cheaper models (#286); skill-gate eval runs each skill on its declared model (#290)
- Skill-eval CI: gate + routing enforced as blocking PR checks (#284), authed via Claude subscription (#285), results posted to PR (#291)
- fix(local-run): inherit test case cloud url as run remoteUrl (#295)
- fix(muggle-test-feature-local): omit showUi when showElectronBrowser=always (#292)
- fix(mcp): explain Smart App Control block instead of bare "spawn UNKNOWN" (#294)
- test: guardrails hook-execution (#293) and mcp tool-surface parity (#298)
- chore(electron-app): CLI points at signed electron-app 1.6.4 (#296)

Electron: unchanged, electronAppVersion 1.6.4 (already latest).

Version manifests propagated by sync:versions: package.json, .claude-plugin/marketplace.json, .cursor-plugin/marketplace.json, plugin/.claude-plugin/plugin.json, plugin/.cursor-plugin/plugin.json, server.json.

Local gate ran clean: lint (0 errors), typecheck, vitest (572 of 572), build, verify:plugin, verify:contracts, verify:electron-release-checksums (1.6.4).

Publish via publish-works-to-npm.yml with version=5.4.0 after merge. No local npm publish.

Generated with Claude Code (https://claude.com/claude-code)