### PR TITLE
feat(pr-post): sign every PR/review/comment muggle works posts

### DIFF
--- a/plugin/skills/_shared/pr-followup-helpers/loop-signature.md
+++ b/plugin/skills/_shared/pr-followup-helpers/loop-signature.md
@@ -8,7 +8,7 @@ Append these two lines as the end of every loop-posted comment body:
 
 ```
 <!-- muggle-do:bot -->
-🤖 _Posted by [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works) · `/muggle-do`_
+🤖 _Posted by `/muggle-do` · [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works)_
 ```
 
 - `<!-- muggle-do:bot -->` — hidden HTML marker; GitHub renders it invisibly and humans never type it. This is the **detection token**. It must stay exactly as written — echo-protection and addressed-by-loop classification read this literal string.

--- a/plugin/skills/_shared/pr-followup-helpers/loop-signature.md
+++ b/plugin/skills/_shared/pr-followup-helpers/loop-signature.md
@@ -8,11 +8,11 @@ Append these two lines as the end of every loop-posted comment body:
 
 ```
 <!-- muggle-do:bot -->
-🤖 _Automated reply from muggle-do._
+🤖 _Posted by [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works) · `/muggle-do`_
 ```
 
-- `<!-- muggle-do:bot -->` — hidden HTML marker; GitHub renders it invisibly and humans never type it. This is the **detection token**.
-- The visible line makes the automation clear to a reader.
+- `<!-- muggle-do:bot -->` — hidden HTML marker; GitHub renders it invisibly and humans never type it. This is the **detection token**. It must stay exactly as written — echo-protection and addressed-by-loop classification read this literal string.
+- The visible line is the shared Muggle Works signature ([`../vcs/post-signature.md`](../vcs/post-signature.md)) with `/muggle-do` as the command. It links a reader back to the tool and names the command that posted the comment.
 
 ## Detection
 

--- a/plugin/skills/_shared/vcs/github/pr-edit.md
+++ b/plugin/skills/_shared/vcs/github/pr-edit.md
@@ -6,3 +6,5 @@ For `open-prs/update.md` when E2E state flips (passing↔failing) or validation 
 gh pr edit <pr-number> --repo <owner>/<repo> --title "<new-title>"
 gh pr edit <pr-number> --repo <owner>/<repo> --body-file <file>
 ```
+
+The `<file>` body must end with the Muggle Works signature. Because the description is re-posted on each refresh, strip the old signature (from the `<!-- muggle-works:signature -->` marker to the end) before re-appending it — see [`../post-signature.md`](../post-signature.md).

--- a/plugin/skills/_shared/vcs/github/reply-line-comment.md
+++ b/plugin/skills/_shared/vcs/github/reply-line-comment.md
@@ -8,3 +8,5 @@ gh api --method POST \
   repos/<owner>/<repo>/pulls/<n>/comments/<comment-id>/replies \
   -f body="<reply-text>"
 ```
+
+The `<reply-text>` must end with the loop signature block — the `<!-- muggle-do:bot -->` detection marker above the Muggle Works line. See [`../post-signature.md`](../post-signature.md).

--- a/plugin/skills/_shared/vcs/github/top-level-comment.md
+++ b/plugin/skills/_shared/vcs/github/top-level-comment.md
@@ -5,3 +5,5 @@ For the resolve-reminder stage and any non-threaded notice.
 ```bash
 gh pr comment <pr-number> --repo <owner>/<repo> --body "<text>"
 ```
+
+The `<text>` you post must end with the Muggle Works signature — see [`../post-signature.md`](../post-signature.md).

--- a/plugin/skills/_shared/vcs/post-signature.md
+++ b/plugin/skills/_shared/vcs/post-signature.md
@@ -7,7 +7,7 @@ Every pull-request / merge-request body, comment, and review-thread reply that m
 Append this as the last line of the posted body:
 
 ```
-🤖 _Posted by [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works) · `<command>`_
+🤖 _Posted by `<command>` · [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works)_
 ```
 
 `<command>` is the slash-command of the skill whose `gh` / `glab` call posts the body:
