### PR TITLE
fix(guardrails): quiet the E2E Stop gate with a skip marker and terse repeats

### DIFF
--- a/plugin/hooks/README.md
+++ b/plugin/hooks/README.md
@@ -20,7 +20,7 @@ A guardrail emits one of two strengths:
 - **Advise** — `additionalContext` (PostToolUse/UserPromptSubmit) or a plain Stop message. A soft nudge the model can ignore.
 - **Enforce** — a `Stop` `decision: "block"` that refuses to end the turn, or a `PreToolUse` `permissionDecision: "deny"` that refuses a tool call. The model cannot proceed until the condition is met.
 
-Enforcement is reserved for the handoffs that were being skipped: the E2E acceptance run and posting a deterministically-rendered report. Each enforcing gate carries an escape so it can't trap a turn — the E2E gate releases to advisory after `MAX_E2E_BLOCKS` (3) blocks; the report gate only denies a body it can positively see is a hand-written report and fails open otherwise.
+Enforcement is reserved for the handoffs that were being skipped: the E2E acceptance run and posting a deterministically-rendered report. Each enforcing gate carries an escape so it can't trap a turn — the E2E gate accepts an explicit skip declaration (`echo "MUGGLE_E2E_SKIP: <reason>"`, session-durable) and hard-releases after `MAX_E2E_BLOCKS` (3) blocks; the report gate only denies a body it can positively see is a hand-written report and fails open otherwise.
 
 ## Mechanism
 
@@ -31,9 +31,9 @@ Each guardrail is a thin bash wrapper in `../scripts/` registered in `hooks.json
 | Hook event | Wrapper | Strength | Condition | Preference | Effect |
 | :--------- | :------ | :------- | :-------- | :--------- | :----- |
 | `PostToolUse` (Bash) | `guardrail-pr-opened.sh` | advise | a `gh pr create`/`gh pr ready` just succeeded | `autoWatchPR` | start a `muggle-pr-followup` watcher on the new PR |
-| `PostToolUse` (Bash + muggle execute/replay MCP tools) | `guardrail-record-tests.sh` | record | a unit-test command passed, or an E2E run happened | — | set `unitTestsGreen` / `e2eRun` session state |
+| `PostToolUse` (Bash + muggle execute/replay MCP tools) | `guardrail-record-tests.sh` | record | a unit-test command passed, an E2E run happened, or an `echo "MUGGLE_E2E_SKIP: <reason>"` marker declared E2E un-runnable | — | set `unitTestsGreen` / `e2eRun` / `e2eSkipped` session state |
 | `PreToolUse` (Bash) | `guardrail-report-format.sh` | **enforce** | a `gh pr comment\|create\|edit` body reads like an E2E report but lacks the `build-pr-section` sentinel | — | **deny** — render via `muggle build-pr-section` instead |
-| `Stop` | `guardrail-e2e-gate.sh` | **enforce** | unit tests passed this session and no E2E ran yet | `autoE2ETest` | **block** the turn until E2E runs via `muggle-test` (releases after 3 blocks) |
+| `Stop` | `guardrail-e2e-gate.sh` | **enforce** | unit tests passed this session, no E2E ran yet, and no skip was recorded | `autoE2ETest` | **block** the turn until E2E runs via `muggle-test` or a `MUGGLE_E2E_SKIP` marker records a legitimate skip (full message once, one-line reminders after; releases after 3 blocks) |
 | `UserPromptSubmit` | `guardrail-build-router.sh` | advise | a build/implement/fix request (first one this session) | `autoRouteBuildToMuggleDo` | route the work through `muggle-do` (build delegated to superpowers) |
 
 ## Session-start reconcile nudge

--- a/plugin/scripts/guardrail-record-tests.sh
+++ b/plugin/scripts/guardrail-record-tests.sh
@@ -8,12 +8,13 @@ set -uo pipefail
 #
 # Fires after every Bash call and every muggle execute/replay, so a keyword
 # pre-filter for test runners and the muggle E2E tool names keeps Node off the
-# hot path. Only a `test` command (npm/pnpm/yarn/jest/vitest/pytest/go/cargo) or
-# a muggle execute/replay/test-generation event reaches guardrails.mjs, which
-# then inspects the output for pass/fail and updates state. Degrades to {}.
+# hot path. Only a `test` command (npm/pnpm/yarn/jest/vitest/pytest/go/cargo),
+# a muggle execute/replay/test-generation event, or an E2E skip marker reaches
+# guardrails.mjs, which then inspects the output for pass/fail and updates
+# state. Degrades to {}.
 payload="$(cat)"
 
-if ! grep -Eiq '(pnpm|npm|yarn)[[:space:]]+(run[[:space:]]+)?test|jest|vitest|pytest|go[[:space:]]+test|cargo[[:space:]]+test|muggle.*(execute|test-generation|replay)' <<<"$payload"; then
+if ! grep -Eiq '(pnpm|npm|yarn)[[:space:]]+(run[[:space:]]+)?test|jest|vitest|pytest|go[[:space:]]+test|cargo[[:space:]]+test|muggle.*(execute|test-generation|replay)|MUGGLE_E2E_SKIP' <<<"$payload"; then
   printf '{}'
   exit 0
 fi

--- a/plugin/scripts/guardrails.mjs
+++ b/plugin/scripts/guardrails.mjs
@@ -44,8 +44,12 @@ ${input2.tool_response?.output ?? ""}`;
 var TEST_CMD = /\b(pnpm|npm|yarn)\s+(run\s+)?test\b|\b(jest|vitest|pytest)\b|\bgo\s+test\b|\bcargo\s+test\b/;
 var FAIL = /\b\d+\s+failed\b|\bFAIL\b|✗/;
 var E2E_TOOL = /muggle.*(execute|test-generation|replay)/i;
