### PR TITLE
[UNIT-ONLY] fix(skills): guard watcher cron-cancel against bash misuse

### DIFF
--- a/plugin/skills/muggle-pr-followup/CLAUDE.md
+++ b/plugin/skills/muggle-pr-followup/CLAUDE.md
@@ -9,6 +9,7 @@ This folder holds the watcher loop that drives one PR toward merge-ready. The wa
 - [`bootstrap.md`](bootstrap.md) — the bootstrap procedure (resolves the validation context once when the PR has a testable surface — else seeds poll-only like auto-track — then dispatches the first watcher).
 - [`contract.md`](contract.md) — the watcher per-tick procedure (poll → dispatch → exit).
 - [`finalize.md`](finalize.md) — shared termination sequence for a terminal PR (mark terminal, `result.md`, log/telemetry, unschedule cron, post-merge cleanup handoff). Called by `contract.md` and `reconcile.md`.
+- [`cancel-cron.md`](cancel-cron.md) — the find-and-delete that stops this watcher's cron, with the tool-call-not-shell guard. Referenced by `contract.md` and `finalize.md`.
 - [`reconcile.md`](reconcile.md) — sweep that finalizes slots whose PR went terminal while polling lapsed; runs at the top of auto-track and on demand.
 - [`state-schemas.md`](state-schemas.md) — canonical JSON shapes of session state files.
 - [`output-templates.md`](output-templates.md) — TOC of message templates; per-group files in `output-templates/`.

--- a/plugin/skills/muggle-pr-followup/cancel-cron.md
+++ b/plugin/skills/muggle-pr-followup/cancel-cron.md
@@ -1,0 +1,11 @@
+# Cancel the watcher's cron
+
+The find-and-delete every tick uses to stop its own loop: the stale-fire guard and terminal unschedule ([`finalize.md`](finalize.md) Step 4), and each single-thread "stop this watcher" before a `/muggle-do` dispatch ([`contract.md`](contract.md) Steps 4–6).
+
+> **`CronList` and `CronDelete` are Claude Code tool calls, not shell commands.** Invoke them directly through the tool system. Never wrap them in a Bash/shell call: `bash -c "CronDelete …"` fails with "command not found", which a `2>/dev/null` on the line swallows, so the delete silently no-ops and the per-minute cron keeps firing — every later tick hits the stale-fire guard and re-fires until the 7-day expiry.
+
+1. Call the `CronList` tool.
+2. Find the job whose command ends with `/muggle:muggle-pr-followup <slug> <n>` — the exact two-arg match for this slot's PR.
+3. Call the `CronDelete` tool with that job's id.
+
+No-op when none matches — a manually-run tick, or a cron that already expired.

--- a/plugin/skills/muggle-pr-followup/contract.md
+++ b/plugin/skills/muggle-pr-followup/contract.md
@@ -27,7 +27,7 @@ If either file is missing or the PR is not in `prs.json`, the tick is a no-op. L
 
 ### Step 0 — Stale-fire guard
 
-If `prs.json[0].state` on disk is already `merged` or `closed`, this slot was finalized by a prior tick and this is a stale (queued) fire — per-minute cron fires enqueued while the session was busy still drain after the cron is cancelled. Defensively cancel any lingering cron for this slug (`CronList` → the job whose command ends with `/muggle:muggle-pr-followup <slug> <n>` → `CronDelete`; no-op if none), append a `stale-tick` line to `followup.log`, and exit. Do not re-fetch or re-finalize.
+If `prs.json[0].state` on disk is already `merged` or `closed`, this slot was finalized by a prior tick and this is a stale (queued) fire — per-minute cron fires enqueued while the session was busy still drain after the cron is cancelled. Defensively cancel any lingering cron for this slug per [`cancel-cron.md`](cancel-cron.md) (no-op if none), append a `stale-tick` line to `followup.log`, and exit. Do not re-fetch or re-finalize.
 
 ### Step 1 — Refresh PR state
 
