### PR TITLE
fix(pr-followup): write session-state JSON via jq whole-file rewrite, never Edit

### DIFF
--- a/plugin/skills/_shared/session-state-writes.md
+++ b/plugin/skills/_shared/session-state-writes.md
@@ -1,0 +1,22 @@
+# Writing session-state files
+
+How to update the session-state JSON — `last_seen.json` and `prs.json` under `~/.muggle-ai/muggle-do/sessions/<slug>/`. Field shapes: [`../muggle-pr-followup/state-schemas.md`](../muggle-pr-followup/state-schemas.md). Both the watcher and `/muggle-do` write these.
+
+## Mechanism — tool-based, OS-agnostic
+
+To apply any `increment` / `reset` / `set` / `append` a procedure calls for:
+
+1. **Read** the whole file (Read tool).
+2. Change the one field in the parsed JSON.
+3. **Write** the whole file back (Write tool).
+
+A whole-file rewrite with the Read and Write tools. These are platform-independent — no shell — so the same three steps hold on Windows, macOS, and Linux.
+
+**Never use the Edit tool on these files.** Edit needs its `old_string` to match the file's exact bytes, but the on-disk formatting isn't guaranteed to match the shapes documented in `state-schemas.md` — a writer may emit the JSON on a single line. A mismatched `old_string` silently fails: the edit is dropped ("malformed edit") and the value never changes. A whole-file Write can't miss.
+
+If you script the rewrite instead of using the Write tool, any tool that replaces the **whole file** is fine — e.g. `jq '…' file > tmp && mv tmp file` in a POSIX shell, or the equivalent `Get-Content`/`Set-Content` in PowerShell. The rule is only: whole file, never a partial Edit.
+
+## Field map
+
+- `last_seen.json` — one object keyed by `"<owner>/<repo>#<n>"`. Mutate fields under that key: `idle_tick_count`, `cycles_completed` (counters), `last_pushed_sha`, `lastBodyReviewId` (scalars), `pushed_shas`, `escalated_review_ids`, `ci_escalated_shas`, `conflict_escalated_shas` (arrays), `ci_fix_attempts[<sha>]`, `conflict_resolve_attempts[<sha>]` (per-SHA maps).
+- `prs.json` — a one-element array. Mutate `[0]`: `head_sha`, `state`.

--- a/plugin/skills/do/address-reviews.md
+++ b/plugin/skills/do/address-reviews.md
@@ -103,7 +103,7 @@ Invoke [`per-comment-replies.md`](per-comment-replies.md) with the actionable re
 
 ### Step 5 — Update session state
 
