### PR TITLE
[UNIT-ONLY] fix(skill-eval): no-coverage crash + gate-eval timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,22 @@ jobs:
       - name: Build
         run: pnpm run build
 
+  # Guards the Python eval harness (skill-routing-eval). Pure stdlib unittest,
+  # no Claude calls, so it runs on every PR without the LLM evals' flake/cost.
+  harness-unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run harness unit tests
+        run: python -m unittest discover -s internal/skill-routing-eval -p "test_*.py" -v
+
   # Type check with different TypeScript versions
   typecheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/skill-eval.yml
+++ b/.github/workflows/skill-eval.yml
@@ -30,7 +30,10 @@ permissions:
 jobs:
   skill-gate-eval:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # LLM-driven and fully sequential: every gate × every scenario × GATE_RUNS
+    # real Claude reps (~1 min each). 45 min cancelled healthy sweeps mid-gate;
+    # match the sibling skill-routing-eval budget so a full run can finish.
+    timeout-minutes: 180
     env:
       # Subscription auth, not a pay-per-use API key. Generate with
       # `claude setup-token` and store as the CLAUDE_CODE_OAUTH_TOKEN secret.

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@ node_modules/
 # Build output
 dist/
 
+# Python (skill-routing-eval harness)
+__pycache__/
+*.pyc
+
 # Declaration emit is disabled; ignore if regenerated locally next to sources
 packages/**/src/**/*.d.ts
 packages/**/src/**/*.d.ts.map

--- a/internal/skill-routing-eval/analyze.py
+++ b/internal/skill-routing-eval/analyze.py
@@ -70,6 +70,19 @@ def per_skill_report(report):
     passed = sum(1 for r in rows_all if r["_pass"])
     total = len(rows_all)
 
+    # An empty result set means the run collected nothing to score. Return a
+    # legible note instead of dividing by zero below — the caller still gets a
+    # combined.md to post rather than an opaque ZeroDivisionError traceback.
+    if total == 0:
+        return (
+            "# Router eval report\n\n"
+            f"- model: `{report.get('model')}`  runs/query: {report.get('runs_per_query')}\n"
+            "- **No routing samples were collected — nothing to score.**\n"
+            "- Either none of the evaluated skills had queries in the eval-set, or "
+            "every chunk flaked (MCP disconnect / subscription limit). Check the run "
+            "log; re-run if it was a flake.\n"
+        )
+
     pos_skills = sorted({r["expected_skill"] for r in rows_all if r["expected_skill"] != NONE})
     lines = []
     lines.append("# Router eval report")

--- a/internal/skill-routing-eval/run.py
+++ b/internal/skill-routing-eval/run.py
@@ -81,6 +81,10 @@ def recall(report: dict, skill: str) -> float:
     return correct / len(rows)
 
 
+def has_no_coverage(skills: list[str], by_skill: dict) -> bool:
+    return not any(by_skill.get(s) for s in skills)
+
+
 def main():
     ap = argparse.ArgumentParser(description="Run the skill-routing eval (chunked, guarded).")
     g = ap.add_mutually_exclusive_group()
@@ -121,6 +125,25 @@ def main():
         skills = [s.strip() for s in args.skills.split(",") if s.strip()]
     else:
         skills = sorted(by_skill)
+
+    # A PR that only touches skills with no positive queries in the eval-set
+    # (e.g. muggle-do) has nothing to route-test. Skip cleanly with a posted note
+    # rather than running zero chunks and hitting analyze.py's empty-input path —
+    # re-running would never help, so this must not red the check.
+    if has_no_coverage(skills, by_skill):
+        missing = ", ".join(skills) or "(none)"
+        msg = (
+            f"No routing queries cover the requested skill(s): {missing}. "
+            "The eval-set has no positive queries for them, so there is nothing "
+            "to evaluate — passing."
+        )
+        print(msg, file=sys.stderr)
+        combined = {"model": "claude (run.py)", "runs_per_query": args.runs, "results": []}
+        (out_dir / "combined.json").write_text(json.dumps(combined, indent=2), encoding="utf-8")
+        (out_dir / "combined.md").write_text("# Router eval report\n\n- " + msg + "\n", encoding="utf-8")
+        print(f"Report: {out_dir / 'combined.md'}", file=sys.stderr)
+        return
+
     all_results = []
     flagged = []
 