@@ -67,7 +67,7 @@ The watcher's dispatch trigger is **derived from current provider state**, not a
 The watcher does **not** classify. Classification, batching, replying, escalation, and cycle execution all live in `/muggle-do`. The watcher hands over the dispatch ids from Step 3 (GitHub: owning review ids; GitLab: discussion ids) and exits — `/muggle-do`'s address-reviews re-derives the unresolved threads itself (its authority), so the watcher only needs to decide *that* there is work, not enumerate it exhaustively.
 
 1. Reset `last_seen.idle_tick_count` to 0.
-2. **Stop this watcher (single-thread).** Cancel its cron so no tick fires while the dev cycle runs: `CronList`, find the job whose command ends with `/muggle:muggle-pr-followup <slug> <n>` (exact two-arg match), `CronDelete` it. `/muggle-do` respawns the watcher when the cycle finishes — exactly one cron ever, and no tick overlaps a running cycle.
+2. **Stop this watcher (single-thread).** Cancel its cron so no tick fires while the dev cycle runs, per [`cancel-cron.md`](cancel-cron.md). `/muggle-do` respawns the watcher when the cycle finishes — exactly one cron ever, and no tick overlaps a running cycle.
 3. Dispatch `/muggle-do` with an *address-reviews* directive carrying:
    - PR URL (from `prs.json[0].url`)
    - Session slug (from the invocation arguments)

