### PR TITLE
feat(skills): enforce one-way skill dependencies with a deterministic gate

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,6 +23,18 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PROJECT_DIR}/scripts/check-skill-deps.mjs\" --hook",
+            "statusMessage": "Checking skill dependency direction"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,23 @@ jobs:
       - name: Run harness unit tests
         run: python -m unittest discover -s internal/skill-routing-eval -p "test_*.py" -v
 
+  # Enforces the one-way skill dependency rule (plugin/skills/CLAUDE.md).
+  # Zero-dep Node script, so no install step — catches reverse dependencies
+  # in PRs from any agent, including ones the local PreToolUse hook never sees.
+  skill-deps:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Check skill dependency direction
+        run: node scripts/check-skill-deps.mjs
+
   # Type check with different TypeScript versions
   typecheck:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "build:release": "npm run build",
     "verify:plugin": "node scripts/verify-plugin-marketplace.mjs",
     "verify:contracts": "node scripts/verify-compatibility-contracts.mjs",
+    "verify:skill-deps": "node scripts/check-skill-deps.mjs",
     "smoke:cli": "node scripts/smoke-cli.mjs",
     "verify:electron-release-checksums": "node scripts/verify-electron-release-checksums.mjs",
     "verify:upgrade-experience": "node scripts/verify-upgrade-experience.mjs",

--- a/plugin/skills/CLAUDE.md
+++ b/plugin/skills/CLAUDE.md
@@ -14,6 +14,12 @@ A reverse reference (A → B and B → A) couples the depended-on skill to its c
 
 When you feel the urge to link "up" to a caller, that is the smell — restructure so the caller passes what is needed in.
 
+### Enforcement
+
+`scripts/check-skill-deps.mjs` derives the cross-skill link graph and fails on any cycle. A "reference" is a markdown file-link into another skill's directory — runtime slash-command dispatch is not a link and is not counted. It runs three ways: the `skill-deps` CI job on every PR, a `PreToolUse` hook (`.claude/settings.json`) that blocks the write mid-session with the offending link named, and `pnpm run verify:skill-deps` locally.
+
+`plugin/skills/skill-deps.config.json` declares support dirs grouped into their owning skill (`do/` → `muggle-do`), shared namespaces exploded to per-file nodes (`_shared`), and `knownReverseDeps` — pre-existing violations grandfathered so CI stays green. That list is debt: fix each link and delete its entry. A new reverse dependency is blocked whether or not it is on the list.
+
 ## Model tiers
 
 Each skill sets a `model:` in its `SKILL.md` frontmatter sized to its cognitive load. `model:` is a native Claude Code field — the override applies while the skill is active and reverts to the session model when it exits. Cheaper, faster models run the mechanical skills; the default (Opus) is reserved for the ones that actually reason. Cost and latency scale with the model, and these skills run often (the watcher fires every minute), so the tier is a real lever, not cosmetics.

--- a/plugin/skills/_shared/dev-loop/run.md
+++ b/plugin/skills/_shared/dev-loop/run.md
@@ -1,6 +1,6 @@
 # Dev Loop — Run a Test
 
-> The local dev loop: run one test case in the browser (replay an existing script, or regenerate from the case), then record the result. Source of truth for the run mechanics; the sibling files in this folder own each invariant. Used by `muggle-test`, `muggle-test-feature-local`, `muggle-do` Stage 6, and the `acceptance-tester` agent.
+> The local dev loop: run one test case in the browser (replay an existing script, or regenerate from the case), then record the result. Source of truth for the run mechanics; the sibling files in this folder own each invariant.
 
 Not owned here — the caller resolves and passes in: which test cases to run, replay-vs-regen classification and failure routing ([`../failure-mode-handling.md`](../failure-mode-handling.md)), dev-server readiness ([`../dev-server-readiness.md`](../dev-server-readiness.md)), validation context ([`../resolve-e2e-validation-context.md`](../resolve-e2e-validation-context.md)), and PR posting ([`../../muggle-pr-visual-walkthrough/SKILL.md`](../../muggle-pr-visual-walkthrough/SKILL.md)).
 

--- a/plugin/skills/_shared/dev-loop/run.md
+++ b/plugin/skills/_shared/dev-loop/run.md
@@ -1,6 +1,6 @@
 # Dev Loop — Run a Test
 
-> The local dev loop: run one test case in the browser (replay an existing script, or regenerate from the case), then record the result. Source of truth for the run mechanics; the sibling files in this folder own each invariant. Used by `muggle-test`, `muggle-test-feature-local`, `muggle-do` Stage 6 ([`../../do/e2e-acceptance.md`](../../do/e2e-acceptance.md)), and the `acceptance-tester` agent.
+> The local dev loop: run one test case in the browser (replay an existing script, or regenerate from the case), then record the result. Source of truth for the run mechanics; the sibling files in this folder own each invariant. Used by `muggle-test`, `muggle-test-feature-local`, `muggle-do` Stage 6, and the `acceptance-tester` agent.
 
 Not owned here — the caller resolves and passes in: which test cases to run, replay-vs-regen classification and failure routing ([`../failure-mode-handling.md`](../failure-mode-handling.md)), dev-server readiness ([`../dev-server-readiness.md`](../dev-server-readiness.md)), validation context ([`../resolve-e2e-validation-context.md`](../resolve-e2e-validation-context.md)), and PR posting ([`../../muggle-pr-visual-walkthrough/SKILL.md`](../../muggle-pr-visual-walkthrough/SKILL.md)).
 

--- a/plugin/skills/_shared/rebase-before-e2e.md
+++ b/plugin/skills/_shared/rebase-before-e2e.md
@@ -16,6 +16,6 @@ Pass `{behind}` and `{default}` to the picker prompts. On `always`:
 2. `git rebase origin/${default}`.
 3. On conflict, branch by [`autoResolveConflicts`](../muggle-preferences/preference-gates/autoResolveConflicts.md):
    - `never` → `git rebase --abort`; stop and report, naming the conflicted files. Never auto-resolve.
-   - `always` → hand off to [`resolve-rebase-conflicts.md`](resolve-rebase-conflicts.md) with `pre_rebase_sha`; it resolves, runs the verify-or-rollback gate, and either proceeds or restores `pre_rebase_sha` and escalates.
+   - `always` → hand off to [`resolve-rebase-conflicts.md`](resolve-rebase-conflicts.md) with `pre_rebase_sha` to resolve the conflicts, then run the [`verify-or-rollback-gate.md`](verify-or-rollback-gate.md) with `pre_rebase_sha`; it either proceeds or restores `pre_rebase_sha` and escalates.
 
 Stale branches produce false failures and false greens — that's why this gate exists.

--- a/plugin/skills/_shared/resolve-e2e-validation-context.md
+++ b/plugin/skills/_shared/resolve-e2e-validation-context.md
@@ -28,7 +28,7 @@ Resolve without prompting; use as questionnaire defaults:
 
 ## Questions
 
-One `AskUserQuestion` for the validation subset, detected values as defaults. Canonical wording lives in [`../do/pre-flight.md`](../do/pre-flight.md) — reference, don't fork:
+One `AskUserQuestion` for the validation subset, detected values as defaults. Ask each with the same intent the interactive pre-flight uses; the caller supplies the exact option wording:
 
 - Validation strategy — pre-flight Q4
 - Local URL — pre-flight Q5 (defers to [`autoSelectLocalHost`](../muggle-preferences/preference-gates/autoSelectLocalHost.md))

--- a/plugin/skills/_shared/resolve-rebase-conflicts.md
+++ b/plugin/skills/_shared/resolve-rebase-conflicts.md
@@ -1,14 +1,13 @@
-# Auto-Resolve Rebase Conflicts
+# Resolve Rebase Conflicts
 
-The autonomous conflict-resolution body, run when a rebase onto `origin/{default}` reports conflicts **and** [`autoResolveConflicts`](../muggle-preferences/preference-gates/autoResolveConflicts.md) is `always`. Under `never` the caller aborts and escalates instead, and this file never runs. The caller hands off the inputs below; this file names no caller — the dependency runs one way.
+How to resolve the conflicts a rebase onto `origin/{default}` reports, when [`autoResolveConflicts`](../muggle-preferences/preference-gates/autoResolveConflicts.md) is `always`. Under `never` the caller aborts and escalates instead, and this file never runs. The caller hands off the inputs below and, once resolution completes, runs the [`verify-or-rollback-gate.md`](verify-or-rollback-gate.md) before anything ships. This file names no caller — the dependency runs one way.
 
-Contract: never push an auto-resolved rebase that has not passed the verify gate, and always keep the branch restorable to its pre-rebase state.
+Contract: resolve deterministically where the change is mechanical, reason about intent where it is semantic, and never guess in load-bearing logic — hand an unreconcilable conflict back to the caller rather than fabricating a merge.
 
 ## Inputs
 
-- `pre_rebase_sha` — branch HEAD captured by the caller **before** `git rebase`; the rollback point.
+- `pre_rebase_sha` — branch HEAD captured by the caller **before** `git rebase`; the caller passes it on to the verify-or-rollback gate as the rollback point.
 - `default` — the branch being rebased onto.
-- Session context: slug, PR url/number, and the persisted validation strategy (for the E2E step).
 
 ## Procedure
 
@@ -26,35 +25,12 @@ Classify each conflicted path:
 ### Step 2 — Resolve
 
 - **Mechanical** → resolve deterministically: regenerate the lockfile with the repo's package manager; regenerate or take-incoming for generated files; run the repo's formatter. Never hand-merge a lockfile.
