### PR TITLE
[UNIT-ONLY] fix(plugin): portable file mtime in session-start hook

### DIFF
--- a/plugin/scripts/ensure-electron-app.sh
+++ b/plugin/scripts/ensure-electron-app.sh
@@ -2,6 +2,26 @@
 
 set -euo pipefail
 
+# Epoch mtime of a file, or 0 if unreadable. GNU coreutils (Linux/WSL/Git Bash)
+# need `stat -c %Y`; BSD/macOS need `stat -f %m`. The wrong form doesn't fail
+# cleanly — GNU `stat -f` prints filesystem info to stdout and exits non-zero —
+# so each form is tried alone and accepted only when all-digits, keeping stray
+# text like `File:` out of the caller's arithmetic.
+file_mtime() {
+    local f="$1" m
+    m=$(stat -c %Y "$f" 2>/dev/null) || m=""
+    case "$m" in ''|*[!0-9]*) ;; *) printf '%s\n' "$m"; return 0 ;; esac
+    m=$(stat -f %m "$f" 2>/dev/null) || m=""
+    case "$m" in ''|*[!0-9]*) ;; *) printf '%s\n' "$m"; return 0 ;; esac
+    printf '0\n'
+}
+
+# Sourcing with MUGGLE_ENSURE_ELECTRON_LIB_ONLY=1 exposes the helper above
+# without running the hook — used by the unit test.
+if [ -n "${MUGGLE_ENSURE_ELECTRON_LIB_ONLY:-}" ]; then
+    return 0 2>/dev/null || exit 0
+fi
+
 # Ensure the Electron browser test runner is installed/up to date (silent, best-effort).
 #
 # Bounded + cached: this script runs from a SessionStart hook on every Claude
@@ -16,7 +36,7 @@ ensure_ttl=$((24 * 60 * 60))
 ensure_now=$(date +%s)
 ensure_last=0
 if [ -f "${ensure_marker}" ]; then
-    ensure_last=$(stat -f %m "${ensure_marker}" 2>/dev/null || stat -c %Y "${ensure_marker}" 2>/dev/null || echo 0)
+    ensure_last=$(file_mtime "${ensure_marker}")
 fi
 
 if [ $((ensure_now - ensure_last)) -ge "${ensure_ttl}" ]; then