--- a/plugin/skills/muggle-pr-followup/finalize.md
+++ b/plugin/skills/muggle-pr-followup/finalize.md
@@ -26,4 +26,4 @@ Append the terminal line per [`output-templates/watcher-log.md`](output-template
 
 ### Step 4 — Unschedule the cron
 
-Call `CronList`, find any job whose command ends with `/muggle:muggle-pr-followup <slug> <n>` (exact two-arg match), and `CronDelete` it. No-op when none matches — a manually-run tick, or a cron that already expired. Recurring `/loop` crons auto-expire after 7 days; that lapse is the gap [`reconcile.md`](reconcile.md) exists to catch.
+Cancel this slot's cron per [`cancel-cron.md`](cancel-cron.md). No-op when none matches — a manually-run tick, or a cron that already expired. Recurring `/loop` crons auto-expire after 7 days; that lapse is the gap [`reconcile.md`](reconcile.md) exists to catch.

--- a/src/test/skills/pr-followup-cron-guard.test.ts
+++ b/src/test/skills/pr-followup-cron-guard.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Static lint for the muggle-pr-followup watcher's cron-cancellation wording.
+ *
+ * The watcher stops its per-minute cron with the `CronList`/`CronDelete` tools.
+ * When the instruction reads like pseudocode an agent can wrap it in a Bash
+ * call, which silently no-ops and orphans the cron (it then fires until the
+ * 7-day expiry). The fix is a single `cancel-cron.md` carrying an explicit
+ * "these are tool calls, not shell commands" guard, referenced from every
+ * cancel site. This test keeps that invariant from regressing; it does NOT
+ * catch an agent that ignores the doc.
+ */
+
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "../../..");
+const WATCHER_DIR = path.join(
+  REPO_ROOT,
+  "plugin",
+  "skills",
+  "muggle-pr-followup",
+);
+const HELPER = "cancel-cron.md";
+
+function markdownFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...markdownFiles(full));
+    else if (entry.name.endsWith(".md")) out.push(full);
+  }
+  return out;
+}
+
+function read(file: string): string {
+  return fs.readFileSync(file, "utf8");
+}
+
+describe("muggle-pr-followup cron-cancellation guard", () => {
+  const helperPath = path.join(WATCHER_DIR, HELPER);
+
+  it("cancel-cron.md exists", () => {
+    expect(
+      fs.existsSync(helperPath),
+      `${HELPER} is the single source of truth for cron cancellation — it must exist`,
+    ).toBe(true);
+  });
+
+  describe("the helper carries the tool-not-shell guard", () => {
+    const md = fs.existsSync(helperPath) ? read(helperPath) : "";
+
+    it("names both Cron tools", () => {
+      expect(/\bCronList\b/.test(md)).toBe(true);
+      expect(/\bCronDelete\b/.test(md)).toBe(true);
+    });
+
+    it("states they are tool calls, not shell commands", () => {
+      expect(/tool call/i.test(md)).toBe(true);
+      expect(/not shell command|not (a )?shell|never .*\bbash\b/i.test(md)).toBe(
+        true,
+      );
+    });
+
+    it("warns that a bash invocation silently no-ops", () => {
+      expect(/\bbash\b/i.test(md)).toBe(true);
+      expect(/no-?op|silently/i.test(md)).toBe(true);
+    });
+  });
+
+  describe("every cron-cancel mention routes through the helper", () => {
+    const sites = markdownFiles(WATCHER_DIR).filter(
+      (f) => path.basename(f) !== HELPER,
+    );
+    const offenders = sites
+      .filter((f) => /\bCronDelete\b/.test(read(f)) && !read(f).includes(HELPER))
+      .map((f) => path.relative(WATCHER_DIR, f));
+
+    it("no file mentions CronDelete without referencing cancel-cron.md", () => {
+      expect(
+        offenders,
+        `these files spell out CronDelete instead of deferring to ${HELPER} (re-inlining drops the tool-not-shell guard): ${offenders.join(", ")}`,
+      ).toEqual([]);
+    });
+  });
+
+  describe("parser sanity: refuse to pass vacuously", () => {
+    it("at least one watcher file references the helper", () => {
+      const refs = markdownFiles(WATCHER_DIR).filter(
+        (f) => path.basename(f) !== HELPER && read(f).includes(HELPER),
+      );
+      expect(
+        refs.length,
+        "no watcher file references cancel-cron.md — the cancel sites are unwired",
+      ).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
## Goal

Stop the `muggle-pr-followup` watcher from orphaning its per-minute cron when a PR goes terminal. On PR #307 the watcher kept ticking every minute after merge because the cron was never actually deleted.

## Root cause

The watcher stops its cron with the `CronList` / `CronDelete` **tools**. But `contract.md` (Step 0 stale-fire guard, Step 4 stop-this-watcher) and `finalize.md` (Step 4 unschedule) spelled the procedure out as backtick-quoted tool names — `` `CronList` → … → `CronDelete` `` — with no statement that these are tool calls. Read as pseudocode, an agent can wrap them in a Bash call: `bash -c "CronDelete …"` fails with "command not found", a `2>/dev/null` on the line swallows it, the delete silently no-ops, and the per-minute cron fires until its 7-day expiry — each later tick just hitting the stale-fire guard.

## Acceptance Criteria

- The cron-cancel procedure is defined once, with an explicit "these are tool calls, not shell commands; bash silently no-ops and orphans the cron" guard.
- Every cancel site (`contract.md` Steps 0 & 4, `finalize.md` Step 4) routes through it; Steps 5/6 keep deferring to Step 4.
- CI-gated coverage that fails if any cancel site re-inlines `CronDelete` without the guard, so the ambiguity can't regress.

## Changes

- **New `plugin/skills/muggle-pr-followup/cancel-cron.md`** — the single find-and-delete procedure with the tool-not-shell guard. Registered in the folder TOC.
- **`contract.md` / `finalize.md`** — the three cancel sites now reference `cancel-cron.md` instead of inlining the steps.
- **`src/test/skills/pr-followup-cron-guard.test.ts`** — vitest lint (modeled on `preference-gates-lint.test.ts`): asserts the helper exists, carries the tool-call/no-bash/silent-no-op guard wording, and that no watcher file mentions `CronDelete` without referencing the helper.

## Validation

unit-only — pure markdown + a doc-lint test, no browser surface. Full vitest suite 48 files / 606 tests PASS; typecheck, eslint, `verify:plugin`, and `verify:contracts` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqMb82qFMPAwk2Bm3NdZz9
