### PR TITLE
docs: stop hard-coding the autoResolveConflicts default in skills

### DIFF
--- a/plugin/skills/_shared/rebase-before-e2e.md
+++ b/plugin/skills/_shared/rebase-before-e2e.md
@@ -15,7 +15,7 @@ Pass `{behind}` and `{default}` to the picker prompts. On `always`:
 1. Capture the rollback point: `pre_rebase_sha=$(git rev-parse HEAD)`.
 2. `git rebase origin/${default}`.
 3. On conflict, branch by [`autoResolveConflicts`](../muggle-preferences/preference-gates/autoResolveConflicts.md):
-   - `never` (default) → `git rebase --abort`; stop and report, naming the conflicted files. Never auto-resolve.
+   - `never` → `git rebase --abort`; stop and report, naming the conflicted files. Never auto-resolve.
    - `always` → hand off to [`resolve-rebase-conflicts.md`](resolve-rebase-conflicts.md) with `pre_rebase_sha`; it resolves, runs the verify-or-rollback gate, and either proceeds or restores `pre_rebase_sha` and escalates.
 
 Stale branches produce false failures and false greens — that's why this gate exists.

--- a/plugin/skills/_shared/resolve-rebase-conflicts.md
+++ b/plugin/skills/_shared/resolve-rebase-conflicts.md
@@ -1,6 +1,6 @@
 # Auto-Resolve Rebase Conflicts
 
-The autonomous conflict-resolution body, run when a rebase onto `origin/{default}` reports conflicts **and** [`autoResolveConflicts`](../muggle-preferences/preference-gates/autoResolveConflicts.md) is `always`. Under the default `never` the caller aborts and escalates instead, and this file never runs. The caller hands off the inputs below; this file names no caller — the dependency runs one way.
+The autonomous conflict-resolution body, run when a rebase onto `origin/{default}` reports conflicts **and** [`autoResolveConflicts`](../muggle-preferences/preference-gates/autoResolveConflicts.md) is `always`. Under `never` the caller aborts and escalates instead, and this file never runs. The caller hands off the inputs below; this file names no caller — the dependency runs one way.
 
 Contract: never push an auto-resolved rebase that has not passed the verify gate, and always keep the branch restorable to its pre-rebase state.
 

--- a/plugin/skills/do/resolve-conflicts.md
+++ b/plugin/skills/do/resolve-conflicts.md
@@ -28,7 +28,7 @@ Run the rebase from [`../_shared/rebase-before-e2e.md`](../_shared/rebase-before
 
 - **Clean replay** — a behind-only branch (and any rebase that hits no conflicts) replays without intervention. Proceed to Step 3.
 - **Conflicts** — handle per [`autoResolveConflicts`](../muggle-preferences/preference-gates/autoResolveConflicts.md):
-  - default `never` → abort and escalate per Step 5 (`kind: "rebase-conflict"`). The watcher keeps polling; the user resolves on GitHub, or opts into `autoResolveConflicts=always`.
+  - `never` → abort and escalate per Step 5 (`kind: "rebase-conflict"`). The watcher keeps polling; the user resolves on GitHub.
   - `always` → resolve behind the verify-or-rollback gate in [`../_shared/resolve-rebase-conflicts.md`](../_shared/resolve-rebase-conflicts.md).
 
 ### Step 3 — Verify the resolution
@@ -61,4 +61,4 @@ Emit one `muggle-do:cycle` event ([`../_shared/telemetry-events/muggle-do-cycle.
 
 - Max 2 rebase attempts per SHA; then escalate rather than churn.
 - Never push an unverified rebase — verify-or-rollback always.
-- The default `autoResolveConflicts=never` escalates to the user rather than guessing a conflict resolution. Auto-resolution of conflicts is strictly opt-in; a clean behind-only rebase needs no opt-in.
+- Resolve `autoResolveConflicts` from the configured preference (per the gate contract — don't assume a default): `always` resolves conflicts behind the verify-or-rollback gate, `never` escalates to the user. A clean behind-only rebase needs neither.

--- a/plugin/skills/muggle-do/SKILL.md
+++ b/plugin/skills/muggle-do/SKILL.md
@@ -62,7 +62,7 @@ When invoked with the directive (PR URL + slug + review ids), routes to [`../do/
 | Preference | Gate |
 | :--------- | :--- |
 | `autoE2ETest` | Stage 6 — run E2E every cycle (default `always`), or fold into pre-flight |
-| `autoResolveConflicts` | On rebase conflict — resolve autonomously behind a verify-or-rollback gate (opt-in), or abort + escalate (default `never`) |
+| `autoResolveConflicts` | On rebase conflict — `always` resolves autonomously behind a verify-or-rollback gate, `never` aborts + escalates; resolve from the configured preference (don't assume a default) |
 | `autoRouteBuildToMuggleDo` | Front-door guardrail — route build/implement/fix requests through this pipeline (build delegated to superpowers); fired by the UserPromptSubmit guardrail, default `ask` |
 
 `autoUseWorktree`, `autoRebase`, `autoResolveConflicts`, `autoCreatePR`, `autoCleanup`, `postPRVisualWalkthrough` fire from per-stage files.

--- a/plugin/skills/muggle-preferences/preference-gates/autoResolveConflicts.md
+++ b/plugin/skills/muggle-preferences/preference-gates/autoResolveConflicts.md
@@ -1,6 +1,6 @@
 # `autoResolveConflicts`
 
-When a rebase onto `origin/{default}` hits conflicts, resolve them autonomously behind a verify-or-rollback gate, or stop and escalate. Default `never` — the loop aborts the rebase and escalates exactly as before. Opt in with `always` to resolve conflicts without a human.
+When a rebase onto `origin/{default}` hits conflicts, `always` resolves them autonomously behind a verify-or-rollback gate and `never` aborts the rebase and escalates. Take the effective value from the configured preference per [`../README.md`](../README.md#resolution) (the injected `Muggle Test Preferences` line) — don't assume a default; an unset key resolves to `ask`.
 
 **Picker 1** — header `Resolve rebase conflicts?`, question `"Rebase onto origin/{default} hit conflicts in {conflicted} file(s) — resolve them autonomously?"`
 - `Resolve autonomously` — `Resolve the conflicts, then re-verify (build + unit + E2E) before any push; roll back and escalate if verification fails.` → `always`


### PR DESCRIPTION
## Bug

`autoResolveConflicts` is registered in `preferences-constants.ts` and defaults to `PreferenceValue.Always`, but several skill files still documented its default as `never`. An agent resolving the gate reads the skill prose, so it reports/behaves as `never` even when the installed preference (and the code default) is `always`.

Root cause: the hardcoded `default never` in the skill prose short-circuits the gate-resolution contract, which is supposed to read the actual value from the injected `Muggle Test Preferences` line (`preference-gates/README.md` → "Resolution"; absent → `ask`).

## Fix

Remove the hardcoded default from the skill prose so the gate resolves from the configured preference, not an assumed constant:

- `muggle-preferences/preference-gates/autoResolveConflicts.md` — describe `always`/`never` behaviors; point to README resolution; an unset key is `ask`.
- `muggle-do/SKILL.md` — drop `(default never)` from the table row.
- `do/resolve-conflicts.md` — drop the `default` labels on the conflict branches and the guardrail line.
- `_shared/rebase-before-e2e.md` — drop `(default)` from the `never` branch.
- `_shared/resolve-rebase-conflicts.md` — drop `the default` from the `never` mention.

No code change — `preferences-constants.ts` already registers the key and defaults it to `always`. Conditional "when `=never`" logic (escalate triggers, telemetry) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)