### PR TITLE
feat(guardrails): hold the stop until the post-merge next-options offer runs

### DIFF
--- a/plugin/hooks/README.md
+++ b/plugin/hooks/README.md
@@ -20,7 +20,7 @@ A guardrail emits one of two strengths:
 - **Advise** — `additionalContext` (PostToolUse/UserPromptSubmit) or a plain Stop message. A soft nudge the model can ignore.
 - **Enforce** — a `Stop` `decision: "block"` that refuses to end the turn, or a `PreToolUse` `permissionDecision: "deny"` that refuses a tool call. The model cannot proceed until the condition is met.
 
-Enforcement is reserved for the handoffs that were being skipped: the E2E acceptance run and posting a deterministically-rendered report. Each enforcing gate carries an escape so it can't trap a turn — the E2E gate accepts an explicit skip declaration (`echo "MUGGLE_E2E_SKIP: <reason>"`, session-durable) and hard-releases after `MAX_E2E_BLOCKS` (3) blocks; the report gate only denies a body it can positively see is a hand-written report and fails open otherwise.
+Enforcement is reserved for the handoffs that were being skipped: the E2E acceptance run, posting a deterministically-rendered report, and the post-merge handoff. Each enforcing gate carries an escape so it can't trap a turn — the E2E gate accepts an explicit skip declaration (`echo "MUGGLE_E2E_SKIP: <reason>"`, session-durable) and hard-releases after `MAX_E2E_BLOCKS` (3) blocks; the report gate only denies a body it can positively see is a hand-written report and fails open otherwise; the post-merge gate hard-releases after `MAX_PR_TERMINAL_BLOCKS` (3) blocks, and only the AskUserQuestion next-options offer clears it — nothing else resets its counter.
 
 ## Mechanism
 
@@ -32,8 +32,11 @@ Each guardrail is a thin bash wrapper in `../scripts/` registered in `hooks.json
 | :--------- | :------ | :------- | :-------- | :--------- | :----- |
 | `PostToolUse` (Bash) | `guardrail-pr-opened.sh` | advise | a `gh pr create`/`gh pr ready` just succeeded | `autoWatchPR` | start a `muggle-pr-followup` watcher on the new PR |
 | `PostToolUse` (Bash + muggle execute/replay MCP tools) | `guardrail-record-tests.sh` | record | a unit-test command passed, an E2E run happened, or an `echo "MUGGLE_E2E_SKIP: <reason>"` marker declared E2E un-runnable | — | set `unitTestsGreen` / `e2eRun` / `e2eSkipped` session state |
+| `PostToolUse` (Bash + Monitor) | `guardrail-pr-terminal.sh` | advise | a PR just went terminal — a `gh pr merge`/`gh pr close` success line or the watch monitor's `TERMINAL pr=N` exit line (never bare `"state":"MERGED"` metadata) | — | record `terminalPending`, direct the post-merge handoff: finalize the watcher slot, tear down per `autoCleanup`, offer next options via AskUserQuestion |
+| `PostToolUse` (AskUserQuestion) | `guardrail-offer-ran.sh` | record | a next-options offer ran while a terminal PR was pending | — | clear `terminalPending` — the only exit for the post-merge Stop gate |
 | `PreToolUse` (Bash) | `guardrail-report-format.sh` | **enforce** | a `gh pr comment\|create\|edit` body reads like an E2E report but lacks the `build-pr-section` sentinel | — | **deny** — render via `muggle build-pr-section` instead |
 | `Stop` | `guardrail-e2e-gate.sh` | **enforce** | unit tests passed this session, no E2E ran yet, and no skip was recorded | `autoE2ETest` | **block** the turn until E2E runs via `muggle-test` or a `MUGGLE_E2E_SKIP` marker records a legitimate skip (full message once, one-line reminders after; releases after 3 blocks) |
+| `Stop` | `guardrail-terminal-gate.sh` | **enforce** | a PR went terminal this session and the AskUserQuestion next-options offer hasn't run since | — | **block** the turn until the post-merge handoff runs (full message once, one-line reminders after; releases after 3 blocks; nothing but the offer resets the counter) |
 | `UserPromptSubmit` | `guardrail-build-router.sh` | advise | a build/implement/fix request (first one this session) | `autoRouteBuildToMuggleDo` | route the work through `muggle-do` (build delegated to superpowers) |
 
 ## Session-start reconcile nudge

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -47,6 +47,12 @@
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/guardrail-record-tests.sh\"",
             "async": false,
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/guardrail-pr-terminal.sh\"",
+            "async": false,
+            "timeout": 10
           }
         ]
       },
@@ -60,6 +66,28 @@
             "timeout": 10
           }
         ]
+      },
+      {
+        "matcher": "Monitor",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/guardrail-pr-terminal.sh\"",
+            "async": false,
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "AskUserQuestion",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/guardrail-offer-ran.sh\"",
+            "async": false,
+            "timeout": 10
+          }
+        ]
       }
     ],
     "Stop": [
@@ -68,6 +96,12 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/guardrail-e2e-gate.sh\"",
+            "async": false,
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/guardrail-terminal-gate.sh\"",
             "async": false,
             "timeout": 10
           }

--- a/plugin/scripts/guardrail-offer-ran.sh
+++ b/plugin/scripts/guardrail-offer-ran.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Next-options-offer observer (PostToolUse/AskUserQuestion). An AskUserQuestion
+# call while a terminal PR is pending IS the post-merge handoff's exit: it
+# clears terminalPending so the Stop gate (guardrail-terminal-gate.sh)
+# releases. Emits no directive.
+#
+# Pre-filter: only spawn Node when the per-session state actually has a
+# pending terminal PR, so the ordinary AskUserQuestion (no PR merged this
+# session) never pays Node cold-start. Degrades to {}.
+payload="$(cat)"
+
+raw_sid="$(printf '%s' "$payload" | grep -oE '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed -E 's/.*:[[:space:]]*"([^"]*)".*/\1/')"
+[ -n "$raw_sid" ] || raw_sid="unknown"
+sid="$(printf '%s' "$raw_sid" | sed 's/[^A-Za-z0-9_-]/_/g')"
+
+# Resolve the same home dir Node's os.homedir() uses. HOME is correct on
+# macOS/Linux and on most Git Bash setups; fall back to converting USERPROFILE
+# when HOME doesn't hold the state dir (some Windows shells point HOME elsewhere).
+home="${HOME:-}"
+if [ ! -d "$home/.muggle-ai" ] && command -v cygpath >/dev/null 2>&1 && [ -n "${USERPROFILE:-}" ]; then
+  home="$(cygpath -u "$USERPROFILE" 2>/dev/null || printf '%s' "$home")"
+fi
+
+state_file="$home/.muggle-ai/guardrails/$sid.json"
+if [ ! -f "$state_file" ] \
+  || ! grep -q '"terminalPending"' "$state_file" \
+  || grep -q '"terminalPending": \[\]' "$state_file"; then
+  printf '{}'
+  exit 0
+fi
+
+root="${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-}}"
+printf '%s' "$payload" | node "${root}/scripts/guardrails.mjs" offer-ran 2>/dev/null || printf '{}'

--- a/plugin/scripts/guardrail-pr-terminal.sh
+++ b/plugin/scripts/guardrail-pr-terminal.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# PR-terminal guardrail (PostToolUse/Bash + Monitor). When a PR just went
+# terminal — a `gh pr merge`/`gh pr close` success line or the pr-followup
+# watch monitor's `TERMINAL pr=N` exit line — arm the post-merge handoff:
+# record the PR as pending, nudge the model to finalize/tear down and offer
+# next options, and hold the Stop gate (guardrail-terminal-gate.sh) until the
+# AskUserQuestion offer runs. Decision logic lives in the bundled guardrails.mjs.
+#
+# Fires after every Bash call, so a keyword pre-filter for the terminal output
+# shapes keeps Node off the hot path. Degrades to {} so it never blocks.
+payload="$(cat)"
+
+if ! grep -Eiq 'merged pull request|closed pull request|TERMINAL pr=' <<<"$payload"; then
+  printf '{}'
+  exit 0
+fi
+
+root="${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-}}"
+printf '%s' "$payload" | node "${root}/scripts/guardrails.mjs" pr-terminal 2>/dev/null || printf '{}'

--- a/plugin/scripts/guardrail-terminal-gate.sh
+++ b/plugin/scripts/guardrail-terminal-gate.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# PR-terminal → post-merge handoff gate (Stop). When a PR went terminal this
+# session (merged/closed) and the next-options offer hasn't run, block the
+# turn end until the handoff — finalize, teardown, AskUserQuestion offer —
+# happens. Releases unconditionally after 3 blocks.
+#
+# This must stay synchronous (only a sync Stop hook can block the turn end),
+# and it fires on EVERY turn end. There is no command payload to key off, so
+# the pre-filter reads the same per-session state file guardrails.mjs uses and
+# only spawns Node when a terminal PR is actually pending. On the overwhelming
+# majority of turns no PR went terminal, so the state file is absent or
+# terminalPending is empty and we return {} in-shell. Degrades to {}.
+payload="$(cat)"
+
+raw_sid="$(printf '%s' "$payload" | grep -oE '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed -E 's/.*:[[:space:]]*"([^"]*)".*/\1/')"
+[ -n "$raw_sid" ] || raw_sid="unknown"
+sid="$(printf '%s' "$raw_sid" | sed 's/[^A-Za-z0-9_-]/_/g')"
+
+# Resolve the same home dir Node's os.homedir() uses. HOME is correct on
+# macOS/Linux and on most Git Bash setups; fall back to converting USERPROFILE
+# when HOME doesn't hold the state dir (some Windows shells point HOME elsewhere).
+home="${HOME:-}"
+if [ ! -d "$home/.muggle-ai" ] && command -v cygpath >/dev/null 2>&1 && [ -n "${USERPROFILE:-}" ]; then
+  home="$(cygpath -u "$USERPROFILE" 2>/dev/null || printf '%s' "$home")"
+fi
+
+state_file="$home/.muggle-ai/guardrails/$sid.json"
+if [ ! -f "$state_file" ] \
+  || ! grep -q '"terminalPending"' "$state_file" \
+  || grep -q '"terminalPending": \[\]' "$state_file"; then
+  printf '{}'
+  exit 0
+fi
+
+root="${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-}}"
+printf '%s' "$payload" | node "${root}/scripts/guardrails.mjs" terminal-gate 2>/dev/null || printf '{}'

--- a/plugin/scripts/guardrails.mjs
+++ b/plugin/scripts/guardrails.mjs
@@ -40,6 +40,59 @@ ${input2.tool_response?.output ?? ""}`;
   return m ? m[0] : null;
 }
 
