### PR TITLE
perf(guardrails): stop hooks blocking the turn on Node cold-start

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -7,7 +7,8 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/ensure-electron-app.sh\"",
-            "async": false
+            "async": false,
+            "timeout": 120
           }
         ]
       }
@@ -19,7 +20,8 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/guardrail-report-format.sh\"",
-            "async": false
+            "async": false,
+            "timeout": 5
           }
         ]
       }
@@ -31,12 +33,14 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/guardrail-pr-opened.sh\"",
-            "async": false
+            "async": true,
+            "timeout": 10
           },
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/guardrail-record-tests.sh\"",
-            "async": false
+            "async": true,
+            "timeout": 10
           }
         ]
       },
@@ -46,7 +50,8 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/guardrail-record-tests.sh\"",
-            "async": false
+            "async": true,
+            "timeout": 10
           }
         ]
       }
@@ -57,7 +62,8 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/guardrail-e2e-gate.sh\"",
-            "async": false
+            "async": false,
+            "timeout": 5
           }
         ]
       }
@@ -68,7 +74,8 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/guardrail-build-router.sh\"",
-            "async": false
+            "async": true,
+            "timeout": 10
           }
         ]
       }

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -21,7 +21,7 @@
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/guardrail-report-format.sh\"",
             "async": false,
-            "timeout": 5
+            "timeout": 10
           }
         ]
       }
@@ -33,13 +33,13 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/guardrail-pr-opened.sh\"",
-            "async": true,
+            "async": false,
             "timeout": 10
           },
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/guardrail-record-tests.sh\"",
-            "async": true,
+            "async": false,
             "timeout": 10
           }
         ]
@@ -50,7 +50,7 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/guardrail-record-tests.sh\"",
-            "async": true,
+            "async": false,
             "timeout": 10
           }
         ]
@@ -63,7 +63,7 @@
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/guardrail-e2e-gate.sh\"",
             "async": false,
-            "timeout": 5
+            "timeout": 10
           }
         ]
       }
@@ -74,7 +74,7 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/guardrail-build-router.sh\"",
-            "async": true,
+            "async": false,
             "timeout": 10
           }
         ]

--- a/plugin/scripts/guardrail-build-router.sh
+++ b/plugin/scripts/guardrail-build-router.sh
@@ -1,9 +1,23 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -uo pipefail
 
 # Front-door router (UserPromptSubmit). On the first build/implement/fix prompt
 # of a session, offers to route the work through /muggle-do (build delegated to
 # superpowers), gated by autoRouteBuildToMuggleDo. Fires once per session.
-# Degrades to {} so it never blocks a turn.
+#
+# Node cold-start (spawn + module load) stalls the turn on a loaded box, and this
+# hook runs on EVERY prompt. A cheap in-shell keyword pre-filter mirrors the build
+# verbs guardrails.mjs looks for, so the vast majority of prompts (questions,
+# status checks, chit-chat) never spawn Node. Node runs only on a keyword hit,
+# then applies the real detectBuildIntent logic (question/slash exclusions,
+# once-per-session dedupe). Over-matching here only costs an occasional needless
+# spawn; it can never emit a spurious offer. Degrades to {} so it never blocks.
+payload="$(cat)"
+
+if ! grep -Eiq '(implement|build|add|create|write|fix|refactor|wire up|hook up|make|change the|conflict|merged|passing|green)' <<<"$payload"; then
+  printf '{}'
+  exit 0
+fi
+
 root="${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-}}"
-node "${root}/scripts/guardrails.mjs" build-router 2>/dev/null || printf '{}'
+printf '%s' "$payload" | node "${root}/scripts/guardrails.mjs" build-router 2>/dev/null || printf '{}'

--- a/plugin/scripts/guardrail-e2e-gate.sh
+++ b/plugin/scripts/guardrail-e2e-gate.sh
@@ -1,8 +1,38 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -uo pipefail
 
 # tests-green → E2E gate (Stop). When unit tests passed this session and no E2E
 # acceptance run has happened, offer to run change-driven E2E (gated by
