### PR TITLE
test(pr-followup): lock the tick decision branches; add tick-decision evals

### DIFF
--- a/plugin/skills/muggle-pr-followup/evals/evals.json
+++ b/plugin/skills/muggle-pr-followup/evals/evals.json
@@ -1,0 +1,89 @@
+{
+  "skill_name": "muggle-pr-followup",
+  "notes": "These evals test the TICK DECISION behavior. A real tick needs live GitHub state and the Cron tools, so each prompt hands the model a concrete slot + provider state and asks for the step-by-step plan it would execute; assertions check the plan takes the branch the contract mandates. Run via skill-creator's eval runner — CI does not execute these (ci.yml gates on vitest/check-skill-deps; skill-eval.yml runs gate scenarios sourced from muggle-ai-brain and the routing eval).",
+  "evals": [
+    {
+      "id": 0,
+      "eval_name": "actionable-threads-dispatch-address-reviews",
+      "prompt": "Tick muggle-ai-works-pr500 500. The slot is open. The PR has two unresolved, not-outdated review threads whose newest comments are from a human (no muggle-do:bot marker), CI is fully green, and the branch is level with master. Walk me through the plan for this tick.",
+      "files": [],
+      "assertions": [
+        { "name": "computes_actionable_from_live_thread_state", "text": "Plan derives the actionable set from current unresolved-thread state, not from a stored review-id cursor." },
+        { "name": "classifies_by_loop_marker", "text": "Plan decides a thread is actionable by the absence of the muggle-do:bot marker on the newest comment, never by author login." },
+        { "name": "cancels_own_cron_before_dispatch", "text": "Plan cancels this watcher's own cron before dispatching, so no tick overlaps the running cycle." },
+        { "name": "dispatches_address_reviews", "text": "Plan dispatches /muggle-do with an address-reviews directive carrying the PR URL, slug, and owning review ids, then exits." },
+        { "name": "stays_a_dumb_pipe", "text": "Plan does NOT classify reviews, post replies, resolve threads, or escalate — those belong to /muggle-do." }
+      ]
+    },
+    {
+      "id": 1,
+      "eval_name": "reviews-preempt-ci",
+      "prompt": "Tick muggle-ai-works-pr501 501. The slot is open. There is one unresolved human review thread AND two red required checks on the head SHA. Walk me through the plan for this tick.",
+      "files": [],
+      "assertions": [
+        { "name": "dispatches_address_reviews_only", "text": "Plan dispatches address-reviews for the review thread." },
+        { "name": "does_not_poll_or_dispatch_ci", "text": "Plan does NOT dispatch fix-ci on this tick — actionable feedback preempts the CI branch entirely." },
+        { "name": "single_dispatch_then_exit", "text": "Plan performs exactly one dispatch and exits rather than handling both concerns in one tick." }
+      ]
+    },
+    {
+      "id": 2,
+      "eval_name": "behind-branch-dispatches-rebase",
+      "prompt": "Tick muggle-ai-works-pr502 502. The slot is open, there are no unresolved review threads, CI is green. GitHub reports mergeStateStatus BLOCKED and mergeable MERGEABLE, and the compare call shows behind_by 4. Walk me through the plan for this tick.",
+      "files": [],
+      "assertions": [
+        { "name": "reads_staleness_from_compare", "text": "Plan determines the branch is out of date from behind_by on the compare call (commit ancestry)." },
+        { "name": "does_not_trust_mergeStateStatus", "text": "Plan does NOT conclude the branch is current just because mergeStateStatus reads BLOCKED rather than BEHIND." },
+        { "name": "dispatches_rebase", "text": "Plan dispatches /muggle-do with a rebase directive (PR URL + slug, no review ids, no check names)." },
+        { "name": "keys_dedup_on_head_and_base_pair", "text": "Plan keys the rebase attempt/escalation lookup on the head..base_tip pair, not the head SHA alone." }
+      ]
+    },
+    {
+      "id": 3,
+      "eval_name": "red-ci-within-budget-dispatches-fix-ci",
+      "prompt": "Tick muggle-ai-works-pr503 503. The slot is open, no unresolved review threads, branch is level with its base. Two checks are red on the head SHA. ci_fix_attempts for that SHA is 1 and the SHA is not in ci_escalated_shas. Walk me through the plan for this tick.",
+      "files": [],
+      "assertions": [
+        { "name": "checks_attempt_budget", "text": "Plan verifies ci_fix_attempts for the head SHA is under the cap of 3 before dispatching." },
+        { "name": "checks_escalated_set", "text": "Plan verifies the head SHA is not in ci_escalated_shas." },
+        { "name": "dispatches_fix_ci_with_check_names", "text": "Plan dispatches /muggle-do with a fix-ci directive carrying the red check names." },
+        { "name": "cancels_own_cron_before_dispatch", "text": "Plan cancels this watcher's cron before dispatching." }
+      ]
+    },
+    {
+      "id": 4,
+      "eval_name": "red-ci-over-budget-idles",
+      "prompt": "Tick muggle-ai-works-pr504 504. The slot is open, no unresolved review threads, branch is level with its base. Three checks are red on the head SHA, ci_fix_attempts for that SHA is 3, and the SHA is in ci_escalated_shas. Walk me through the plan for this tick.",
+      "files": [],
+      "assertions": [
+        { "name": "does_not_dispatch", "text": "Plan does NOT dispatch fix-ci — the budget is spent and the SHA is already escalated." },
+        { "name": "treats_as_durable_block", "text": "Plan classifies this idle as blocked pending a human (reason ci_escalated), not as a transient idle." },
+        { "name": "reminds_owner_at_1m", "text": "Plan emits a one-line owner reminder and keeps the normal 1m cadence — it does not back off, slow down, or stop polling." },
+        { "name": "no_pr_side_post", "text": "Plan does NOT post anything to the PR for a blocked tick; the reminder goes to the loop owner in-session." }
+      ]
+    },
+    {
+      "id": 5,
+      "eval_name": "merged-pr-finalizes-without-respawn",
+      "prompt": "Tick muggle-ai-works-pr505 505. Refreshing the PR shows state MERGED. The slot on disk still says open. Walk me through the plan for this tick.",
+      "files": [],
+      "assertions": [
+        { "name": "finalizes_the_slot", "text": "Plan finalizes the slot: marks it terminal, writes result.md, logs, and unschedules this watcher's cron." },
+        { "name": "does_not_respawn", "text": "Plan does NOT respawn or re-arm a watcher — a terminal PR needs none." },
+        { "name": "hands_off_terminal_wrapup", "text": "Plan hands the terminal wrap-up to /muggle-do post-merge cleanup as the turn's last action." },
+        { "name": "unschedules_recorded_id_first", "text": "Plan cancels the cron by the id recorded in cron.json first, falling back to a CronList match — so teardown works even after CronList has gone blind." }
+      ]
+    },
+    {
+      "id": 6,
+      "eval_name": "stale-queued-fire-does-not-refinalize",
+      "prompt": "Tick muggle-ai-works-pr506 506. Reading the slot, prs.json already records state merged and result.md exists — this fire was queued before the cron was cancelled. Walk me through the plan for this tick.",
+      "files": [],
+      "assertions": [
+        { "name": "detects_stale_fire", "text": "Plan recognises this as a stale queued fire from the on-disk terminal state before fetching anything." },
+        { "name": "does_not_refetch_or_refinalize", "text": "Plan does NOT re-fetch the PR, re-write result.md, or re-run the terminal handoff." },
+        { "name": "defensively_cancels_and_logs", "text": "Plan defensively cancels any lingering cron for the slug and appends a stale-tick line to followup.log, then exits." }
+      ]
+    }
+  ]
+}