+// src/guardrails/prTerminal.ts
+var GH_MERGED_LINE = /\b(?:Merged|Squashed and merged|Rebased and merged) pull request [\w./-]*#(\d+)/;
+var GH_CLOSED_LINE = /\bClosed pull request [\w./-]*#(\d+)/;
+var MONITOR_TERMINAL_LINE = /\bTERMINAL pr=(\d+): (MERGED|CLOSED)\b/;
+function detectPrTerminal(input2) {
+  if (input2.tool_name !== "Bash" && input2.tool_name !== "Monitor") return null;
+  const response = input2.tool_response;
+  const haystack = [response?.stdout, response?.stderr, response?.output, response?.content].filter((part) => typeof part === "string").join("\n");
+  const mergedMatch = haystack.match(GH_MERGED_LINE);
+  if (mergedMatch) {
+    return { prNumber: Number(mergedMatch[1]), verdict: "merged" /* Merged */ };
+  }
+  const closedMatch = haystack.match(GH_CLOSED_LINE);
+  if (closedMatch) {
+    return { prNumber: Number(closedMatch[1]), verdict: "closed" /* Closed */ };
+  }
+  const monitorMatch = haystack.match(MONITOR_TERMINAL_LINE);
+  if (monitorMatch) {
+    return {
+      prNumber: Number(monitorMatch[1]),
+      verdict: monitorMatch[2] === "MERGED" ? "merged" /* Merged */ : "closed" /* Closed */
+    };
+  }
+  return null;
+}
+function applyPrTerminalDetected(state, prNumber) {
+  const pending = state.terminalPending ?? [];
+  const handled = state.terminalHandled ?? [];
+  if (pending.includes(prNumber) || handled.includes(prNumber)) return state;
+  return { ...state, terminalPending: [...pending, prNumber] };
+}
+function applyNextOptionsOffered(state) {
+  const pending = state.terminalPending ?? [];
+  if (pending.length === 0) return state;
+  return {
+    ...state,
+    terminalPending: [],
+    terminalHandled: [...state.terminalHandled ?? [], ...pending],
+    terminalBlockCount: 0
+  };
+}
+var MAX_PR_TERMINAL_BLOCKS = 3;
+function prTerminalGateDecision(state, maxBlocks = MAX_PR_TERMINAL_BLOCKS) {
+  const blockCount = state.terminalBlockCount ?? 0;
+  if ((state.terminalPending ?? []).length === 0) {
+    return { action: "none" /* None */, blockCount };
+  }
+  if (blockCount >= maxBlocks) {
+    return { action: "release" /* Release */, blockCount };
+  }
+  return { action: "block" /* Block */, blockCount: blockCount + 1 };
+}
+
 // src/guardrails/testsGreen.ts
 var TEST_CMD = /\b(pnpm|npm|yarn)\s+(run\s+)?test\b|\b(jest|vitest|pytest)\b|\bgo\s+test\b|\bcargo\s+test\b/;
 var FAIL = /\b\d+\s+failed\b|\bFAIL\b|✗/;