-# autoE2ETest). Fires once per session. Degrades to {} so it never blocks a turn.
+# autoE2ETest). Fires once per session.
+#
+# This must stay synchronous (only a sync Stop hook can block the turn end), and
+# it fires on EVERY turn end. There is no command payload to key off, so the
+# pre-filter reads the same per-session state file guardrails.mjs uses and only
+# spawns Node when the gate could actually fire — i.e. shouldRunE2E: unit tests
+# went green and no E2E run is recorded yet. On the overwhelming majority of
+# turns (no test run this session) the state file is absent or unitTestsGreen is
+# unset, so we return {} in-shell and never pay Node cold-start. Degrades to {}.
+payload="$(cat)"
+
+raw_sid="$(printf '%s' "$payload" | grep -oE '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed -E 's/.*:[[:space:]]*"([^"]*)".*/\1/')"
+[ -n "$raw_sid" ] || raw_sid="unknown"
+sid="$(printf '%s' "$raw_sid" | sed 's/[^A-Za-z0-9_-]/_/g')"
+
+# Resolve the same home dir Node's os.homedir() uses. HOME is correct on
+# macOS/Linux and on most Git Bash setups; fall back to converting USERPROFILE
+# when HOME doesn't hold the state dir (some Windows shells point HOME elsewhere).
+home="${HOME:-}"
+if [ ! -d "$home/.muggle-ai" ] && command -v cygpath >/dev/null 2>&1 && [ -n "${USERPROFILE:-}" ]; then
+  home="$(cygpath -u "$USERPROFILE" 2>/dev/null || printf '%s' "$home")"
+fi
+
+state_file="$home/.muggle-ai/guardrails/$sid.json"
+if [ ! -f "$state_file" ] \
+  || ! grep -q '"unitTestsGreen": true' "$state_file" \
+  || grep -q '"e2eRun": true' "$state_file"; then
+  printf '{}'
+  exit 0
+fi
+
 root="${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-}}"
-node "${root}/scripts/guardrails.mjs" e2e-gate 2>/dev/null || printf '{}'
+printf '%s' "$payload" | node "${root}/scripts/guardrails.mjs" e2e-gate 2>/dev/null || printf '{}'

--- a/plugin/scripts/guardrail-pr-opened.sh
+++ b/plugin/scripts/guardrail-pr-opened.sh
@@ -1,10 +1,21 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -uo pipefail
 
 # PR-opened guardrail (PostToolUse/Bash). When a `gh pr create`/`gh pr ready`
 # just succeeded, offer to start a muggle-pr-followup watcher on the new PR
 # (gated by autoWatchPR, deduped per session). Decision logic lives in the
-# bundled guardrails.mjs; this wrapper just pipes the event payload through and
-# degrades to {} so a guardrail can never block a turn.
+# bundled guardrails.mjs.
+#
+# This fires after EVERY Bash call, so a keyword pre-filter for the PR-open
+# commands keeps Node off the hot path — only a `gh pr create|ready` or
+# `glab mr create|update` even reaches guardrails.mjs, which then confirms the
+# command succeeded and extracts the URL. Degrades to {} so it never blocks.
+payload="$(cat)"
+
+if ! grep -Eiq 'gh[[:space:]]+pr[[:space:]]+(create|ready)|glab[[:space:]]+mr[[:space:]]+(create|update)' <<<"$payload"; then
+  printf '{}'
+  exit 0
+fi
+
 root="${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-}}"
-node "${root}/scripts/guardrails.mjs" pr-opened 2>/dev/null || printf '{}'
+printf '%s' "$payload" | node "${root}/scripts/guardrails.mjs" pr-opened 2>/dev/null || printf '{}'

--- a/plugin/scripts/guardrail-record-tests.sh
+++ b/plugin/scripts/guardrail-record-tests.sh
@@ -1,9 +1,22 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -uo pipefail
 
-# tests-green observer (PostToolUse/Bash). Records in per-session state when a
-# unit-test command passed (and when a muggle E2E run happened). Emits no
-# directive — the Stop gate (guardrail-e2e-gate.sh) reads the state. Degrades
-# to {} so it never blocks a turn.
+# tests-green observer (PostToolUse/Bash + muggle E2E tools). Records in
+# per-session state when a unit-test command passed (and when a muggle E2E run
+# happened). Emits no directive — the Stop gate (guardrail-e2e-gate.sh) reads
+# the state.
+#
+# Fires after every Bash call and every muggle execute/replay, so a keyword
+# pre-filter for test runners and the muggle E2E tool names keeps Node off the
+# hot path. Only a `test` command (npm/pnpm/yarn/jest/vitest/pytest/go/cargo) or
+# a muggle execute/replay/test-generation event reaches guardrails.mjs, which
+# then inspects the output for pass/fail and updates state. Degrades to {}.
+payload="$(cat)"
+
+if ! grep -Eiq '(pnpm|npm|yarn)[[:space:]]+(run[[:space:]]+)?test|jest|vitest|pytest|go[[:space:]]+test|cargo[[:space:]]+test|muggle.*(execute|test-generation|replay)' <<<"$payload"; then
+  printf '{}'
+  exit 0
+fi
+
 root="${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-}}"
-node "${root}/scripts/guardrails.mjs" record-tests 2>/dev/null || printf '{}'
+printf '%s' "$payload" | node "${root}/scripts/guardrails.mjs" record-tests 2>/dev/null || printf '{}'

--- a/plugin/scripts/guardrail-report-format.sh
+++ b/plugin/scripts/guardrail-report-format.sh
@@ -1,9 +1,23 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -uo pipefail
 
 # Report-format gate (PreToolUse, Bash). Denies a `gh pr comment|create|edit`
 # whose body reads like a hand-written E2E report — one that lacks the
 # build-pr-section sentinel — so every posted walkthrough goes through the
-# deterministic renderer. Degrades to {} so it never blocks an unrelated command.
+# deterministic renderer.
+#
+# This must stay synchronous (only a sync PreToolUse hook can deny), and it fires
+# before every Bash call. A keyword pre-filter for the three PR-posting commands
+# keeps Node off the hot path: a plain `ls`/`git status`/build command returns {}
+# in-shell and never pays cold-start. Only a `gh pr comment|create|edit` reaches
+# guardrails.mjs, which reads the body (incl. --body-file) and decides. Degrades
+# to {} so it never blocks an unrelated command.
+payload="$(cat)"
+
+if ! grep -Eiq 'gh[[:space:]]+pr[[:space:]]+(comment|create|edit)' <<<"$payload"; then
+  printf '{}'
+  exit 0
+fi
+
 root="${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-}}"
-node "${root}/scripts/guardrails.mjs" report-gate 2>/dev/null || printf '{}'
+printf '%s' "$payload" | node "${root}/scripts/guardrails.mjs" report-gate 2>/dev/null || printf '{}'

--- a/src/test/guardrails/hook-execution.test.ts
+++ b/src/test/guardrails/hook-execution.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { spawnSync } from "child_process";
 import { fileURLToPath } from "url";
-import { mkdtempSync, readFileSync, readdirSync } from "fs";
+import { chmodSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
-import { join } from "path";
+import { delimiter, dirname, join } from "path";
 
 // End-to-end hook contract. The per-function guardrail logic is unit-tested
 // elsewhere; this file exercises the *entry* the way Claude Code runs it —
@@ -152,6 +152,79 @@ describe("guardrail wrapper never-block fallback (Lazy-core tripwire)", () => {
       expect(body, `${f} must keep its never-block fallback`).toContain("printf '{}'");
       expect(body, `${f} must swallow guardrail stderr`).toContain("2>/dev/null");
     }
+  });
+});
+
+// The wrappers guard guardrails.mjs behind an in-shell keyword pre-filter so the
+// common case (a prompt, a Bash call, a turn end that doesn't concern a guardrail)
+// never pays Node cold-start — the fix for hooks stalling the turn on a loaded
+// box. These run the real bash wrappers with `node` stubbed on PATH: a marker in
+// the output proves Node ran; its absence proves the pre-filter short-circuited.
+// Bash-only, so skipped on win32 (covered by the Linux/macOS platform-compat jobs).
+describe.skipIf(process.platform === "win32")("guardrail wrapper pre-filter (no Node on the cold path)", () => {
+  const NODE_RAN = "__STUB_NODE_RAN__";
+  const event = (o: unknown): string => JSON.stringify(o);
+  let root: string;
+  let binDir: string;
+
+  beforeEach(() => {
+    root = dirname(SCRIPTS); // plugin/, so ${root}/scripts/guardrails.mjs resolves
+    binDir = mkdtempSync(join(tmpdir(), "gr-stub-"));
+    const stub = join(binDir, "node");
+    writeFileSync(stub, `#!/usr/bin/env bash\nprintf '%s' '${NODE_RAN}'\n`);
+    chmodSync(stub, 0o755);
+  });
+
+  function runWrapper(script: string, stdin: string): string {
+    const home = mkdtempSync(join(tmpdir(), "gr-home-"));
+    const r = spawnSync("bash", [join(SCRIPTS, script)], {
+      input: stdin,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}`,
+        CLAUDE_PLUGIN_ROOT: root,
+        HOME: home,
+        USERPROFILE: home,
+      },
+    });
+    return (r.stdout ?? "").trim();
+  }
+
+  it("build-router: skips Node on a non-build prompt, spawns it on a build ask", () => {
+    expect(runWrapper("guardrail-build-router.sh", event({ session_id: "a", prompt: "what time is it?" }))).toBe("{}");
+    expect(runWrapper("guardrail-build-router.sh", event({ session_id: "b", prompt: "implement dark mode" }))).toContain(NODE_RAN);
+  });
+
+  it("pr-opened: skips Node on a plain command, spawns it on gh pr create", () => {
+    expect(
+      runWrapper("guardrail-pr-opened.sh", event({ tool_name: "Bash", tool_input: { command: "ls -la" } })),
+    ).toBe("{}");
+    expect(
+      runWrapper("guardrail-pr-opened.sh", event({ tool_name: "Bash", tool_input: { command: "gh pr create --fill" } })),
+    ).toContain(NODE_RAN);
+  });
+
+  it("report-format: skips Node on a plain command, spawns it on gh pr comment", () => {
+    expect(
+      runWrapper("guardrail-report-format.sh", event({ tool_name: "Bash", tool_input: { command: "git status" } })),
+    ).toBe("{}");
+    expect(
+      runWrapper("guardrail-report-format.sh", event({ tool_name: "Bash", tool_input: { command: "gh pr comment 1 --body x" } })),
+    ).toContain(NODE_RAN);
+  });
+
+  it("record-tests: skips Node on a plain command, spawns it on a test run", () => {
+    expect(
+      runWrapper("guardrail-record-tests.sh", event({ tool_name: "Bash", tool_input: { command: "git log" } })),
+    ).toBe("{}");
+    expect(
+      runWrapper("guardrail-record-tests.sh", event({ tool_name: "Bash", tool_input: { command: "pnpm test" } })),
+    ).toContain(NODE_RAN);
+  });
+
+  it("e2e-gate: skips Node when no armed state file exists for the session", () => {
+    expect(runWrapper("guardrail-e2e-gate.sh", event({ session_id: "no-state" }))).toBe("{}");
   });
 });
 


### PR DESCRIPTION
## Problem

Every guardrail hook shells to `node guardrails.mjs <sub>`. The handler logic is trivial and pure (regex + a tiny JSON read/write in `~/.muggle-ai/guardrails/` — no network, no LLM). But **Node process cold-start** on a loaded Windows box measured:

```
node -e 0  →  1778 ms / 1767 ms / 5256 ms   (normal is ~100-150 ms)
```

Each **synchronous** hook stalled the turn 1.7-5.3s. `UserPromptSubmit` (fires on *every* prompt) hit the 30s default hook timeout under load and had its output discarded:

> UserPromptSubmit hook timed out after 30s — output discarded.

Contributing factors on the affected machine: ~30 concurrent node/gh/muggle/electron processes (per-minute watcher cron + parallel jobs) and Defender real-time-scanning `node.exe` per spawn.

## Approach: bash pre-filter (per review)

The first cut made the hot hooks **async**, which fixed the stall but silenced the in-turn auto-offers — async `UserPromptSubmit`/`PostToolUse` hooks can't emit `additionalContext`, so `autoRouteBuildToMuggleDo` and `autoWatchPR` degraded to advisory. Redone the way the review asked instead: each `guardrail-*.sh` reads the event payload once and cheap-greps for the subcommand's real trigger, spawning Node **only** on a match. The common case returns `{}` in-shell with zero cold-start, so every hook can stay **synchronous** and the auto-offers inject in-turn again.

| Hook | Pre-filter (spawns Node only when…) |
|---|---|
| UserPromptSubmit `build-router` | prompt contains a build verb (implement/build/add/fix/refactor/…) |
| PostToolUse `pr-opened` | command matches `gh pr create\|ready` / `glab mr create\|update` |
| PostToolUse `record-tests` | command is a test runner (npm/pnpm/yarn/jest/vitest/pytest/go/cargo) or a muggle execute/replay/test-generation event |
| PreToolUse `report-format` (report-gate) | command matches `gh pr comment\|create\|edit` |
| Stop `e2e-gate` | the per-session state file shows `unitTestsGreen && !e2eRun` |

The pre-filter deliberately over-approximates (a keyword hit still runs the full `guardrails.mjs` logic — question/slash exclusions, URL/output inspection, once-per-session dedupe), so it can never emit a spurious offer or a wrong deny; it only ever avoids an irrelevant Node spawn. Every wrapper keeps its never-block `printf '{}'` fallback and swallows guardrail stderr.

## hooks.json

All hooks return to `async: false` (reverting the async regressions), with a `timeout` cap retained as a safety bound — cheap now that Node spawns rarely. Skip-path measured ~58ms (pure bash) vs ~123ms for the Node path on an idle box; under load the skip path avoids the multi-second cold-start entirely.

## Tests

`hook-execution.test.ts` gains a wrapper-level block that stubs `node` on `PATH` and asserts the skip path never spawns it while the match path does (Bash-only, skipped on win32 — covered by the Linux/macOS platform-compat jobs). Existing cli-entry, tripwire, and hooks.json-shape tests unchanged and green.

Complementary machine-level win (not in this PR): a Defender process exclusion for `node.exe` collapses the cold-start back toward ~150ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FfaSSKEhmiCvPdcyz94qoF
