### PR TITLE
chore(release): @muggleai/works 5.4.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "5.4.0"
+      "version": "5.4.1"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "5.4.0"
+      "version": "5.4.1"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@muggleai/works",
   "mcpName": "io.github.multiplex-ai/muggle",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
   "type": "module",
   "main": "dist/index.js",
@@ -43,14 +43,14 @@
     "test:gates:behavioral": "tsx internal/skill-gate-eval/src/run.ts"
   },
   "muggleConfig": {
-    "electronAppVersion": "1.6.4",
+    "electronAppVersion": "1.6.5",
     "downloadBaseUrl": "https://github.com/multiplex-ai/muggle-ai-works/releases/download",
     "runtimeTargetDefault": "dev",
     "checksums": {
-      "darwin-arm64": "224ad15cf1676f31b907d2bada439b4845a169595ba3d81ae8edeaeb996733bc",
-      "darwin-x64": "cd48224f9cd5e25132f8433389d1a95b67c53dba001e40943a79e564af8a55dd",
-      "linux-x64": "7e30f0afb9d6099f736f85fb2a987c784dc71c3b4818132ca2261a7c340518a3",
-      "win32-x64": "b1b6758f39dfac2a347827bca82c8944962c1b345614cb91c5d2e81ae7d779a3"
+      "darwin-arm64": "e6aea93ea560565a6633d58c709ece1f1a7d1dcb76668a2e6ed2a7c0f15c780d",
+      "darwin-x64": "02b280897cc3d6b17d5b394ba814f680afed5035b8fc59b26ab26c3f235374f9",
+      "linux-x64": "da4f6d58e05926a023e692cde7482fd773c22b5dfa51b6fec09e21f2e9198106",
+      "win32-x64": "c0aae762a26dd623ed16fc07a9dfd0c124002637d29d107e2f855e96a406fd5a"
     }
   },
   "dependencies": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "5.4.0",
+  "version": "5.4.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "5.4.0",
+      "version": "5.4.1",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
Ships **electron-app 1.6.5** — the first fully code-signed desktop build.

- `electronAppVersion` 1.6.4 → 1.6.5 + all four checksums (verified via `verify:electron-release-checksums`).
- **Windows:** Authenticode-signed via Azure Trusted Signing (CN "Multiplex AI, LLC").
- **macOS:** Developer ID signed + **notarized** (Team `9B2AKX295Y`); `spctl` accepts it.
- Result: Smart App Control (Win) and Gatekeeper (mac) no longer block the binary.
- `sync:versions` propagated 5.4.1 across the 5 plugin/marketplace manifests; no source changes.

Publishes via `publish-works-to-npm.yml` (OIDC) after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)