@@ -197,6 +250,33 @@ function prOpened() {
 Per the autoWatchPR preference, a muggle-pr-followup watcher should handle its incoming reviews. If autoWatchPR=always, start it now by invoking /muggle:muggle-pr-followup with the PR URL; if =ask, offer it to the user; if =never, do nothing.`;
   return envelope("PostToolUse", ctx, host);
 }
+function prTerminal() {
+  const terminalEvent = detectPrTerminal(input);
+  if (!terminalEvent) return "{}";
+  const state = readState(sessionId);
+  const next = applyPrTerminalDetected(state, terminalEvent.prNumber);
+  if (next === state) return "{}";
+  writeState(next);
+  const ctx = `PR #${terminalEvent.prNumber} went terminal (${terminalEvent.verdict}). Run the post-merge handoff now: finalize the watcher slot, tear down per autoCleanup, then OFFER NEXT OPTIONS to the user (AskUserQuestion) \u2014 release, queued work, deferred items. The stop gate holds until the offer runs.`;
+  return envelope("PostToolUse", ctx, host);
+}
+function offerRan() {
+  if (input.tool_name !== "AskUserQuestion") return "{}";
+  const state = readState(sessionId);
+  const next = applyNextOptionsOffered(state);
+  if (next !== state) writeState(next);
+  return "{}";
+}
+function terminalGate() {
+  const state = readState(sessionId);
+  const decision = prTerminalGateDecision(state);
+  if (decision.action !== "block" /* Block */) return "{}";
+  state.terminalBlockCount = decision.blockCount;
+  writeState(state);
+  const pendingPrList = (state.terminalPending ?? []).map((prNumber) => `#${prNumber}`).join(", ");
+  const reason = decision.blockCount === 1 ? `Do not end the turn yet. PR ${pendingPrList} went terminal (merged/closed) but the post-merge handoff has not run. Finalize the watcher slot, tear down per autoCleanup, then offer next options to the user via AskUserQuestion \u2014 release, queued work, deferred items. Only the AskUserQuestion offer clears this gate.` : `Post-merge handoff still owed for PR ${pendingPrList} (reminder ${decision.blockCount}/${MAX_PR_TERMINAL_BLOCKS}): finalize + tear down, then run the AskUserQuestion next-options offer.`;
+  return blockStop(reason, host);
+}
 function recordTests() {
   const cmd = input.tool_input?.command ?? "";
   const state = readState(sessionId);
@@ -233,8 +313,11 @@ function buildRouter() {
 }
 var handlers = {
   "pr-opened": prOpened,
+  "pr-terminal": prTerminal,
+  "offer-ran": offerRan,
   "record-tests": recordTests,
   "e2e-gate": e2eGate,
+  "terminal-gate": terminalGate,
   "report-gate": reportGate,
   "build-router": buildRouter
 };

--- a/plugin/scripts/guardrails.mjs
+++ b/plugin/scripts/guardrails.mjs
@@ -40,23 +40,26 @@ ${input2.tool_response?.output ?? ""}`;
   return m ? m[0] : null;
 }
 
+// src/guardrails/constants.ts
+var GH_PR_MERGED_LINE = /\b(?:Merged|Squashed and merged|Rebased and merged) pull request [\w./-]*#(\d+)/;
+var GH_PR_CLOSED_LINE = /\bClosed pull request [\w./-]*#(\d+)/;
+var PR_MONITOR_TERMINAL_LINE = /\bTERMINAL pr=(\d+): (MERGED|CLOSED)\b/;
+var MAX_PR_TERMINAL_BLOCKS = 3;
+
 // src/guardrails/prTerminal.ts
-var GH_MERGED_LINE = /\b(?:Merged|Squashed and merged|Rebased and merged) pull request [\w./-]*#(\d+)/;
-var GH_CLOSED_LINE = /\bClosed pull request [\w./-]*#(\d+)/;
-var MONITOR_TERMINAL_LINE = /\bTERMINAL pr=(\d+): (MERGED|CLOSED)\b/;
 function detectPrTerminal(input2) {
   if (input2.tool_name !== "Bash" && input2.tool_name !== "Monitor") return null;
   const response = input2.tool_response;
   const haystack = [response?.stdout, response?.stderr, response?.output, response?.content].filter((part) => typeof part === "string").join("\n");
-  const mergedMatch = haystack.match(GH_MERGED_LINE);
+  const mergedMatch = haystack.match(GH_PR_MERGED_LINE);
   if (mergedMatch) {
     return { prNumber: Number(mergedMatch[1]), verdict: "merged" /* Merged */ };
   }
-  const closedMatch = haystack.match(GH_CLOSED_LINE);
+  const closedMatch = haystack.match(GH_PR_CLOSED_LINE);
   if (closedMatch) {
     return { prNumber: Number(closedMatch[1]), verdict: "closed" /* Closed */ };
   }
-  const monitorMatch = haystack.match(MONITOR_TERMINAL_LINE);
+  const monitorMatch = haystack.match(PR_MONITOR_TERMINAL_LINE);
   if (monitorMatch) {
     return {
       prNumber: Number(monitorMatch[1]),
@@ -81,7 +84,6 @@ function applyNextOptionsOffered(state) {
     terminalBlockCount: 0
   };
 }
-var MAX_PR_TERMINAL_BLOCKS = 3;
 function prTerminalGateDecision(state, maxBlocks = MAX_PR_TERMINAL_BLOCKS) {
   const blockCount = state.terminalBlockCount ?? 0;
   if ((state.terminalPending ?? []).length === 0) {

--- a/src/guardrails/cli.ts
+++ b/src/guardrails/cli.ts
@@ -1,6 +1,14 @@
 import { readFileSync } from "fs";
 import { readState, writeState, markPrHandled } from "./sessionState.js";
 import { detectPrOpened } from "./prOpened.js";
+import {
+  detectPrTerminal,
+  applyPrTerminalDetected,
+  applyNextOptionsOffered,
+  prTerminalGateDecision,
+  PrTerminalGateAction,
+  MAX_PR_TERMINAL_BLOCKS,
+} from "./prTerminal.js";
 import { isTestCommand, testsPassed, isE2ERun, isE2ESkipMarker } from "./testsGreen.js";
 import { e2eGateDecision, E2eGateAction, MAX_E2E_BLOCKS, applyRecordedRun } from "./shouldRunE2E.js";
 import { detectBuildIntent } from "./detectBuildIntent.js";
@@ -32,6 +40,47 @@ function prOpened(): string {
     `If autoWatchPR=always, start it now by invoking /muggle:muggle-pr-followup with the PR URL; ` +
     `if =ask, offer it to the user; if =never, do nothing.`;
   return envelope("PostToolUse", ctx, host);
+}
+
+function prTerminal(): string {
+  const terminalEvent = detectPrTerminal(input);
+  if (!terminalEvent) return "{}";
+  const state = readState(sessionId);
+  const next = applyPrTerminalDetected(state, terminalEvent.prNumber);
+  if (next === state) return "{}";
+  writeState(next);
+  const ctx =
+    `PR #${terminalEvent.prNumber} went terminal (${terminalEvent.verdict}). Run the post-merge handoff now: ` +
+    `finalize the watcher slot, tear down per autoCleanup, then OFFER NEXT OPTIONS to the user ` +
+    `(AskUserQuestion) — release, queued work, deferred items. The stop gate holds until the offer runs.`;
+  return envelope("PostToolUse", ctx, host);
+}
+
+function offerRan(): string {
+  if (input.tool_name !== "AskUserQuestion") return "{}";
+  const state = readState(sessionId);
+  const next = applyNextOptionsOffered(state);
+  if (next !== state) writeState(next);
+  return "{}";
+}
+
+function terminalGate(): string {
+  const state = readState(sessionId);
+  const decision = prTerminalGateDecision(state);
+  if (decision.action !== PrTerminalGateAction.Block) return "{}";
+  state.terminalBlockCount = decision.blockCount;
+  writeState(state);
+  const pendingPrList = (state.terminalPending ?? []).map((prNumber) => `#${prNumber}`).join(", ");
+  // Full instruction once; repeats are one line (same rationale as e2eGate).
+  const reason =
+    decision.blockCount === 1
+      ? `Do not end the turn yet. PR ${pendingPrList} went terminal (merged/closed) but the post-merge ` +
+        `handoff has not run. Finalize the watcher slot, tear down per autoCleanup, then offer next ` +
+        `options to the user via AskUserQuestion — release, queued work, deferred items. Only the ` +
+        `AskUserQuestion offer clears this gate.`
+      : `Post-merge handoff still owed for PR ${pendingPrList} (reminder ${decision.blockCount}/${MAX_PR_TERMINAL_BLOCKS}): ` +
+        `finalize + tear down, then run the AskUserQuestion next-options offer.`;
+  return blockStop(reason, host);
 }
 
 function recordTests(): string {
@@ -88,8 +137,11 @@ function buildRouter(): string {
 
 const handlers: Record<string, () => string> = {
   "pr-opened": prOpened,
+  "pr-terminal": prTerminal,
+  "offer-ran": offerRan,
   "record-tests": recordTests,
   "e2e-gate": e2eGate,
+  "terminal-gate": terminalGate,
   "report-gate": reportGate,
   "build-router": buildRouter,
 };

--- a/src/guardrails/cli.ts
+++ b/src/guardrails/cli.ts
@@ -6,15 +6,14 @@ import {
   applyPrTerminalDetected,
   applyNextOptionsOffered,
   prTerminalGateDecision,
-  PrTerminalGateAction,
-  MAX_PR_TERMINAL_BLOCKS,
 } from "./prTerminal.js";
+import { MAX_PR_TERMINAL_BLOCKS } from "./constants.js";
 import { isTestCommand, testsPassed, isE2ERun, isE2ESkipMarker } from "./testsGreen.js";
 import { e2eGateDecision, E2eGateAction, MAX_E2E_BLOCKS, applyRecordedRun } from "./shouldRunE2E.js";
 import { detectBuildIntent } from "./detectBuildIntent.js";
 import { evaluateReportPost } from "./reportGate.js";
 import { envelope, blockStop, denyTool, type Host } from "./emit.js";
-import type { HookInput } from "./types.js";
+import { PrTerminalGateAction, type HookInput } from "./types.js";
 
 function readStdin(): HookInput {
   try {

--- a/src/guardrails/constants.ts
+++ b/src/guardrails/constants.ts
@@ -1,0 +1,18 @@
+// gh success lines: `✓ Merged pull request #12 (title)` — also the
+// "Squashed and merged" / "Rebased and merged" strategy variants — and
+// `✓ Closed pull request owner/repo#12 (title)`. Newer gh prefixes the number
+// with owner/repo, older prints a bare `#12`; the optional [\w./-]* run accepts
+// both. Anchoring on the full verb phrase (never a bare MERGED/CLOSED token) is
+// what keeps `"state":"MERGED"` out: every `gh pr view --json`/API fetch
+// carries that token, and matching it would arm the gate on a routine status
+// query. It also excludes git's own merge-commit subject ("Merge pull
+// request #N"), which differs by verb tense.
+export const GH_PR_MERGED_LINE = /\b(?:Merged|Squashed and merged|Rebased and merged) pull request [\w./-]*#(\d+)/;
+export const GH_PR_CLOSED_LINE = /\bClosed pull request [\w./-]*#(\d+)/;
+
+// The pr-followup watch monitor's exit line (e.g. `TERMINAL pr=331: MERGED`),
+// which also surfaces when a monitor event notification is replayed through a
+// tool result.
+export const PR_MONITOR_TERMINAL_LINE = /\bTERMINAL pr=(\d+): (MERGED|CLOSED)\b/;
+
+export const MAX_PR_TERMINAL_BLOCKS = 3;

--- a/src/guardrails/prTerminal.ts
+++ b/src/guardrails/prTerminal.ts
@@ -1,0 +1,117 @@
+import type { GuardrailState, HookInput } from "./types.js";
+
+export enum PrTerminalVerdict {
+  Merged = "merged",
+  Closed = "closed",
+}
+
+export interface PrTerminalEvent {
+  prNumber: number;
+  verdict: PrTerminalVerdict;
+}
+
+// gh success lines: `✓ Merged pull request #12 (title)` — also the
+// "Squashed and merged" / "Rebased and merged" strategy variants — and
+// `✓ Closed pull request owner/repo#12 (title)`. Newer gh prefixes the number
+// with owner/repo, older prints a bare `#12`; the optional [\w./-]* run accepts
+// both. Anchoring on the full verb phrase (never a bare MERGED/CLOSED token) is
+// what keeps `"state":"MERGED"` out: every `gh pr view --json`/API fetch
+// carries that token, and matching it would arm the gate on a routine status
+// query. It also excludes git's own merge-commit subject ("Merge pull
+// request #N"), which differs by verb tense.
+const GH_MERGED_LINE = /\b(?:Merged|Squashed and merged|Rebased and merged) pull request [\w./-]*#(\d+)/;
+const GH_CLOSED_LINE = /\bClosed pull request [\w./-]*#(\d+)/;
+// The pr-followup watch monitor's exit line (e.g. `TERMINAL pr=331: MERGED`),
+// which also surfaces when a monitor event notification is replayed through a
+// tool result.
+const MONITOR_TERMINAL_LINE = /\bTERMINAL pr=(\d+): (MERGED|CLOSED)\b/;
+
+// gh writes its success line to stderr, the monitor exit line arrives on
+// stdout/output, and a replayed Monitor notification may carry it in content —
+// scan all four.
+export function detectPrTerminal(input: HookInput): PrTerminalEvent | null {
+  if (input.tool_name !== "Bash" && input.tool_name !== "Monitor") return null;
+  const response = input.tool_response;
+  const haystack = [response?.stdout, response?.stderr, response?.output, response?.content]
+    .filter((part): part is string => typeof part === "string")
+    .join("\n");
+  const mergedMatch = haystack.match(GH_MERGED_LINE);
+  if (mergedMatch) {
+    return { prNumber: Number(mergedMatch[1]), verdict: PrTerminalVerdict.Merged };
+  }
+  const closedMatch = haystack.match(GH_CLOSED_LINE);
+  if (closedMatch) {
+    return { prNumber: Number(closedMatch[1]), verdict: PrTerminalVerdict.Closed };
+  }
+  const monitorMatch = haystack.match(MONITOR_TERMINAL_LINE);
+  if (monitorMatch) {
+    return {
+      prNumber: Number(monitorMatch[1]),
+      verdict: monitorMatch[2] === "MERGED" ? PrTerminalVerdict.Merged : PrTerminalVerdict.Closed,
+    };
+  }
+  return null;
+}
+
+// Arm the handoff for a newly terminal PR. Returns the same reference when the
+// PR is already pending or already handled so the caller can skip the write and
+// the repeat nudge — the same terminal line can resurface later in the session
+// (a log tail, a replayed monitor notification) and must not re-arm a gate the
+// offer already cleared.
+export function applyPrTerminalDetected(state: GuardrailState, prNumber: number): GuardrailState {
+  const pending = state.terminalPending ?? [];
+  const handled = state.terminalHandled ?? [];
+  if (pending.includes(prNumber) || handled.includes(prNumber)) return state;
+  return { ...state, terminalPending: [...pending, prNumber] };
+}
+
+// The ONLY exit: an AskUserQuestion call while a terminal PR is pending. Moves
+// the pending PRs to handled and resets the block counter. Nothing else —
+// not a passing unit test, not a tick, not another Bash call — may clear the
+// pending set or rewind the counter: any other reset path lets routine
+// activity turn the 3-block cap into an unbounded nag loop.
+export function applyNextOptionsOffered(state: GuardrailState): GuardrailState {
+  const pending = state.terminalPending ?? [];
+  if (pending.length === 0) return state;
+  return {
+    ...state,
+    terminalPending: [],
+    terminalHandled: [...(state.terminalHandled ?? []), ...pending],
+    terminalBlockCount: 0,
+  };
+}
+
+export const MAX_PR_TERMINAL_BLOCKS = 3;
+
+export enum PrTerminalGateAction {
+  Block = "block",
+  Release = "release",
+  None = "none",
+}
+
+export interface PrTerminalGateDecision {
+  action: PrTerminalGateAction;
+  blockCount: number;
+}
+
+// Decide what the Stop hook does when a terminal PR's handoff is still owed.
+//
+// - `None`    — nothing pending (no terminal PR, or the offer already ran).
+// - `Block`   — refuse the turn end so the handoff runs; increments blockCount.
+// - `Release` — blocked MAX_PR_TERMINAL_BLOCKS times already; allow the turn to
+//               end so an un-offerable situation can't trap the session. The
+//               release is unconditional and the counter only ever moves up
+//               (here) or back to zero (applyNextOptionsOffered).
+export function prTerminalGateDecision(
+  state: GuardrailState,
+  maxBlocks: number = MAX_PR_TERMINAL_BLOCKS,
+): PrTerminalGateDecision {
+  const blockCount = state.terminalBlockCount ?? 0;
+  if ((state.terminalPending ?? []).length === 0) {
+    return { action: PrTerminalGateAction.None, blockCount: blockCount };
+  }
+  if (blockCount >= maxBlocks) {
+    return { action: PrTerminalGateAction.Release, blockCount: blockCount };
+  }
+  return { action: PrTerminalGateAction.Block, blockCount: blockCount + 1 };
+}

--- a/src/guardrails/prTerminal.ts
+++ b/src/guardrails/prTerminal.ts
@@ -1,30 +1,11 @@
-import type { GuardrailState, HookInput } from "./types.js";
-
-export enum PrTerminalVerdict {
-  Merged = "merged",
-  Closed = "closed",
-}
-
-export interface PrTerminalEvent {
-  prNumber: number;
-  verdict: PrTerminalVerdict;
-}
-
-// gh success lines: `✓ Merged pull request #12 (title)` — also the
-// "Squashed and merged" / "Rebased and merged" strategy variants — and
-// `✓ Closed pull request owner/repo#12 (title)`. Newer gh prefixes the number
-// with owner/repo, older prints a bare `#12`; the optional [\w./-]* run accepts
-// both. Anchoring on the full verb phrase (never a bare MERGED/CLOSED token) is
-// what keeps `"state":"MERGED"` out: every `gh pr view --json`/API fetch
-// carries that token, and matching it would arm the gate on a routine status
-// query. It also excludes git's own merge-commit subject ("Merge pull
-// request #N"), which differs by verb tense.
-const GH_MERGED_LINE = /\b(?:Merged|Squashed and merged|Rebased and merged) pull request [\w./-]*#(\d+)/;
-const GH_CLOSED_LINE = /\bClosed pull request [\w./-]*#(\d+)/;
-// The pr-followup watch monitor's exit line (e.g. `TERMINAL pr=331: MERGED`),
-// which also surfaces when a monitor event notification is replayed through a
-// tool result.
-const MONITOR_TERMINAL_LINE = /\bTERMINAL pr=(\d+): (MERGED|CLOSED)\b/;
+import { PrTerminalGateAction, PrTerminalVerdict } from "./types.js";
+import type { GuardrailState, HookInput, PrTerminalEvent, PrTerminalGateDecision } from "./types.js";
+import {
+  GH_PR_MERGED_LINE,
+  GH_PR_CLOSED_LINE,
+  PR_MONITOR_TERMINAL_LINE,
+  MAX_PR_TERMINAL_BLOCKS,
+} from "./constants.js";
 
 // gh writes its success line to stderr, the monitor exit line arrives on
 // stdout/output, and a replayed Monitor notification may carry it in content —
@@ -35,15 +16,15 @@ export function detectPrTerminal(input: HookInput): PrTerminalEvent | null {
   const haystack = [response?.stdout, response?.stderr, response?.output, response?.content]
     .filter((part): part is string => typeof part === "string")
     .join("\n");
-  const mergedMatch = haystack.match(GH_MERGED_LINE);
+  const mergedMatch = haystack.match(GH_PR_MERGED_LINE);
   if (mergedMatch) {
     return { prNumber: Number(mergedMatch[1]), verdict: PrTerminalVerdict.Merged };
   }
-  const closedMatch = haystack.match(GH_CLOSED_LINE);
+  const closedMatch = haystack.match(GH_PR_CLOSED_LINE);
   if (closedMatch) {
     return { prNumber: Number(closedMatch[1]), verdict: PrTerminalVerdict.Closed };
   }
-  const monitorMatch = haystack.match(MONITOR_TERMINAL_LINE);
+  const monitorMatch = haystack.match(PR_MONITOR_TERMINAL_LINE);
   if (monitorMatch) {
     return {
       prNumber: Number(monitorMatch[1]),
@@ -79,19 +60,6 @@ export function applyNextOptionsOffered(state: GuardrailState): GuardrailState {
     terminalHandled: [...(state.terminalHandled ?? []), ...pending],
     terminalBlockCount: 0,
   };
-}
-
-export const MAX_PR_TERMINAL_BLOCKS = 3;
-
-export enum PrTerminalGateAction {
-  Block = "block",
-  Release = "release",
-  None = "none",
-}
-
-export interface PrTerminalGateDecision {
-  action: PrTerminalGateAction;
-  blockCount: number;
 }
 
 // Decide what the Stop hook does when a terminal PR's handoff is still owed.

--- a/src/guardrails/types.ts
+++ b/src/guardrails/types.ts
@@ -6,6 +6,9 @@ export interface GuardrailState {
   e2eSkipped?: boolean;
   e2eBlockCount?: number;
   buildIntentRouted?: boolean;
+  terminalPending?: number[];
+  terminalHandled?: number[];
+  terminalBlockCount?: number;
 }
 
 export interface HookInput {
@@ -13,6 +16,6 @@ export interface HookInput {
   cwd?: string;
   tool_name?: string;
   tool_input?: { command?: string };
-  tool_response?: { stdout?: string; stderr?: string; output?: string };
+  tool_response?: { stdout?: string; stderr?: string; output?: string; content?: string };
   prompt?: string;
 }

--- a/src/guardrails/types.ts
+++ b/src/guardrails/types.ts
@@ -11,6 +11,27 @@ export interface GuardrailState {
   terminalBlockCount?: number;
 }
 
+export enum PrTerminalVerdict {
+  Merged = "merged",
+  Closed = "closed",
+}
+
+export interface PrTerminalEvent {
+  prNumber: number;
+  verdict: PrTerminalVerdict;
+}
+
+export enum PrTerminalGateAction {
+  Block = "block",
+  Release = "release",
+  None = "none",
+}
+
+export interface PrTerminalGateDecision {
+  action: PrTerminalGateAction;
+  blockCount: number;
+}
+
 export interface HookInput {
   session_id?: string;
   cwd?: string;

--- a/src/test/guardrails/hook-execution.test.ts
+++ b/src/test/guardrails/hook-execution.test.ts
@@ -101,6 +101,68 @@ describe("guardrail hook execution (cli entry)", () => {
     expect(runHook("e2e-gate", event({ session_id: "fresh" })).out).toBe("{}");
   });
 
+  it("pr-terminal -> terminal-gate: a merged PR holds the Stop until the AskUserQuestion offer runs", () => {
+    const session = "terminal-chain";
+    const detect = runHook(
+      "pr-terminal",
+      event({
+        session_id: session,
+        tool_name: "Bash",
+        tool_input: { command: "gh pr merge 341 --squash" },
+        tool_response: { stdout: "", stderr: "✓ Squashed and merged pull request #341 (feat: thing)\n" },
+      }),
+    );
+    const nudge = JSON.parse(detect.out);
+    expect(nudge.hookSpecificOutput.hookEventName).toBe("PostToolUse");
+    expect(nudge.hookSpecificOutput.additionalContext).toContain("PR #341");
+    expect(nudge.hookSpecificOutput.additionalContext).toContain("AskUserQuestion");
+
+    const blocked = JSON.parse(runHook("terminal-gate", event({ session_id: session })).out);
+    expect(blocked.decision).toBe("block");
+    expect(blocked.reason).toContain("#341");
+
+    expect(runHook("offer-ran", event({ session_id: session, tool_name: "AskUserQuestion" })).out).toBe("{}");
+    expect(runHook("terminal-gate", event({ session_id: session })).out).toBe("{}");
+  });
+
+  it("terminal-gate: full instruction once, one-line reminders after, hard release after 3 blocks", () => {
+    const session = "terminal-cap";
+    runHook(
+      "pr-terminal",
+      event({
+        session_id: session,
+        tool_name: "Bash",
+        tool_response: { stderr: "✓ Closed pull request o/r#12 (stale)\n" },
+      }),
+    );
+    const first = JSON.parse(runHook("terminal-gate", event({ session_id: session })).out);
+    expect(first.decision).toBe("block");
+    expect(first.reason).toContain("Do not end the turn yet");
+    const second = JSON.parse(runHook("terminal-gate", event({ session_id: session })).out);
+    expect(second.reason).toContain("2/3");
+    expect(second.reason.length).toBeLessThan(first.reason.length);
+    expect(JSON.parse(runHook("terminal-gate", event({ session_id: session })).out).decision).toBe("block");
+    expect(runHook("terminal-gate", event({ session_id: session })).out).toBe("{}");
+  });
+
+  it("pr-terminal: ignores PR state metadata in a JSON fetch", () => {
+    const { out } = runHook(
+      "pr-terminal",
+      event({
+        session_id: "terminal-json",
+        tool_name: "Bash",
+        tool_input: { command: "gh pr view 9 --json state" },
+        tool_response: { stdout: '{"state":"MERGED"}' },
+      }),
+    );
+    expect(out).toBe("{}");
+  });
+
+  it("offer-ran: an AskUserQuestion with nothing pending is a no-op", () => {
+    expect(runHook("offer-ran", event({ session_id: "no-pending", tool_name: "AskUserQuestion" })).out).toBe("{}");
+    expect(runHook("terminal-gate", event({ session_id: "no-pending" })).out).toBe("{}");
+  });
+
   it("record-tests -> e2e-gate: an explicit skip marker releases an armed gate", () => {
     const session = "skip-chain";
     runHook(
@@ -281,6 +343,31 @@ describe.skipIf(process.platform === "win32")("guardrail wrapper pre-filter (no 
   it("e2e-gate: skips Node when no armed state file exists for the session", () => {
     expect(runWrapper("guardrail-e2e-gate.sh", event({ session_id: "no-state" }))).toBe("{}");
   });
+
+  it("pr-terminal: skips Node on a plain command, spawns it on a merge success line", () => {
+    expect(
+      runWrapper("guardrail-pr-terminal.sh", event({ tool_name: "Bash", tool_input: { command: "git status" } })),
+    ).toBe("{}");
+    expect(
+      runWrapper(
+        "guardrail-pr-terminal.sh",
+        event({ tool_name: "Bash", tool_response: { stderr: "✓ Merged pull request #341 (x)" } }),
+      ),
+    ).toContain(NODE_RAN);
+    expect(
+      runWrapper(
+        "guardrail-pr-terminal.sh",
+        event({ tool_name: "Bash", tool_response: { stdout: "TERMINAL pr=331: MERGED" } }),
+      ),
+    ).toContain(NODE_RAN);
+  });
+
+  it("terminal-gate and offer-ran: skip Node when no terminal PR is pending", () => {
+    expect(runWrapper("guardrail-terminal-gate.sh", event({ session_id: "no-state" }))).toBe("{}");
+    expect(
+      runWrapper("guardrail-offer-ran.sh", event({ session_id: "no-state", tool_name: "AskUserQuestion" })),
+    ).toBe("{}");
+  });
 });
 
 describe("hooks.json fan-out (Lazy-core tripwire)", () => {
@@ -293,12 +380,30 @@ describe("hooks.json fan-out (Lazy-core tripwire)", () => {
     );
   });
 
-  it("fires exactly two observers on a Bash PostToolUse (pr-opened + record-tests)", () => {
+  it("fires exactly three observers on a Bash PostToolUse (pr-opened + record-tests + pr-terminal)", () => {
     const bash = hooks.PostToolUse.find((g) => g.matcher === "Bash");
     expect(bash).toBeDefined();
     const cmds = bash!.hooks.map((h) => h.command);
-    expect(cmds).toHaveLength(2);
+    expect(cmds).toHaveLength(3);
     expect(cmds.some((c) => c.includes("guardrail-pr-opened.sh"))).toBe(true);
     expect(cmds.some((c) => c.includes("guardrail-record-tests.sh"))).toBe(true);
+    expect(cmds.some((c) => c.includes("guardrail-pr-terminal.sh"))).toBe(true);
+  });
+
+  it("fires the offer observer on AskUserQuestion and the terminal detector on Monitor", () => {
+    const ask = hooks.PostToolUse.find((g) => g.matcher === "AskUserQuestion");
+    expect(ask!.hooks.map((h) => h.command)).toEqual([
+      expect.stringContaining("guardrail-offer-ran.sh"),
+    ]);
+    const monitor = hooks.PostToolUse.find((g) => g.matcher === "Monitor");
+    expect(monitor!.hooks.map((h) => h.command)).toEqual([
+      expect.stringContaining("guardrail-pr-terminal.sh"),
+    ]);
+  });
+
+  it("runs both gates on Stop (e2e + post-merge handoff)", () => {
+    const stop = hooks.Stop[0].hooks.map((h) => h.command);
+    expect(stop.some((c) => c.includes("guardrail-e2e-gate.sh"))).toBe(true);
+    expect(stop.some((c) => c.includes("guardrail-terminal-gate.sh"))).toBe(true);
   });
 });

--- a/src/test/guardrails/prTerminal.test.ts
+++ b/src/test/guardrails/prTerminal.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from "vitest";
+import {
+  detectPrTerminal,
+  applyPrTerminalDetected,
+  applyNextOptionsOffered,
+  prTerminalGateDecision,
+  PrTerminalGateAction,
+  PrTerminalVerdict,
+  MAX_PR_TERMINAL_BLOCKS,
+} from "../../guardrails/prTerminal";
+import { applyRecordedRun } from "../../guardrails/shouldRunE2E";
+import type { GuardrailState } from "../../guardrails/types";
+
+describe("detectPrTerminal", () => {
+  it("detects a gh pr merge success line (gh writes it to stderr)", () => {
+    expect(
+      detectPrTerminal({
+        tool_name: "Bash",
+        tool_input: { command: "gh pr merge 341 --squash" },
+        tool_response: { stdout: "", stderr: "✓ Squashed and merged pull request #341 (feat: thing)\n" },
+      }),
+    ).toEqual({ prNumber: 341, verdict: PrTerminalVerdict.Merged });
+  });
+
+  it("detects the plain merge and owner/repo-prefixed shapes", () => {
+    expect(
+      detectPrTerminal({
+        tool_name: "Bash",
+        tool_response: { stderr: "✓ Merged pull request #12 (fix: y)" },
+      }),
+    ).toEqual({ prNumber: 12, verdict: PrTerminalVerdict.Merged });
+    expect(
+      detectPrTerminal({
+        tool_name: "Bash",
+        tool_response: { stderr: "✓ Rebased and merged pull request multiplex-ai/muggle-ai-works#98 (x)" },
+      }),
+    ).toEqual({ prNumber: 98, verdict: PrTerminalVerdict.Merged });
+  });
+
+  it("detects a gh pr close success line", () => {
+    expect(
+      detectPrTerminal({
+        tool_name: "Bash",
+        tool_input: { command: "gh pr close 55" },
+        tool_response: { stderr: "✓ Closed pull request multiplex-ai/muggle-ai-ui#55 (stale spike)\n" },
+      }),
+    ).toEqual({ prNumber: 55, verdict: PrTerminalVerdict.Closed });
+  });
+
+  it("detects the watch monitor's TERMINAL exit line, both verdicts", () => {
+    expect(
+      detectPrTerminal({
+        tool_name: "Bash",
+        tool_response: { stdout: "tick 41 ok\nTERMINAL pr=331: MERGED\n" },
+      }),
+    ).toEqual({ prNumber: 331, verdict: PrTerminalVerdict.Merged });
+    expect(
+      detectPrTerminal({
+        tool_name: "Monitor",
+        tool_response: { content: "TERMINAL pr=45: CLOSED" },
+      }),
+    ).toEqual({ prNumber: 45, verdict: PrTerminalVerdict.Closed });
+  });
+
+  it("ignores state metadata in JSON fetches — a PR state query is not a terminal event", () => {
+    expect(
+      detectPrTerminal({
+        tool_name: "Bash",
+        tool_input: { command: "gh pr view 341 --json state,mergedAt" },
+        tool_response: { stdout: '{"state":"MERGED","mergedAt":"2026-07-22T10:00:00Z"}' },
+      }),
+    ).toBeNull();
+    expect(
+      detectPrTerminal({
+        tool_name: "Bash",
+        tool_response: { stdout: '{ "state": "CLOSED" }' },
+      }),
+    ).toBeNull();
+  });
+
+  it("ignores gh pr view human output for an already-merged PR", () => {
+    expect(
+      detectPrTerminal({
+        tool_name: "Bash",
+        tool_response: {
+          stdout: "feat: thing multiplex-ai/muggle-ai-works#341\nMerged • stan4git merged 3 commits into master\n",
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("ignores git's merge-commit subject in a log", () => {
+    expect(
+      detectPrTerminal({
+        tool_name: "Bash",
+        tool_input: { command: "git log --oneline -5" },
+        tool_response: { stdout: "a4b41da Merge pull request #331 from feat/watch-monitor\n" },
+      }),
+    ).toBeNull();
+  });
+
+  it("ignores non-Bash, non-Monitor tools", () => {
+    expect(
+      detectPrTerminal({
+        tool_name: "Edit",
+        tool_response: { stdout: "✓ Merged pull request #341 (x)" },
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("applyPrTerminalDetected / applyNextOptionsOffered", () => {
+  const base: GuardrailState = { sessionId: "s", prsHandled: [] };
+
+  it("arms a newly terminal PR and dedupes repeats", () => {
+    const armed = applyPrTerminalDetected(base, 341);
+    expect(armed.terminalPending).toEqual([341]);
+    expect(applyPrTerminalDetected(armed, 341)).toBe(armed);
+  });
+
+  it("accumulates distinct PRs", () => {
+    const two = applyPrTerminalDetected(applyPrTerminalDetected(base, 1), 2);
+    expect(two.terminalPending).toEqual([1, 2]);
+  });
+
+  it("the offer clears pending, records handled, and resets the counter", () => {
+    const armed = { ...base, terminalPending: [341, 12], terminalBlockCount: 2 };
+    const cleared = applyNextOptionsOffered(armed);
+    expect(cleared.terminalPending).toEqual([]);
+    expect(cleared.terminalHandled).toEqual([341, 12]);
+    expect(cleared.terminalBlockCount).toBe(0);
+  });
+
+  it("a handled PR never re-arms — a replayed terminal line after the offer stays quiet", () => {
+    const afterOffer = applyNextOptionsOffered({ ...base, terminalPending: [341] });
+    expect(applyPrTerminalDetected(afterOffer, 341)).toBe(afterOffer);
+  });
+
+  it("the offer is a no-op when nothing is pending", () => {
+    expect(applyNextOptionsOffered(base)).toBe(base);
+    const emptyPending: GuardrailState = { ...base, terminalPending: [] };
+    expect(applyNextOptionsOffered(emptyPending)).toBe(emptyPending);
+  });
+});
+
+describe("prTerminalGateDecision", () => {
+  const pending: GuardrailState = { sessionId: "s", prsHandled: [], terminalPending: [341] };
+
+  it("does nothing when no terminal PR is pending", () => {
+    expect(prTerminalGateDecision({ sessionId: "s", prsHandled: [] }).action).toBe(PrTerminalGateAction.None);
+    expect(
+      prTerminalGateDecision({ sessionId: "s", prsHandled: [], terminalPending: [], terminalHandled: [341] }).action,
+    ).toBe(PrTerminalGateAction.None);
+  });
+
+  it("blocks and increments the count while the offer is owed", () => {
+    expect(prTerminalGateDecision(pending)).toEqual({ action: PrTerminalGateAction.Block, blockCount: 1 });
+    expect(prTerminalGateDecision({ ...pending, terminalBlockCount: 2 })).toEqual({
+      action: PrTerminalGateAction.Block,
+      blockCount: 3,
+    });
+  });
+
+  it("releases unconditionally after MAX_PR_TERMINAL_BLOCKS blocks", () => {
+    const decision = prTerminalGateDecision({ ...pending, terminalBlockCount: MAX_PR_TERMINAL_BLOCKS });
+    expect(decision.action).toBe(PrTerminalGateAction.Release);
+    expect(decision.blockCount).toBe(MAX_PR_TERMINAL_BLOCKS);
+  });
+
+  it("walks pending → block ×3 → release", () => {
+    let state = { ...pending };
+    for (let expected = 1; expected <= MAX_PR_TERMINAL_BLOCKS; expected++) {
+      const decision = prTerminalGateDecision(state);
+      expect(decision).toEqual({ action: PrTerminalGateAction.Block, blockCount: expected });
+      state = { ...state, terminalBlockCount: decision.blockCount };
+    }
+    expect(prTerminalGateDecision(state).action).toBe(PrTerminalGateAction.Release);
+  });
+
+  it("the offer clears an armed gate", () => {
+    const cleared = applyNextOptionsOffered({ ...pending, terminalBlockCount: 2 });
+    expect(prTerminalGateDecision(cleared).action).toBe(PrTerminalGateAction.None);
+  });
+
+  it("a passing unit test never rewinds the counter (the e2e gate's reset bug must not recur)", () => {
+    const blockedTwice = { ...pending, terminalBlockCount: 2 };
+    const afterUnitPass = applyRecordedRun(blockedTwice, { unitTestPassed: true });
+    expect(afterUnitPass.terminalBlockCount).toBe(2);
+    expect(afterUnitPass.terminalPending).toEqual([341]);
+    expect(prTerminalGateDecision(afterUnitPass)).toEqual({ action: PrTerminalGateAction.Block, blockCount: 3 });
+  });
+});

--- a/src/test/guardrails/prTerminal.test.ts
+++ b/src/test/guardrails/prTerminal.test.ts
@@ -4,12 +4,10 @@ import {
   applyPrTerminalDetected,
   applyNextOptionsOffered,
   prTerminalGateDecision,
-  PrTerminalGateAction,
-  PrTerminalVerdict,
-  MAX_PR_TERMINAL_BLOCKS,
 } from "../../guardrails/prTerminal";
+import { PrTerminalGateAction, PrTerminalVerdict, type GuardrailState } from "../../guardrails/types";
+import { MAX_PR_TERMINAL_BLOCKS } from "../../guardrails/constants";
 import { applyRecordedRun } from "../../guardrails/shouldRunE2E";
-import type { GuardrailState } from "../../guardrails/types";
 
 describe("detectPrTerminal", () => {
   it("detects a gh pr merge success line (gh writes it to stderr)", () => {


### PR DESCRIPTION
## Gap

On 2026-07-23 a PR merged mid-session and the session ended with only a status line — no watcher-slot finalization, no teardown, no next-options offer. The post-merge handoff exists as skill guidance but nothing enforced it, so it silently skipped. This productizes the fix as a guardrail for all muggle-works users.

## Design

**Detection (PostToolUse, Bash + Monitor)** — `detectPrTerminal` matches only the verb-phrase output shapes of an actual terminal transition:

- `✓ Merged pull request [owner/repo]#N` (plus the `Squashed and merged` / `Rebased and merged` strategy variants) and `✓ Closed pull request [owner/repo]#N` — both old (bare `#N`) and new (owner/repo-prefixed) gh shapes, scanned across stdout/stderr/output/content since gh writes its success line to stderr
- `TERMINAL pr=N: MERGED|CLOSED` — the pr-followup watch monitor's exit line

It deliberately never matches bare `"state":"MERGED"` metadata (every `gh pr view --json` carries it) or git's `Merge pull request #N` commit subject. On detection the PR number lands in `terminalPending` (deduped against pending and already-handled) and a PostToolUse envelope directs the handoff: finalize the watcher slot, tear down per `autoCleanup`, then offer next options via AskUserQuestion.

**Satisfaction** — a PostToolUse firing on AskUserQuestion (`offer-ran`) is the only exit: it moves pending PRs to `terminalHandled` and resets the block counter. The handled list keeps a replayed terminal line (log tail, monitor notification replay) from re-arming a gate the offer already cleared.

**Stop gate** — `terminal-gate` blocks the turn end while `terminalPending` is non-empty, naming the pending PR(s); full instruction on the first block, one-line reminders after; unconditional release after 3 blocks (`MAX_PR_TERMINAL_BLOCKS`).

## No counter reset

The e2e gate's counter resets on every passing unit test, which turned its 3-block cap into ~20 nags in one long session. Here nothing resets `terminalBlockCount` except the offer itself — not a unit test, not a tick, not another Bash call. `prTerminal.test.ts` pins this with a regression test that runs `applyRecordedRun({unitTestPassed: true})` against an armed gate and asserts the counter is untouched.

## Wiring

- `hooks.json`: `guardrail-pr-terminal.sh` joins the Bash PostToolUse fan-out (keyword pre-filter keeps Node off the hot path) and a `Monitor` matcher; `guardrail-offer-ran.sh` on `AskUserQuestion`; `guardrail-terminal-gate.sh` on `Stop` — both state-file pre-filtered so turns with no terminal PR never spawn Node.
- Bundle `plugin/scripts/guardrails.mjs` rebuilt via `npx tsup` (never hand-edited); rebuild is deterministic — identical sha256 across two builds.

## Test evidence

- `npx vitest run src/test/guardrails` — 9 files, 97 passed, 8 skipped (win32-skipped bash pre-filter suite), exit 0
- `npx eslint src/guardrails/ src/test/guardrails/` — exit 0; `npx tsc --noEmit` — exit 0; `node scripts/check-skill-deps.mjs` — OK, 311 links, no reverse deps
- End-to-end through the real wrappers + rebuilt bundle (Git Bash, temp HOME): detect → nudge, dedupe repeat → `{}`, Stop blocks 1/2/3 with escalating-terse reasons → 4th releases `{}`; offer clears an armed gate and a replayed `TERMINAL pr=N` line afterwards stays quiet

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AbQrUE8QdjskUwqbVmj8am
