### PR TITLE
chore(release): @muggleai/works 5.5.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "5.4.2"
+      "version": "5.5.0"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "5.4.2"
+      "version": "5.5.0"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@muggleai/works",
   "mcpName": "io.github.multiplex-ai/muggle",
-  "version": "5.4.2",
+  "version": "5.5.0",
   "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
   "type": "module",
   "main": "dist/index.js",
@@ -47,14 +47,14 @@
     "eval:studio-gen": "tsx internal/studio-gen-eval/src/run.ts"
   },
   "muggleConfig": {
-    "electronAppVersion": "1.6.6",
+    "electronAppVersion": "1.6.9",
     "downloadBaseUrl": "https://github.com/multiplex-ai/muggle-ai-works/releases/download",
     "runtimeTargetDefault": "dev",
     "checksums": {
-      "darwin-arm64": "c905921dda5412bdbb66735cdb81b0e0f76f4211c9ec129eae599d910213547e",
-      "darwin-x64": "3ad51b6babadf73ae607e965dd713fb9ad8a530e6c15c47779c34a96ea90dab4",
-      "linux-x64": "444c603453967f91b4a4ccb12f4344d7bed8d83b5b99d04fc43924c6c45b08f7",
-      "win32-x64": "ab7864489da53920af13905671aca4960cc141e41637590044757e47a439a9d7"
+      "darwin-arm64": "293f4ca402ab4132946801b9a3a354818e431f4839b1f91f40e0890f4477b3c5",
+      "darwin-x64": "c34f923f7fd3b37e60d2d335d01069e117632113ec0c811c573d219f0109291e",
+      "linux-x64": "d7ce0910043f5b557448dc800bcba8cf86b663df961959603deb6f6451b4904f",
+      "win32-x64": "c376de74e1e3bd34206aa002107b789f47a15972d91a888ae12d0eb5385bbf5f"
     }
   },
   "dependencies": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "5.4.2",
+  "version": "5.5.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "5.4.2",
+  "version": "5.5.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "5.4.2",
+  "version": "5.5.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "5.4.2",
+      "version": "5.5.0",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
Minor release **5.4.2 → 5.5.0**.

## Shipping since 5.4.2
| PR | Change | Signal |
|---|---|---|
| #316 | feat(skills): enforce one-way skill dependencies with a deterministic gate | minor |
| #318 | perf(guardrails): bash pre-filter so hooks skip Node cold-start; hooks back to sync so auto-offers inject in-turn | patch |
| #315 | fix(pr-followup): 5m poll when blocked; harden cron lifecycle + guarantee respawn | patch |

Highest signal is a `feat` (no breaking changes) → **minor**.

## Electron
Runner bumped **1.6.6 → 1.6.9** — `electronAppVersion` + all four `muggleConfig.checksums`, verified against `electron-app-v1.6.9/checksums.txt`.

## Manifests
Version propagated by `sync:versions` across `.claude-plugin/marketplace.json`, `.cursor-plugin/marketplace.json`, `plugin/.claude-plugin/plugin.json`, `plugin/.cursor-plugin/plugin.json`, and `server.json`.

## Test plan
- [x] `lint:check` (0 errors)
- [x] `typecheck`
- [x] `test` — 665 passed, 5 skipped
- [x] `build`
- [x] `verify:plugin`
- [x] `verify:contracts`
- [x] `verify:electron-release-checksums` — verified for 1.6.9

Publish via `publish-works-to-npm.yml` (OIDC trusted publishing) after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
