### PR TITLE
ci(skill-eval): run-full-eval label forces the full gate + routing sweep

### DIFF
--- a/.github/workflows/skill-eval.yml
+++ b/.github/workflows/skill-eval.yml
@@ -4,9 +4,17 @@ name: Skill Evals
 # contract) and the routing eval (skill descriptions route the right queries).
 # Both are LLM-driven, so the per-PR routing run is scoped to the skills the PR
 # touches; the full 391-query routing sweep runs nightly and on demand.
+#
+# The `run-full-eval` label forces the full gate + routing suite on any PR — even
+# one that changes only runtime and touches no skill/gate file (which the change
+# detection would skip). The on-demand lever for de-risking a refactor that alters
+# how skills are delivered but not their definitions.
 on:
   pull_request:
     branches: [master]
+    # Re-declaring the defaults keeps opened/synchronize/reopened; `labeled` lets
+    # the run-full-eval label force the full suite (each job's scope step reads it).
+    types: [opened, synchronize, reopened, labeled]
   schedule:
     - cron: "0 7 * * *"
   workflow_dispatch:
@@ -71,8 +79,18 @@ jobs:
       # `skills` is the scoped list (empty = full suite). Non-PR events run full.
       - name: Determine scope
         id: scope
+        env:
+          RUN_FULL_EVAL: ${{ contains(github.event.pull_request.labels.*.name, 'run-full-eval') }}
         run: |
           set -euo pipefail
