### PR TITLE
ci(skill-eval): scope each eval to what a change actually affects (routing↔description, gate↔body+model)

### DIFF
--- a/.github/workflows/skill-eval.yml
+++ b/.github/workflows/skill-eval.yml
@@ -235,20 +235,24 @@ jobs:
           fi
           git fetch --no-tags origin "${{ github.base_ref }}"
           base="origin/${{ github.base_ref }}"
-          # Routing depends only on a skill's `description:`. A change that only
-          # touches the `model:` frontmatter cannot affect routing, so exclude
-          # those skills — otherwise a model-only PR needlessly runs (and flakes)
-          # the eval. Keep a skill when its SKILL.md has any non-`model:` change.
+          # Routing depends only on a skill's frontmatter (`name` + `description`)
+          # — the body (gate contracts, procedure) never reaches the router. So
+          # compare just the frontmatter block, minus `model:`, between base and
+          # head: a `model:`-only or body-only change leaves it identical and is
+          # skipped. This is what stops a gate-body edit needlessly running (and
+          # flaking) the routing eval; a description/name change still runs it.
+          fm() { awk 'NR==1 && $0=="---"{f=1;next} f&&$0=="---"{exit} f{print}' | grep -vE '^model:[[:space:]]'; }
           relevant=""
           for s in $(git diff --name-only "$base...HEAD" -- 'plugin/skills/*/SKILL.md' | awk -F/ '{print $3}' | sort -u); do
-            if git diff -U0 "$base...HEAD" -- "plugin/skills/$s/SKILL.md" \
-                 | grep -E '^[+-]' | grep -vE '^(\+\+\+|---) ' | grep -qvE '^[+-]model:[[:space:]]'; then
+            before="$(git show "$base:plugin/skills/$s/SKILL.md" 2>/dev/null | fm || true)"
+            after="$(git show "HEAD:plugin/skills/$s/SKILL.md" 2>/dev/null | fm || true)"
+            if [ "$before" != "$after" ]; then
               relevant="${relevant:+$relevant,}$s"
             fi
           done
           if [ -z "$relevant" ]; then
             echo "should_run=false" >> "$GITHUB_OUTPUT"
-            echo "No routing-relevant SKILL.md changes (model:-only) — routing eval not required."
+            echo "No routing-relevant frontmatter changes (model:-only / body-only) — routing eval not required."
           else
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "skills=$relevant" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Why

Per-PR eval scoping was imprecise in two opposite ways. Both stem from one fact: **routing** selects a skill from its `description:` *before* the skill runs, while the **gate** eval runs the skill's body *under its configured `model:`*.

1. **Routing ran too often.** The scope guard kept a skill whenever *any non-`model:` line* of its `SKILL.md` changed — but routing depends only on the frontmatter (`name`+`description`), never the body. So a gate-body or procedure edit still triggered the LLM-driven routing eval, which occasionally drops its MCP connection mid-run and reports a **spurious red** (this failed #302 twice).

2. **Gate ran too rarely.** The gate scope *skipped* `model:`-only changes. But a gate runs under the skill's model, so retiering opus→haiku is exactly when a cheaper model might mishandle the contract — and CI ran no gate eval, going green on an untested downgrade (**false confidence**).

## What

**Routing scope** — compare only the frontmatter block (minus `model:`) between base and head:

| Change | Before | After |
| :-- | :-- | :-- |
| `model:`-only | skip | skip |
| body-only (gate/procedure) | **run (flake-prone)** | **skip** |
| `description` / `name` | run | run |

**Gate scope** — a `model:`-only change now runs the gate eval **scoped to that skill** (its gate re-runs under the new model; unrelated gates skip). The scope step emits a `skills` list (empty = full suite); the runner filters scenarios to it and treats "scoped, no matching scenario" as a clean pass. Full-suite triggers (harness, `preference-gates/*`, non-`SKILL.md` file, gate-body line) are unchanged.

| Change | Before | After |
| :-- | :-- | :-- |
| `model:`-only | **skip (no coverage)** | **run, scoped to that skill** |
| gate-body / non-`SKILL.md` / harness | full suite | full suite |
| docs-only | skip | skip |

The nightly `--all` sweeps (both evals) are unchanged, so anything a scoped PR skips is still caught within a day.

## Verification

- YAML parses (`yaml.safe_load`).
- Routing scope simulated: `model_only → SKIP`, `body_only → SKIP`, `desc_change → RUN`.
- Gate scope simulated: `model-only → scoped`, `description / gate-body / model+desc → full`, `docs → skip`.
- Run-step membership: exact comma-list match (no partial-match, empty = full suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)