### PR TITLE
feat(pr-followup): auto-reconcile stale watchers at session start

### DIFF
--- a/plugin/hooks/README.md
+++ b/plugin/hooks/README.md
@@ -35,3 +35,9 @@ Each guardrail is a thin bash wrapper in `../scripts/` registered in `hooks.json
 | `PreToolUse` (Bash) | `guardrail-report-format.sh` | **enforce** | a `gh pr comment\|create\|edit` body reads like an E2E report but lacks the `build-pr-section` sentinel | — | **deny** — render via `muggle build-pr-section` instead |
 | `Stop` | `guardrail-e2e-gate.sh` | **enforce** | unit tests passed this session and no E2E ran yet | `autoE2ETest` | **block** the turn until E2E runs via `muggle-test` (releases after 3 blocks) |
 | `UserPromptSubmit` | `guardrail-build-router.sh` | advise | a build/implement/fix request (first one this session) | `autoRouteBuildToMuggleDo` | route the work through `muggle-do` (build delegated to superpowers) |
+
+## Session-start reconcile nudge
+
+`SessionStart` (`scripts/reconcile-stale-watchers.sh`) — a standalone advisory, not part of the `guardrails.mjs` decision tree above.
+
+`muggle-pr-followup` watchers are session-only `/loop` crons; they die on session end and the 7-day `/loop` expiry, leaving open PRs with no live poller. The skill's [`reconcile`](../skills/muggle-pr-followup/reconcile.md) procedure recovers them — finalizes slots whose PR went terminal, sweeps orphan crons, re-arms silently-stopped open watchers — but re-arming needs the `CronCreate` tool, which a shell hook can't call. So this hook nudges rather than acts: it scans `~/.muggle-ai/muggle-do/sessions/*/` for open slots (a `prs.json` with no `result.md`) and, **only when one or more exist**, injects `additionalContext` telling the agent to run `/muggle:muggle-pr-followup reconcile`. Zero open slots → it emits nothing. A pure directory scan (no `gh`, no writes), so it's cheap enough for every session start.

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -9,6 +9,12 @@
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/ensure-electron-app.sh\"",
             "async": false,
             "timeout": 120
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/reconcile-stale-watchers.sh\"",
+            "async": false,
+            "timeout": 10
           }
         ]
       }

--- a/plugin/scripts/reconcile-stale-watchers.sh
+++ b/plugin/scripts/reconcile-stale-watchers.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# muggle-pr-followup watchers are session-only crons — they die on session end
+# and on the 7-day /loop expiry, leaving open PRs with no live poller. Re-arming
+# needs CronCreate, a Claude tool a shell hook can't call, so this hook can't
+# recover a watcher itself. It nudges instead: on session start, if any open slot
+# exists, it tells the agent to run reconcile (which finalizes terminal slots and
+# re-arms silently-dead open watchers). A pure directory scan — no gh, no writes —
+# so it stays cheap enough to run on every session start.
+
+escape_for_json() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\n'/\\n}"
+    s="${s//$'\r'/\\r}"
+    s="${s//$'\t'/\\t}"
+    printf '%s' "$s"
+}
+
+# A slot is a live-or-dead open watcher iff it has prs.json (a tracked PR) but no
+# result.md (not yet finalized). result.md is the terminal marker.
+sessions_dir="${HOME}/.muggle-ai/muggle-do/sessions"
+stale_count=0
+if [ -d "$sessions_dir" ]; then
+    for slot in "$sessions_dir"/*/; do
+        [ -d "$slot" ] || continue
+        if [ -f "${slot}prs.json" ] && [ ! -f "${slot}result.md" ]; then
+            stale_count=$((stale_count + 1))
+        fi
+    done
+fi
+
+# Clean state: no open slots to reconcile → stay completely silent, never nudge.
+if [ "$stale_count" -eq 0 ]; then
+    exit 0
+fi
+
+if [ "$stale_count" -eq 1 ]; then
+    slot_word="slot"
+else
+    slot_word="slots"
+fi
+
+context="muggle-pr-followup: ${stale_count} open watcher ${slot_word} found (a tracked PR with no result.md). Session-only watcher crons die on session end and after the 7-day /loop expiry, so these may have no live poller. Run \`/muggle:muggle-pr-followup reconcile\` to finalize any whose PR went terminal and re-arm silently-stopped open watchers. Reconcile is idempotent — it re-arms only genuinely dead watchers and stays quiet on the rest."
+
+escaped_context=$(escape_for_json "$context")
+
+if [ -n "${CURSOR_PLUGIN_ROOT:-}" ]; then
+    printf '{\n  "additional_context": "%s"\n}\n' "$escaped_context"
+elif [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+    printf '{\n  "hookSpecificOutput": {\n    "hookEventName": "SessionStart",\n    "additionalContext": "%s"\n  }\n}\n' "$escaped_context"
+else
+    printf '{\n  "additional_context": "%s"\n}\n' "$escaped_context"
+fi
+
+exit 0

--- a/plugin/skills/muggle-pr-followup/CLAUDE.md
+++ b/plugin/skills/muggle-pr-followup/CLAUDE.md
@@ -12,7 +12,7 @@ This folder holds the watcher loop that drives one PR toward merge-ready. The wa
 - [`finalize.md`](finalize.md) — shared termination sequence for a terminal PR (mark terminal, `result.md`, log/telemetry, unschedule cron, post-merge cleanup handoff). Called by `contract.md` and `reconcile.md`.
 - [`cancel-cron.md`](cancel-cron.md) — stops this watcher's cron, recorded-id-first (survives `CronList` going blind) with a `CronList`-match fallback, plus the tool-call-not-shell guard. Referenced by `contract.md` and `finalize.md`.
 - [`record-cron-id.md`](record-cron-id.md) — the per-tick self-record that keeps this slot's cron id in `cron.json` deletable after a compaction blinds `CronList`. Referenced by `contract.md` Step 0.
-- [`reconcile.md`](reconcile.md) — sweep that finalizes slots whose PR went terminal while polling lapsed, deletes orphaned crons, and re-arms open slots whose watcher stopped silently (dropped respawn); runs at the top of auto-track and on demand.
+- [`reconcile.md`](reconcile.md) — sweep that finalizes slots whose PR went terminal while polling lapsed, deletes orphaned crons, and re-arms open slots whose watcher stopped silently (dropped respawn); runs on demand, at the top of auto-track, and nudged by a session-start hook.
 - [`state-schemas.md`](state-schemas.md) — canonical JSON shapes of session state files.
 - [`output-templates.md`](output-templates.md) — TOC of message templates; per-group files in `output-templates/`.
 

--- a/plugin/skills/muggle-pr-followup/SKILL.md
+++ b/plugin/skills/muggle-pr-followup/SKILL.md
@@ -35,6 +35,8 @@ The skill recognizes its mode by inspecting `$ARGUMENTS` and falling back to on-
 
 Auto-track runs **reconcile** first, so a no-arg invocation also finalizes any slot whose PR merged or closed while its watcher was down (expired cron, ended session) and re-arms any open slot whose watcher stopped silently (a dropped respawn). Reconcile recovers a watcher that was already running; it never seeds a first watcher for a PR — that is auto-track's / bootstrap's job.
 
+**Reconcile is also triggered at session start**, so a dead watcher gets caught without waiting for a manual sweep: a `SessionStart` hook ([`../../hooks/README.md`](../../hooks/README.md)) scans for open slots and, only when some exist, nudges the agent to run reconcile. Session-only crons die on session end and the 7-day `/loop` expiry, so without this a merged-away PR's slot could sit un-finalized indefinitely. The hook only nudges — it can't call `CronCreate` to re-arm — and stays silent when no open slot exists. See [`reconcile.md`](reconcile.md#triggers).
+
 Bootstrap accepts three optional trailing flags:
 
 - `--slug=<name>` — override the default `<repo>-pr<n>` slug

--- a/plugin/skills/muggle-pr-followup/SKILL.md
+++ b/plugin/skills/muggle-pr-followup/SKILL.md
@@ -35,7 +35,7 @@ The skill recognizes its mode by inspecting `$ARGUMENTS` and falling back to on-
 
 Auto-track runs **reconcile** first, so a no-arg invocation also finalizes any slot whose PR merged or closed while its watcher was down (expired cron, ended session) and re-arms any open slot whose watcher stopped silently (a dropped respawn). Reconcile recovers a watcher that was already running; it never seeds a first watcher for a PR — that is auto-track's / bootstrap's job.
 
-**Reconcile is also triggered at session start**, so a dead watcher gets caught without waiting for a manual sweep: a `SessionStart` hook ([`../../hooks/README.md`](../../hooks/README.md)) scans for open slots and, only when some exist, nudges the agent to run reconcile. Session-only crons die on session end and the 7-day `/loop` expiry, so without this a merged-away PR's slot could sit un-finalized indefinitely. The hook only nudges — it can't call `CronCreate` to re-arm — and stays silent when no open slot exists. See [`reconcile.md`](reconcile.md#triggers).
+**Reconcile also runs at session start** — a `SessionStart` hook ([`../../hooks/README.md`](../../hooks/README.md)) surfaces the sweep when open slots exist, catching a watcher that died with its session (end, or 7-day `/loop` expiry) before a manual sweep would. See [`reconcile.md`](reconcile.md#triggers).
 
 Bootstrap accepts three optional trailing flags:
 

--- a/plugin/skills/muggle-pr-followup/reconcile.md
+++ b/plugin/skills/muggle-pr-followup/reconcile.md
@@ -4,6 +4,16 @@ The procedure for the **reconcile mode** of `muggle-pr-followup` — a sweep tha
 
 Termination is otherwise tick-driven ([`contract.md`](contract.md) Step 2): a slot finalizes only when a tick fires and observes `MERGED` / `CLOSED`. If the tick stream stops first — the recurring `/loop` cron auto-expires after 7 days, the session ends, or the machine is off when the PR merges — no tick catches the transition, and the slot is left un-finalized: no `result.md`, no post-merge cleanup, and a surviving cron would keep polling a dead PR. Reconcile is the catch-up.
 
+## Triggers
+
+Three ways in, all running the same procedure:
+
+- **Manual** — `/muggle:muggle-pr-followup reconcile` (or `sweep`).
+- **Auto-track** — the top of a no-arg invocation ([`auto-track.md`](auto-track.md)).
+- **Session start** — the `reconcile-stale-watchers.sh` hook ([`../../hooks/README.md`](../../hooks/README.md)). It scans for open slots (a `prs.json` with no `result.md`) and nudges the agent to run this procedure **only when some exist**, staying silent otherwise. The hook can't re-arm anything itself — re-arming needs the `CronCreate` tool, which a shell hook can't call — so it only surfaces the work. This closes the gap where session-only crons die (session end, 7-day expiry) and open PRs accumulate dead watchers with nothing to notice.
+
+Recover-don't-seed holds on every trigger: a session-start run still never seeds a first watcher (see Invariants).
+
 ## Input
 
 `$ARGUMENTS` is `reconcile` (or `sweep`), optionally followed by a `<slug>` to scope the sweep to one slot.

--- a/plugin/skills/muggle-pr-followup/reconcile.md
+++ b/plugin/skills/muggle-pr-followup/reconcile.md
@@ -10,7 +10,7 @@ Three ways in, all running the same procedure:
 
 - **Manual** — `/muggle:muggle-pr-followup reconcile` (or `sweep`).
 - **Auto-track** — the top of a no-arg invocation ([`auto-track.md`](auto-track.md)).
-- **Session start** — the `reconcile-stale-watchers.sh` hook ([`../../hooks/README.md`](../../hooks/README.md)). It scans for open slots (a `prs.json` with no `result.md`) and nudges the agent to run this procedure **only when some exist**, staying silent otherwise. The hook can't re-arm anything itself — re-arming needs the `CronCreate` tool, which a shell hook can't call — so it only surfaces the work. This closes the gap where session-only crons die (session end, 7-day expiry) and open PRs accumulate dead watchers with nothing to notice.
+- **Session start** — the `reconcile-stale-watchers.sh` hook ([`../../hooks/README.md`](../../hooks/README.md)) runs this sweep, catching a watcher that died with its session (end, or 7-day `/loop` cron expiry) before its PR's merge was observed.
 
 Recover-don't-seed holds on every trigger: a session-start run still never seeds a first watcher (see Invariants).
 

--- a/src/test/skills/pr-followup-reconcile-hook.test.ts
+++ b/src/test/skills/pr-followup-reconcile-hook.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Static wiring lint for the session-start reconcile nudge. muggle-pr-followup
+ * watchers are session-only crons, so open PRs accumulate dead watchers with
+ * nothing to notice; a SessionStart hook closes that gap by nudging reconcile
+ * when open slots exist. This test locks the wiring — the hook is registered and
+ * points at the script, and the script nudges only when a non-terminal slot
+ * exists (never when clean). It reads the files; it does not run the hook.
+ */
+
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "../../..");
+const SKILL_DIR = path.join(REPO_ROOT, "plugin", "skills", "muggle-pr-followup");
+const SCRIPT = path.join(
+  REPO_ROOT,
+  "plugin",
+  "scripts",
+  "reconcile-stale-watchers.sh",
+);
+const HOOKS_JSON = path.join(REPO_ROOT, "plugin", "hooks", "hooks.json");
+const HOOKS_README = path.join(REPO_ROOT, "plugin", "hooks", "README.md");
+
+function read(p: string): string {
+  return fs.readFileSync(p, "utf8");
+}
+
+describe("pr-followup session-start reconcile nudge", () => {
+  it("the nudge script exists", () => {
+    expect(fs.existsSync(SCRIPT)).toBe(true);
+  });
+
+  const script = fs.existsSync(SCRIPT) ? read(SCRIPT) : "";
+
+  describe("hooks.json registers it as a SessionStart command", () => {
+    const hooks = JSON.parse(read(HOOKS_JSON));
+    const sessionStart = (hooks.hooks?.SessionStart ?? []) as Array<{
+      matcher?: string;
+      hooks: Array<{ command: string }>;
+    }>;
+
+    it("a SessionStart entry runs reconcile-stale-watchers.sh", () => {
+      const commands = sessionStart.flatMap((e) =>
+        e.hooks.map((h) => h.command),
+      );
+      expect(
+        commands.some((c) => c.includes("reconcile-stale-watchers.sh")),
+        "no SessionStart hook invokes reconcile-stale-watchers.sh",
+      ).toBe(true);
+    });
+
+    it("shares the startup|clear|compact matcher with the existing ensure-electron-app hook", () => {
+      const entry = sessionStart.find((e) =>
+        e.hooks.some((h) => h.command.includes("reconcile-stale-watchers.sh")),
+      );
+      expect(entry?.matcher).toBe("startup|clear|compact");
+      // Registered alongside — the existing hook must survive the addition.
+      expect(
+        entry?.hooks.some((h) =>
+          h.command.includes("ensure-electron-app.sh"),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("the script nudges reconcile, and only when a slot is non-terminal", () => {
+    it("dispatches the skill's reconcile mode", () => {
+      expect(script).toMatch(
+        /\/muggle:muggle-pr-followup\s+reconcile/,
+      );
+    });
+
+    it("scans slots under the user's home", () => {
+      expect(script).toMatch(/\$\{HOME\}/);
+      expect(script).toMatch(/muggle-do\/sessions/);
+    });
+
+    it("keys an open slot on prs.json present and result.md absent", () => {
+      expect(script).toMatch(/-f\s+[^\n]*prs\.json/);
+      expect(script).toMatch(/!\s*-f\s+[^\n]*result\.md/);
+    });
+
+    it("emits nothing when no open slot exists — the empty-state exit precedes any context emission", () => {
+      const emptyGuard = script.search(/stale_count["'}]?\s*-eq\s*0/);
+      const emit = script.indexOf("additionalContext");
+      expect(emptyGuard, "no zero-slot guard found").toBeGreaterThan(-1);
+      expect(emit, "no additionalContext emission found").toBeGreaterThan(-1);
+      expect(
+        emptyGuard,
+        "the zero-slot exit must come before any nudge is printed",
+      ).toBeLessThan(emit);
+    });
+
+    it("emits the SessionStart additionalContext contract when slots exist", () => {
+      expect(script).toMatch(/hookSpecificOutput/);
+      expect(script).toMatch(/"hookEventName":\s*"SessionStart"/);
+      expect(script).toMatch(/additionalContext/);
+    });
+
+    it("is a pure scan — no gh, no network", () => {
+      // Strip full-line comments so prose ("no gh, no writes") isn't read as a call.
+      const code = script
+        .split("\n")
+        .filter((l) => !/^\s*#/.test(l))
+        .join("\n");
+      expect(/\bgh\b/.test(code)).toBe(false);
+      expect(/\bcurl\b|\bwget\b|npm\s+view/.test(code)).toBe(false);
+    });
+  });
+
+  describe("docs reflect the new trigger", () => {
+    const reconcile = read(path.join(SKILL_DIR, "reconcile.md"));
+    const skill = read(path.join(SKILL_DIR, "SKILL.md"));
+    const readme = read(HOOKS_README);
+
+    it("reconcile.md documents the session-start trigger and keeps recover-don't-seed", () => {
+      expect(reconcile).toMatch(/session start/i);
+      expect(reconcile).toMatch(/reconcile-stale-watchers\.sh/);
+      // The invariant this feature must not weaken.
+      expect(reconcile).toMatch(/Recover,?\s*don'?t\s*seed/i);
+    });
+
+    it("SKILL.md notes reconcile is also triggered at session start", () => {
+      expect(skill).toMatch(/session start/i);
+      expect(skill).toMatch(/SessionStart|session-start hook/i);
+    });
+
+    it("hooks README documents the nudge script", () => {
+      expect(readme).toMatch(/reconcile-stale-watchers\.sh/);
+    });
+  });
+});


### PR DESCRIPTION
## Gap

`muggle-pr-followup` watchers are session-only `/loop` crons — they die on session end and after the 7-day `/loop` expiry. The skill already ships a recovery procedure, `reconcile.md`: it finalizes slots whose PR went terminal while polling lapsed, sweeps orphan crons, and re-arms open slots whose watcher stopped silently.

But reconcile had **no automatic trigger** — it ran only on a manual `/muggle:muggle-pr-followup reconcile` or a no-arg auto-track invocation. So open PRs quietly accumulated permanently-dead watchers with nothing to notice. Real evidence: 9 open PRs sat un-watched for ~7 weeks.

## Fix

A `SessionStart` hook can't invoke a skill and can't call `CronCreate` to re-arm, so the trigger is a **nudge**, not an action:

`plugin/scripts/reconcile-stale-watchers.sh` scans `~/.muggle-ai/muggle-do/sessions/*/` for **open slots** (a `prs.json` with no `result.md`). When one or more exist, it injects `additionalContext` (the same `SessionStart` contract the existing `ensure-electron-app.sh` hook uses) telling the agent to run `/muggle:muggle-pr-followup reconcile`. Reconcile then does the real work — finalizing terminal slots and re-arming genuinely-dead open watchers.

It's a pure directory scan under `${HOME}` — no `gh`, no network, no writes — cheap enough to run on every session start.

## Silent when there's nothing to do

Zero open slots → the script emits nothing and exits 0. It only ever nudges when a non-terminal slot actually exists, and reconcile itself is idempotent (re-arms only stale watchers, leaves live ones alone), so a clean workspace produces no noise.

## Changes

- **`plugin/scripts/reconcile-stale-watchers.sh`** (new) — the scan-and-nudge hook script.
- **`plugin/hooks/hooks.json`** — registers it as a second `SessionStart` command (matcher `startup|clear|compact`, `timeout: 10`), alongside the existing `ensure-electron-app.sh`.
- **`reconcile.md` / `SKILL.md` / `CLAUDE.md` / `hooks/README.md`** — document the new session-start trigger; the recover-don't-seed invariant is unchanged (a session-start run still never seeds a first watcher).
- **`src/test/skills/pr-followup-reconcile-hook.test.ts`** (new) — drift-lint: the hook is registered and points at the script; the script keys open-slot on `prs.json` present + `result.md` absent, its empty-state exit precedes any emission, it stays a pure scan, and the docs carry the trigger.

## Verification

- `npx vitest run` — 677 passed, 5 skipped (full suite).
- `node scripts/check-skill-deps.mjs` — OK, no reverse dependencies.
- Functional smoke of the script: 11 real open slots → nudge emitted; clean `HOME` and all-terminal slots → silent (exit 0, no output); singular/plural wording correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
