### PR TITLE
test(cli): real-subprocess smoke of the shipped CLI, run after build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,3 +140,6 @@ jobs:
 
       - name: Verify compatibility contracts
         run: pnpm run verify:contracts
+
+      - name: Smoke-test the built CLI
+        run: pnpm run smoke:cli

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "build:release": "npm run build",
     "verify:plugin": "node scripts/verify-plugin-marketplace.mjs",
     "verify:contracts": "node scripts/verify-compatibility-contracts.mjs",
+    "smoke:cli": "node scripts/smoke-cli.mjs",
     "verify:electron-release-checksums": "node scripts/verify-electron-release-checksums.mjs",
     "verify:upgrade-experience": "node scripts/verify-upgrade-experience.mjs",
     "build:workspace": "turbo run build",

--- a/scripts/smoke-cli.mjs
+++ b/scripts/smoke-cli.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+
+// Real-subprocess smoke of the shipped CLI. Runs the published entry
+// (bin/muggle.js -> dist/cli.js) the way a user does — argv in, stdout/exit
+// out — so a break in the bin shim, the commander wiring, or the bundled boot
+// path surfaces here. The handler logic is unit-tested from source; this pins
+// the end-to-end contract the "Lazy core" footprint refactor (which pins the
+// launch and lazy-loads the server) must preserve. Runs after `pnpm run build`.
+
+import { spawnSync } from "child_process";
+import { readFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const bin = join(root, "bin", "muggle.js");
+const version = JSON.parse(readFileSync(join(root, "package.json"), "utf-8")).version;
+
+// Every command createProgram() registers (run-cli.ts). The --help check below
+// is the surface oracle: a boot regression that drops one fails here.
+const expectedCommands = [
+  "serve",
+  "setup",
+  "upgrade",
+  "versions",
+  "cleanup",
+  "doctor",
+  "login",
+  "logout",
+  "status",
+  "build-pr-section",
+];
+
+// https-only report: collectGsUrls() finds nothing, so build-pr-section renders
+// offline with no prompt-service call or credential lookup — deterministic in CI.
+const sampleReport = JSON.stringify({
+  projectId: "p1",
+  tests: [
+    {
+      name: "A",
+      testCaseId: "a",
+      runId: "ra",
+      viewUrl: "https://example.com/a",
+      status: "passed",
+      steps: [{ stepIndex: 0, action: "Click", screenshotUrl: "https://cdn/a0.png" }],
+    },
+  ],
+});
+
+const failures = [];
+
+function run(args, input) {
+  return spawnSync(process.execPath, [bin, ...args], { input, encoding: "utf-8", timeout: 30_000 });
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function check(name, fn) {
+  try {
+    fn();
+  } catch (error) {
+    failures.push(`${name} — ${error.message}`);
+  }
+}
+
+check("muggle --version prints the package version", () => {
+  const result = run(["--version"]);
+  assert(result.status === 0, `exited ${result.status}`);
+  assert(result.stdout.trim() === version, `printed '${result.stdout.trim()}', expected '${version}'`);
+});
+
+check("muggle --help advertises every registered command", () => {
+  const result = run(["--help"]);
+  assert(result.status === 0, `exited ${result.status}`);
+  for (const command of expectedCommands) {
+    assert(result.stdout.includes(command), `--help omits '${command}'`);
+  }
+});
+
+check("muggle help prints the how-to guide", () => {
+  const result = run(["help"]);
+  assert(result.status === 0, `exited ${result.status}`);
+  assert(result.stdout.includes("Muggle AI Works"), "guide text missing");
+});
+
+check("muggle build-pr-section renders the PR evidence block from stdin", () => {
+  const result = run(["build-pr-section"], sampleReport);
+  assert(result.status === 0, `exited ${result.status}: ${result.stderr}`);
+  const body = JSON.parse(result.stdout).body;
+  assert(body.startsWith("<!-- muggle-pr-section:v1 -->\n"), "missing section marker");
+  assert(body.includes("E2E Acceptance Results"), "missing results heading");
+});
+
+check("muggle rejects an unknown command with a nonzero exit (never hangs)", () => {
+  const result = run(["definitely-not-a-command"]);
+  assert(result.status === 1, `expected exit 1, got ${result.status}`);
+});
+
+if (failures.length > 0) {
+  console.error("CLI smoke failed:");
+  for (const failure of failures) {
+    console.error(`  - ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log(`CLI smoke passed (${expectedCommands.length} commands, ${bin}).`);


### PR DESCRIPTION
## What

Third de-risk coverage layer (after #293 hooks, #298 MCP): a **real-subprocess smoke of the shipped CLI**, run after build in CI.

`scripts/smoke-cli.mjs` runs the published entry — `bin/muggle.js` → `dist/cli.js` — the way a user does (argv in, stdout/exit out) and asserts the end-to-end contract the handler unit tests can't reach:

- `--version` prints the `package.json` version
- `--help` advertises **every** registered command (surface oracle — a dropped command fails here)
- `help` renders the how-to guide
- `build-pr-section` emits the `<!-- muggle-pr-section:v1 -->` evidence block from an https-only report (no `gs://` URLs → offline, deterministic, no prompt-service call)
- an unknown command exits nonzero without hanging

## Why

The handler logic is already unit-tested from source. What was uncovered is the integration seam: the bin shim, the commander wiring, and the **bundled boot path**. That seam is exactly what the upcoming "Lazy core" footprint refactor changes (it pins the launch and lazy-loads the server). This smoke turns any such regression into a reviewed CI failure instead of a silent ship.

## Wiring

- New `smoke:cli` script.
- New step in the existing `verify-compatibility` job, which already runs `pnpm run build` — so `dist/` exists. The root `pnpm test` suite still runs *before* build, so a CLI smoke that needs the built artifact can't live there; it belongs post-build alongside `verify:plugin` / `verify:contracts`.

## Verification

- `pnpm run smoke:cli` → passes (10 commands).
- `pnpm run lint:check` → 0 errors (8 pre-existing warnings in `internal/skill-gate-eval`, untouched).
- `pnpm run typecheck` → clean.
- `pnpm test` → 571/572; the one failure is a confirmed environment flake (`local-execution-lock` timed out at 5s on a loaded box, passes 4/4 in isolation). This diff touches no `packages/mcps` code.

No web app ships in this repo, so there is no browser E2E surface; verification is the suite + this CI smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