@@ -23,7 +23,7 @@ A description is re-posted whenever state changes, so its signature must not sta
 
 ```
 <!-- muggle-works:signature -->
-🤖 _Posted by [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works) · `/muggle-do`_
+🤖 _Posted by `/muggle-do` · [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works)_
 ```
 
 Before writing an edited body, delete everything from the `<!-- muggle-works:signature -->` marker to the end of the body, then append the block fresh. This keeps exactly one signature no matter how many times the description is refreshed.

--- a/plugin/skills/_shared/vcs/post-signature.md
+++ b/plugin/skills/_shared/vcs/post-signature.md
@@ -1,0 +1,31 @@
+# PR post signature
+
+Every pull-request / merge-request body, comment, and review-thread reply that muggle works posts ends with a signature line. Under a single-account workflow the automation posts as the repo owner, so the signature is what tells a reader — and a reviewer — that the post came from Muggle Works and which command produced it.
+
+## The line
+
+Append this as the last line of the posted body:
+
+```
+🤖 _Posted by [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works) · `<command>`_
+```
+
+`<command>` is the slash-command of the skill whose `gh` / `glab` call posts the body:
+
+- `/muggle-do` — PR/MR descriptions, per-comment thread replies, top-level reference replies, and resolve-reminders.
+- `/muggle-pr-visual-walkthrough` — a walkthrough comment the walkthrough skill posts itself (Mode A).
+
+Name the command that owns the post, not the one that generated the content. When the walkthrough hands its rendered block back for embedding (Mode B/C), the caller owns the post, so the caller's command is what the signature names.
+
+## Editable bodies (PR / MR description)
+
+A description is re-posted whenever state changes, so its signature must not stack. Precede the line with a hidden marker and treat the pair as one unit:
+
+```
+<!-- muggle-works:signature -->
+🤖 _Posted by [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works) · `/muggle-do`_
+```
+
+Before writing an edited body, delete everything from the `<!-- muggle-works:signature -->` marker to the end of the body, then append the block fresh. This keeps exactly one signature no matter how many times the description is refreshed.
+
+A comment or reply is posted once and never edited, so it needs no dedup marker — append the line alone. A loop-authored reply already carries the `<!-- muggle-do:bot -->` detection marker (defined in loop-signature.md) directly above this line; that marker stays, and this line replaces the old visible text.

--- a/plugin/skills/do/open-prs/forward.md
+++ b/plugin/skills/do/open-prs/forward.md
@@ -31,12 +31,13 @@ Forward pipeline's Stage 7. Invoked by `/muggle-do` after stages 1–6 of a fres
    - `## Changes` — summary of what changed in this repo.
    - `## Validation` — one line: link to E2E report, `unit-only`, or `skip — <reason>`.
    - **Walkthrough block** — only when an E2E report exists. Fire [`postPRVisualWalkthrough`](../../muggle-preferences/preference-gates/postPRVisualWalkthrough.md); on skip, omit this block. Otherwise invoke [`../../muggle-pr-visual-walkthrough/SKILL.md`](../../muggle-pr-visual-walkthrough/SKILL.md) Mode B and embed the returned `body` verbatim. No report → skip the block.
+   - **Signature** — end the body with the Muggle Works signature, editable-body form (the `<!-- muggle-works:signature -->` marker + line, command `/muggle-do`) per [`../../_shared/vcs/post-signature.md`](../../_shared/vcs/post-signature.md). It is the last thing in the body, after the walkthrough block.
 
 4. **Create:** resolve the provider per [`../../_shared/vcs/detect-vcs.md`](../../_shared/vcs/detect-vcs.md).
    - `github` → `gh pr create --title "..." --body "..." --head <branch>`. Capture the PR URL and number.
    - `gitlab` → open the change via [`../../_shared/vcs/gitlab/mr-create.md`](../../_shared/vcs/gitlab/mr-create.md): `glab mr create --source-branch <branch> --target-branch <base> --title "..." --description "..."`. Capture the MR URL and iid.
 
-5. **Overflow comment:** if the walkthrough skill returned a non-null `comment`, post it once using the provider resolved in Step 4 — `github` per [`../../_shared/vcs/github/top-level-comment.md`](../../_shared/vcs/github/top-level-comment.md), `gitlab` per [`../../_shared/vcs/gitlab/mr-note.md`](../../_shared/vcs/gitlab/mr-note.md). Never post when `comment` is `null`.
+5. **Overflow comment:** if the walkthrough skill returned a non-null `comment`, post it once using the provider resolved in Step 4 — `github` per [`../../_shared/vcs/github/top-level-comment.md`](../../_shared/vcs/github/top-level-comment.md), `gitlab` per [`../../_shared/vcs/gitlab/mr-note.md`](../../_shared/vcs/gitlab/mr-note.md). End the posted body with the signature line (command `/muggle-do`) per [`../../_shared/vcs/post-signature.md`](../../_shared/vcs/post-signature.md). Never post when `comment` is `null`.
 
 ## Stage 8 handoff
 

--- a/plugin/skills/do/open-prs/update.md
+++ b/plugin/skills/do/open-prs/update.md
@@ -32,11 +32,11 @@ Resolve the provider once per [`../../_shared/vcs/detect-vcs.md`](../../_shared/
    - Validation now ran (was unit-only/skip, now has E2E report) → strip `[UNVERIFIED]` or `[UNIT-ONLY]`.
    - Otherwise → no title change.
 
-4. **Refresh body when validation outcome changed** — only when the `## Validation` section's content differs from what's in the body. Use the `--body-file` form in [`../../_shared/vcs/github/pr-edit.md`](../../_shared/vcs/github/pr-edit.md). Preserve `## Goal` and `## Acceptance Criteria` verbatim.
+4. **Refresh body when validation outcome changed** — only when the `## Validation` section's content differs from what's in the body. Use the `--body-file` form in [`../../_shared/vcs/github/pr-edit.md`](../../_shared/vcs/github/pr-edit.md). Preserve `## Goal` and `## Acceptance Criteria` verbatim. Re-stamp the signature: delete the existing block from the `<!-- muggle-works:signature -->` marker to the end, then append the editable-body signature (command `/muggle-do`) as the last thing in the body per [`../../_shared/vcs/post-signature.md`](../../_shared/vcs/post-signature.md) — this keeps exactly one signature across refreshes.
 
 5. **Visual walkthrough comment** — only when an E2E report exists. Fire [`postPRVisualWalkthrough`](../../muggle-preferences/preference-gates/postPRVisualWalkthrough.md) (PR number from `prs.json`); on skip, record `skipped (gate)` and continue. Otherwise invoke [`../../muggle-pr-visual-walkthrough/SKILL.md`](../../muggle-pr-visual-walkthrough/SKILL.md) Mode A — a fresh comment per cycle; do not edit prior walkthrough comments.
 
-6. **Overflow comment** — same rule as forward mode: post when the walkthrough skill returns non-null `comment`, via [`../../_shared/vcs/github/top-level-comment.md`](../../_shared/vcs/github/top-level-comment.md).
+6. **Overflow comment** — same rule as forward mode: post when the walkthrough skill returns non-null `comment`, via [`../../_shared/vcs/github/top-level-comment.md`](../../_shared/vcs/github/top-level-comment.md). End the posted body with the signature line (command `/muggle-do`) per [`../../_shared/vcs/post-signature.md`](../../_shared/vcs/post-signature.md).
 
 ## Handoff
 

--- a/plugin/skills/do/per-comment-replies.md
+++ b/plugin/skills/do/per-comment-replies.md
@@ -44,7 +44,7 @@ Reply body uses the template in [`../muggle-pr-followup/output-templates/inline-
 Addressed in <short-sha>: <one-line summary of the change made for THIS comment>.
 
 <!-- muggle-do:bot -->
-🤖 _Posted by [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works) · `/muggle-do`_
+🤖 _Posted by `/muggle-do` · [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works)_
 ```
 
 `<short-sha>` is the first 7 chars of `new_sha`; the body must contain that substring so the resolve-reminder stage knows which push addressed the thread. The trailing signature block is mandatory — its `<!-- muggle-do:bot -->` marker is what identifies the reply as loop-authored (see [`../_shared/pr-followup-helpers/loop-signature.md`](../_shared/pr-followup-helpers/loop-signature.md)).
@@ -60,7 +60,7 @@ If an actionable review has a non-empty `body` and **zero** line comments, GitHu
 Re: review #<review_id> — addressed in <short-sha>: <one-line summary>.
 
 <!-- muggle-do:bot -->
-🤖 _Posted by [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works) · `/muggle-do`_
+🤖 _Posted by `/muggle-do` · [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works)_
 ```
 
 Posted per [`../_shared/vcs/github/top-level-comment.md`](../_shared/vcs/github/top-level-comment.md). Fires at most once per actionable review-with-no-line-comments. Does not fire if the review has line comments — Step 2 covers those.

--- a/plugin/skills/do/per-comment-replies.md
+++ b/plugin/skills/do/per-comment-replies.md
@@ -44,7 +44,7 @@ Reply body uses the template in [`../muggle-pr-followup/output-templates/inline-
 Addressed in <short-sha>: <one-line summary of the change made for THIS comment>.
 
 <!-- muggle-do:bot -->
-🤖 _Automated reply from muggle-do._
+🤖 _Posted by [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works) · `/muggle-do`_
 ```
 
 `<short-sha>` is the first 7 chars of `new_sha`; the body must contain that substring so the resolve-reminder stage knows which push addressed the thread. The trailing signature block is mandatory — its `<!-- muggle-do:bot -->` marker is what identifies the reply as loop-authored (see [`../_shared/pr-followup-helpers/loop-signature.md`](../_shared/pr-followup-helpers/loop-signature.md)).
@@ -60,7 +60,7 @@ If an actionable review has a non-empty `body` and **zero** line comments, GitHu
 Re: review #<review_id> — addressed in <short-sha>: <one-line summary>.
 
 <!-- muggle-do:bot -->
-🤖 _Automated reply from muggle-do._
+🤖 _Posted by [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works) · `/muggle-do`_
 ```
 
 Posted per [`../_shared/vcs/github/top-level-comment.md`](../_shared/vcs/github/top-level-comment.md). Fires at most once per actionable review-with-no-line-comments. Does not fire if the review has line comments — Step 2 covers those.

--- a/plugin/skills/muggle-pr-followup/output-templates/inline-reply.md
+++ b/plugin/skills/muggle-pr-followup/output-templates/inline-reply.md
@@ -6,7 +6,7 @@ Posted via `gh api .../comments/<comment-id>/replies` per cycle, one per line co
 Addressed in <short-sha>: <one-line summary of the change made for THIS comment>.
 
 <!-- muggle-do:bot -->
-🤖 _Posted by [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works) · `/muggle-do`_
+🤖 _Posted by `/muggle-do` · [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works)_
 ```
 
 `<short-sha>` is the first 7 chars of the new SHA; the body must contain that substring so the resolve-reminder stage knows *which push* addressed the thread. The trailing signature block — defined in [`../../_shared/pr-followup-helpers/loop-signature.md`](../../_shared/pr-followup-helpers/loop-signature.md) — is mandatory; its `<!-- muggle-do:bot -->` marker is what identifies the comment as loop-authored.
@@ -19,5 +19,5 @@ When an actionable review has a non-empty body but zero line comments, GitHub ha
 Re: review #<review_id> — addressed in <short-sha>: <one-line summary>.
 
 <!-- muggle-do:bot -->
-🤖 _Posted by [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works) · `/muggle-do`_
+🤖 _Posted by `/muggle-do` · [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works)_
 ```

--- a/plugin/skills/muggle-pr-followup/output-templates/inline-reply.md
+++ b/plugin/skills/muggle-pr-followup/output-templates/inline-reply.md
@@ -6,7 +6,7 @@ Posted via `gh api .../comments/<comment-id>/replies` per cycle, one per line co
 Addressed in <short-sha>: <one-line summary of the change made for THIS comment>.
 
 <!-- muggle-do:bot -->
-🤖 _Automated reply from muggle-do._
+🤖 _Posted by [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works) · `/muggle-do`_
 ```
 
 `<short-sha>` is the first 7 chars of the new SHA; the body must contain that substring so the resolve-reminder stage knows *which push* addressed the thread. The trailing signature block — defined in [`../../_shared/pr-followup-helpers/loop-signature.md`](../../_shared/pr-followup-helpers/loop-signature.md) — is mandatory; its `<!-- muggle-do:bot -->` marker is what identifies the comment as loop-authored.
@@ -19,5 +19,5 @@ When an actionable review has a non-empty body but zero line comments, GitHub ha
 Re: review #<review_id> — addressed in <short-sha>: <one-line summary>.
 
 <!-- muggle-do:bot -->
-🤖 _Automated reply from muggle-do._
+🤖 _Posted by [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works) · `/muggle-do`_
 ```

--- a/plugin/skills/muggle-pr-followup/output-templates/resolve-reminder.md
+++ b/plugin/skills/muggle-pr-followup/output-templates/resolve-reminder.md
@@ -9,7 +9,7 @@ These threads are addressed and still open — mark them resolved if satisfied, 
 - ...
 
 <!-- muggle-do:bot -->
-🤖 _Posted by [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works) · `/muggle-do`_
+🤖 _Posted by `/muggle-do` · [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works)_
 ```
 
 If no such thread exists, no comment is posted (silent). The trailing signature block ([`loop-signature.md`](../../_shared/pr-followup-helpers/loop-signature.md)) keeps the loop from later mistaking its own reminder for a human comment.

--- a/plugin/skills/muggle-pr-followup/output-templates/resolve-reminder.md
+++ b/plugin/skills/muggle-pr-followup/output-templates/resolve-reminder.md
@@ -9,7 +9,7 @@ These threads are addressed and still open — mark them resolved if satisfied, 
 - ...
 
 <!-- muggle-do:bot -->
-🤖 _Automated reply from muggle-do._
+🤖 _Posted by [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works) · `/muggle-do`_
 ```
 
 If no such thread exists, no comment is posted (silent). The trailing signature block ([`loop-signature.md`](../../_shared/pr-followup-helpers/loop-signature.md)) keeps the loop from later mistaking its own reminder for a human comment.

--- a/plugin/skills/muggle-pr-visual-walkthrough/SKILL.md
+++ b/plugin/skills/muggle-pr-visual-walkthrough/SKILL.md
@@ -149,7 +149,7 @@ Extract the `body` field with `jq -r` (not `sed`) so JSON escape sequences are p
 ```bash
 {
   jq -r '.body' /tmp/muggle-pr-section.json
-  printf '\n\n%s\n' '🤖 _Posted by [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works) · `/muggle-pr-visual-walkthrough`_'
+  printf '\n\n%s\n' '🤖 _Posted by `/muggle-pr-visual-walkthrough` · [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works)_'
 } | gh pr comment <pr-number> --body-file -
 ```
 
@@ -158,7 +158,7 @@ Extract the `body` field with `jq -r` (not `sed`) so JSON escape sequences are p
 ```bash
 {
   jq -r '.comment' /tmp/muggle-pr-section.json
-  printf '\n\n%s\n' '🤖 _Posted by [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works) · `/muggle-pr-visual-walkthrough`_'
+  printf '\n\n%s\n' '🤖 _Posted by `/muggle-pr-visual-walkthrough` · [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works)_'
 } | gh pr comment <pr-number> --body-file -
 ```
 
@@ -183,7 +183,7 @@ Instead of posting, **return** the CLI output to the caller's context so they ca
    ```bash
    {
      jq -r '.comment' /tmp/muggle-pr-section.json
-     printf '\n\n%s\n' '🤖 _Posted by [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works) · `/muggle-do`_'
+     printf '\n\n%s\n' '🤖 _Posted by `/muggle-do` · [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works)_'
    } | gh pr comment <new-pr-number> --body-file -
    ```
 

--- a/plugin/skills/muggle-pr-visual-walkthrough/SKILL.md
+++ b/plugin/skills/muggle-pr-visual-walkthrough/SKILL.md
@@ -144,16 +144,22 @@ gh pr view --json number,url,title 2>/dev/null
 
 ### 3A.2: Post the body as a PR comment
 
-Extract the `body` field with `jq -r` (not `sed`) so JSON escape sequences are properly decoded, then pipe to `--body-file -`:
+Extract the `body` field with `jq -r` (not `sed`) so JSON escape sequences are properly decoded, append the Muggle Works signature (command `/muggle-pr-visual-walkthrough`) per [`../_shared/vcs/post-signature.md`](../_shared/vcs/post-signature.md), then pipe to `--body-file -`. The renderer's sentinel stays at the top of `body`, so the report-format guardrail still recognises the post:
 
 ```bash
-jq -r '.body' /tmp/muggle-pr-section.json | gh pr comment <pr-number> --body-file -
+{
+  jq -r '.body' /tmp/muggle-pr-section.json
+  printf '\n\n%s\n' '🤖 _Posted by [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works) · `/muggle-pr-visual-walkthrough`_'
+} | gh pr comment <pr-number> --body-file -
 ```
 
 ### 3A.3: Post the overflow comment only if the CLI emitted one
 
 ```bash
-jq -r '.comment' /tmp/muggle-pr-section.json | gh pr comment <pr-number> --body-file -
+{
+  jq -r '.comment' /tmp/muggle-pr-section.json
+  printf '\n\n%s\n' '🤖 _Posted by [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works) · `/muggle-pr-visual-walkthrough`_'
+} | gh pr comment <pr-number> --body-file -
 ```
 
 **Skip this step entirely if `comment` is `null`** — do not post a placeholder. The CLI decides fit-vs-overflow; never post the overflow comment speculatively.
@@ -172,10 +178,13 @@ Instead of posting, **return** the CLI output to the caller's context so they ca
 
 1. **Embed `body`** in their PR body, concatenated after `## Changes`. `body` already includes its own `## E2E Acceptance Results` header — do not add another.
 2. **Create the PR** with `gh pr create --title "..." --body "..."` using the concatenated body.
-3. **Post `comment` as a follow-up only if the CLI emitted one:**
+3. **Post `comment` as a follow-up only if the CLI emitted one**, ending the posted body with the signature (the caller owns this post, so command `/muggle-do`) per [`../_shared/vcs/post-signature.md`](../_shared/vcs/post-signature.md):
 
    ```bash
-   jq -r '.comment' /tmp/muggle-pr-section.json | gh pr comment <new-pr-number> --body-file -
+   {
+     jq -r '.comment' /tmp/muggle-pr-section.json
+     printf '\n\n%s\n' '🤖 _Posted by [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works) · `/muggle-do`_'
+   } | gh pr comment <new-pr-number> --body-file -
    ```
 
    Skip if `comment` is `null`.


### PR DESCRIPTION
## What

Every automated GitHub post from muggle works now ends with a signature that links back to the tool and names the command that authored it — so under the shared account a reader can tell an automated post from a hand-typed one.

Rendered:

> 🤖 _Posted by [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works) · `/muggle-do`_

## Coverage

| Post | Before | Command it names |
|---|---|---|
| Thread replies, top-level references, resolve-reminders | `🤖 _Automated reply from muggle-do._` | `/muggle-do` |
| PR create / edit description | unsigned | `/muggle-do` |
| E2E visual-walkthrough comment | unsigned | `/muggle-pr-visual-walkthrough` |

## How

- New canonical spec `_shared/vcs/post-signature.md` — the line, the command-naming rule, and a `<!-- muggle-works:signature -->` dedup marker for editable bodies.
- `loop-signature.md` keeps its load-bearing `<!-- muggle-do:bot -->` detection marker (echo-protection and addressed-by-loop classification read it verbatim); only the visible line changed.
- PR-description edits strip the old signature block and re-stamp it, so it never stacks across refreshes.
- The walkthrough comment appends the signature after the rendered body; the renderer's `muggle-pr-section` sentinel stays at the top, so the report-format guardrail still recognises the post.

## Verification

- `vitest run` — 893 passed, 9 skipped (markdown-only; no `src/` changes).
- `tsc --noEmit` — clean.
- `check-skill-deps` — OK, no reverse dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Szpvct8AHhVGgiSYFTohND