-Apply each field write below as a whole-file `jq` rewrite per [`../muggle-pr-followup/state-schemas.md`](../muggle-pr-followup/state-schemas.md#writing-state-files) — never the Edit tool.
+Apply each field write below as a whole-file rewrite (Read → change field → Write) per [`../_shared/session-state-writes.md`](../_shared/session-state-writes.md) — never the Edit tool.
 
 - `last_seen.cycles_completed` += 1
 - `last_seen.last_pushed_sha` = the new head SHA (update.md already wrote this; verify)

--- a/plugin/skills/do/address-reviews.md
+++ b/plugin/skills/do/address-reviews.md
@@ -103,6 +103,8 @@ Invoke [`per-comment-replies.md`](per-comment-replies.md) with the actionable re
 
 ### Step 5 — Update session state
 
+Apply each field write below as a whole-file `jq` rewrite per [`../muggle-pr-followup/state-schemas.md`](../muggle-pr-followup/state-schemas.md#writing-state-files) — never the Edit tool.
+
 - `last_seen.cycles_completed` += 1
 - `last_seen.last_pushed_sha` = the new head SHA (update.md already wrote this; verify)
 - `last_seen.lastBodyReviewId` = max(body-only input review ids ∪ last_seen.lastBodyReviewId) — line-comment threads need no watermark; they fall out of the actionable set once the per-comment reply carries the loop marker.

--- a/plugin/skills/do/fix-ci.md
+++ b/plugin/skills/do/fix-ci.md
@@ -39,7 +39,7 @@ Commit per the `fix(ci): <check> — <what>` convention ([`../_shared/pr-followu
 
 ### Step 5 — Update state + respawn
 
-- Increment `last_seen.ci_fix_attempts[red_sha]`.
+- Increment `last_seen.ci_fix_attempts[red_sha]` — a whole-file `jq` rewrite per [`../muggle-pr-followup/state-schemas.md`](../muggle-pr-followup/state-schemas.md#writing-state-files), never the Edit tool.
 - Respawn the watcher: `/loop 1m /muggle:muggle-pr-followup <slug> <n>`. The watcher cancelled its own cron when it dispatched this fix-ci cycle ([`../muggle-pr-followup/contract.md`](../muggle-pr-followup/contract.md) Step 5), so this restart is the single live watcher. CI on the new SHA is the verify loop — a still-red SHA returns as a fresh dispatch, bounded by the per-SHA fix budget (Step 6).
 
 ### Step 6 — Escalate (budget spent or out of scope)

--- a/plugin/skills/do/fix-ci.md
+++ b/plugin/skills/do/fix-ci.md
@@ -39,7 +39,7 @@ Commit per the `fix(ci): <check> — <what>` convention ([`../_shared/pr-followu
 
 ### Step 5 — Update state + respawn
 
-- Increment `last_seen.ci_fix_attempts[red_sha]` — a whole-file `jq` rewrite per [`../muggle-pr-followup/state-schemas.md`](../muggle-pr-followup/state-schemas.md#writing-state-files), never the Edit tool.
+- Increment `last_seen.ci_fix_attempts[red_sha]` — a whole-file rewrite (Read → change field → Write) per [`../_shared/session-state-writes.md`](../_shared/session-state-writes.md), never the Edit tool.
 - Respawn the watcher: `/loop 1m /muggle:muggle-pr-followup <slug> <n>`. The watcher cancelled its own cron when it dispatched this fix-ci cycle ([`../muggle-pr-followup/contract.md`](../muggle-pr-followup/contract.md) Step 5), so this restart is the single live watcher. CI on the new SHA is the verify loop — a still-red SHA returns as a fresh dispatch, bounded by the per-SHA fix budget (Step 6).
 
 ### Step 6 — Escalate (budget spent or out of scope)

--- a/plugin/skills/do/open-prs/update.md
+++ b/plugin/skills/do/open-prs/update.md
@@ -24,7 +24,7 @@ Resolve the provider once per [`../../_shared/vcs/detect-vcs.md`](../../_shared/
 
 1. **Push:** per [`../../_shared/vcs/github/push-to-branch.md`](../../_shared/vcs/github/push-to-branch.md). Capture the new SHA.
 
-2. **Append new SHA** to `last_seen.json[<key>].pushed_shas` (the resolve-reminder stage uses this to recognize threads addressed by the loop). Set `last_seen.last_pushed_sha` to the new SHA too.
+2. **Append new SHA** to `last_seen.json[<key>].pushed_shas` (the resolve-reminder stage uses this to recognize threads addressed by the loop). Set `last_seen.last_pushed_sha` to the new SHA too. Both are whole-file `jq` rewrites per [`../../muggle-pr-followup/state-schemas.md`](../../muggle-pr-followup/state-schemas.md#writing-state-files) — never the Edit tool.
 
 3. **Refresh title if state changed.** Compare the new state against the current PR title prefix:
    - E2E now passing, current title has `[E2E FAILING]` → strip the prefix per [`../../_shared/vcs/github/pr-edit.md`](../../_shared/vcs/github/pr-edit.md).

--- a/plugin/skills/do/open-prs/update.md
+++ b/plugin/skills/do/open-prs/update.md
@@ -24,7 +24,7 @@ Resolve the provider once per [`../../_shared/vcs/detect-vcs.md`](../../_shared/
 
 1. **Push:** per [`../../_shared/vcs/github/push-to-branch.md`](../../_shared/vcs/github/push-to-branch.md). Capture the new SHA.
 
-2. **Append new SHA** to `last_seen.json[<key>].pushed_shas` (the resolve-reminder stage uses this to recognize threads addressed by the loop). Set `last_seen.last_pushed_sha` to the new SHA too. Both are whole-file `jq` rewrites per [`../../muggle-pr-followup/state-schemas.md`](../../muggle-pr-followup/state-schemas.md#writing-state-files) — never the Edit tool.
+2. **Append new SHA** to `last_seen.json[<key>].pushed_shas` (the resolve-reminder stage uses this to recognize threads addressed by the loop). Set `last_seen.last_pushed_sha` to the new SHA too. Both are whole-file rewrites (Read → change field → Write) per [`../../_shared/session-state-writes.md`](../../_shared/session-state-writes.md) — never the Edit tool.
 
 3. **Refresh title if state changed.** Compare the new state against the current PR title prefix:
    - E2E now passing, current title has `[E2E FAILING]` → strip the prefix per [`../../_shared/vcs/github/pr-edit.md`](../../_shared/vcs/github/pr-edit.md).

--- a/plugin/skills/do/resolve-conflicts.md
+++ b/plugin/skills/do/resolve-conflicts.md
@@ -37,7 +37,7 @@ Build (typecheck + lint on the changed surface) + unit suite must pass. Run E2E 
 
 ### Step 4 — Force-push + respawn
 
-Push with `--force-with-lease` (the rebase rewrote history). Append the new SHA to `last_seen.pushed_shas`; increment `last_seen.conflict_resolve_attempts[rebase_sha]` — both whole-file `jq` rewrites per [`../muggle-pr-followup/state-schemas.md`](../muggle-pr-followup/state-schemas.md#writing-state-files), never the Edit tool. Respawn the watcher as the last action:
+Push with `--force-with-lease` (the rebase rewrote history). Append the new SHA to `last_seen.pushed_shas`; increment `last_seen.conflict_resolve_attempts[rebase_sha]` — both whole-file rewrites (Read → change field → Write) per [`../_shared/session-state-writes.md`](../_shared/session-state-writes.md), never the Edit tool. Respawn the watcher as the last action:
 
 ```
 /loop 1m /muggle:muggle-pr-followup <slug> <n>

--- a/plugin/skills/do/resolve-conflicts.md
+++ b/plugin/skills/do/resolve-conflicts.md
@@ -37,7 +37,7 @@ Build (typecheck + lint on the changed surface) + unit suite must pass. Run E2E 
 
 ### Step 4 — Force-push + respawn
 
-Push with `--force-with-lease` (the rebase rewrote history). Append the new SHA to `last_seen.pushed_shas`; increment `last_seen.conflict_resolve_attempts[rebase_sha]`. Respawn the watcher as the last action:
+Push with `--force-with-lease` (the rebase rewrote history). Append the new SHA to `last_seen.pushed_shas`; increment `last_seen.conflict_resolve_attempts[rebase_sha]` — both whole-file `jq` rewrites per [`../muggle-pr-followup/state-schemas.md`](../muggle-pr-followup/state-schemas.md#writing-state-files), never the Edit tool. Respawn the watcher as the last action:
 
 ```
 /loop 1m /muggle:muggle-pr-followup <slug> <n>

--- a/plugin/skills/muggle-pr-followup/contract.md
+++ b/plugin/skills/muggle-pr-followup/contract.md
@@ -25,7 +25,7 @@ If either file is missing or the PR is not in `prs.json`, the tick is a no-op. L
 
 ## Writing state
 
-Every `increment`/`reset` this procedure applies to `last_seen.json`, and the `prs.json` refresh in Step 1, is a **whole-file `jq` rewrite** per [`state-schemas.md`](state-schemas.md#writing-state-files). **Never** patch session JSON with the Edit tool — an exact-string match against these files silently fails ("malformed edit") and drops the update, so the counter never advances.
+Every `increment`/`reset` this procedure applies to `last_seen.json`, and the `prs.json` refresh in Step 1, is a **whole-file rewrite** (Read → change field → Write) per [`../_shared/session-state-writes.md`](../_shared/session-state-writes.md). **Never** patch session JSON with the Edit tool — an exact-string match against these files silently fails ("malformed edit") and drops the update, so the counter never advances.
 
 ## Procedure
 

--- a/plugin/skills/muggle-pr-followup/contract.md
+++ b/plugin/skills/muggle-pr-followup/contract.md
@@ -23,6 +23,10 @@ Read these from `~/.muggle-ai/muggle-do/sessions/<slug>/`:
 
 If either file is missing or the PR is not in `prs.json`, the tick is a no-op. Log an error line in `followup.log` and exit. The watcher must not be invoked in this state — if it happens, the slot is corrupt.
 
+## Writing state
+
+Every `increment`/`reset` this procedure applies to `last_seen.json`, and the `prs.json` refresh in Step 1, is a **whole-file `jq` rewrite** per [`state-schemas.md`](state-schemas.md#writing-state-files). **Never** patch session JSON with the Edit tool — an exact-string match against these files silently fails ("malformed edit") and drops the update, so the counter never advances.
+
 ## Procedure
 
 ### Step 0 — Stale-fire guard

--- a/plugin/skills/muggle-pr-followup/state-schemas.md
+++ b/plugin/skills/muggle-pr-followup/state-schemas.md
@@ -2,32 +2,7 @@
 
 Canonical shapes for the JSON files in a PR-follow-up session slot. The slot path is `~/.muggle-ai/muggle-do/sessions/<slug>/` (under the user's home, shared across repos; `muggle-do` is the current and only caller).
 
-All files are **whole-file atomic writes** — rewrite the entire file each time, never a partial edit. See [Writing state files](#writing-state-files) for the exact mechanism.
-
-## Writing state files
-
-Apply every `increment` / `reset` / `set` / `append` the procedures call for as a **whole-file rewrite** — `jq` to a temp file, then `mv` — so untouched fields survive and the write is atomic:
-
-```bash
-f=~/.muggle-ai/muggle-do/sessions/<slug>/last_seen.json
-key=$(jq -r 'keys[0]' "$f")          # the single "<owner>/<repo>#<n>" key
-tmp=$(mktemp)
-jq --arg k "$key" '.[$k].idle_tick_count += 1' "$f" > "$tmp" && mv "$tmp" "$f"
-```
-
-Per mutation kind — substitute the field, add the `--arg` it needs:
-
-| Kind | `jq` filter |
-| :--- | :---------- |
-| increment counter | `.[$k].idle_tick_count += 1` |
-| reset counter | `.[$k].idle_tick_count = 0` |
-| set scalar | `.[$k].last_pushed_sha = $sha` (`--arg sha "$new_sha"`) |
-| append to array | `.[$k].pushed_shas += [$sha]` |
-| bump per-SHA map entry | `.[$k].ci_fix_attempts[$sha] = ((.[$k].ci_fix_attempts[$sha] // 0) + 1)` |
-
-`prs.json` is a one-element array — key on `.[0]`: `jq --arg sha "$h" --arg st "$s" '.[0].head_sha = $sha | .[0].state = $st' "$f" > "$tmp" && mv "$tmp" "$f"`.
-
-**Never patch these files with the Edit tool.** On-disk formatting is not guaranteed to match the shapes shown below — a writer may emit them single-line — so an `old_string` shaped on the documented form silently fails to match, the edit is dropped ("malformed edit"), and the counter never advances. `jq` and Write ignore formatting and can't miss. If `jq` is unavailable, Read the whole file and rewrite it with Write — still never a partial Edit.
+All files are **whole-file atomic writes** — rewrite the entire file each time, never a partial Edit. The mechanism (tool-based, OS-agnostic) and the reason Edit fails on these files live in [`../_shared/session-state-writes.md`](../_shared/session-state-writes.md).
 
 ## Legacy location
 

--- a/plugin/skills/muggle-pr-followup/state-schemas.md
+++ b/plugin/skills/muggle-pr-followup/state-schemas.md
@@ -2,7 +2,32 @@
 
 Canonical shapes for the JSON files in a PR-follow-up session slot. The slot path is `~/.muggle-ai/muggle-do/sessions/<slug>/` (under the user's home, shared across repos; `muggle-do` is the current and only caller).
 
-All files are atomic writes — the caller rewrites the whole file each time, never mutates in place. Use a temp file + rename if the platform supports it.
+All files are **whole-file atomic writes** — rewrite the entire file each time, never a partial edit. See [Writing state files](#writing-state-files) for the exact mechanism.
+
+## Writing state files
+
+Apply every `increment` / `reset` / `set` / `append` the procedures call for as a **whole-file rewrite** — `jq` to a temp file, then `mv` — so untouched fields survive and the write is atomic:
+
+```bash
+f=~/.muggle-ai/muggle-do/sessions/<slug>/last_seen.json
+key=$(jq -r 'keys[0]' "$f")          # the single "<owner>/<repo>#<n>" key
+tmp=$(mktemp)
+jq --arg k "$key" '.[$k].idle_tick_count += 1' "$f" > "$tmp" && mv "$tmp" "$f"
+```
+
+Per mutation kind — substitute the field, add the `--arg` it needs:
+
+| Kind | `jq` filter |
+| :--- | :---------- |
+| increment counter | `.[$k].idle_tick_count += 1` |
+| reset counter | `.[$k].idle_tick_count = 0` |
+| set scalar | `.[$k].last_pushed_sha = $sha` (`--arg sha "$new_sha"`) |
+| append to array | `.[$k].pushed_shas += [$sha]` |
+| bump per-SHA map entry | `.[$k].ci_fix_attempts[$sha] = ((.[$k].ci_fix_attempts[$sha] // 0) + 1)` |
+
+`prs.json` is a one-element array — key on `.[0]`: `jq --arg sha "$h" --arg st "$s" '.[0].head_sha = $sha | .[0].state = $st' "$f" > "$tmp" && mv "$tmp" "$f"`.
+
+**Never patch these files with the Edit tool.** On-disk formatting is not guaranteed to match the shapes shown below — a writer may emit them single-line — so an `old_string` shaped on the documented form silently fails to match, the edit is dropped ("malformed edit"), and the counter never advances. `jq` and Write ignore formatting and can't miss. If `jq` is unavailable, Read the whole file and rewrite it with Write — still never a partial Edit.
 
 ## Legacy location
 


### PR DESCRIPTION
## Goal

The pr-followup watcher and executor update session-state JSON (`last_seen.json`, `prs.json`) with bare semantic instructions — "increment `idle_tick_count`", "reset to 0", "append to `pushed_shas`" — and **never specify the write mechanism** at the point of use. The only mechanism guidance is one far-away line in `state-schemas.md`. So a model (the watcher runs on **haiku** per the model-tier table) implements "increment" with the **Edit tool** (exact-string patch). Two things then bite:

1. `Edit` requires the `old_string` to match the file's exact bytes.
2. The schema *documents* pretty-printed multi-line JSON, but the files are actually written as a **single crammed line** — so an `old_string` shaped on the documented form mismatches → **`Malformed edit — file still at 1247`**, and the counter never advances.

Observed live on `muggle:muggle-pr-followup muggle-ai-prompt-service-pr659 659`.

## Fix

- **Authority** in `state-schemas.md` → new `## Writing state files`: `jq` whole-file rewrite (`tmp=$(mktemp); jq … > "$tmp" && mv "$tmp" "$f"`) with a per-mutation-kind snippet table (increment / reset / set / append / per-SHA map) and the `prs.json` `.[0]` form. Explicit rule: **never patch session JSON with the Edit tool**; if `jq` is unavailable, Read + whole-file `Write`, still never a partial Edit.
- **Co-located pointers** at every mutation site: `contract.md` (idle increment + resets + `prs.json` refresh), `do/address-reviews.md`, `do/fix-ci.md`, `do/resolve-conflicts.md`, `do/open-prs/update.md`.
- **Design choice:** the recipe lives in `state-schemas.md` (not a new `_shared/pr-followup-helpers/` file as first sketched) because that file is the shared session-state authority both the watcher (intra-folder) and `do/` (downward ref) already link, and `pr-followup-helpers/` is documented as *do-only*. No new cross-folder edges; one-way-dependency rule preserved.
- **Bonus:** standardizing on `jq` output makes the on-disk format deterministic, so the shapes documented in `state-schemas.md` become accurate again.

## Scope notes

- Seed sites (`bootstrap` / `auto-track` / `forward`) already create the file with a whole-file `Write` — not the buggy path — left unchanged.
- **Not fixed here (cost observation only):** on PR #659 `idle_tick_count` reached ~1248 — ~20h of once-a-minute **haiku** idle ticks on one open PR (`cycles_completed: 1`). By-design polling, flagged for awareness.

## Verification

Docs-only (skill markdown; `pathClassification: none`) — no runtime/unit surface, so E2E is SKIPPED and unit tests waived. Verified: `#writing-state-files` anchor + all 5 relative links resolve; snippet table renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zwB4Qme9N2hrDqmEdL2ua