+var E2E_SKIP_MARKER = /^\s*echo\s+["']?MUGGLE_E2E_SKIP\b/;
 function isTestCommand(cmd) {
   return TEST_CMD.test(cmd);
+}
+function isE2ESkipMarker(cmd) {
+  return E2E_SKIP_MARKER.test(cmd);
 }
 function testsPassed(input2) {
   const out = `${input2.tool_response?.stdout ?? ""}
@@ -60,7 +64,7 @@ function isE2ERun(input2) {
 // src/guardrails/shouldRunE2E.ts
 var MAX_E2E_BLOCKS = 3;
 function shouldRunE2E(state) {
-  return state.unitTestsGreen === true && state.e2eRun !== true;
+  return state.unitTestsGreen === true && state.e2eRun !== true && state.e2eSkipped !== true;
 }
 function applyRecordedRun(state, run) {
   let next = state;
@@ -69,6 +73,9 @@ function applyRecordedRun(state, run) {
   }
   if (run.e2eRan) {
     next = { ...next, e2eRun: true };
+  }
+  if (run.e2eSkipped) {
+    next = { ...next, e2eSkipped: true };
   }
   return next;
 }
@@ -195,7 +202,8 @@ function recordTests() {
   const state = readState(sessionId);
   const next = applyRecordedRun(state, {
     unitTestPassed: isTestCommand(cmd) && testsPassed(input),
-    e2eRan: isE2ERun(input)
+    e2eRan: isE2ERun(input),
+    e2eSkipped: isE2ESkipMarker(cmd)
   });
   if (next !== state) writeState(next);
   return "{}";
@@ -206,7 +214,7 @@ function e2eGate() {
   if (decision.action === "none" /* None */ || decision.action === "release" /* Release */) return "{}";
   state.e2eBlockCount = decision.blockCount;
   writeState(state);
-  const reason = `Do not end the turn yet. Unit tests passed this session but no E2E acceptance run has happened. Per the autoE2ETest preference (default: always), run change-driven E2E now via /muggle:muggle-test, then finish. If E2E genuinely cannot run here (no app, services down, no PR), say so explicitly to the user \u2014 this gate releases after ${MAX_E2E_BLOCKS} attempts.`;
+  const reason = decision.blockCount === 1 ? `Do not end the turn yet. Unit tests passed this session but no E2E acceptance run has happened. Per the autoE2ETest preference (default: always), run change-driven E2E now via /muggle:muggle-test, then finish. If E2E genuinely cannot run here (no app to drive, services down, no PR), tell the user why and run \`echo "MUGGLE_E2E_SKIP: <reason>"\` \u2014 that records the skip and keeps this gate quiet for the rest of the session.` : `E2E acceptance run still owed (reminder ${decision.blockCount}/${MAX_E2E_BLOCKS}): run /muggle:muggle-test, or record a legitimate skip via \`echo "MUGGLE_E2E_SKIP: <reason>"\`.`;
   return blockStop(reason, host);
 }
 function reportGate() {

--- a/plugin/skills/do/e2e-acceptance.md
+++ b/plugin/skills/do/e2e-acceptance.md
@@ -20,6 +20,8 @@ This stage is **mode-driven by pre-flight**:
 
 - `local-e2e` runs the local browser flow (`test-feature-local` approach).
 - `unit-only` or `skip` does not execute browser runs and must emit an explicit non-pass verdict (`SKIPPED` / `UNIT-ONLY` equivalent in downstream reporting).
+
+**Every SKIPPED exit from this stage** (Step 0 poll-only, Step 1 `unit-only`/`skip`, Step 1.5 placeholder branch) also runs `echo "MUGGLE_E2E_SKIP: <one-line reason>"` as a single Bash call before exiting — it records the skip in guardrail session state so the Stop-hook E2E gate releases instead of blocking the turn.
 - `staging-replay` is not executed in this stage path and should be surfaced as `INCONCLUSIVE` unless the caller has already routed to a dedicated staging runner.
 
 For local runs, the tool boundaries are:

--- a/src/guardrails/cli.ts
+++ b/src/guardrails/cli.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "fs";
 import { readState, writeState, markPrHandled } from "./sessionState.js";
 import { detectPrOpened } from "./prOpened.js";
-import { isTestCommand, testsPassed, isE2ERun } from "./testsGreen.js";
+import { isTestCommand, testsPassed, isE2ERun, isE2ESkipMarker } from "./testsGreen.js";
 import { e2eGateDecision, E2eGateAction, MAX_E2E_BLOCKS, applyRecordedRun } from "./shouldRunE2E.js";
 import { detectBuildIntent } from "./detectBuildIntent.js";
 import { evaluateReportPost } from "./reportGate.js";
@@ -40,6 +40,7 @@ function recordTests(): string {
   const next = applyRecordedRun(state, {
     unitTestPassed: isTestCommand(cmd) && testsPassed(input),
     e2eRan: isE2ERun(input),
+    e2eSkipped: isE2ESkipMarker(cmd),
   });
   if (next !== state) writeState(next);
   return "{}";
@@ -51,11 +52,17 @@ function e2eGate(): string {
   if (decision.action === E2eGateAction.None || decision.action === E2eGateAction.Release) return "{}";
   state.e2eBlockCount = decision.blockCount;
   writeState(state);
+  // Full instruction once; repeats are one line. The first block already
+  // taught the model both exits, so repeating the paragraph is pure noise.
   const reason =
-    `Do not end the turn yet. Unit tests passed this session but no E2E acceptance run has happened. ` +
-    `Per the autoE2ETest preference (default: always), run change-driven E2E now via /muggle:muggle-test, ` +
-    `then finish. If E2E genuinely cannot run here (no app, services down, no PR), say so explicitly to the ` +
-    `user — this gate releases after ${MAX_E2E_BLOCKS} attempts.`;
+    decision.blockCount === 1
+      ? `Do not end the turn yet. Unit tests passed this session but no E2E acceptance run has happened. ` +
+        `Per the autoE2ETest preference (default: always), run change-driven E2E now via /muggle:muggle-test, ` +
+        `then finish. If E2E genuinely cannot run here (no app to drive, services down, no PR), tell the user ` +
+        `why and run \`echo "MUGGLE_E2E_SKIP: <reason>"\` — that records the skip and keeps this gate quiet ` +
+        `for the rest of the session.`
+      : `E2E acceptance run still owed (reminder ${decision.blockCount}/${MAX_E2E_BLOCKS}): ` +
+        `run /muggle:muggle-test, or record a legitimate skip via \`echo "MUGGLE_E2E_SKIP: <reason>"\`.`;
   return blockStop(reason, host);
 }
 

--- a/src/guardrails/shouldRunE2E.ts
+++ b/src/guardrails/shouldRunE2E.ts
@@ -3,12 +3,13 @@ import type { GuardrailState } from "./types.js";
 export const MAX_E2E_BLOCKS = 3;
 
 export function shouldRunE2E(state: GuardrailState): boolean {
-  return state.unitTestsGreen === true && state.e2eRun !== true;
+  return state.unitTestsGreen === true && state.e2eRun !== true && state.e2eSkipped !== true;
 }
 
 export interface RecordedRun {
   unitTestPassed?: boolean;
   e2eRan?: boolean;
+  e2eSkipped?: boolean;
 }
 
 // Fold a recorded test run into the gate state, returning the same reference
@@ -19,6 +20,11 @@ export interface RecordedRun {
 // the reset the first E2E of a long-lived session keeps the gate satisfied for
 // every later round, so a watcher addressing a second round of review comments
 // would change code, go unit-green, and end the turn with no fresh E2E.
+//
+// A recorded skip is deliberately NOT cleared by the re-arm: the reasons E2E
+// can't run (no app to drive, CLI/library repo, no PR) don't change because
+// more unit tests passed, so re-nagging every round is pure noise. The skip
+// holds for the rest of the session.
 export function applyRecordedRun(state: GuardrailState, run: RecordedRun): GuardrailState {
   let next = state;
   if (run.unitTestPassed) {
@@ -26,6 +32,9 @@ export function applyRecordedRun(state: GuardrailState, run: RecordedRun): Guard
   }
   if (run.e2eRan) {
     next = { ...next, e2eRun: true };
+  }
+  if (run.e2eSkipped) {
+    next = { ...next, e2eSkipped: true };
   }
   return next;
 }

--- a/src/guardrails/testsGreen.ts
+++ b/src/guardrails/testsGreen.ts
@@ -11,8 +11,19 @@ const FAIL = /\b\d+\s+failed\b|\bFAIL\b|✗/;
 // `cd …/muggle-ai-works && npm test`, both armed and disarmed it in one call).
 const E2E_TOOL = /muggle.*(execute|test-generation|replay)/i;
 
+// A deliberate "E2E can't run here" declaration: the model runs
+// `echo "MUGGLE_E2E_SKIP: <reason>"` and the Stop gate stays quiet for the
+// session. Anchored to a leading `echo` for the same reason E2E_TOOL matches
+// tool names, not command text — a grep, commit message, or skill edit that
+// merely *mentions* the token must not disarm the gate.
+const E2E_SKIP_MARKER = /^\s*echo\s+["']?MUGGLE_E2E_SKIP\b/;
+
 export function isTestCommand(cmd: string): boolean {
   return TEST_CMD.test(cmd);
+}
+
+export function isE2ESkipMarker(cmd: string): boolean {
+  return E2E_SKIP_MARKER.test(cmd);
 }
 
 export function testsPassed(input: HookInput): boolean {

--- a/src/guardrails/types.ts
+++ b/src/guardrails/types.ts
@@ -3,6 +3,7 @@ export interface GuardrailState {
   prsHandled: string[];
   unitTestsGreen?: boolean;
   e2eRun?: boolean;
+  e2eSkipped?: boolean;
   e2eBlockCount?: number;
   buildIntentRouted?: boolean;
 }

--- a/src/test/guardrails/hook-execution.test.ts
+++ b/src/test/guardrails/hook-execution.test.ts
@@ -101,6 +101,52 @@ describe("guardrail hook execution (cli entry)", () => {
     expect(runHook("e2e-gate", event({ session_id: "fresh" })).out).toBe("{}");
   });
 
+  it("record-tests -> e2e-gate: an explicit skip marker releases an armed gate", () => {
+    const session = "skip-chain";
+    runHook(
+      "record-tests",
+      event({
+        session_id: session,
+        tool_name: "Bash",
+        tool_input: { command: "pnpm test" },
+        tool_response: { stdout: "Tests: 18 passed", stderr: "" },
+      }),
+    );
+    runHook(
+      "record-tests",
+      event({
+        session_id: session,
+        tool_name: "Bash",
+        tool_input: { command: 'echo "MUGGLE_E2E_SKIP: CLI package, no web surface to drive"' },
+        tool_response: { stdout: "MUGGLE_E2E_SKIP: CLI package, no web surface to drive" },
+      }),
+    );
+    expect(runHook("e2e-gate", event({ session_id: session })).out).toBe("{}");
+  });
+
+  it("e2e-gate: full instruction on the first block, one-line reminder on repeats", () => {
+    const session = "terse-repeats";
+    runHook(
+      "record-tests",
+      event({
+        session_id: session,
+        tool_name: "Bash",
+        tool_input: { command: "pnpm test" },
+        tool_response: { stdout: "Tests: 18 passed", stderr: "" },
+      }),
+    );
+    const first = JSON.parse(runHook("e2e-gate", event({ session_id: session })).out);
+    expect(first.decision).toBe("block");
+    expect(first.reason).toContain("Do not end the turn yet");
+    expect(first.reason).toContain("MUGGLE_E2E_SKIP");
+
+    const second = JSON.parse(runHook("e2e-gate", event({ session_id: session })).out);
+    expect(second.decision).toBe("block");
+    expect(second.reason).toContain("2/3");
+    expect(second.reason).toContain("MUGGLE_E2E_SKIP");
+    expect(second.reason.length).toBeLessThan(first.reason.length);
+  });
+
   it("build-router: nudges a build ask toward muggle-do, once per session", () => {
     const ev = event({ session_id: "br", prompt: "implement a dark-mode toggle" });
     const first = JSON.parse(runHook("build-router", ev).out);
@@ -220,6 +266,15 @@ describe.skipIf(process.platform === "win32")("guardrail wrapper pre-filter (no 
     ).toBe("{}");
     expect(
       runWrapper("guardrail-record-tests.sh", event({ tool_name: "Bash", tool_input: { command: "pnpm test" } })),
+    ).toContain(NODE_RAN);
+  });
+
+  it("record-tests: spawns Node on an E2E skip marker", () => {
+    expect(
+      runWrapper(
+        "guardrail-record-tests.sh",
+        event({ tool_name: "Bash", tool_input: { command: 'echo "MUGGLE_E2E_SKIP: no app"' } }),
+      ),
     ).toContain(NODE_RAN);
   });
 

--- a/src/test/guardrails/shouldRunE2E.test.ts
+++ b/src/test/guardrails/shouldRunE2E.test.ts
@@ -11,6 +11,9 @@ describe("shouldRunE2E", () => {
   it("does not fire if tests never went green", () => {
     expect(shouldRunE2E({ sessionId: "s", prsHandled: [], unitTestsGreen: false })).toBe(false);
   });
+  it("does not fire once a skip was recorded", () => {
+    expect(shouldRunE2E({ sessionId: "s", prsHandled: [], unitTestsGreen: true, e2eSkipped: true })).toBe(false);
+  });
 });
 
 describe("e2eGateDecision", () => {
@@ -60,6 +63,20 @@ describe("applyRecordedRun", () => {
     expect(afterRound2Unit.e2eRun).toBe(false);
     expect(afterRound2Unit.e2eBlockCount).toBe(0);
     expect(shouldRunE2E(afterRound2Unit)).toBe(true);
+  });
+
+  it("a recorded skip satisfies the gate", () => {
+    const next = applyRecordedRun({ ...base, unitTestsGreen: true }, { e2eSkipped: true });
+    expect(next.e2eSkipped).toBe(true);
+    expect(shouldRunE2E(next)).toBe(false);
+    expect(e2eGateDecision(next).action).toBe(E2eGateAction.None);
+  });
+
+  it("a skip survives a later unit-green re-arm — no re-nagging within the session", () => {
+    const skipped = applyRecordedRun({ ...base, unitTestsGreen: true }, { e2eSkipped: true });
+    const afterNextUnitPass = applyRecordedRun(skipped, { unitTestPassed: true });
+    expect(afterNextUnitPass.e2eSkipped).toBe(true);
+    expect(shouldRunE2E(afterNextUnitPass)).toBe(false);
   });
 
   it("returns the same reference when nothing was recorded", () => {

--- a/src/test/guardrails/testsGreen.test.ts
+++ b/src/test/guardrails/testsGreen.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isTestCommand, testsPassed, isE2ERun } from "../../guardrails/testsGreen";
+import { isTestCommand, testsPassed, isE2ERun, isE2ESkipMarker } from "../../guardrails/testsGreen";
 
 describe("testsGreen", () => {
   it("recognizes common test commands", () => {
@@ -33,5 +33,19 @@ describe("testsGreen", () => {
     expect(bash("cd /c/Users/x/muggle-ai-works && npm test")).toBe(false);
     expect(bash("muggle test --local")).toBe(false);
     expect(bash("pnpm test")).toBe(false);
+  });
+
+  it("recognizes a deliberate skip marker command", () => {
+    expect(isE2ESkipMarker('echo "MUGGLE_E2E_SKIP: CLI package, no web surface to drive"')).toBe(true);
+    expect(isE2ESkipMarker("echo 'MUGGLE_E2E_SKIP: services down'")).toBe(true);
+    expect(isE2ESkipMarker("echo MUGGLE_E2E_SKIP: no PR")).toBe(true);
+    expect(isE2ESkipMarker('  echo "MUGGLE_E2E_SKIP: reason"')).toBe(true);
+  });
+
+  it("ignores commands that merely mention the skip token", () => {
+    expect(isE2ESkipMarker('grep -rn "MUGGLE_E2E_SKIP" src/')).toBe(false);
+    expect(isE2ESkipMarker("git commit -m 'add MUGGLE_E2E_SKIP marker'")).toBe(false);
+    expect(isE2ESkipMarker('gh pr create --title "MUGGLE_E2E_SKIP support"')).toBe(false);
+    expect(isE2ESkipMarker('cat file && echo "MUGGLE_E2E_SKIP: nope"')).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

When unit tests pass but E2E legitimately cannot run (CLI/plugin repo with no web surface, poll-only watcher, placeholder branch), the Stop-hook E2E gate re-blocks the turn **three times with the same full paragraph** — a clean `/muggle:muggle-test` SKIP never reaches guardrail state, so the gate has no way to know the skip was deliberate. In long watcher sessions every unit-green re-arm repeats the whole cycle.

## Fix

1. **Skip marker** — `echo "MUGGLE_E2E_SKIP: <reason>"` is now recognized by the record-tests observer and sets a session-durable `e2eSkipped` flag that satisfies the gate. It survives unit-green re-arms (the reason E2E can't run doesn't change because more unit tests passed), so a session declares the skip once. The matcher is anchored to a leading `echo` — greps, commit messages, or PR titles mentioning the token cannot disarm the gate (same false-positive class `E2E_TOOL` already guards against).
2. **Terse repeats** — the full gate instruction (now teaching the marker) fires only on the first block; reminders 2/3 and 3/3 are a single line.
3. **Proactive recording** — `do/e2e-acceptance.md` SKIPPED exits (poll-only, `unit-only`/`skip`, placeholder branch) run the marker before exiting, so skill-driven skips release the gate before it ever nags.

The 3-block hard release stays as the safety valve.

## Verification

- `npx vitest run` — 717 passed, 11 skipped (bash-only pre-filter tests run on the Linux/macOS CI jobs)
- `npx tsc --noEmit` — clean
- `node scripts/check-skill-deps.mjs` — OK, no reverse dependencies
- `plugin/scripts/guardrails.mjs` rebuilt via tsup from the same source

New tests: marker recognition (positives + mention-only negatives), skip satisfies gate, skip survives re-arm, cross-hook record→gate release, first-block-full/repeat-terse message shape, wrapper pre-filter spawns Node on the marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZeLFBWxDseqotKb9L2UZs
