### PR TITLE
[UNIT-ONLY] Parallelize skill evals with throttle-aware pools

### DIFF
--- a/.github/workflows/skill-eval.yml
+++ b/.github/workflows/skill-eval.yml
@@ -22,9 +22,15 @@ on:
       gate_runs:
         description: "skill-gate-eval: runs per scenario"
         default: "10"
+      gate_concurrency:
+        description: "skill-gate-eval: parallel reps per gate"
+        default: "4"
       routing_runs:
         description: "skill-routing-eval: runs per query"
         default: "3"
+      routing_workers:
+        description: "skill-routing-eval: parallel sessions per chunk"
+        default: "6"
 
 concurrency:
   group: skill-eval-${{ github.ref }}
@@ -38,15 +44,17 @@ permissions:
 jobs:
   skill-gate-eval:
     runs-on: ubuntu-latest
-    # LLM-driven and fully sequential: every gate × every scenario × GATE_RUNS
-    # real Claude reps (~1 min each). 45 min cancelled healthy sweeps mid-gate;
-    # match the sibling skill-routing-eval budget so a full run can finish.
+    # LLM-driven: every gate × every scenario × GATE_RUNS real Claude reps
+    # (~1 min each). Reps run GATE_CONCURRENCY-wide with throttle backoff
+    # (run.ts); gates stay sequential so ::group:: logs stay attributable.
+    # Budget kept generous — throttling can serialize a run back down.
     timeout-minutes: 180
     env:
       # Subscription auth, not a pay-per-use API key. Generate with
       # `claude setup-token` and store as the CLAUDE_CODE_OAUTH_TOKEN secret.
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       GATE_RUNS: ${{ inputs.gate_runs || '10' }}
+      GATE_CONCURRENCY: ${{ inputs.gate_concurrency || '4' }}
       MUGGLE_BRAIN_DIR: ${{ github.workspace }}/muggle-ai-brain
       # Fresh, writable config dir for the headless Claude Code CLI (same as
       # skill-routing-eval) — avoids first-run state in an unwritable HOME.
@@ -212,6 +220,7 @@ jobs:
             echo "::group::gate=$gate skill=$skill runs=$GATE_RUNS"
             if pnpm exec tsx internal/skill-gate-eval/src/run.ts \
                  --gate "$gate" --skill "$skill" --runs "$GATE_RUNS" \
+                 --concurrency "$GATE_CONCURRENCY" \
                  --brain-dir "$MUGGLE_BRAIN_DIR"; then
               echo "PASS $gate"
             else
@@ -261,6 +270,9 @@ jobs:
       # Subscription auth, not a pay-per-use API key (see skill-gate-eval above).
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       ROUTING_RUNS: ${{ inputs.routing_runs || '3' }}
+      # Safe above the old default of 3 now that router_eval retries throttled
+      # runs with a pool-wide backoff instead of scoring them as `none`.
+      ROUTING_WORKERS: ${{ inputs.routing_workers || '6' }}
       CLAUDE_CONFIG_DIR: ${{ github.workspace }}/.cc-config
       CLEAN_CWD: ${{ github.workspace }}/.clean-cwd
     steps:
@@ -380,11 +392,13 @@ jobs:
           # route perfectly.
           if [ "${{ steps.scope.outputs.full }}" = "true" ]; then
             python internal/skill-routing-eval/run.py \
-              --all --runs "$ROUTING_RUNS" --repo-root "$CLEAN_CWD" --fail-under 0.95
+              --all --runs "$ROUTING_RUNS" --workers "$ROUTING_WORKERS" \
+              --repo-root "$CLEAN_CWD" --fail-under 0.95
           else
             python internal/skill-routing-eval/run.py \
               --skills "${{ steps.scope.outputs.skills }}" \
-              --runs "$ROUTING_RUNS" --repo-root "$CLEAN_CWD" --fail-under 1.0
+              --runs "$ROUTING_RUNS" --workers "$ROUTING_WORKERS" \
+              --repo-root "$CLEAN_CWD" --fail-under 1.0
           fi
 
       # Post the routing report (reports/run/combined.md) to the job summary and,

--- a/internal/skill-gate-eval/README.md
+++ b/internal/skill-gate-eval/README.md
@@ -17,6 +17,7 @@ internal/skill-gate-eval/
     scenario.ts     # scenario file loader (types live in types.ts)
     types.ts        # shared types + PreferenceValue enum
     constants.ts    # ASK_QUESTION_TOOL, PASS_THRESHOLD, DEFAULT_MODEL
+    concurrency.ts  # bounded rep pool + shared throttle gate (vitest-covered)
     run.ts          # CLI entrypoint
 ```
 
@@ -47,6 +48,14 @@ The harness loads
 runs each scenario `--runs` times, and writes results to
 `$MUGGLE_BRAIN_DIR/eval/skill-gate-eval/showElectronBrowser/results.json`.
 
+**Concurrency:** reps are isolated agent sessions, so they run through a
+bounded pool — `--concurrency N` (or `SKILL_GATE_EVAL_CONCURRENCY`), default 4;
+`--concurrency 1` restores strictly sequential runs. Rate-limited reps retry up
+to 3× with exponential backoff, and the cooldown is shared across the pool so
+one 429 pauses new starts for every worker instead of compounding. `--verbose`
+traces interleave under concurrency; each line is prefixed with its
+scenario/rep label.
+
 A scenario passes if it succeeds on ≥ 99% of runs (per the design doc).
 
 ## Why not vitest
@@ -61,8 +70,10 @@ blocking workflow — see CI below.
 
 `.github/workflows/skill-eval.yml` runs every gate found under
 `$MUGGLE_BRAIN_DIR/eval/skill-gate-eval/*/scenarios.json` on each PR to
-`master` (`--runs 10`, each scenario must hold ≥99%), plus nightly and on
-`workflow_dispatch`. A PR that changes only runtime (no gate/skill files) is
+`master` (`--runs 10` at `--concurrency 4`, each scenario must hold ≥99%),
+plus nightly and on `workflow_dispatch`. Gates run one at a time — the
+parallelism lives inside each gate's rep pool — so per-gate log groups stay
+attributable. A PR that changes only runtime (no gate/skill files) is
 skipped; label it `run-full-eval` to force the whole suite anyway — the lever
 for de-risking a refactor that changes how skills run, not their definitions.
 It checks out `muggle-ai-brain` for the scenarios, so

--- a/internal/skill-gate-eval/src/concurrency.test.ts
+++ b/internal/skill-gate-eval/src/concurrency.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computeThrottleBackoffMs,
+  isThrottleError,
+  runWithConcurrencyLimit,
+  ThrottleGate,
+  withThrottleRetry,
+} from "./concurrency.js";
+import {
+  THROTTLE_BACKOFF_BASE_MS,
+  THROTTLE_BACKOFF_CAP_MS,
+} from "./constants.js";
+
+function manualClock(): { now: () => number; sleep: (ms: number) => Promise<void>; time: () => number } {
+  let currentMs = 0;
+  return {
+    now: () => currentMs,
+    sleep: (ms: number) => {
+      currentMs += ms;
+      return Promise.resolve();
+    },
+    time: () => currentMs,
+  };
+}
+
+describe("isThrottleError", () => {
+  it.each([
+    "API error: 429 Too Many Requests",
+    "rate limit exceeded, retry later",
+    "Overloaded",
+    "You have reached your usage limit",
+    "server responded with 529",
+  ])("classifies %j as throttle", (message) => {
+    expect(isThrottleError(new Error(message))).toBe(true);
+  });
+
+  it("does not classify ordinary failures as throttle", () => {
+    expect(isThrottleError(new Error("Claude Code process exited with code 1"))).toBe(false);
+    expect(isThrottleError(new Error("ENOENT: no such file"))).toBe(false);
+  });
+});
+
+describe("computeThrottleBackoffMs", () => {
+  it("grows exponentially with zero jitter", () => {
+    expect(computeThrottleBackoffMs(1, () => 0)).toBe(THROTTLE_BACKOFF_BASE_MS);
+    expect(computeThrottleBackoffMs(2, () => 0)).toBe(THROTTLE_BACKOFF_BASE_MS * 2);
+    expect(computeThrottleBackoffMs(3, () => 0)).toBe(THROTTLE_BACKOFF_BASE_MS * 4);
+  });
+
+  it("caps at THROTTLE_BACKOFF_CAP_MS", () => {
+    expect(computeThrottleBackoffMs(10, () => 0.999)).toBe(THROTTLE_BACKOFF_CAP_MS);
+  });
+});
+
+describe("ThrottleGate", () => {
+  it("waits out a reported cooldown and keeps the max of concurrent reports", async () => {
+    const clock = manualClock();
+    const gate = new ThrottleGate(clock.now, clock.sleep);
+    gate.reportThrottle(5_000);
+    gate.reportThrottle(2_000);
+    await gate.waitUntilClear();
+    expect(clock.time()).toBe(5_000);
+  });
+
+  it("returns immediately when no cooldown is active", async () => {
+    const clock = manualClock();
+    const gate = new ThrottleGate(clock.now, clock.sleep);
+    await gate.waitUntilClear();
+    expect(clock.time()).toBe(0);
+  });
+});
+
+describe("withThrottleRetry", () => {
+  const instantGate = () => {
+    const clock = manualClock();
+    return new ThrottleGate(clock.now, clock.sleep);
+  };
+
+  it("retries a throttled run and returns the eventual success", async () => {
+    let calls = 0;
+    const result = await withThrottleRetry(
+      () => {
+        calls++;
+        if (calls === 1) return Promise.reject(new Error("429 rate limit"));
+        return Promise.resolve("ok");
+      },
+      { gate: instantGate(), computeBackoffMs: () => 1 },
+    );
+    expect(result).toBe("ok");
+    expect(calls).toBe(2);
+  });
+
+  it("propagates non-throttle errors without retrying", async () => {
+    let calls = 0;
+    await expect(
+      withThrottleRetry(
+        () => {
+          calls++;
+          return Promise.reject(new Error("scenario file missing"));
+        },
+        { gate: instantGate(), computeBackoffMs: () => 1 },
+      ),
+    ).rejects.toThrow("scenario file missing");
+    expect(calls).toBe(1);
+  });
+
+  it("gives up after maxRetries throttle failures", async () => {
+    let calls = 0;
+    await expect(
+      withThrottleRetry(
+        () => {
+          calls++;
+          return Promise.reject(new Error("overloaded"));
+        },
+        { gate: instantGate(), maxRetries: 2, computeBackoffMs: () => 1 },
+      ),
+    ).rejects.toThrow("overloaded");
+    expect(calls).toBe(3);
+  });
+
+  it("reports each backoff through onThrottle", async () => {
+    const observedAttempts: number[] = [];
+    let calls = 0;
+    await withThrottleRetry(
+      () => {
+        calls++;
+        if (calls <= 2) return Promise.reject(new Error("rate limit"));
+        return Promise.resolve("done");
+      },
+      {
+        gate: instantGate(),
+        computeBackoffMs: () => 1,
+        onThrottle: (attempt) => observedAttempts.push(attempt),
+      },
+    );
+    expect(observedAttempts).toEqual([1, 2]);
+  });
+});
+
+describe("runWithConcurrencyLimit", () => {
+  it("never exceeds the concurrency limit", async () => {
+    let active = 0;
+    let maxActive = 0;
+    const jobs = Array.from({ length: 8 }, () => async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      active--;
+      return maxActive;
+    });
+    await runWithConcurrencyLimit(jobs, 3);
+    expect(maxActive).toBeLessThanOrEqual(3);
+    expect(maxActive).toBeGreaterThan(1);
+  });
+
+  it("returns results in job order regardless of completion order", async () => {
+    const delaysMs = [30, 5, 20, 1];
+    const jobs = delaysMs.map((delayMs, jobIndex) => async () => {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      return jobIndex;
+    });
+    const results = await runWithConcurrencyLimit(jobs, 4);
+    expect(results).toEqual([0, 1, 2, 3]);
+  });
+
+  it("runs everything with a limit larger than the job count", async () => {
+    const results = await runWithConcurrencyLimit(
+      [async () => "a", async () => "b"],
+      16,
+    );
+    expect(results).toEqual(["a", "b"]);
+  });
+
+  it("rejects when a job rejects", async () => {
+    const jobs = [
+      async () => "fine",
+      async () => {
+        throw new Error("boom");
+      },
+    ];
+    await expect(runWithConcurrencyLimit(jobs, 2)).rejects.toThrow("boom");
+  });
+});

--- a/internal/skill-gate-eval/src/concurrency.ts
+++ b/internal/skill-gate-eval/src/concurrency.ts
@@ -1,0 +1,108 @@
+/**
+ * Bounded-concurrency pool + throttle-aware retry for eval reps.
+ *
+ * Every rep is an isolated agent session (its own CLI subprocess), so reps can
+ * run concurrently — the only shared resource is the subscription token's rate
+ * budget. The pool bounds how many sessions run at once; the throttle gate is
+ * shared across the pool so one rate-limited rep pauses new starts for all of
+ * them instead of letting N workers pile onto an already-throttled token.
+ */
+
+import {
+  THROTTLE_BACKOFF_BASE_MS,
+  THROTTLE_BACKOFF_CAP_MS,
+  THROTTLE_BACKOFF_JITTER_MAX_MS,
+  THROTTLE_MAX_RETRIES,
+} from "./constants.js";
+import type { ThrottleGateLike, ThrottleRetryOptions } from "./types.js";
+
+const THROTTLE_SIGNATURE =
+  /\b429\b|\b529\b|rate.?limit|overloaded|too many requests|usage.?limit|quota exceeded/i;
+
+export function isThrottleError(error: unknown): boolean {
+  const text =
+    error instanceof Error ? `${error.message}\n${error.stack ?? ""}` : String(error);
+  return THROTTLE_SIGNATURE.test(text);
+}
+
+export function computeThrottleBackoffMs(
+  attempt: number,
+  random: () => number = Math.random,
+): number {
+  const exponentialMs = THROTTLE_BACKOFF_BASE_MS * 2 ** (attempt - 1);
+  const jitterMs = Math.floor(random() * THROTTLE_BACKOFF_JITTER_MAX_MS);
+  return Math.min(exponentialMs + jitterMs, THROTTLE_BACKOFF_CAP_MS);
+}
+
+function sleepMs(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export class ThrottleGate implements ThrottleGateLike {
+  private cooldownUntilEpochMs = 0;
+
+  constructor(
+    private readonly now: () => number = Date.now,
+    private readonly sleep: (ms: number) => Promise<void> = sleepMs,
+  ) {}
+
+  reportThrottle(backoffMs: number): void {
+    this.cooldownUntilEpochMs = Math.max(
+      this.cooldownUntilEpochMs,
+      this.now() + backoffMs,
+    );
+  }
+
+  async waitUntilClear(): Promise<void> {
+    for (;;) {
+      // Re-check after every sleep: another worker may have extended the
+      // cooldown while this one was waiting.
+      const remainingMs = this.cooldownUntilEpochMs - this.now();
+      if (remainingMs <= 0) return;
+      await this.sleep(remainingMs);
+    }
+  }
+}
+
+/** Retries `run` on throttle-classified failures only; any other error propagates untouched. */
+export async function withThrottleRetry<T>(
+  run: () => Promise<T>,
+  options: ThrottleRetryOptions,
+): Promise<T> {
+  const maxRetries = options.maxRetries ?? THROTTLE_MAX_RETRIES;
+  const computeBackoffMs = options.computeBackoffMs ?? computeThrottleBackoffMs;
+  for (let attempt = 1; ; attempt++) {
+    await options.gate.waitUntilClear();
+    try {
+      return await run();
+    } catch (error) {
+      if (!isThrottleError(error) || attempt > maxRetries) throw error;
+      const backoffMs = computeBackoffMs(attempt);
+      options.gate.reportThrottle(backoffMs);
+      if (options.onThrottle) options.onThrottle(attempt, backoffMs, error);
+    }
+  }
+}
+
+/**
+ * Runs `jobs` with at most `concurrencyLimit` in flight; resolves to results
+ * in job order. A job rejection propagates (fail-fast, matching the previous
+ * sequential behavior); in-flight siblings finish but their results are dropped.
+ */
+export async function runWithConcurrencyLimit<T>(
+  jobs: Array<() => Promise<T>>,
+  concurrencyLimit: number,
+): Promise<T[]> {
+  const results = new Array<T>(jobs.length);
+  let nextJobIndex = 0;
+  async function drainQueue(): Promise<void> {
+    for (;;) {
+      const jobIndex = nextJobIndex++;
+      if (jobIndex >= jobs.length) return;
+      results[jobIndex] = await jobs[jobIndex]();
+    }
+  }
+  const workerCount = Math.max(1, Math.min(concurrencyLimit, jobs.length));
+  await Promise.all(Array.from({ length: workerCount }, () => drainQueue()));
+  return results;
+}

--- a/internal/skill-gate-eval/src/constants.ts
+++ b/internal/skill-gate-eval/src/constants.ts
@@ -14,6 +14,18 @@ export const PASS_THRESHOLD = 0.8;
 /** Default eval target — used when a skill leaves `model:` unset (inherits the session model). */
 export const DEFAULT_MODEL = "claude-sonnet-4-6";
 
+/**
+ * Reps are isolated agent sessions sharing one subscription token, so the
+ * ceiling is the token's rate budget, not CPU. 4 keeps a healthy sweep fast
+ * while leaving headroom before the throttle gate starts firing.
+ */
+export const DEFAULT_GATE_EVAL_CONCURRENCY = 4;
+
+export const THROTTLE_MAX_RETRIES = 3;
+export const THROTTLE_BACKOFF_BASE_MS = 15_000;
+export const THROTTLE_BACKOFF_CAP_MS = 120_000;
+export const THROTTLE_BACKOFF_JITTER_MAX_MS = 5_000;
+
 /** Map `/model`-style aliases (as used in SKILL.md `model:`) to concrete model ids. */
 export const MODEL_ALIASES: Record<string, string> = {
   haiku: "claude-haiku-4-5-20251001",

--- a/internal/skill-gate-eval/src/run.ts
+++ b/internal/skill-gate-eval/src/run.ts
@@ -10,6 +10,7 @@
  *     --runs 10 \
  *     [--brain-dir ../muggle-ai-brain] \
  *     [--model claude-sonnet-4-6] \
+ *     [--concurrency 4]           # parallel reps; SKILL_GATE_EVAL_CONCURRENCY env also works
  *     [--scenario <substring>]   # only run scenarios whose name contains this
  *     [--verbose]                 # dump per-run trace to stderr
  */
@@ -17,7 +18,17 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-import { DEFAULT_MODEL, MODEL_ALIASES, PASS_THRESHOLD } from "./constants.js";
+import {
+  runWithConcurrencyLimit,
+  ThrottleGate,
+  withThrottleRetry,
+} from "./concurrency.js";
+import {
+  DEFAULT_GATE_EVAL_CONCURRENCY,
+  DEFAULT_MODEL,
+  MODEL_ALIASES,
+  PASS_THRESHOLD,
+} from "./constants.js";
 import { runScenarioOnce } from "./harness.js";
 import { loadScenarioFile } from "./scenario.js";
 import type { CliArgs, RunVerdict, ScenarioReport } from "./types.js";
@@ -73,6 +84,14 @@ function parseArgs(argv: string[]): RunCliArgs {
   const model = out.model
     ? resolveModel(out.model, DEFAULT_MODEL)
     : resolveModel(frontmatterModel(skillsDir, out.skill), DEFAULT_MODEL);
+  const concurrencyRaw =
+    out.concurrency ??
+    process.env.SKILL_GATE_EVAL_CONCURRENCY ??
+    String(DEFAULT_GATE_EVAL_CONCURRENCY);
+  const concurrency = parseInt(concurrencyRaw, 10);
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw new Error(`--concurrency must be a positive integer, got "${concurrencyRaw}"`);
+  }
   return {
     gate: out.gate,
     skill: out.skill,
@@ -80,6 +99,7 @@ function parseArgs(argv: string[]): RunCliArgs {
     brainDir: out["brain-dir"] ?? process.env.MUGGLE_BRAIN_DIR ?? "../muggle-ai-brain",
     skillsDir: skillsDir,
     model: model,
+    concurrency: concurrency,
     scenarioFilter: out.scenario,
     verbose: flags.has("verbose"),
   };
@@ -88,7 +108,9 @@ function parseArgs(argv: string[]): RunCliArgs {
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
   // eslint-disable-next-line no-console
-  console.error(`[skill-gate-eval] ${args.gate} on ${args.skill} — model=${args.model} runs=${args.runs}`);
+  console.error(
+    `[skill-gate-eval] ${args.gate} on ${args.skill} — model=${args.model} runs=${args.runs} concurrency=${args.concurrency}`,
+  );
   const scenarioFilePath = path.resolve(
     args.brainDir,
     "eval",
@@ -115,43 +137,70 @@ async function main(): Promise<void> {
     );
   }
 
-  const reports: ScenarioReport[] = [];
-  for (const scenario of filteredScenarios) {
-    const verdicts: RunVerdict[] = [];
-    for (let i = 0; i < args.runs; i++) {
-      // eslint-disable-next-line no-console
-      console.error(`[skill-gate-eval] running ${scenario.name} (rep ${i + 1}/${args.runs})…`);
-      // eslint-disable-next-line no-await-in-loop
-      const v = await runScenarioOnce(
-        {
-          scenarioFile: scenarioFile,
-          scenarioFilePath: scenarioFilePath,
-          scenario: scenario,
-          skillsDir: path.resolve(args.skillsDir),
-          model: args.model,
-        },
-        args.verbose ? (msg) => process.stderr.write(`[sdk] ${oneLine(msg)}\n`) : undefined,
-      );
-      verdicts.push(v);
-      if (args.verbose) {
+  // Each rep is an isolated agent session, so reps run through a bounded pool.
+  // One shared gate: a rate-limited rep pauses new starts for every worker.
+  const throttleGate = new ThrottleGate();
+  const repJobs = filteredScenarios.flatMap((scenario, scenarioIndex) =>
+    Array.from({ length: args.runs }, (_, repIndex) => {
+      const repLabel = `${scenario.name} (rep ${repIndex + 1}/${args.runs})`;
+      return async (): Promise<{ scenarioIndex: number; verdict: RunVerdict }> => {
         // eslint-disable-next-line no-console
-        console.error(JSON.stringify(v, null, 2));
-      }
-    }
+        console.error(`[skill-gate-eval] running ${repLabel}…`);
+        const verdict = await withThrottleRetry(
+          () =>
+            runScenarioOnce(
+              {
+                scenarioFile: scenarioFile,
+                scenarioFilePath: scenarioFilePath,
+                scenario: scenario,
+                skillsDir: path.resolve(args.skillsDir),
+                model: args.model,
+              },
+              args.verbose
+                ? (msg) => process.stderr.write(`[sdk ${repLabel}] ${oneLine(msg)}\n`)
+                : undefined,
+            ),
+          {
+            gate: throttleGate,
+            onThrottle: (attempt, backoffMs, error) => {
+              // eslint-disable-next-line no-console
+              console.error(
+                `[skill-gate-eval] ${repLabel}: rate-limited (attempt ${attempt}) — backing off ${Math.round(backoffMs / 1000)}s: ${oneLine(String(error))}`,
+              );
+            },
+          },
+        );
+        if (args.verbose) {
+          // eslint-disable-next-line no-console
+          console.error(JSON.stringify(verdict, null, 2));
+        }
+        return { scenarioIndex: scenarioIndex, verdict: verdict };
+      };
+    }),
+  );
+  const repOutcomes = await runWithConcurrencyLimit(repJobs, args.concurrency);
+
+  const verdictsByScenario: RunVerdict[][] = filteredScenarios.map(() => []);
+  for (const outcome of repOutcomes) {
+    verdictsByScenario[outcome.scenarioIndex].push(outcome.verdict);
+  }
+
+  const reports: ScenarioReport[] = filteredScenarios.map((scenario, scenarioIndex) => {
+    const verdicts = verdictsByScenario[scenarioIndex];
     const passes = verdicts.filter((v) => v.pass).length;
     const passRate = passes / verdicts.length;
     const failureReasons = Array.from(
       new Set(verdicts.flatMap((v) => v.reasons)),
     );
-    reports.push({
+    return {
       name: scenario.name,
       runs: verdicts.length,
       passes: passes,
       passRate: passRate,
       passed: passRate >= PASS_THRESHOLD,
       failureReasons: failureReasons,
-    });
-  }
+    };
+  });
 
   const resultsPath = path.resolve(
     path.dirname(scenarioFilePath),

--- a/internal/skill-gate-eval/src/types.ts
+++ b/internal/skill-gate-eval/src/types.ts
@@ -127,6 +127,21 @@ export interface CliArgs {
   brainDir: string;
   skillsDir: string;
   model: string;
+  /** Max eval reps in flight at once; 1 reproduces the old sequential behavior. */
+  concurrency: number;
+}
+
+/** Shared cooldown: one throttled rep pauses new starts for every worker. */
+export interface ThrottleGateLike {
+  reportThrottle(backoffMs: number): void;
+  waitUntilClear(): Promise<void>;
+}
+
+export interface ThrottleRetryOptions {
+  gate: ThrottleGateLike;
+  maxRetries?: number;
+  computeBackoffMs?: (attempt: number) => number;
+  onThrottle?: (attempt: number, backoffMs: number, error: unknown) => void;
 }
 
 export interface ScenarioReport {

--- a/internal/skill-routing-eval/README.md
+++ b/internal/skill-routing-eval/README.md
@@ -26,7 +26,7 @@ python internal/skill-routing-eval/run.py --skill muggle-status   # one skill
 python internal/skill-routing-eval/run.py --all --sync-cache      # see below
 ```
 
-Output lands in `reports/run/` (`combined.json` + `combined.md`, plus per-skill `chunk_*.json`). `run.py` runs each skill's queries as a separate `claude -p` batch so an MCP disconnect can only spoil one chunk, not the whole sweep; a positive chunk that comes back all-`none` (the disconnect signature) is re-run once and flagged if it stays empty. Keep `--workers` low (default 3) — high concurrency is what trips the disconnect.
+Output lands in `reports/run/` (`combined.json` + `combined.md`, plus per-skill `chunk_*.json`). `run.py` runs each skill's queries as a separate `claude -p` batch so an MCP disconnect can only spoil one chunk, not the whole sweep; a positive chunk that comes back all-`none` (the disconnect signature) is re-run once and flagged if it stays empty. Within a chunk, a run that fails with a rate-limit signature retries up to 3× with exponential backoff shared across the worker pool (`throttle.py`), and exhausted retries score as `THROTTLED` rather than a silent `none` — which is what makes `--workers` above the old default of 3 safe (CI uses 6).
 
 **`--sync-cache`:** the harness routes via the *installed* muggle plugin, not the working tree. When you've edited a `SKILL.md` description but not reinstalled, `claude -p` sees both the cached copy and the bare-name working-tree skill and results are unreliable. `--sync-cache` copies `plugin/skills/*/SKILL.md` over the installed cache first (auto-detected from `~/.claude/plugins/installed_plugins.json`) so the eval tests your edits. Always pass it when validating a description change.
 

--- a/internal/skill-routing-eval/router_eval.py
+++ b/internal/skill-routing-eval/router_eval.py
@@ -22,7 +22,12 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from threading import Lock
 
+import throttle
+
 NONE = "none"
+
+# Shared across the worker pool: one rate-limited run pauses new starts for all.
+THROTTLE_GATE = throttle.ThrottleGate()
 
 
 def normalize_skill(raw: str) -> str:
@@ -39,28 +44,7 @@ def _route_from_path(path: str) -> str:
     return normalize_skill(m.group(1)) if m else ""
 
 
-def detect_route(query: str, repo_root: str, timeout: int, model: str | None) -> str:
-    cmd = [
-        "claude", "-p", query,
-        "--output-format", "stream-json",
-        "--verbose",
-        "--max-turns", "1",
-    ]
-    if model:
-        cmd.extend(["--model", model])
-
-    env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
-
-    try:
-        proc = subprocess.run(
-            cmd, cwd=repo_root, env=env,
-            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
-            timeout=timeout,
-        )
-    except subprocess.TimeoutExpired:
-        return "TIMEOUT"
-
-    out = proc.stdout.decode("utf-8", errors="replace")
+def parse_route_from_stream(out: str) -> str:
     for line in out.splitlines():
         line = line.strip()
         if not line:
@@ -84,6 +68,80 @@ def detect_route(query: str, repo_root: str, timeout: int, model: str | None) ->
         elif etype == "result":
             return NONE
     return NONE
+
+
+def stream_error_text(out: str) -> str:
+    """Text of an `is_error` result event, or "" — a normal result is not an error."""
+    for line in out.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if event.get("type") == "result" and event.get("is_error"):
+            return line
+    return ""
+
+
+def run_claude_once(query: str, repo_root: str, timeout: int, model: str | None) -> tuple[str, str]:
+    """One isolated `claude -p` session. Returns (status, stdout) where status is
+    OK | TIMEOUT | THROTTLED | ERROR."""
+    cmd = [
+        "claude", "-p", query,
+        "--output-format", "stream-json",
+        "--verbose",
+        "--max-turns", "1",
+    ]
+    if model:
+        cmd.extend(["--model", model])
+
+    env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+
+    try:
+        proc = subprocess.run(
+            cmd, cwd=repo_root, env=env,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return ("TIMEOUT", "")
+
+    out = proc.stdout.decode("utf-8", errors="replace")
+    err = proc.stderr.decode("utf-8", errors="replace")
+    error_text = stream_error_text(out)
+    if proc.returncode != 0 or error_text:
+        # Classify before parsing: a throttled run's stream often still carries a
+        # result event, and silently scoring it as `none` is what used to pollute
+        # negatives and crater positive chunks into the disconnect guard.
+        if throttle.is_throttle_text("\n".join([error_text, err])):
+            return ("THROTTLED", "")
+        if proc.returncode != 0:
+            return ("ERROR", "")
+    return ("OK", out)
+
+
+def detect_route(query: str, repo_root: str, timeout: int, model: str | None) -> str:
+    attempt = 1
+    while True:
+        THROTTLE_GATE.wait_until_clear()
+        status, out = run_claude_once(query, repo_root, timeout, model)
+        if status == "THROTTLED" and attempt <= throttle.MAX_THROTTLE_RETRIES:
+            backoff = throttle.backoff_seconds(attempt)
+            THROTTLE_GATE.report_throttle(backoff)
+            print(
+                f"  rate-limited (attempt {attempt}/{throttle.MAX_THROTTLE_RETRIES + 1}) — backing off {backoff:.0f}s",
+                file=sys.stderr, flush=True,
+            )
+            attempt += 1
+            continue
+        if status == "OK":
+            return parse_route_from_stream(out)
+        # TIMEOUT / ERROR / THROTTLED-with-retries-exhausted: all non-muggle
+        # strings, so they score exactly like the old silent `none` on negatives
+        # while staying attributable in the fired[] lists.
+        return status
 
 
 def main():

--- a/internal/skill-routing-eval/run.py
+++ b/internal/skill-routing-eval/run.py
@@ -92,7 +92,7 @@ def main():
     g.add_argument("--skill", help="run only this expected_skill chunk")
     g.add_argument("--skills", help="comma-separated subset of expected_skills to run (e.g. the skills changed in a PR)")
     ap.add_argument("--runs", type=int, default=3)
-    ap.add_argument("--workers", type=int, default=3, help="keep low — high concurrency trips the MCP disconnect")
+    ap.add_argument("--workers", type=int, default=3, help="parallel claude sessions per chunk; router_eval's per-run throttle retry + shared backoff make higher values safe (CI uses 6)")
     ap.add_argument("--timeout", type=int, default=200)
     ap.add_argument("--out-dir", default=str(HERE / "reports" / "run"))
     ap.add_argument("--repo-root", default=str(REPO_ROOT))

--- a/internal/skill-routing-eval/test_router_eval.py
+++ b/internal/skill-routing-eval/test_router_eval.py
@@ -1,0 +1,47 @@
+import json
+import unittest
+
+import router_eval
+
+
+def assistant_event(tool_name: str, tool_input: dict) -> str:
+    return json.dumps({
+        "type": "assistant",
+        "message": {"content": [{"type": "tool_use", "name": tool_name, "input": tool_input}]},
+    })
+
+
+class TestParseRouteFromStream(unittest.TestCase):
+    def test_skill_tool_call_routes_to_skill(self):
+        out = assistant_event("Skill", {"skill": "muggle:muggle-test"})
+        self.assertEqual(router_eval.parse_route_from_stream(out), "muggle-test")
+
+    def test_read_of_skill_md_routes_via_path(self):
+        out = assistant_event("Read", {"file_path": "C:\\repo\\plugin\\skills\\muggle-status\\SKILL.md"})
+        self.assertEqual(router_eval.parse_route_from_stream(out), "muggle-status")
+
+    def test_other_tool_call_is_none(self):
+        out = assistant_event("Bash", {"command": "ls"})
+        self.assertEqual(router_eval.parse_route_from_stream(out), router_eval.NONE)
+
+    def test_result_without_tool_call_is_none(self):
+        out = json.dumps({"type": "result", "result": "answered directly"})
+        self.assertEqual(router_eval.parse_route_from_stream(out), router_eval.NONE)
+
+    def test_garbage_lines_are_skipped(self):
+        out = "not json\n" + assistant_event("Skill", {"skill": "muggle-do"})
+        self.assertEqual(router_eval.parse_route_from_stream(out), "muggle-do")
+
+
+class TestStreamErrorText(unittest.TestCase):
+    def test_error_result_is_surfaced(self):
+        line = json.dumps({"type": "result", "is_error": True, "result": "rate limit reached"})
+        self.assertEqual(router_eval.stream_error_text(line), line)
+
+    def test_normal_result_is_not_an_error(self):
+        out = json.dumps({"type": "result", "result": "fine"})
+        self.assertEqual(router_eval.stream_error_text(out), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/internal/skill-routing-eval/test_throttle.py
+++ b/internal/skill-routing-eval/test_throttle.py
@@ -1,0 +1,91 @@
+import unittest
+
+import throttle
+
+
+class FakeRand:
+    def __init__(self, value: float):
+        self._value = value
+
+    def uniform(self, low: float, high: float) -> float:
+        return self._value
+
+
+class FakeClock:
+    def __init__(self):
+        self.now = 0.0
+        self.sleeps = []
+
+    def clock(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        self.now += seconds
+
+
+class TestIsThrottleText(unittest.TestCase):
+    def test_matches_throttle_signatures(self):
+        for text in (
+            "API Error: 429 Too Many Requests",
+            "rate limit exceeded",
+            "Overloaded",
+            "you have hit your usage limit",
+            "upstream returned 529",
+            "quota exceeded for this billing period",
+        ):
+            self.assertTrue(throttle.is_throttle_text(text), text)
+
+    def test_rejects_ordinary_failures(self):
+        for text in ("", "claude: command not found", "MCP server disconnected"):
+            self.assertFalse(throttle.is_throttle_text(text), text)
+
+
+class TestBackoffSeconds(unittest.TestCase):
+    def test_grows_exponentially_with_zero_jitter(self):
+        rand = FakeRand(0.0)
+        self.assertEqual(throttle.backoff_seconds(1, rand), 15.0)
+        self.assertEqual(throttle.backoff_seconds(2, rand), 30.0)
+        self.assertEqual(throttle.backoff_seconds(3, rand), 60.0)
+
+    def test_caps_at_backoff_cap(self):
+        rand = FakeRand(throttle.JITTER_MAX_SECONDS)
+        self.assertEqual(throttle.backoff_seconds(10, rand), throttle.BACKOFF_CAP_SECONDS)
+
+
+class TestThrottleGate(unittest.TestCase):
+    def test_waits_out_cooldown_and_keeps_max_of_reports(self):
+        fake = FakeClock()
+        gate = throttle.ThrottleGate(clock=fake.clock, sleeper=fake.sleep)
+        gate.report_throttle(5.0)
+        gate.report_throttle(2.0)
+        gate.wait_until_clear()
+        self.assertEqual(fake.now, 5.0)
+        self.assertEqual(fake.sleeps, [5.0])
+
+    def test_clear_gate_returns_immediately(self):
+        fake = FakeClock()
+        gate = throttle.ThrottleGate(clock=fake.clock, sleeper=fake.sleep)
+        gate.wait_until_clear()
+        self.assertEqual(fake.sleeps, [])
+
+    def test_rechecks_after_sleep_when_cooldown_extended(self):
+        fake = FakeClock()
+        gate = throttle.ThrottleGate(clock=fake.clock, sleeper=fake.sleep)
+        gate.report_throttle(3.0)
+
+        original_sleep = fake.sleep
+
+        def sleep_then_extend(seconds: float) -> None:
+            original_sleep(seconds)
+            if len(fake.sleeps) == 1:
+                gate.report_throttle(4.0)
+
+        gate._sleeper = sleep_then_extend
+        gate.wait_until_clear()
+        self.assertEqual(fake.now, 7.0)
+        self.assertEqual(len(fake.sleeps), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/internal/skill-routing-eval/throttle.py
+++ b/internal/skill-routing-eval/throttle.py
@@ -1,0 +1,53 @@
+"""Throttle detection + shared backoff for the routing-eval worker threads.
+
+Every eval run is an isolated `claude -p` subprocess sharing one subscription
+token, so the scarce resource is the token's rate budget. The gate is shared
+across the thread pool: one rate-limited run pauses new starts for all workers
+instead of letting the pool pile onto an already-throttled token.
+"""
+
+import random
+import re
+import threading
+import time
+
+THROTTLE_SIGNATURE = re.compile(
+    r"\b429\b|\b529\b|rate.?limit|overloaded|too many requests|usage.?limit|quota exceeded",
+    re.IGNORECASE,
+)
+
+MAX_THROTTLE_RETRIES = 3
+BACKOFF_BASE_SECONDS = 15.0
+BACKOFF_CAP_SECONDS = 120.0
+JITTER_MAX_SECONDS = 5.0
+
+
+def is_throttle_text(text: str) -> bool:
+    return bool(text) and bool(THROTTLE_SIGNATURE.search(text))
+
+
+def backoff_seconds(attempt: int, rand: random.Random | None = None) -> float:
+    jitter = (rand or random).uniform(0, JITTER_MAX_SECONDS)
+    return min(BACKOFF_BASE_SECONDS * 2 ** (attempt - 1) + jitter, BACKOFF_CAP_SECONDS)
+
+
+class ThrottleGate:
+    def __init__(self, clock=time.monotonic, sleeper=time.sleep):
+        self._lock = threading.Lock()
+        self._cooldown_until = 0.0
+        self._clock = clock
+        self._sleeper = sleeper
+
+    def report_throttle(self, backoff: float) -> None:
+        with self._lock:
+            self._cooldown_until = max(self._cooldown_until, self._clock() + backoff)
+
+    def wait_until_clear(self) -> None:
+        # Re-check after every sleep: another worker may have extended the
+        # cooldown while this one was waiting.
+        while True:
+            with self._lock:
+                remaining = self._cooldown_until - self._clock()
+            if remaining <= 0:
+                return
+            self._sleeper(remaining)


### PR DESCRIPTION
Replaces #334 (wedged after a dropped head-synchronize event, then unable to reopen — GitHub cannot reopen a PR whose recorded head was rebased away).

## Goal
Cut Skill Evals CI wall-clock by running both evals' agent sessions concurrently under bounded, throttle-aware pools.

## Acceptance Criteria
- skill-gate-eval runs (scenario × rep) jobs through a bounded pool: `--concurrency` / `SKILL_GATE_EVAL_CONCURRENCY`, default 4; `--concurrency 1` reproduces sequential behavior.
- Throttle failures (429/529, rate limit, overloaded, usage limit) retry ≤3× with exponential backoff + jitter; the cooldown is shared across the pool.
- results.json schema, PASS_THRESHOLD semantics, and per-scenario aggregation unchanged; log lines carry scenario/rep labels.
- router_eval.py classifies per-run throttle (nonzero exit / `is_error` result) and retries through a shared gate instead of silently scoring `none`; exhausted retries score `THROTTLED`.
- CI passes `--concurrency 4` (gate) and `--workers 6` (routing), both overridable via workflow_dispatch inputs.

## Changes
- `internal/skill-gate-eval/src/concurrency.ts` — bounded pool, throttle classifier, exponential backoff, shared `ThrottleGate`; wired into `run.ts` (reps flattened to pooled jobs, aggregation unchanged).
- `internal/skill-routing-eval/throttle.py` — same mechanism for the Python harness; `router_eval.py` now captures stderr, classifies throttle per run, retries with pool-wide cooldown, and reports `THROTTLED`/`ERROR` instead of silent `none`.
- `.github/workflows/skill-eval.yml` — `gate_concurrency` (default 4) and `routing_workers` (default 6) inputs, wired into both run steps.
- READMEs updated; sequential-era comments corrected.

## Validation
unit-only — vitest 741 passed (18 new in `concurrency.test.ts`); Python unittest 19 passed (12 new); both re-verified after rebasing onto the 5.6.0 release. Live smoke: 2 concurrent reps of `showElectronBrowser/always-omits-showUi` ran in parallel and passed 2/2 with intact aggregation. No runtime web surface → E2E skipped. Carries `run-full-eval` so the full gate + routing sweeps exercise the parallel runners in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6ytfCxMr54WyGTiJvfpqk