--- a/internal/skill-routing-eval/test_analyze.py
+++ b/internal/skill-routing-eval/test_analyze.py
@@ -1,0 +1,43 @@
+import unittest
+
+import analyze
+import run
+
+
+class PerSkillReportEmptyInput(unittest.TestCase):
+    def test_empty_results_does_not_divide_by_zero(self):
+        report = {"model": "m", "runs_per_query": 3, "results": []}
+        out = analyze.per_skill_report(report)
+        self.assertIn("No routing samples were collected", out)
+
+    def test_normal_results_are_scored(self):
+        report = {
+            "model": "m",
+            "runs_per_query": 1,
+            "results": [
+                {"query": "q1", "expected_skill": "muggle-test", "majority": "muggle-test", "fired": ["muggle-test"]},
+                {"query": "q2", "expected_skill": "muggle-test", "majority": "none", "fired": ["none"]},
+                {"query": "q3", "expected_skill": "none", "majority": "debugging", "fired": ["debugging"]},
+            ],
+        }
+        out = analyze.per_skill_report(report)
+        # q1 exact match + q3 negative-clean pass; q2 misses → 2 of 3.
+        self.assertIn("2/3", out)
+
+
+class NoCoverageDetection(unittest.TestCase):
+    def setUp(self):
+        self.by_skill = {"muggle-test": [{"query": "x"}], "none": [{"query": "y"}]}
+
+    def test_all_requested_skills_uncovered(self):
+        self.assertTrue(run.has_no_coverage(["muggle-do"], self.by_skill))
+
+    def test_at_least_one_covered(self):
+        self.assertFalse(run.has_no_coverage(["muggle-do", "muggle-test"], self.by_skill))
+
+    def test_empty_skill_list(self):
+        self.assertTrue(run.has_no_coverage([], self.by_skill))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Goal

Make the skill-eval harness robust: the routing eval must not crash (or permanently red a PR) when a changed skill has no eval-set coverage, and the gate eval must have enough time to finish a healthy run instead of being cancelled by an under-set timeout.

## Acceptance Criteria

- Routing eval skips cleanly (exit 0, posted note) when no changed skill has eval-set coverage; does not call `analyze.py` on empty input.
- Mixed case still evaluates the covered skills and applies `--fail-under` to them.
- `analyze.py report` never divides by zero on empty input (defensive).
- `skill-gate-eval` `timeout-minutes` raised 45 → 180 (matches the sibling routing job); `GATE_RUNS` unchanged (it is the pass-threshold sample size).
- New stdlib-`unittest` coverage runs in CI on every PR (the harness had no Python tests).
- No regression to existing Node/TS checks.

## Changes

**Root cause (the PR #305 red):** `muggle-do` has **0** positive queries in `eval-set.json`. A PR touching only `muggle-do/SKILL.md` resolves to `run.py --skills muggle-do` → no queries → empty `combined.json` → `analyze.py`'s `passed/total` divides by zero — an opaque traceback the workflow mislabels as the "MCP-disconnect / subscription-limit flake; re-run." It is **deterministic**: re-running never helped, and any PR touching only a no-coverage skill's `SKILL.md` red the check permanently.

- `internal/skill-routing-eval/run.py` — `has_no_coverage()` + a clean-skip in `main()`: when no requested skill has eval-set queries, write `combined.md`/`combined.json` and exit 0 instead of running zero chunks into the empty-input crash. The genuine flake path (chunks ran but came back all-`none`) is unchanged.
- `internal/skill-routing-eval/analyze.py` — `per_skill_report()` returns a legible "no routing samples collected" note when `results` is empty, instead of dividing by zero.
- `internal/skill-routing-eval/test_analyze.py` (new) — 5 stdlib-`unittest` cases (empty-input guard, normal scoring, no-coverage detection).
- `.github/workflows/skill-eval.yml` — `skill-gate-eval` `timeout-minutes` 45 → 180. The job runs `GATE_RUNS` (10) real Claude reps per scenario across every gate, fully sequential (~48 min at the current gate count), so 45 cancelled healthy sweeps mid-gate; 180 matches the sibling `skill-routing-eval` budget.
- `.github/workflows/ci.yml` — new `harness-unit-tests` job (`setup-python` + `unittest discover`).
- `.gitignore` — Python bytecode.

## Validation

`unit-only` — `python -m unittest discover -s internal/skill-routing-eval` → **5/5 PASS**. End-to-end harness checks: `analyze.py` on an empty `combined.json` → exit 0 with the note (was `ZeroDivisionError`); `run.py --skills muggle-do` → exit 0 clean-skip, no Claude call. No web/UI surface → E2E **SKIPPED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
