### PR TITLE
chore(release): @muggleai/works 5.4.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "5.4.1"
+      "version": "5.4.2"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "5.4.1"
+      "version": "5.4.2"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@muggleai/works",
   "mcpName": "io.github.multiplex-ai/muggle",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
   "type": "module",
   "main": "dist/index.js",
@@ -46,14 +46,14 @@
     "eval:studio-gen": "tsx internal/studio-gen-eval/src/run.ts"
   },
   "muggleConfig": {
-    "electronAppVersion": "1.6.5",
+    "electronAppVersion": "1.6.6",
     "downloadBaseUrl": "https://github.com/multiplex-ai/muggle-ai-works/releases/download",
     "runtimeTargetDefault": "dev",
     "checksums": {
-      "darwin-arm64": "e6aea93ea560565a6633d58c709ece1f1a7d1dcb76668a2e6ed2a7c0f15c780d",
-      "darwin-x64": "02b280897cc3d6b17d5b394ba814f680afed5035b8fc59b26ab26c3f235374f9",
-      "linux-x64": "da4f6d58e05926a023e692cde7482fd773c22b5dfa51b6fec09e21f2e9198106",
-      "win32-x64": "c0aae762a26dd623ed16fc07a9dfd0c124002637d29d107e2f855e96a406fd5a"
+      "darwin-arm64": "c905921dda5412bdbb66735cdb81b0e0f76f4211c9ec129eae599d910213547e",
+      "darwin-x64": "3ad51b6babadf73ae607e965dd713fb9ad8a530e6c15c47779c34a96ea90dab4",
+      "linux-x64": "444c603453967f91b4a4ccb12f4344d7bed8d83b5b99d04fc43924c6c45b08f7",
+      "win32-x64": "ab7864489da53920af13905671aca4960cc141e41637590044757e47a439a9d7"
     }
   },
   "dependencies": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "5.4.1",
+  "version": "5.4.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "5.4.1",
+      "version": "5.4.2",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
## Release: @muggleai/works 5.4.2 (patch)

**Version:** 5.4.1 → **5.4.2** (patch; baseline = npm/master 5.4.1).
**Electron:** `electronAppVersion` 1.6.5 → **1.6.6** (fresh `electron-app-v1.6.6` studio release); all 4 `muggleConfig.checksums` updated and **verified** against the release `checksums.txt`.

## Shipping since 5.4.1

- **fix(pr-followup) #313** — session-state JSON now written by an OS-agnostic whole-file rewrite (Read → change → Write), never the Edit tool. Fixes the "malformed edit" idle-tick failure; mechanism in `_shared/session-state-writes.md`.
- **fix(plugin) #307** — portable file-mtime lookup in the session-start hook.
- **fix(skills) #308** — guard watcher cron-cancel against bash-misinvocation.
- **ci(skill-eval) #302/#309/#310/#311/#312** — reliable, scoped gate + routing evals.
- **fix(skills) #304** — self-healing linker for the maintainer-only release skill.
- **docs(muggle-do) #305**, **test(cli) #306** (real-subprocess smoke), **feat(internal) #297** (studio-gen-eval CLI).

## Manifests

`sync:versions` propagated 5.4.2 across `.claude-plugin/marketplace.json`, `.cursor-plugin/marketplace.json`, `plugin/.claude-plugin/plugin.json`, `plugin/.cursor-plugin/plugin.json`, `server.json` (not hand-edited).

## Verify (local, green)

- [x] `lint:check` (0 errors; 8 pre-existing warnings)
- [x] `typecheck`
- [x] `test` — 606 tests / 48 files
- [x] `build`
- [x] `verify:plugin`
- [x] `verify:contracts`
- [x] `verify:electron-release-checksums` — confirmed 1.6.6 checksums

Publish is CI-only via `publish-works-to-npm.yml` after merge (no local `npm publish`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zwB4Qme9N2hrDqmEdL2ua
