### PR TITLE
fix(pr-followup): key rebase dedup on head+base pair

### DIFF
--- a/plugin/skills/_shared/session-state-writes.md
+++ b/plugin/skills/_shared/session-state-writes.md
@@ -18,5 +18,5 @@ If you script the rewrite instead of using the Write tool, any tool that replace
 
 ## Field map
 
-- `last_seen.json` — one object keyed by `"<owner>/<repo>#<n>"`. Mutate fields under that key: `idle_tick_count`, `cycles_completed` (counters), `last_pushed_sha`, `lastBodyReviewId` (scalars), `pushed_shas`, `escalated_review_ids`, `ci_escalated_shas`, `conflict_escalated_shas` (arrays), `ci_fix_attempts[<sha>]`, `conflict_resolve_attempts[<sha>]` (per-SHA maps).
+- `last_seen.json` — one object keyed by `"<owner>/<repo>#<n>"`. Mutate fields under that key: `idle_tick_count`, `cycles_completed` (counters), `last_pushed_sha`, `lastBodyReviewId` (scalars), `pushed_shas`, `escalated_review_ids`, `ci_escalated_shas`, `conflict_escalated_keys` (arrays), `ci_fix_attempts[<sha>]` (keyed by head SHA), `conflict_resolve_attempts[<head-sha>..<base-tip-sha>]` (keyed by the head/base-tip pair).
 - `prs.json` — a one-element array. Mutate `[0]`: `head_sha`, `state`.

--- a/plugin/skills/_shared/telemetry-events/muggle-do-cycle.md
+++ b/plugin/skills/_shared/telemetry-events/muggle-do-cycle.md
@@ -30,6 +30,6 @@ One per address-reviews invocation, regardless of outcome.
 - `"ci-fixed"` — a watcher-dispatched fix-ci cycle pushed a fix for one or more red checks.
 - `"ci-escalated"` — fix-ci exhausted its 3 attempts for the SHA or the failing checks were out of scope; the SHA was added to `ci_escalated_shas`. No further auto-fix on it.
 - `"rebased"` — a watcher-dispatched rebase cycle rebased the branch onto its base (behind-only or conflicts resolved), verified, and force-pushed.
-- `"rebase-escalated"` — the rebase couldn't be completed (a conflict under `autoResolveConflicts=never`, verification failed, or the 2-attempt budget for the SHA was spent); the SHA was added to `conflict_escalated_shas`. No further auto-rebase on it.
+- `"rebase-escalated"` — the rebase couldn't be completed (a conflict under `autoResolveConflicts=never`, verification failed, or the 2-attempt budget for the head/base-tip pair was spent); the pair was added to `conflict_escalated_keys`. No further auto-rebase until either side moves.
 
 For fix-ci cycles (`ci-fixed` / `ci-escalated`) the `review_ids_*` arrays are empty and the `ci_checks_*` arrays carry the data: `ci_checks_in` (red checks dispatched), `ci_checks_fixed` (made green and pushed), `ci_checks_escalated` (out-of-scope or unresolved). For rebase cycles (`rebased` / `rebase-escalated`) all the `review_ids_*` and `ci_checks_*` arrays are empty; the SHA fields carry the before/after of the rebase.