--- a/src/test/skills/pr-followup-tick-decisions.test.ts
+++ b/src/test/skills/pr-followup-tick-decisions.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Static lint for the muggle-pr-followup tick's decision branches.
+ *
+ * The watcher decides, every minute, whether to dispatch or idle. Each branch
+ * below encodes a failure the loop already hit in production — a stale PR going
+ * unseen because GitHub masks BEHIND, a hopeless SHA re-dispatched forever, a
+ * queued fire re-finalizing a torn-down slot, a recorded cron id overwritten
+ * with null once CronList went blind, a counter silently dropped by the Edit
+ * tool. Prose is the implementation here, so these assert the procedure still
+ * says the load-bearing thing; they do NOT catch an agent that ignores the doc.
+ *
+ * Deliberately disjoint from the existing suites: rebase dedup keying lives in
+ * pr-followup-conflict-dedup-key, cron-cancel wording in pr-followup-cron-guard,
+ * blocked/respawn wiring in pr-followup-blocked-cron-lint.
+ */
+
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "../../..");
+const WATCHER_DIR = path.join(
+  REPO_ROOT,
+  "plugin",
+  "skills",
+  "muggle-pr-followup",
+);
+
+function read(name: string): string {
+  return fs.readFileSync(path.join(WATCHER_DIR, name), "utf8");
+}
+
+/** Slice a markdown heading's body so an assertion can't match text from a different step. */
+function section(md: string, startHeading: RegExp, endHeading: RegExp): string {
+  const start = md.search(startHeading);
+  if (start === -1) return "";
+  const rest = md.slice(start);
+  const end = rest.slice(1).search(endHeading);
+  return end === -1 ? rest : rest.slice(0, end + 1);
+}
+
+const contract = read("contract.md");
+const step0 = section(contract, /^### Step 0\b/m, /^### Step 1\b/m);
+const step5 = section(contract, /^### Step 5\b/m, /^### Step 6\b/m);
+const step6 = section(contract, /^### Step 6\b/m, /^### Step 7\b/m);
+const writingState = section(contract, /^## Writing state\b/m, /^## Procedure\b/m);
+
+describe("parser sanity: refuse to pass vacuously", () => {
+  it("every contract section this suite reads was actually found", () => {
+    const missing = Object.entries({ step0, step5, step6, writingState })
+      .filter(([, body]) => body.trim().length === 0)
+      .map(([name]) => name);
+    expect(
+      missing,
+      `contract.md headings moved or were renamed, so these assertions would pass against empty strings: ${missing.join(", ")}`,
+    ).toEqual([]);
+  });
+});
+
+describe("Step 5 — staleness is read from commit ancestry, never mergeStateStatus", () => {
+  it("keys out-of-date on behind_by from the compare call", () => {
+    expect(/behind_by/.test(step5)).toBe(true);
+    expect(/compare/i.test(step5)).toBe(true);
+  });
+
+  it("explicitly forbids mergeStateStatus == BEHIND as the source", () => {
+    expect(
+      /never\W{0,4}from\W{0,3}mergeStateStatus\s*==\s*BEHIND/i.test(step5),
+      "the never-use-mergeStateStatus rule is what stops a stale PR going unseen — GitHub reports BLOCKED instead of BEHIND once a PR also awaits review or has a red check",
+    ).toBe(true);
+  });
+
+  it("keeps the rationale so the rule is not mistaken for style", () => {
+    expect(/masks\s*`?BEHIND`?\s*behind/i.test(step5)).toBe(true);
+  });
+});
+
+describe("Step 6 — CI bucket routing and the fix budget", () => {
+  it("idles while any check is still pending", () => {
+    expect(/bucket\s*==\s*"pending"/.test(step6)).toBe(true);
+    expect(/idle/i.test(step6)).toBe(true);
+  });
+
+  it("dispatches fix-ci only under the per-SHA attempt cap", () => {
+    expect(/ci_fix_attempts\[head_sha\]\s*<\s*3/.test(step6)).toBe(true);
+    expect(/fix ci/i.test(step6)).toBe(true);
+  });
+
+  it("excludes a SHA the fix-ci stage already gave up on", () => {
+    expect(/ci_escalated_shas/.test(step6)).toBe(true);
+  });
+
+  it("stops re-dispatching once the budget is spent", () => {
+    expect(/ci_fix_attempts\[head_sha\]\s*>=\s*3/.test(step6)).toBe(true);
+    expect(
+      /does not re-?dispatch/i.test(step6),
+      "without this the watcher burns a cycle every minute on CI it can never fix",
+    ).toBe(true);
+  });
+});
+
+describe("Step 0 — stale-fire guard", () => {
+  it("treats a fire on an already-terminal slot as stale", () => {
+    expect(/stale/i.test(step0)).toBe(true);
+    expect(/merged.*closed|closed.*merged/is.test(step0)).toBe(true);
+  });
+
+  it("cancels the lingering cron and logs a stale-tick", () => {
+    expect(/cancel-cron\.md/.test(step0)).toBe(true);
+    expect(/stale-tick/.test(step0)).toBe(true);
+  });
+
+  it("exits without re-finalizing", () => {
+    expect(
+      /(do not|never)[^.]*re-?finalize/i.test(step0),
+      "re-finalizing a torn-down slot rewrites result.md and re-fires the terminal handoff",
+    ).toBe(true);
+  });
+});
+
+describe("record-cron-id — the recorded id survives CronList going blind", () => {
+  const md = read("record-cron-id.md");
+
+  it("records every tick, starting with the first", () => {
+    expect(/every tick/i.test(md)).toBe(true);
+  });
+
+  it("never overwrites a non-null recorded id with null", () => {
+    expect(/non-null/i.test(md)).toBe(true);
+    expect(
+      /never overwrite it with\s*`?null/i.test(md),
+      "once CronList is blind the recorded id is the only CronDelete handle left — nulling it orphans the cron until the 7-day expiry",
+    ).toBe(true);
+  });
+
+  it("skips recording on the stale-fire path", () => {
+    expect(/stale-fire/i.test(md)).toBe(true);
+  });
+});
+
+describe("session state is rewritten whole-file, never patched with Edit", () => {
+  it("mandates a whole-file rewrite", () => {
+    expect(/whole-file rewrite/i.test(writingState)).toBe(true);
+  });
+
+  it("bans the Edit tool on session JSON", () => {
+    expect(
+      /never\W{0,4}patch session JSON with the Edit tool/i.test(writingState),
+      "an exact-string Edit against these files fails silently, so the counter never advances",
+    ).toBe(true);
+  });
+
+  it("keeps the silent-failure rationale", () => {
+    expect(/silently fails|malformed edit/i.test(writingState)).toBe(true);
+  });
+});
+
+describe("SKILL.md routing — the error branches stay documented", () => {
+  const skill = read("SKILL.md");
+
+  it("errors when the named session dir is missing", () => {
+    expect(/session dir missing/i.test(skill)).toBe(true);
+    expect(
+      /no session at/i.test(skill),
+      "without this row a bare slug silently starts nothing",
+    ).toBe(true);
+  });
+
+  it("refuses an ambiguous bare PR number instead of guessing a slot", () => {
+    expect(/zero or multiple matches/i.test(skill)).toBe(true);
+    expect(/ambiguous/i.test(skill)).toBe(true);
+  });
+});


### PR DESCRIPTION
The watcher's per-tick decision branches had no regression guard. Every invariant pinned here is one the loop already got wrong in production, and each was a one-line prose edit away from silently regressing.

## What's locked

`src/test/skills/pr-followup-tick-decisions.test.ts` (19 assertions):

- **staleness** reads `behind_by` from the compare call, **never** `mergeStateStatus == BEHIND` — GitHub masks `BEHIND` behind `DIRTY`/`BLOCKED`, so a stale PR that also awaits review reports `BLOCKED` and its staleness goes unseen
- **CI fix budget** — cap of 3 plus the `ci_escalated_shas` exclusion, so a hopeless SHA isn't re-dispatched every minute
- **CI bucket routing** — pending and green both idle
- **Step 0 stale-fire guard** — a queued fire on a torn-down slot cancels, logs `stale-tick`, exits without re-finalizing
- **`record-cron-id`** never overwrites a non-null `cron_id` with `null` once `CronList` goes blind; that id is the last `CronDelete` handle
- **session JSON** is rewritten whole-file, never patched with `Edit`
- **`SKILL.md` routing error rows** — missing session dir, ambiguous bare PR number

## Verified by mutation, not by green

A doc-lint that passes proves nothing on its own, so each guard was mutation-tested:

- stripping the never-`mergeStateStatus` rule → that assertion fails
- renaming `### Step 6` → 5 failures, including the vacuity guard
- restored → 19/19 green

Assertions slice the relevant contract section first, so a check can't match text from a different step, and a vacuity guard fails loudly if a heading moves.

## Scope

Deliberately disjoint from the five existing pr-followup suites — rebase dedup keying (`conflict-dedup-key`), cron-cancel wording (`cron-guard`), blocked/respawn wiring (`blocked-cron-lint`), the session-start hook (`reconcile-hook`), and the 5-step flow (`tracking-flow`) are already covered.

## Evals

`plugin/skills/muggle-pr-followup/evals/evals.json` — 7 evals / 27 assertions over the tick decision tree, in the skill-creator plan-eval format `muggle-test-regenerate-missing` already uses.

Worth flagging for reviewers: **CI does not execute plugin-side evals.** `ci.yml` gates on vitest / `check-skill-deps` / lint / tsc; `skill-eval.yml` runs gate scenarios sourced from `muggle-ai-brain` (preference-gate scoped — its expectation vocabulary can't express "dispatched address-reviews") plus the routing eval. The vitest suite above is therefore the part that actually gates every PR; the evals file is run via skill-creator. Its `notes` field says so, so nobody mistakes it for a gate.

## Checks

- `vitest run` — 53 files, 708 passed / 5 skipped
- `check-skill-deps` — OK, 314 links, no reverse dependencies
- `eslint` clean; `tsc --noEmit` exit 0
- E2E: **SKIPPED** — muggle-ai-works is a CLI/MCP plugin (`bin: muggle`, `start: node dist/index.js`) with no web surface, and the change is test/eval files with no runtime user flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)