@@ -60,7 +80,7 @@ version_check() {
     now=$(date +%s)
 
     if [ -f "$cache_file" ]; then
-        mtime=$(stat -f %m "$cache_file" 2>/dev/null || stat -c %Y "$cache_file" 2>/dev/null || echo 0)
+        mtime=$(file_mtime "$cache_file")
         age=$((now - mtime))
         if [ "$age" -lt "$ttl" ]; then
             cached=$(cat "$cache_file" 2>/dev/null || true)

--- a/src/test/scripts/ensure-electron-app.test.ts
+++ b/src/test/scripts/ensure-electron-app.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { mkdtempSync, writeFileSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const toBash = (p: string) => p.replace(/\\/g, "/");
+
+const scriptPath = toBash(
+  fileURLToPath(new URL("../../../plugin/scripts/ensure-electron-app.sh", import.meta.url)),
+);
+
+let hasBash = false;
+try {
+  execFileSync("bash", ["-c", "true"], { stdio: "ignore" });
+  hasBash = true;
+} catch {
+  // bash unavailable — the suite below skips
+}
+
+// Run `snippet` in bash with the script and a throwaway file exposed as
+// $SCRIPT / $TESTFILE. The script is sourced in lib-only mode so only its
+// helpers load — the hook body (muggle setup, npm view, JSON output) never runs.
+function runBash(snippet: string): { stdout: string; status: number } {
+  const dir = mkdtempSync(join(tmpdir(), "ensure-electron-"));
+  const file = join(dir, "marker");
+  writeFileSync(file, "x");
+  try {
+    const stdout = execFileSync("bash", ["-c", snippet], {
+      env: { ...process.env, SCRIPT: scriptPath, TESTFILE: toBash(file) },
+      encoding: "utf-8",
+    });
+    return { stdout: stdout.trim(), status: 0 };
+  } catch (e: unknown) {
+    const err = e as { stdout?: Buffer | string; status?: number };
+    return {
+      stdout: (err.stdout?.toString() ?? "").trim(),
+      status: err.status ?? 1,
+    };
+  }
+}
+
+const load = 'MUGGLE_ENSURE_ELECTRON_LIB_ONLY=1 source "$SCRIPT";';
+
+describe.skipIf(!hasBash)("ensure-electron-app.sh file_mtime", () => {
+  it("returns the file's epoch mtime as a bare number", () => {
+    const { stdout } = runBash(`${load} file_mtime "$TESTFILE"`);
+    expect(stdout).toMatch(/^\d+$/);
+  });
+
+  it("returns 0 — never leaked junk — when stat exits non-zero with noise", () => {
+    // Mimics GNU `stat -f` on Linux/Git Bash: writes a `File: ...` block to
+    // stdout and exits non-zero. The old code appended this to the real mtime.
+    const { stdout } = runBash(
+      `stat() { printf 'File: junk\\n'; return 1; }; ${load} file_mtime "$TESTFILE"`,
+    );
+    expect(stdout).toBe("0");
+  });
+
+  it("rejects non-numeric stat output even when stat exits zero", () => {
+    const { stdout } = runBash(
+      `stat() { printf 'File: junk\\n'; return 0; }; ${load} file_mtime "$TESTFILE"`,
+    );
+    expect(stdout).toBe("0");
+  });
+
+  it("feeds the TTL arithmetic safely under set -u (the original crash)", () => {
+    // Reproduces line 22: a non-numeric mtime here aborted with
+    // `File: unbound variable`. With the fix, file_mtime yields a number.
+    const { stdout, status } = runBash(
+      `set -u; stat() { printf 'File: junk\\n'; return 0; }; ${load} ` +
+        `now=$(date +%s); echo $((now - $(file_mtime "$TESTFILE")))`,
+    );
+    expect(status).toBe(0);
+    expect(stdout).toMatch(/^\d+$/);
+  });
+
+  it("matches node's view of the file mtime", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ensure-electron-"));
+    const file = join(dir, "marker");
+    writeFileSync(file, "x");
+    const expected = Math.floor(statSync(file).mtimeMs / 1000);
+    const stdout = execFileSync("bash", ["-c", `${load} file_mtime "$TESTFILE"`], {
+      env: { ...process.env, SCRIPT: scriptPath, TESTFILE: toBash(file) },
+      encoding: "utf-8",
+    }).trim();
+    expect(Number(stdout)).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Goal

The `ensure-electron-app.sh` SessionStart hook aborts on every session after the first with `ensure-electron-app.sh: line 22: File: unbound variable`, so it never reaches its context-injection block — Muggle Test preferences, last-project, last-host, and the upgrade nudge are silently dropped.

## Root cause

Lines 19 and 63 read a file's mtime with `stat -f %m … || stat -c %Y …`. `-f` is BSD/macOS "format" but GNU coreutils "file-system". On GNU (Linux, WSL, Git Bash on Windows) `stat -f %m FILE` writes a filesystem block beginning `File:` to stdout **and** exits non-zero; the `||` then appends the GNU epoch, leaving a non-numeric value. The next `$((now - mtime))` evaluates that text as an arithmetic expression and, under `set -u`, dies on the unset token `File`. First session works (no marker yet → `mtime=0`); every session afterward crashes.

## Acceptance Criteria

- Mtime read returns a bare integer on Linux, macOS, WSL, and Git Bash on Windows.
- A wrong-platform / polluting `stat` can't leak non-numeric text into the arithmetic (ordering **and** numeric validation — defense in depth).
- Both occurrences fixed, not just the one in the stack trace.
- Regression test reproduces the original crash and asserts it's gone.

## Changes

- New `file_mtime` helper: tries `stat -c %Y` (GNU) then `stat -f %m` (BSD) each in its own subshell, accepting the result only when it's all digits, else `0`.
- Both call sites (daily marker check, version-check cache) routed through it.
- `src/test/scripts/ensure-electron-app.test.ts` — 5 bash-driven cases incl. the exact `File: unbound variable` crash repro; skips where bash is unavailable.

## Validation

unit-only — no browser surface (SessionStart shell hook). Full vitest suite 47 files / 600 tests PASS; typecheck + eslint clean; direct bash repro confirms the original crash returns a number under `set -u`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqMb82qFMPAwk2Bm3NdZz9