-- **Semantic** → a reasoned 3-way resolution preserving the intent of **both** sides (ours = the PR's change, theirs = the new default-branch line). If intent in load-bearing logic can't be confidently reconciled, do not guess → Step 5.
+- **Semantic** → a reasoned 3-way resolution preserving the intent of **both** sides (ours = the PR's change, theirs = the new default-branch line). If intent in load-bearing logic can't be confidently reconciled, do not guess: `git rebase --abort` and hand the unreconcilable paths back to the caller, which restores `pre_rebase_sha` and escalates via the verify-or-rollback gate.
 
-Then `git add -A && git rebase --continue`, and repeat Steps 1–2 for each remaining conflicted commit until the rebase completes.
-
-### Step 3 — Verify gate (mandatory)
-
-Each must pass, in order:
-
-1. **Build** — typecheck + lint on the changed surface, run via the caller's build step.
-2. **Unit suite** — the caller's unit run; record PASS.
-3. **E2E** — the caller's E2E step under the persisted [`autoE2ETest`](../muggle-preferences/preference-gates/autoE2ETest.md) strategy. A poll-only session with no validation context reports `SKIPPED`, same as the normal cycle.
-
-### Step 4 — Pass → proceed
-
-Return success. The caller resumes the normal flow; the push happens downstream, so a resolved rebase ships only after it has verified.
-
-### Step 5 — Fail → restore + escalate
-
-On an unreconcilable semantic conflict (Step 2) or any verify failure (Step 3):
-
-```bash
-git rebase --abort 2>/dev/null || true
-git reset --hard <pre_rebase_sha>
-```
-
-The branch is now byte-for-byte its pre-rebase state. Emit one terminal escalation — the caller's escalation message — naming the conflicted files and the failing step, plus the `muggle-do:escalation` event with `kind: "rebase-conflict"` ([`telemetry-events/muggle-do-escalation.md`](telemetry-events/muggle-do-escalation.md)). Do not push.
+Then `git add -A && git rebase --continue`, and repeat Steps 1–2 for each remaining conflicted commit until the rebase completes. On success, return to the caller, which runs the verify-or-rollback gate before the resolved tree ships.
 
 ## Invariants
 
-- A push never follows a verify failure.
-- The branch is always restorable to `pre_rebase_sha`.
-- This file runs only under `autoResolveConflicts = always`; `never` is the caller's unchanged abort-and-escalate path.
+- Never fabricate a merge in load-bearing logic; an unreconcilable conflict goes back to the caller.
+- This file resolves; it does not verify or push. The [`verify-or-rollback-gate.md`](verify-or-rollback-gate.md) owns the ship-or-rollback decision.
+- Runs only under `autoResolveConflicts = always`; `never` is the caller's unchanged abort-and-escalate path.

--- a/plugin/skills/_shared/resolve-rebase-conflicts.md
+++ b/plugin/skills/_shared/resolve-rebase-conflicts.md
@@ -34,9 +34,9 @@ Then `git add -A && git rebase --continue`, and repeat Steps 1–2 for each rema
 
 Each must pass, in order:
 
-1. **Build** — typecheck + lint on the changed surface, per [`../do/build.md`](../do/build.md).
-2. **Unit suite** — per [`../do/unit-tests.md`](../do/unit-tests.md); record PASS.
-3. **E2E** — per [`../do/e2e-acceptance.md`](../do/e2e-acceptance.md) and the persisted [`autoE2ETest`](../muggle-preferences/preference-gates/autoE2ETest.md) strategy. A poll-only session with no validation context reports `SKIPPED`, same as the normal cycle.
+1. **Build** — typecheck + lint on the changed surface, run via the caller's build step.
+2. **Unit suite** — the caller's unit run; record PASS.
+3. **E2E** — the caller's E2E step under the persisted [`autoE2ETest`](../muggle-preferences/preference-gates/autoE2ETest.md) strategy. A poll-only session with no validation context reports `SKIPPED`, same as the normal cycle.
 
 ### Step 4 — Pass → proceed
 
@@ -51,7 +51,7 @@ git rebase --abort 2>/dev/null || true
 git reset --hard <pre_rebase_sha>
 ```
 
-The branch is now byte-for-byte its pre-rebase state. Emit one terminal escalation per [`../muggle-pr-followup/output-templates/escalation.md`](../muggle-pr-followup/output-templates/escalation.md) naming the conflicted files and the failing step, plus the `muggle-do:escalation` event with `kind: "rebase-conflict"` ([`telemetry-events/muggle-do-escalation.md`](telemetry-events/muggle-do-escalation.md)). Do not push.
+The branch is now byte-for-byte its pre-rebase state. Emit one terminal escalation — the caller's escalation message — naming the conflicted files and the failing step, plus the `muggle-do:escalation` event with `kind: "rebase-conflict"` ([`telemetry-events/muggle-do-escalation.md`](telemetry-events/muggle-do-escalation.md)). Do not push.
 
 ## Invariants
 

--- a/plugin/skills/_shared/session-state-writes.md
+++ b/plugin/skills/_shared/session-state-writes.md
@@ -1,6 +1,6 @@
 # Writing session-state files
 
-How to update the session-state JSON — `last_seen.json` and `prs.json` under `~/.muggle-ai/muggle-do/sessions/<slug>/`. Field shapes: [`../muggle-pr-followup/state-schemas.md`](../muggle-pr-followup/state-schemas.md). Both the watcher and `/muggle-do` write these.
+How to update the session-state JSON — `last_seen.json` and `prs.json` under `~/.muggle-ai/muggle-do/sessions/<slug>/`. Field shapes: see the [`## Field map`](#field-map) below. Both the watcher and `/muggle-do` write these.
 
 ## Mechanism — tool-based, OS-agnostic
 

--- a/plugin/skills/_shared/session-state-writes.md
+++ b/plugin/skills/_shared/session-state-writes.md
@@ -1,6 +1,6 @@
 # Writing session-state files
 
-How to update the session-state JSON — `last_seen.json` and `prs.json` under `~/.muggle-ai/muggle-do/sessions/<slug>/`. Field shapes: see the [`## Field map`](#field-map) below. Both the watcher and `/muggle-do` write these.
+How to update the session-state JSON — `last_seen.json` and `prs.json` under `~/.muggle-ai/muggle-do/sessions/<slug>/`. Field shapes: see the [`## Field map`](#field-map) below.
 
 ## Mechanism — tool-based, OS-agnostic
 

--- a/plugin/skills/_shared/use-worktrees.md
+++ b/plugin/skills/_shared/use-worktrees.md
@@ -7,7 +7,6 @@ Use this for feature development, local validation, and PR iteration.
 - **One worktree per branch.** Never switch branches inside a long-lived checkout.
 - **Isolate runtime resources.** Parallel worktrees need unique ports and isolated mutable test state.
 - **Keep worktrees disposable.** Create for focused work, remove after merge.
-- **Existing PR branch?** Check it out into the same `<repo>/.claude/worktrees/` path scheme instead of creating a new branch. The skill that takes a PR URL owns that operation.
 
 ## Start new change work
 

--- a/plugin/skills/_shared/use-worktrees.md
+++ b/plugin/skills/_shared/use-worktrees.md
@@ -7,7 +7,7 @@ Use this for feature development, local validation, and PR iteration.
 - **One worktree per branch.** Never switch branches inside a long-lived checkout.
 - **Isolate runtime resources.** Parallel worktrees need unique ports and isolated mutable test state.
 - **Keep worktrees disposable.** Create for focused work, remove after merge.
-- **Existing PR branch?** Materialize it via [`pr-branch-worktree.md`](pr-branch-worktree.md) — same `<repo>/.claude/worktrees/` path scheme, checking out the existing branch instead of creating a new one.
+- **Existing PR branch?** Check it out into the same `<repo>/.claude/worktrees/` path scheme instead of creating a new branch. The skill that takes a PR URL owns that operation.
 
 ## Start new change work
 

--- a/plugin/skills/_shared/vcs/github/verify-working-tree.md
+++ b/plugin/skills/_shared/vcs/github/verify-working-tree.md
@@ -14,4 +14,4 @@ Accept any remote URL form for `<owner>/<repo>` (with or without trailing `.git`
 - `git@github.com:<owner>/<repo>`
 - `ssh://git@github.com/<owner>/<repo>`
 
-Any mismatch → bootstrap aborts using the wrong-checkout template in [`../../../muggle-pr-followup/output-templates/bootstrap.md`](../../../muggle-pr-followup/output-templates/bootstrap.md).
+Any mismatch → abort; the calling skill reports the wrong checkout to the user with its own message.

--- a/plugin/skills/_shared/verify-or-rollback-gate.md
+++ b/plugin/skills/_shared/verify-or-rollback-gate.md
@@ -1,0 +1,39 @@
+# Verify-or-Rollback Gate
+
+The mandatory gate a caller runs after an operation has mutated the working tree and that tree must be proven safe before anything ships — e.g. a resolved rebase onto `origin/{default}`. It verifies the changed surface; on any failure it restores the branch to its pre-mutation state and escalates. The caller hands off the inputs below; this file names no caller — the dependency runs one way.
+
+Contract: never let a mutated tree ship without passing verification, and always keep the branch restorable to its pre-mutation state.
+
+## Inputs
+
+- `pre_rebase_sha` — branch HEAD the caller captured **before** the mutating operation; the rollback point.
+- Session context: slug, PR url/number, and the persisted validation strategy (for the E2E step).
+
+## Procedure
+
+### Step 1 — Verify (mandatory)
+
+Each must pass, in order:
+
+1. **Build** — typecheck + lint on the changed surface, run via the caller's build step.
+2. **Unit suite** — the caller's unit run; record PASS.
+3. **E2E** — the caller's E2E step under the persisted [`autoE2ETest`](../muggle-preferences/preference-gates/autoE2ETest.md) strategy. A poll-only session with no validation context reports `SKIPPED`, same as the normal cycle.
+
+### Step 2 — Pass → proceed
+
+Return success. The caller resumes the normal flow; the push happens downstream, so a mutated tree ships only after it has verified.
+
+### Step 3 — Fail → restore + escalate
+
+On any verify failure — or when the caller reports the preceding operation could not complete:
+
+```bash
+git reset --hard <pre_rebase_sha>
+```
+
+The branch is now byte-for-byte its pre-mutation state. Emit one terminal escalation — the caller's escalation message — naming the failing step, plus the `muggle-do:escalation` event with `kind: "rebase-conflict"` ([`telemetry-events/muggle-do-escalation.md`](telemetry-events/muggle-do-escalation.md)). Do not push.
+
+## Invariants
+
+- A push never follows a verify failure.
+- The branch is always restorable to `pre_rebase_sha`.

--- a/plugin/skills/do/resolve-conflicts.md
+++ b/plugin/skills/do/resolve-conflicts.md
@@ -29,7 +29,7 @@ Run the rebase from [`../_shared/rebase-before-e2e.md`](../_shared/rebase-before
 - **Clean replay** — a behind-only branch (and any rebase that hits no conflicts) replays without intervention. Proceed to Step 3.
 - **Conflicts** — handle per [`autoResolveConflicts`](../muggle-preferences/preference-gates/autoResolveConflicts.md):
   - `never` → abort and escalate per Step 5 (`kind: "rebase-conflict"`). The watcher keeps polling; the user resolves on GitHub.
-  - `always` → resolve behind the verify-or-rollback gate in [`../_shared/resolve-rebase-conflicts.md`](../_shared/resolve-rebase-conflicts.md).
+  - `always` → resolve via [`../_shared/resolve-rebase-conflicts.md`](../_shared/resolve-rebase-conflicts.md); Steps 3 and 5 below are this mode's instance of the [`../_shared/verify-or-rollback-gate.md`](../_shared/verify-or-rollback-gate.md).
 
 ### Step 3 — Verify the resolution
 

--- a/plugin/skills/skill-deps.config.json
+++ b/plugin/skills/skill-deps.config.json
@@ -2,17 +2,7 @@
   "supportDirs": { "do": "muggle-do" },
   "sharedNamespaces": ["_shared"],
   "knownReverseDeps": {
-    "comment": "Pre-existing reverse dependencies grandfathered when the one-way guard was added. Each is a genuine violation of plugin/skills/CLAUDE.md (a shared module or lower-level skill linking UP into a caller) — debt to fix and delete from this list, not a pattern to copy. The guard blocks any NEW cycle regardless of this list; these entries only keep the pre-existing tangle from failing CI. Burn this list down to empty.",
-    "edges": [
-      { "from": "_shared/dev-loop/run.md", "to": "../../do/e2e-acceptance.md" },
-      { "from": "_shared/resolve-e2e-validation-context.md", "to": "../do/pre-flight.md" },
-      { "from": "_shared/resolve-rebase-conflicts.md", "to": "../do/build.md" },
-      { "from": "_shared/resolve-rebase-conflicts.md", "to": "../do/unit-tests.md" },
-      { "from": "_shared/resolve-rebase-conflicts.md", "to": "../do/e2e-acceptance.md" },
-      { "from": "_shared/resolve-rebase-conflicts.md", "to": "../muggle-pr-followup/output-templates/escalation.md" },
-      { "from": "_shared/session-state-writes.md", "to": "../muggle-pr-followup/state-schemas.md" },
-      { "from": "_shared/vcs/github/verify-working-tree.md", "to": "../../../muggle-pr-followup/output-templates/bootstrap.md" },
-      { "from": "_shared/use-worktrees.md", "to": "pr-branch-worktree.md" }
-    ]
+    "comment": "Reverse dependencies grandfathered so CI stays green — each is a genuine violation of plugin/skills/CLAUDE.md (a shared module or lower-level skill linking UP into a caller). Currently empty: the tree is one-way. If an entry is ever added here, it is debt to fix and delete, not a pattern to copy. The guard blocks any NEW cycle regardless of this list.",
+    "edges": []
   }
 }

--- a/plugin/skills/skill-deps.config.json
+++ b/plugin/skills/skill-deps.config.json
@@ -1,0 +1,18 @@
+{
+  "supportDirs": { "do": "muggle-do" },
+  "sharedNamespaces": ["_shared"],
+  "knownReverseDeps": {
+    "comment": "Pre-existing reverse dependencies grandfathered when the one-way guard was added. Each is a genuine violation of plugin/skills/CLAUDE.md (a shared module or lower-level skill linking UP into a caller) — debt to fix and delete from this list, not a pattern to copy. The guard blocks any NEW cycle regardless of this list; these entries only keep the pre-existing tangle from failing CI. Burn this list down to empty.",
+    "edges": [
+      { "from": "_shared/dev-loop/run.md", "to": "../../do/e2e-acceptance.md" },
+      { "from": "_shared/resolve-e2e-validation-context.md", "to": "../do/pre-flight.md" },
+      { "from": "_shared/resolve-rebase-conflicts.md", "to": "../do/build.md" },
+      { "from": "_shared/resolve-rebase-conflicts.md", "to": "../do/unit-tests.md" },
+      { "from": "_shared/resolve-rebase-conflicts.md", "to": "../do/e2e-acceptance.md" },
+      { "from": "_shared/resolve-rebase-conflicts.md", "to": "../muggle-pr-followup/output-templates/escalation.md" },
+      { "from": "_shared/session-state-writes.md", "to": "../muggle-pr-followup/state-schemas.md" },
+      { "from": "_shared/vcs/github/verify-working-tree.md", "to": "../../../muggle-pr-followup/output-templates/bootstrap.md" },
+      { "from": "_shared/use-worktrees.md", "to": "pr-branch-worktree.md" }
+    ]
+  }
+}

--- a/scripts/check-skill-deps.mjs
+++ b/scripts/check-skill-deps.mjs
@@ -1,0 +1,359 @@
+#!/usr/bin/env node
+
+// Enforces the one-way dependency rule documented in plugin/skills/CLAUDE.md:
+// a reference is a cross-skill markdown file-link, and if skill A links to B
+// then no file in B may link back to A. A reverse reference shows up as a cycle
+// in the derived link graph. Runtime slash-command dispatch is prose, not a
+// link, so it is ignored; a shared namespace is exploded to per-file nodes so
+// unrelated modules under it never manufacture a false cycle.
+//
+// Modes:
+//   (default)  full-tree lint for CI — scans plugin/skills, exits 1 on violations.
+//   --hook     PreToolUse gate — reads hook JSON on stdin, denies only when the
+//              edited file itself introduces a new upward/cyclic link.
+
+import fs from "node:fs";
+import path from "node:path";
+
+const SKILLS_DIR = path.join("plugin", "skills");
+
+function findSkillsRoot(start) {
+  let dir = fs.existsSync(start) && fs.statSync(start).isDirectory() ? start : path.dirname(start);
+  for (let i = 0; i < 50; i++) {
+    if (path.basename(dir) === "skills" && path.basename(path.dirname(dir)) === "plugin") return dir;
+    const candidate = path.join(dir, SKILLS_DIR);
+    if (fs.existsSync(candidate)) return candidate;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+function loadConfig(skillsRoot) {
+  const file = path.join(skillsRoot, "skill-deps.config.json");
+  const base = { supportDirs: {}, sharedNamespaces: [], knownReverseDeps: { edges: [] } };
+  if (!fs.existsSync(file)) return base;
+  try {
+    return { ...base, ...JSON.parse(fs.readFileSync(file, "utf8")) };
+  } catch {
+    return base;
+  }
+}
+
+function segments(relPath) {
+  return relPath.split(/[\\/]/).filter(Boolean);
+}
+
+function skillOf(relFromRoot, config) {
+  const segs = segments(relFromRoot);
+  if (segs.length < 2) return null; // file sits directly in skills root (repo docs, config)
+  const top = segs[0];
+  if (top === ".." || top === ".") return null; // escaped the skills tree
+  // A shared namespace is not a skill but a bag of independent modules; each file
+  // is its own node so unrelated modules don't manufacture a false cycle.
+  if (config.sharedNamespaces.includes(top)) return segs.join("/");
+  return config.supportDirs[top] || top;
+}
+
+function listMarkdown(dir, acc = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) listMarkdown(full, acc);
+    else if (entry.isFile() && entry.name.endsWith(".md")) acc.push(full);
+  }
+  return acc;
+}
+
+const LINK_RE = /\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+const REFDEF_RE = /^\s*\[[^\]]+\]:\s*(\S+)/;
+
+function extractTargets(line) {
+  const out = [];
+  let m;
+  LINK_RE.lastIndex = 0;
+  while ((m = LINK_RE.exec(line)) !== null) out.push(m[1]);
+  const ref = REFDEF_RE.exec(line);
+  if (ref) out.push(ref[1]);
+  return out;
+}
+
+function isExternalTarget(raw) {
+  return /^(https?:|mailto:|tel:|#|\/\/)/.test(raw);
+}
+
+// Cross-skill edges out of one file's content.
+function edgesFromFile(absFile, content, skillsRoot, config) {
+  const relFile = path.relative(skillsRoot, absFile);
+  const sourceSkill = skillOf(relFile, config);
+  if (!sourceSkill) return [];
+  const edges = [];
+  const lines = content.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    for (const rawFull of extractTargets(lines[i])) {
+      const raw = rawFull.split("#")[0];
+      if (!raw || isExternalTarget(rawFull)) continue;
+      const targetAbs = path.resolve(path.dirname(absFile), raw);
+      const targetRel = path.relative(skillsRoot, targetAbs);
+      if (targetRel.startsWith("..")) continue; // outside the skills tree (agents, commands)
+      const targetSkill = skillOf(targetRel, config);
+      if (!targetSkill || targetSkill === sourceSkill) continue;
+      const sourceFile = relFile.split(/[\\/]/).join("/");
+      edges.push({ source: sourceSkill, target: targetSkill, sourceFile, line: i + 1, raw: rawFull });
+    }
+  }
+  return edges;
+}
+
+function buildEdges(skillsRoot, config, overrides = new Map()) {
+  const files = new Set(listMarkdown(skillsRoot).map((f) => path.resolve(f)));
+  for (const f of overrides.keys()) files.add(path.resolve(f));
+  const edges = [];
+  for (const abs of files) {
+    let content;
+    if (overrides.has(abs)) content = overrides.get(abs);
+    else {
+      try {
+        content = fs.readFileSync(abs, "utf8");
+      } catch {
+        continue;
+      }
+    }
+    if (content == null) continue;
+    edges.push(...edgesFromFile(abs, content, skillsRoot, config));
+  }
+  return edges;
+}
+
+// Tarjan SCCs; returns skill -> scc id, plus the set of skills in a cycle
+// (scc size > 1). Self-loops are impossible here (source !== target).
+function cyclicSkills(edges) {
+  const adj = new Map();
+  for (const e of edges) {
+    if (!adj.has(e.source)) adj.set(e.source, new Set());
+    adj.get(e.source).add(e.target);
+    if (!adj.has(e.target)) adj.set(e.target, new Set());
+  }
+  let idx = 0;
+  const index = new Map();
+  const low = new Map();
+  const onStack = new Set();
+  const stack = [];
+  const inCycle = new Set();
+
+  const strongconnect = (v) => {
+    index.set(v, idx);
+    low.set(v, idx);
+    idx++;
+    stack.push(v);
+    onStack.add(v);
+    for (const w of adj.get(v) || []) {
+      if (!index.has(w)) {
+        strongconnect(w);
+        low.set(v, Math.min(low.get(v), low.get(w)));
+      } else if (onStack.has(w)) {
+        low.set(v, Math.min(low.get(v), index.get(w)));
+      }
+    }
+    if (low.get(v) === index.get(v)) {
+      const comp = [];
+      let w;
+      do {
+        w = stack.pop();
+        onStack.delete(w);
+        comp.push(w);
+      } while (w !== v);
+      if (comp.length > 1) for (const s of comp) inCycle.add(s);
+    }
+  };
+
+  for (const v of adj.keys()) if (!index.has(v)) strongconnect(v);
+  return inCycle;
+}
+
+function ignoreMatcher(config) {
+  const edges = (config.knownReverseDeps && config.knownReverseDeps.edges) || [];
+  const keys = new Set(edges.map((g) => `${g.from}|${g.to}`));
+  return (e) => keys.has(`${e.sourceFile}|${e.raw}`);
+}
+
+// Grandfathered links are dropped before cycle detection so the pre-existing
+// tangle dissolves and only genuinely new back-edges surface as cycles.
+function activeEdges(edges, config) {
+  const isIgnored = ignoreMatcher(config);
+  return edges.filter((e) => !isIgnored(e));
+}
+
+function findViolations(edges, config) {
+  const active = activeEdges(edges, config);
+  const inCycle = cyclicSkills(active);
+  const violations = [];
+  for (const e of active) {
+    if (inCycle.has(e.source) && inCycle.has(e.target)) {
+      violations.push({ kind: "cycle", ...e });
+    }
+  }
+  return violations;
+}
+
+function violationKey(v) {
+  return `${v.kind}|${v.sourceFile}|${v.raw}`;
+}
+
+function reasonLine(v) {
+  return `${v.sourceFile}:${v.line} — '${v.source}' links to '${v.target}' (${v.raw}), which links back: a reverse dependency (cycle). Reference downward only.`;
+}
+
+function runFullLint() {
+  const skillsRoot = findSkillsRoot(process.cwd());
+  if (!skillsRoot) {
+    console.error("check-skill-deps: could not locate plugin/skills from", process.cwd());
+    process.exit(2);
+  }
+  const config = loadConfig(skillsRoot);
+  const edges = buildEdges(skillsRoot, config);
+  const violations = findViolations(edges, config);
+  if (violations.length === 0) {
+    console.log(`check-skill-deps: OK — ${edges.length} cross-skill links, no reverse dependencies.`);
+    return;
+  }
+  const seen = new Set();
+  console.error("check-skill-deps: reverse dependencies found:\n");
+  for (const v of violations) {
+    const k = violationKey(v);
+    if (seen.has(k)) continue;
+    seen.add(k);
+    console.error("  - " + reasonLine(v));
+  }
+  console.error("\nSee plugin/skills/CLAUDE.md — One-way dependencies. Reference downward; pass what the caller needs as input.");
+  process.exit(1);
+}
+
+async function readStdin() {
+  const chunks = [];
+  for await (const c of process.stdin) chunks.push(c);
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function applyEdit(orig, ti) {
+  const replaceOnce = (s, oldStr, newStr, all) => {
+    if (all) return s.split(oldStr).join(newStr);
+    const i = s.indexOf(oldStr);
+    if (i < 0) return null;
+    return s.slice(0, i) + newStr + s.slice(i + oldStr.length);
+  };
+  if (typeof ti.content === "string") return ti.content; // Write
+  if (Array.isArray(ti.edits)) {
+    let s = orig;
+    for (const e of ti.edits) {
+      s = replaceOnce(s, e.old_string, e.new_string, e.replace_all);
+      if (s == null) return null;
+    }
+    return s;
+  }
+  if (typeof ti.old_string === "string") return replaceOnce(orig, ti.old_string, ti.new_string, ti.replace_all);
+  return null;
+}
+
+function allow() {
+  process.exit(0);
+}
+
+function deny(reason) {
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: reason,
+      },
+    })
+  );
+  process.exit(0);
+}
+
+async function runHook() {
+  let payload;
+  try {
+    payload = JSON.parse(await readStdin());
+  } catch {
+    allow();
+  }
+  const ti = payload.tool_input || {};
+  const filePath = ti.file_path;
+  if (!filePath || !filePath.endsWith(".md")) allow();
+  const absFile = path.resolve(filePath);
+  const skillsRoot = findSkillsRoot(absFile);
+  if (!skillsRoot) allow();
+  const relFile = path.relative(skillsRoot, absFile).split(/[\\/]/).join("/");
+  if (relFile.startsWith("..")) allow();
+
+  const config = loadConfig(skillsRoot);
+  let orig = "";
+  try {
+    orig = fs.readFileSync(absFile, "utf8");
+  } catch {
+    orig = "";
+  }
+  const proposed = applyEdit(orig, ti);
+  if (proposed == null) allow(); // couldn't reconstruct; the tool will handle it
+
+  const baseline = buildEdges(skillsRoot, config);
+  const overrides = new Map([[absFile, proposed]]);
+  const proposedEdges = buildEdges(skillsRoot, config, overrides);
+
+  const baseKeys = new Set(baseline.map((e) => `${e.sourceFile}|${e.raw}`));
+  const proposedViolations = findViolations(proposedEdges, config);
+
+  const newFromThisFile = proposedViolations.filter(
+    (v) => v.sourceFile === relFile && !baseKeys.has(`${v.sourceFile}|${v.raw}`)
+  );
+  if (newFromThisFile.length === 0) allow();
+
+  const seen = new Set();
+  const lines = [];
+  for (const v of newFromThisFile) {
+    const k = violationKey(v);
+    if (seen.has(k)) continue;
+    seen.add(k);
+    lines.push(reasonLine(v));
+  }
+  deny(
+    "Blocked: this edit adds a reverse skill dependency.\n" +
+      lines.map((l) => "  - " + l).join("\n") +
+      "\nReference downward only (see plugin/skills/CLAUDE.md). Pass what the caller needs as an input, not a link back up."
+  );
+}
+
+function runGraph() {
+  const skillsRoot = findSkillsRoot(process.cwd());
+  const config = loadConfig(skillsRoot);
+  const edges = activeEdges(buildEdges(skillsRoot, config), config);
+  const pairs = new Map();
+  for (const e of edges) {
+    const k = `${e.source} -> ${e.target}`;
+    if (!pairs.has(k)) pairs.set(k, e);
+  }
+  const directed = new Set(pairs.keys());
+  console.log("== mutual pairs (A <-> B): direct reverse dependencies ==");
+  const reported = new Set();
+  for (const k of directed) {
+    const [a, b] = k.split(" -> ");
+    const back = `${b} -> ${a}`;
+    if (directed.has(back)) {
+      const key = [a, b].sort().join(" <-> ");
+      if (reported.has(key)) continue;
+      reported.add(key);
+      const ex1 = pairs.get(k);
+      const ex2 = pairs.get(back);
+      console.log(`\n  ${key}`);
+      console.log(`    ${a}->${b}: ${ex1.sourceFile}:${ex1.line} (${ex1.raw})`);
+      console.log(`    ${b}->${a}: ${ex2.sourceFile}:${ex2.line} (${ex2.raw})`);
+    }
+  }
+  if (reported.size === 0) console.log("  (none)");
+}
+
+if (process.argv.includes("--hook")) runHook();
+else if (process.argv.includes("--graph")) runGraph();
+else runFullLint();

--- a/scripts/check-skill-deps.mjs
+++ b/scripts/check-skill-deps.mjs
@@ -289,7 +289,7 @@ async function runHook() {
   if (relFile.startsWith("..")) allow();
 
   const config = loadConfig(skillsRoot);
-  let orig = "";
+  let orig;
   try {
     orig = fs.readFileSync(absFile, "utf8");
   } catch {


### PR DESCRIPTION
## Why

`plugin/skills/CLAUDE.md` documents a **one-way dependency rule** — if skill A links to B, no file in B may link back to A — but nothing enforced it. Reverse dependencies kept getting introduced. This makes the rule a **deterministic gate** instead of a hope, **and cleans up every violation it found** so the tree ships genuinely one-way.

## What a "reference" is

Exactly what the rule says: a **markdown file-link into another skill's directory**. Prose mentions, descriptions naming other skills, and runtime `/slash-command` dispatch are **not** references and are ignored — so the gate doesn't false-positive on the ~300 legitimate cross-skill links.

## How it works

`scripts/check-skill-deps.mjs` (zero-dep Node) derives the cross-skill link graph and fails on any **cycle** — a cycle *is* a reverse dependency (A→B and B→A). It runs three ways:

| Surface | Catches |
|---|---|
| `skill-deps` CI job | reverse deps in **any** agent's PR, at merge — the unconditional backstop |
| `PreToolUse` deny hook (`.claude/settings.json`) | the write in-session, naming the offending link, before it lands |
| `pnpm run verify:skill-deps` | local check |

Modeling notes (in `plugin/skills/skill-deps.config.json`):
- `_shared` is a namespace of independent modules, not one skill → **exploded to per-file nodes** so unrelated shared modules don't manufacture false cycles.
- `do/` is `muggle-do`'s externalized step files → **grouped into `muggle-do`**.

## The reverse deps it found — now fixed

The gate caught **9 real reverse-dependency links already in the tree** — shared modules linking *up* into `muggle-do`'s `do/` steps and `muggle-pr-followup`'s templates/schemas, plus one intra-`_shared` 2-cycle. Every one is now fixed by genericizing the shared module to describe the **contract** and letting the caller own the specifics — which matches each file's own stated intent (*"the caller passes in"*, *"this file names no caller"*):

- `dev-loop/run`, `resolve-rebase-conflicts` — drop links into `muggle-do`'s `do/` verify steps; the caller runs its own build/unit/E2E
- `resolve-rebase-conflicts`, `vcs/github/verify-working-tree` — drop links into `muggle-pr-followup` templates; the caller renders its own escalation / wrong-checkout message
- `resolve-e2e-validation-context` — stop deferring question wording to `do/pre-flight`; ask the same intent, caller supplies option text
- `session-state-writes` — point at its own `## Field map`, not the watcher's `state-schemas`
- `use-worktrees` — stop linking down to the PR-branch specialization (the general file must not point at the specific)

**`knownReverseDeps` is now empty.** The tree is genuinely one-way: 307 cross-skill links, 0 cycles. No behavior change — only reverse *links* removed; the information each shared file needs is preserved (inlined, self-anchored, or owned by the caller that was already running the procedure).

## Verified

- Full lint green with an **empty baseline**: `307 cross-skill links, no reverse dependencies`
- Hook **denies** a new reverse edge (`muggle-pr-followup → muggle-do`) with a precise reason; **allows** downward links, non-skill files
- Handles Write / Edit / MultiEdit payloads; safe-allows on unparseable input
- eslint / typecheck / build / all CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLDR4ox777q3M1un5AdhbM