--- a/plugin/skills/do/resolve-conflicts.md
+++ b/plugin/skills/do/resolve-conflicts.md
@@ -14,13 +14,13 @@ Rebase a PR's branch onto its base — whether it's merely **behind** (out of da
 
 ## Inputs from disk
 
-From `~/.muggle-ai/muggle-do/sessions/<slug>/`: `prs.json` (PR + branch + `head_sha`), `last_seen.json` (`conflict_resolve_attempts`, `conflict_escalated_shas`, `pushed_shas`), `state.md` (worktree path, validation strategy, base branch).
+From `~/.muggle-ai/muggle-do/sessions/<slug>/`: `prs.json` (PR + branch + `head_sha`), `last_seen.json` (`conflict_resolve_attempts`, `conflict_escalated_keys`, `pushed_shas`), `state.md` (worktree path, validation strategy, base branch).
 
 ## Procedure
 
 ### Step 1 — Re-attach
 
-Materialize the PR branch in its worktree per [`../_shared/pr-branch-worktree.md`](../_shared/pr-branch-worktree.md) (or use `state.md`'s `worktreePath`). Capture `rebase_sha = prs.json[0].head_sha` and the base branch (`baseRefName` from [`../_shared/vcs/github/pr-metadata.md`](../_shared/vcs/github/pr-metadata.md)).
+Materialize the PR branch in its worktree per [`../_shared/pr-branch-worktree.md`](../_shared/pr-branch-worktree.md) (or use `state.md`'s `worktreePath`). Capture `rebase_sha = prs.json[0].head_sha` and the base branch (`baseRefName` from [`../_shared/vcs/github/pr-metadata.md`](../_shared/vcs/github/pr-metadata.md)). Capture the base tip too — `.base_commit.sha` from that recipe's `compare` call — and form `rebase_key = "<rebase_sha>..<base_tip_sha>"`. Both budget fields below are keyed on that pair, matching the watcher's Step 5; writing a bare SHA instead leaves an entry the watcher ignores, and the rebase re-dispatches forever.
 
 ### Step 2 — Rebase onto base (resolve conflicts if any)
 
@@ -37,13 +37,13 @@ Build (typecheck + lint on the changed surface) + unit suite must pass. Run E2E 
 
 ### Step 4 — Force-push + respawn
 
-Push with `--force-with-lease` (the rebase rewrote history). Append the new SHA to `last_seen.pushed_shas`; increment `last_seen.conflict_resolve_attempts[rebase_sha]` — both whole-file rewrites (Read → change field → Write) per [`../_shared/session-state-writes.md`](../_shared/session-state-writes.md), never the Edit tool. Respawn the watcher per [`respawn-watcher.md`](respawn-watcher.md). Its next tick re-checks the branch against its base on the new head — the rebase is its own verify loop, bounded by the per-SHA attempt budget.
+Push with `--force-with-lease` (the rebase rewrote history). Append the new SHA to `last_seen.pushed_shas`; increment `last_seen.conflict_resolve_attempts[rebase_key]` — both whole-file rewrites (Read → change field → Write) per [`../_shared/session-state-writes.md`](../_shared/session-state-writes.md), never the Edit tool. Respawn the watcher per [`respawn-watcher.md`](respawn-watcher.md). Its next tick re-checks the branch against its base on the new head — the rebase is its own verify loop, bounded by the per-SHA attempt budget.
 
 ### Step 5 — Escalate (can't resolve / budget spent)
 
-When `autoResolveConflicts=never`, the resolution failed verification, or `conflict_resolve_attempts[rebase_sha]` has reached 2:
+When `autoResolveConflicts=never`, the resolution failed verification, or `conflict_resolve_attempts[rebase_key]` has reached 2:
 
-1. Add `rebase_sha` to `last_seen.conflict_escalated_shas` so the watcher does not re-dispatch this SHA.
+1. Add `rebase_key` to `last_seen.conflict_escalated_keys` so the watcher does not re-dispatch this head against this base. If the base later moves, the key changes and the branch re-arms on its own — a conflict the user resolved upstream stops being this watcher's dead end.
 2. Emit one terminal escalation naming the PR and the conflicting files (or the failing verification, for a behind-only rebase that didn't verify).
 3. Respawn the watcher per [`respawn-watcher.md`](respawn-watcher.md) — it keeps polling for the user's manual resolution or any new reviews.
 

--- a/plugin/skills/muggle-pr-followup/contract.md
+++ b/plugin/skills/muggle-pr-followup/contract.md
@@ -37,7 +37,7 @@ Otherwise, self-record this watcher's cron id per [`record-cron-id.md`](record-c
 
 ### Step 1 — Refresh PR state
 
-Per [`../_shared/vcs/github/pr-metadata.md`](../_shared/vcs/github/pr-metadata.md). Update `prs.json[0].head_sha` and `prs.json[0].state` from the response; keep `mergeable` (conflict signal) for Step 5, and run the recipe's `compare` call to capture `behind_by` (out-of-date signal) for Step 5.
+Per [`../_shared/vcs/github/pr-metadata.md`](../_shared/vcs/github/pr-metadata.md). Update `prs.json[0].head_sha` and `prs.json[0].state` from the response; keep `mergeable` (conflict signal) for Step 5, and run the recipe's `compare` call to capture both `behind_by` (out-of-date signal) and `.base_commit.sha` — the base branch tip, Step 5's `base_tip_sha`.
 
 ### Step 2 — Termination check
 
@@ -102,7 +102,11 @@ A merge-ready branch is **current with its base** — neither conflicting nor be
 
 This trigger is **independent of approval and CI state**: an out-of-date branch is rebased whether or not it has been reviewed, approved, or has green checks. The watcher acts on staleness directly — it never waits for an approval to surface it.
 
-If a rebase is due **and** `conflict_resolve_attempts[head_sha] < 2` **and** `head_sha` ∉ `conflict_escalated_shas` → dispatch and exit:
+Rebase dedup is keyed on the **pair** `rebase_key = "<head_sha>..<base_tip_sha>"`, not on the head alone. Whether a branch conflicts is a function of both sides, so a head-only key wedges a PR permanently the first time the base moves: the head cannot change while nobody pushes, so one stale entry suppresses every genuinely new conflict that base movement introduces, forever. Take `base_tip_sha` from the Step 1 compare's `.base_commit.sha` (the base branch tip, which advances when the base does) — **never** `.merge_base_commit.sha`, which does not move when only the base advances and so would never re-arm.
+
+Entries written by an older watcher are bare head SHAs with no `..` — ignore them when reading `conflict_escalated_keys`, which re-arms any slot a head-only key had wedged.
+
+If a rebase is due **and** `conflict_resolve_attempts[rebase_key] < 2` **and** `rebase_key` ∉ `conflict_escalated_keys` → dispatch and exit:
 
   1. Reset `last_seen.idle_tick_count` to 0.
   2. **Stop this watcher (single-thread):** cancel its cron exactly as in Step 4 — `/muggle-do`'s rebase respawns it when the cycle is done.
@@ -114,7 +118,7 @@ If a rebase is due **and** `conflict_resolve_attempts[head_sha] < 2` **and** `he
   4. Append a dispatching line to `followup.log`; emit a `tick` event with `rebase_needed: true`, `dispatched_rebase: true`.
   5. Exit. The dev cycle owns the PR; its respawn restarts the watcher, whose next tick re-checks the branch against its base on the new head — the rebase is its own verify loop, bounded by the per-SHA attempt budget.
 
-Otherwise — `behind_by == 0` and not conflicting (`mergeable == UNKNOWN` is fine here: `behind_by` is exact while GitHub is still computing conflict state, so a stale branch still triggers), or budget spent (`conflict_resolve_attempts[head_sha] >= 2` or `head_sha` ∈ `conflict_escalated_shas`) → fall through to CI.
+Otherwise — `behind_by == 0` and not conflicting (`mergeable == UNKNOWN` is fine here: `behind_by` is exact while GitHub is still computing conflict state, so a stale branch still triggers), or budget spent (`conflict_resolve_attempts[rebase_key] >= 2` or `rebase_key` ∈ `conflict_escalated_keys`) → fall through to CI.
 
 ### Step 6 — No actionable feedback, branch current → poll CI for the head SHA
 
@@ -137,7 +141,7 @@ Fetch the CI rollup for `prs.json[0].head_sha`, provider resolved as in Step 3 �
 
 Any idle branch (Steps 4–6 that did not dispatch). First classify **why** this tick idled. It is **blocked pending a human** when the head is under a durable block that only the user can clear:
 
-- `head_sha` ∈ `conflict_escalated_shas` — a rebase `/muggle-do` gave up on (a semantic conflict, or `autoResolveConflicts=never`), reason `conflict_escalated`; or
+- `rebase_key` ∈ `conflict_escalated_keys` — a rebase `/muggle-do` gave up on (a semantic conflict, or `autoResolveConflicts=never`), reason `conflict_escalated`. This block clears on its own when the base moves: the new `base_tip_sha` yields a key the set does not contain, and the branch re-arms for a fresh rebase attempt; or
 - `head_sha` ∈ `ci_escalated_shas` — CI the fix-ci stage gave up on, reason `ci_escalated`; or
 - `last_seen.escalated_review_ids` is non-empty with the actionable set empty — an ambiguous review awaiting the user's direction, reason `reviews_escalated`.
 

--- a/plugin/skills/muggle-pr-followup/state-schemas.md
+++ b/plugin/skills/muggle-pr-followup/state-schemas.md
@@ -62,8 +62,8 @@ Keyed by `"<owner>/<repo>#<n>"`. One key per PR in the slot.
     "pushed_shas": ["<sha>", ...],
     "ci_fix_attempts": { "<sha>": <int> },
     "ci_escalated_shas": ["<sha>", ...],
-    "conflict_resolve_attempts": { "<sha>": <int> },
-    "conflict_escalated_shas": ["<sha>", ...],
+    "conflict_resolve_attempts": { "<head-sha>..<base-tip-sha>": <int> },
+    "conflict_escalated_keys": ["<head-sha>..<base-tip-sha>", ...],
     "blocked": {
       "reason": "conflict_escalated" | "ci_escalated" | "reviews_escalated",
       "since": "<ISO-8601>",
@@ -85,10 +85,14 @@ Keyed by `"<owner>/<repo>#<n>"`. One key per PR in the slot.
 - `pushed_shas`: every SHA `/muggle-do` has pushed for this PR. Append-only. Used by the resolve-reminder stage to recognize threads addressed by the loop.
 - `ci_fix_attempts`: per-SHA count of fix-ci cycles `/muggle-do` has run. The watcher stops dispatching fix-ci for a SHA once its count reaches 3. Keyed by head SHA.
 - `ci_escalated_shas`: head SHAs whose CI the fix-ci stage gave up on (attempts exhausted or only out-of-scope checks). The watcher excludes these from CI dispatch so a hopeless SHA is never re-fixed.
-- `conflict_resolve_attempts`: per-SHA count of rebase cycles `/muggle-do` has run for this SHA (behind-only or conflicting — both rebase onto the base). The watcher stops dispatching a rebase for a SHA once its count reaches 2. Keyed by head SHA. A clean behind-only rebase produces a new SHA, so the cap only bites a SHA that keeps failing to rebase-and-verify.
-- `conflict_escalated_shas`: head SHAs whose rebase `/muggle-do` gave up on (attempts exhausted, or a conflict under `autoResolveConflicts=never`). The watcher excludes these from rebase dispatch so a hopeless SHA is never re-attempted.
+- `conflict_resolve_attempts`: count of rebase cycles `/muggle-do` has run (behind-only or conflicting — both rebase onto the base). The watcher stops dispatching once a key's count reaches 2. Keyed by `rebase_key` — `"<head_sha>..<base_tip_sha>"`, the head paired with the base branch tip it was measured against.
+- `conflict_escalated_keys`: `rebase_key`s whose rebase `/muggle-do` gave up on (attempts exhausted, or a conflict under `autoResolveConflicts=never`). The watcher excludes these from rebase dispatch so a hopeless pairing is never re-attempted.
+
+Both are keyed on the pair, not the head alone, because whether a branch conflicts depends on both sides. Under a head-only key, a base that moves produces a genuinely new conflict against an unchanged head — and the stale entry suppresses it permanently, because nothing can change the head while the branch sits blocked. Pairing re-arms the budget whenever either side moves. Legacy entries written before this change are bare SHAs with no `..`; readers ignore them, which un-wedges any slot they had blocked.
+
+Unlike these, `ci_fix_attempts` / `ci_escalated_shas` stay keyed on the head SHA alone — a CI result is a function of the head only, so base movement must not re-arm them.
 - `blocked`: present only while the watcher is **awaiting the owner** on a PR that cannot progress without a human ([`contract.md`](contract.md) Step 7). Absent ⇒ the watcher is in its normal dispatch flow. When present, the watcher **keeps the normal `1m` cadence** and each tick is a reminder-or-resume check ([`contract.md`](contract.md) Step 2.5): it re-emits a one-line reminder to the owner, recomputes the `fingerprint`, and clears the block the moment any component moves. Its value is the reason-specific reminder plus fingerprint auto-resume.
-  - `reason`: which durable block is being awaited — `conflict_escalated` (`head_sha` ∈ `conflict_escalated_shas`), `ci_escalated` (`head_sha` ∈ `ci_escalated_shas`), or `reviews_escalated` (a review sits in `escalated_review_ids` awaiting the user, actionable set empty). Selects the reminder wording; the resume decision is fingerprint-driven, not reason-driven.
+  - `reason`: which durable block is being awaited — `conflict_escalated` (`rebase_key` ∈ `conflict_escalated_keys`), `ci_escalated` (`head_sha` ∈ `ci_escalated_shas`), or `reviews_escalated` (a review sits in `escalated_review_ids` awaiting the user, actionable set empty). Selects the reminder wording; the resume decision is fingerprint-driven, not reason-driven.
   - `since`: when the block was first flagged — lets the reminder state how long the owner has been the blocker.
   - `fingerprint`: the external state the block is waiting on. `head_sha` moves on a new push (which also clears the per-SHA escalation sets, keyed by SHA); `latest_review_id` is `max(id)` over submitted reviews and moves when a reviewer submits anything new; `ci_digest` is a stable digest of the head SHA's CI rollup (bucket + each check's name/conclusion, sorted) and moves when a check flips, a rerun lands, or an external check such as a staging deploy posts. Any change clears the block and resumes evaluation.
 

--- a/src/test/skills/pr-followup-conflict-dedup-key.test.ts
+++ b/src/test/skills/pr-followup-conflict-dedup-key.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Static lint for the muggle-pr-followup watcher's rebase dedup key.
+ *
+ * Whether a branch conflicts is a function of both sides — head and base.
+ * An earlier contract deduped rebase dispatch on the head SHA alone, which
+ * wedges a PR permanently the first time the base moves: the new conflict is
+ * real, but the stale entry suppresses it, and nothing can change the head
+ * while the branch sits blocked. Observed on muggle-ai-prompt-service#674,
+ * which idled ~1000 ticks against a conflict no tick would ever dispatch.
+ *
+ * The fix keys rebase dedup on `rebase_key = "<head_sha>..<base_tip_sha>"`
+ * while leaving CI dedup on the head alone (a CI result really is a function
+ * of the head). These samples pin both halves. They check the contract text,
+ * so they catch an edit that reintroduces the head-only key; they do NOT
+ * catch an agent that reads the contract correctly and ignores it.
+ */
+
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "../../..");
+const SKILLS_DIR = path.join(REPO_ROOT, "plugin", "skills");
+const WATCHER_DIR = path.join(SKILLS_DIR, "muggle-pr-followup");
+
+const contract = fs.readFileSync(path.join(WATCHER_DIR, "contract.md"), "utf8");
+const schemas = fs.readFileSync(
+  path.join(WATCHER_DIR, "state-schemas.md"),
+  "utf8",
+);
+const resolveConflicts = fs.readFileSync(
+  path.join(SKILLS_DIR, "do", "resolve-conflicts.md"),
+  "utf8",
+);
+
+function markdownFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...markdownFiles(full));
+    else if (entry.name.endsWith(".md")) out.push(full);
+  }
+  return out;
+}
+
+interface Sample {
+  name: string;
+  check: () => void;
+}
+
+const samples: Sample[] = [
+  {
+    name: "1. the rebase guard keys on the pair, never the bare head",
+    check: () => {
+      expect(contract).toMatch(/conflict_resolve_attempts\[rebase_key\]\s*<\s*2/);
+      expect(contract).toMatch(/rebase_key`?\s*∉\s*`?conflict_escalated_keys/);
+      expect(
+        /conflict_resolve_attempts\[head_sha\]/.test(contract),
+        "head-only rebase budget is the #674 regression",
+      ).toBe(false);
+    },
+  },
+  {
+    name: "2. rebase_key is defined as head..base_tip",
+    check: () => {
+      expect(contract).toMatch(
+        /rebase_key\s*=\s*"?<head_sha>\.\.<base_tip_sha>"?/,
+      );
+    },
+  },
+  {
+    name: "3. Step 1 captures the base tip from the compare",
+    check: () => {
+      const step1 = contract.slice(
+        contract.indexOf("### Step 1"),
+        contract.indexOf("### Step 2"),
+      );
+      expect(step1).toMatch(/\.base_commit\.sha/);
+      expect(step1).toMatch(/base_tip_sha/);
+    },
+  },
+  {
+    name: "4. the contract rules out .merge_base_commit.sha as the key source",
+    check: () => {
+      expect(contract).toMatch(/merge_base_commit\.sha/);
+      const sentence = contract
+        .split("\n")
+        .find((l) => l.includes("merge_base_commit.sha"));
+      expect(sentence).toMatch(/never|not/i);
+    },
+  },
+  {
+    name: "5. the budget-spent fall-through uses the same key as the trigger",
+    check: () => {
+      expect(contract).toMatch(
+        /conflict_resolve_attempts\[rebase_key\]\s*>=\s*2/,
+      );
+      expect(contract).toMatch(/rebase_key`?\s*∈\s*`?conflict_escalated_keys/);
+    },
+  },
+  {
+    name: "6. NEGATIVE — CI dedup stays keyed on the head alone",
+    check: () => {
+      expect(contract).toMatch(/ci_fix_attempts\[head_sha\]/);
+      expect(contract).toMatch(/head_sha`?\s*∉\s*`?ci_escalated_shas/);
+      expect(
+        /ci_fix_attempts\[rebase_key\]|ci_escalated_keys/.test(contract),
+        "CI is a function of the head only — base movement must not re-arm it",
+      ).toBe(false);
+    },
+  },
+  {
+    name: "7. the schema documents the composite key shape",
+    check: () => {
+      expect(schemas).toMatch(/conflict_escalated_keys/);
+      expect(schemas).toMatch(
+        /conflict_resolve_attempts.*<head-sha>\.\.<base-tip-sha>/,
+      );
+      expect(schemas).toMatch(/ci_fix_attempts.*<sha>/);
+    },
+  },
+  {
+    name: "8. the superseded head-only rationale is gone",
+    check: () => {
+      expect(
+        /A clean behind-only rebase produces a new SHA/.test(schemas),
+        "this sentence justified the head-only key by assuming the head always moves",
+      ).toBe(false);
+    },
+  },
+  {
+    name: "9. the contract explains why the pair is required",
+    check: () => {
+      expect(contract).toMatch(/base\b[^.]{0,60}\bmoves?\b/i);
+      expect(contract).toMatch(/wedge|permanent|forever/i);
+    },
+  },
+  {
+    name: "10. legacy bare-SHA entries are explicitly ignored",
+    check: () => {
+      expect(contract).toMatch(/no\s+`?\.\.`?|bare head SHAs?/i);
+      expect(contract).toMatch(/ignore/i);
+    },
+  },
+  {
+    name: "11. the writer records the same composite key the watcher reads",
+    check: () => {
+      expect(resolveConflicts).toMatch(
+        /rebase_key\s*=\s*"?<rebase_sha>\.\.<base_tip_sha>"?/,
+      );
+      expect(resolveConflicts).toMatch(
+        /conflict_resolve_attempts\[rebase_key\]/,
+      );
+      expect(resolveConflicts).toMatch(/conflict_escalated_keys/);
+      expect(
+        /conflict_escalated_shas/.test(resolveConflicts),
+        "a bare SHA here writes an entry the watcher ignores — rebase re-dispatches forever",
+      ).toBe(false);
+    },
+  },
+];
+
+describe("muggle-pr-followup rebase dedup key", () => {
+  for (const sample of samples) {
+    it(sample.name, sample.check);
+  }
+
+  it("no skill file still names the head-only escalation set", () => {
+    const offenders = markdownFiles(SKILLS_DIR).filter((file) =>
+      /conflict_escalated_shas/.test(fs.readFileSync(file, "utf8")),
+    );
+    expect(
+      offenders.map((f) => path.relative(REPO_ROOT, f)),
+      "conflict_escalated_shas was renamed to conflict_escalated_keys",
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
A merge conflict is a function of both sides — head and base — but the watcher deduped rebase dispatch on the head SHA alone:

```
conflict_resolve_attempts[head_sha] < 2  and  head_sha ∉ conflict_escalated_shas
```

The first time the base moves, the resulting conflict is genuinely new, but the stale head-keyed entry suppresses it. Nothing can change the head while the branch sits blocked, so the PR wedges permanently.

Observed on `muggle-ai-prompt-service#674`: it idled ~1000 ticks against a conflict no tick would ever dispatch, after #675 merging moved `main` underneath it.

## Fix

Rebase dedup keys on the pair `rebase_key = "<head_sha>..<base_tip_sha>"`. The base tip comes from the `compare` call Step 1 already runs, so it costs no extra API request.

`.base_commit.sha` is the correct source — it is the base branch tip and advances when the base does. `.merge_base_commit.sha` does **not** move when only the base advances, so keying on it would never re-arm. The contract now says so explicitly, because that is the subtle way a future edit gets this wrong.

CI dedup deliberately stays head-keyed (`ci_fix_attempts[head_sha]`, `ci_escalated_shas`) — a CI result really is a function of the head, and base movement must not re-arm it. Sample 6 is a negative test pinning that asymmetry.

The writer side (`do/resolve-conflicts.md`) moves in lockstep. A bare SHA written there would leave an entry the reader ignores, re-dispatching the rebase forever.

Legacy bare-SHA entries (no `..`) are ignored on read, which un-wedges slots the old key had blocked — including #674.

## Evals

`src/test/skills/pr-followup-conflict-dedup-key.test.ts` — 11 samples plus a repo-wide sweep for the retired field name, following the sibling `pr-followup-cron-guard.test.ts` pattern. Layer 1 (vitest), so it is already blocking in `ci.yml` on every commit.

Verified the samples fail against the pre-fix contract rather than merely passing after it: restoring the old `contract.md` turns 8 of 12 red, including the sweep. The 4 that stay green cover the schema, writer, and CI-negative — untouched by that revert.

Full suite: 52 files, 689 passed / 5 skipped.

## Layer 2 gap

These samples check contract text, so they catch an edit that reintroduces the head-only key; they do **not** catch an agent that reads the contract correctly and ignores it.

The behavioral harness (`internal/skill-gate-eval`) cannot express this case as it stands. Its `Scenario` type is preference-gate shaped — `preferences` → whether `AskQuestion` fired → `executeTool`/`executeArgs`. This bug is a watcher state-machine decision (dispatch vs idle on `(head, base)`) with no `AskQuestion` and no muggle execute tool. Covering it at Layer 2 needs a new expectation kind, which is a larger change than this fix.