+          # The run-full-eval label runs the whole gate suite regardless of what
+          # the PR changed — the change detection below skips runtime-only PRs.
+          if [ "$RUN_FULL_EVAL" = "true" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "skills=" >> "$GITHUB_OUTPUT"
+            echo "Full gate sweep (run-full-eval label)"
+            exit 0
+          fi
           if [ "${{ github.event_name }}" != "pull_request" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "skills=" >> "$GITHUB_OUTPUT"
@@ -256,10 +274,22 @@ jobs:
       # remaining steps are skipped — the required check still goes green.
       - name: Determine scope
         id: scope
+        env:
+          RUN_FULL_EVAL: ${{ contains(github.event.pull_request.labels.*.name, 'run-full-eval') }}
         run: |
           set -euo pipefail
+          # The run-full-eval label runs the full 391-query sweep on any PR, even
+          # one that changed no skill description (which the detection below skips).
+          if [ "$RUN_FULL_EVAL" = "true" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "full=true" >> "$GITHUB_OUTPUT"
+            echo "skills=" >> "$GITHUB_OUTPUT"
+            echo "Full routing sweep (run-full-eval label)"
+            exit 0
+          fi
           if [ "${{ github.event_name }}" != "pull_request" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "full=true" >> "$GITHUB_OUTPUT"
             echo "skills=" >> "$GITHUB_OUTPUT"
             echo "Full routing sweep (event: ${{ github.event_name }})"
             exit 0
@@ -283,9 +313,11 @@ jobs:
           done
           if [ -z "$relevant" ]; then
             echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "full=false" >> "$GITHUB_OUTPUT"
             echo "No routing-relevant frontmatter changes (model:-only / body-only) — routing eval not required."
           else
             echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "full=false" >> "$GITHUB_OUTPUT"
             echo "skills=$relevant" >> "$GITHUB_OUTPUT"
             echo "Routing-relevant skills: $relevant"
           fi
@@ -342,13 +374,17 @@ jobs:
         run: |
           set -euo pipefail
           unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          # A full sweep (nightly, dispatch, or the run-full-eval label) scores the
+          # whole 391-query set at the nightly 0.95 bar — it carries known-flaky
+          # tail queries. A scoped PR run demands 1.0: the skills it changed must
+          # route perfectly.
+          if [ "${{ steps.scope.outputs.full }}" = "true" ]; then
+            python internal/skill-routing-eval/run.py \
+              --all --runs "$ROUTING_RUNS" --repo-root "$CLEAN_CWD" --fail-under 0.95
+          else
             python internal/skill-routing-eval/run.py \
               --skills "${{ steps.scope.outputs.skills }}" \
               --runs "$ROUTING_RUNS" --repo-root "$CLEAN_CWD" --fail-under 1.0
-          else
-            python internal/skill-routing-eval/run.py \
-              --all --runs "$ROUTING_RUNS" --repo-root "$CLEAN_CWD" --fail-under 0.95
           fi
 
       # Post the routing report (reports/run/combined.md) to the job summary and,

--- a/internal/skill-gate-eval/README.md
+++ b/internal/skill-gate-eval/README.md
@@ -62,6 +62,9 @@ blocking workflow — see CI below.
 `.github/workflows/skill-eval.yml` runs every gate found under
 `$MUGGLE_BRAIN_DIR/eval/skill-gate-eval/*/scenarios.json` on each PR to
 `master` (`--runs 10`, each scenario must hold ≥99%), plus nightly and on
-`workflow_dispatch`. It checks out `muggle-ai-brain` for the scenarios, so
+`workflow_dispatch`. A PR that changes only runtime (no gate/skill files) is
+skipped; label it `run-full-eval` to force the whole suite anyway — the lever
+for de-risking a refactor that changes how skills run, not their definitions.
+It checks out `muggle-ai-brain` for the scenarios, so
 CI needs two repo secrets: `CLAUDE_CODE_OAUTH_TOKEN` (subscription auth, from
 `claude setup-token`) and `BRAIN_REPO_TOKEN` (read access to the scenario repo).

--- a/internal/skill-routing-eval/README.md
+++ b/internal/skill-routing-eval/README.md
@@ -41,6 +41,9 @@ python internal/skill-routing-eval/analyze.py report --in <report.json> --out <r
 
 `.github/workflows/skill-eval.yml` runs this on every PR to `master`, scoped to
 the skills the PR changed; the full set runs nightly and on `workflow_dispatch`.
+A PR that changed no skill description is skipped; label it `run-full-eval` to
+force the full 391-query sweep anyway (the lever for de-risking a runtime
+refactor that touches no `SKILL.md`).
 
 - `--skills a,b` — run a subset (CI derives it from the PR's changed `plugin/skills/*/SKILL.md`).
 - `--fail-under F` — exit non-zero if accuracy < F, or if a chunk stays 0% (suspected disconnect, unverified). Default `0.0` keeps dev runs informational. CI uses `1.0` on PRs (changed skills must route perfectly) and `0.95` for the nightly full sweep.


### PR DESCRIPTION
## What

Adds a `run-full-eval` label lever to the existing `skill-eval.yml` (routing + gate LLM evals).

Both eval jobs already **skip** a PR that changes no skill/gate file — correct for routine PRs, but it means a PR that changes the plugin *runtime* (how skills are delivered) gets green eval checks **without the evals ever running**. This adds a `labeled` trigger and a `run-full-eval` check to each job's scope step: with the label present, the gate suite runs every scenario and routing runs the full 391-query sweep — regardless of what the PR touched.

## Why

This is the on-demand lever for de-risking the upcoming **"Lazy-core" footprint refactor** (`@muggleai/works`: drop bash hook wrappers, collapse the hook fan-out, lazy-load the MCP server, defer telemetry/disclosure off boot). That PR changes `src/`, `packages/mcps/`, `plugin/scripts/*.sh`, and `hooks.json` — but no `SKILL.md` — so the scoped skip would green both LLM eval jobs without validating that skills still route and preference gates still fire against the refactored plugin. Label it `run-full-eval` and they run.

The deterministic layers (hooks #293, MCP surface #298, CLI smoke #306) already run per-PR unconditionally; this closes the LLM-eval half.

## Changes

- **Trigger:** `pull_request` now lists `types: [opened, synchronize, reopened, labeled]` (re-declares the defaults so nothing regresses).
- **Both jobs' scope step:** a `RUN_FULL_EVAL` env from `contains(labels.*.name, 'run-full-eval')`; when true, `should_run=true` and full scope, short-circuiting the change detection.
- **Routing run step:** the sweep-vs-scoped choice now keys on a new `full` scope output instead of `github.event_name`, so nightly / dispatch / label all take `--all --fail-under 0.95` and only a scoped PR run keeps `--fail-under 1.0`. Behavior unchanged for existing triggers.
- READMEs (routing + gate) document the label.

## Notes / validation

- The `run-full-eval` label must exist in the repo before it can be applied — `gh label create run-full-eval` once, or create it in the Labels UI.
- This PR itself changes only `.github/` + READMEs, so both eval jobs scope to skip (fast green). To exercise the lever end-to-end, add `run-full-eval` to this PR — it triggers the full ~180-min routing + gate sweep on subscription auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
