### PR TITLE
feat(ops): host-level memwatch memory sampler + commit tripwire

### DIFF
--- a/ops/memwatch/README.md
+++ b/ops/memwatch/README.md
@@ -19,6 +19,18 @@ Start-Process powershell -Verb RunAs -ArgumentList '-NoProfile','-ExecutionPolic
 
 `install-memwatch.ps1` copies the sampler to `~\.muggle-ai\memwatch\bin\` so the task survives checkout deletion. The elevated installer writes `~\.muggle-ai\memwatch\install-elevated-result.json` for verification from an unelevated shell.
 
+## Pause / resume
+
+Turn the sampler off or on without unregistering it — samples and `trip-state.json` are kept:
+
+```powershell
+.\toggle-memwatch.ps1 -Off    # pause the per-minute sampler
+.\toggle-memwatch.ps1 -On     # resume it
+.\toggle-memwatch.ps1         # show current state / last run
+```
+
+`-Off` disables the scheduled task, `-On` re-enables it — both unprivileged. This is the reversible switch; to remove the task entirely instead, see [Uninstall](#uninstall). The elevated flight-recorder and audit pieces are not covered by this switch (they have no per-user disable) — manage them via their own commands in Uninstall.
+
 ## Data locations
 
 All under `~\.muggle-ai\memwatch\`: `memwatch-YYYYMMDD.jsonl` (14-day retention), `memsnapshot-*.json` (tripwire dumps, 90-day retention), `flight\memflight*.blg` (circular), `trip-state.json`.
@@ -31,6 +43,8 @@ All under `~\.muggle-ai\memwatch\`: `memwatch-YYYYMMDD.jsonl` (14-day retention)
 4. Security log 4688 events: spawn tree with command lines.
 
 ## Uninstall
+
+Full removal. To only pause the sampler (reversible), use [Pause / resume](#pause--resume) instead.
 
 ```powershell
 Unregister-ScheduledTask MuggleMemwatch -Confirm:$false

--- a/ops/memwatch/README.md
+++ b/ops/memwatch/README.md
@@ -1,0 +1,41 @@
+# memwatch — memory-exhaustion flight recorder
+
+Captures the context a memory-leak post-mortem needs: who held the memory, their parentage, and the growth timeline. Born from the 2026-07-26 exhaustion freeze, where Windows' own Resource-Exhaustion-Detector OOM'd before recording any of it.
+
+## Components
+
+| Piece | Needs admin | What it captures |
+| :---- | :---------- | :--------------- |
+| `memwatch.ps1` (scheduled task, 1/min) | no | JSON line per minute: commit %, free RAM, top-15 processes by private bytes with pid/ppid/parent-alive/command line. Tripwire at 85% commit: full process snapshot + toast, re-arms below 75%. |
+| perfmon flight recorder (`logman`, via `install-elevated.ps1`) | yes | 30s circular counter log (512 MB cap): system commit + per-process Private Bytes / Working Set. Open the `.blg` in perfmon after a crash. |
+| process-creation audit (via `install-elevated.ps1`) | yes | Security event 4688 per process birth, including command line — names who spawned what after processes die. CLI-passed secrets land in the local Security log; accepted trade-off. |
+
+## Install
+
+```powershell
+.\install-memwatch.ps1                                  # sampler task (current user)
+Start-Process powershell -Verb RunAs -ArgumentList '-NoProfile','-ExecutionPolicy','Bypass','-File',"$PWD\install-elevated.ps1"
+```
+
+`install-memwatch.ps1` copies the sampler to `~\.muggle-ai\memwatch\bin\` so the task survives checkout deletion. The elevated installer writes `~\.muggle-ai\memwatch\install-elevated-result.json` for verification from an unelevated shell.
+
+## Data locations
+
+All under `~\.muggle-ai\memwatch\`: `memwatch-YYYYMMDD.jsonl` (14-day retention), `memsnapshot-*.json` (tripwire dumps, 90-day retention), `flight\memflight*.blg` (circular), `trip-state.json`.
+
+## Reading a post-mortem
+
+1. `memwatch-*.jsonl` around the incident: growth curve + top consumers per minute (`parentAlive: false` on a heavy process = orphaned work).
+2. `memsnapshot-*.json`: full process table at the 85% crossing.
+3. `relog flight\memflight*.blg -f csv -o out.csv` (or perfmon) for per-process counter history.
+4. Security log 4688 events: spawn tree with command lines.
+
+## Uninstall
+
+```powershell
+Unregister-ScheduledTask MuggleMemwatch -Confirm:$false
+logman stop muggle-memflight; logman delete muggle-memflight   # elevated
+schtasks /Delete /F /TN MuggleMemflightBoot                    # elevated
+auditpol /set /subcategory:"{0CCE922B-69AE-11D9-BED3-505054503030}" /success:disable  # elevated
+reg delete "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\Audit" /v ProcessCreationIncludeCmdLine_Enabled /f  # elevated
+```

--- a/ops/memwatch/install-elevated.ps1
+++ b/ops/memwatch/install-elevated.ps1
@@ -1,0 +1,80 @@
+# Elevated half of the memwatch install: the perfmon flight recorder (logman
+# circular counter log + boot autostart) and process-creation auditing (4688
+# with command lines). Requires admin; writes a machine-readable result file so
+# an unelevated caller can verify the outcome.
+[CmdletBinding()]
+param(
+    [string]$CollectorName = "muggle-memflight",
+    [string]$LogDir = (Join-Path $env:USERPROFILE ".muggle-ai\memwatch"),
+    [int]$SampleIntervalSeconds = 30,
+    [int]$MaxLogMb = 512
+)
+
+$ErrorActionPreference = "Continue"
+New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
+$resultFile = Join-Path $LogDir "install-elevated-result.json"
+
+$isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
+    ).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+if (-not $isAdmin) {
+    Set-Content $resultFile ([ordered]@{ ok = $false; error = "not elevated" } | ConvertTo-Json)
+    exit 2
+}
+
+$steps = [ordered]@{}
+
+# --- A: flight recorder -------------------------------------------------------
+$flightDir = Join-Path $LogDir "flight"
+New-Item -ItemType Directory -Force -Path $flightDir | Out-Null
+& logman stop $CollectorName 2>$null | Out-Null
+& logman delete $CollectorName 2>$null | Out-Null
+$counters = @(
+    '\Memory\Committed Bytes',
+    '\Memory\% Committed Bytes In Use',
+    '\Memory\Available MBytes',
+    '\Process(*)\Private Bytes',
+    '\Process(*)\Working Set'
+)
+& logman create counter $CollectorName -f bincirc -max $MaxLogMb `
+    -si ([TimeSpan]::FromSeconds($SampleIntervalSeconds).ToString()) `
+    -c $counters -o (Join-Path $flightDir "memflight") -ow -y | Out-Null
+$createExit = $LASTEXITCODE
+& logman start $CollectorName | Out-Null
+$startExit = $LASTEXITCODE
+$queryOutput = (& logman query $CollectorName 2>&1) -join "`n"
+$flightRunning = ($startExit -eq 0) -and ($queryOutput -match "Running")
+$steps.flightRecorder = [ordered]@{
+    ok        = $flightRunning
+    createExit = $createExit
+    startExit  = $startExit
+    logDir     = $flightDir
+}
+
+# Auto-restart after reboot: a DCS does not survive one on its own.
+& schtasks /Create /F /TN "MuggleMemflightBoot" /SC ONSTART /RU SYSTEM `
+    /TR "logman start $CollectorName" | Out-Null
+$steps.flightBootTask = [ordered]@{ ok = ($LASTEXITCODE -eq 0) }
+
+# --- C: process-creation audit (4688 + command lines) -------------------------
+# GUID form survives non-English locales; it is the Process Creation subcategory.
+& auditpol /set /subcategory:"{0CCE922B-69AE-11D9-BED3-505054503030}" /success:enable | Out-Null
+$auditExit = $LASTEXITCODE
+& reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\Audit" `
+    /v ProcessCreationIncludeCmdLine_Enabled /t REG_DWORD /d 1 /f | Out-Null
+$regExit = $LASTEXITCODE
+$auditState = (& auditpol /get /subcategory:"{0CCE922B-69AE-11D9-BED3-505054503030}" 2>&1) -join "`n"
+$steps.processAudit = [ordered]@{
+    ok        = ($auditExit -eq 0 -and $regExit -eq 0)
+    auditExit = $auditExit
+    regExit   = $regExit
+    state     = ($auditState -split "`n" | Select-Object -Last 2) -join " "
+}
+
+$allOk = $true
+foreach ($step in $steps.Values) { if (-not $step.ok) { $allOk = $false } }
+Set-Content $resultFile ([ordered]@{
+        ok          = $allOk
+        completedAt = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+        steps       = $steps
+    } | ConvertTo-Json -Depth 4)
+if (-not $allOk) { exit 1 }

--- a/ops/memwatch/install-memwatch.ps1
+++ b/ops/memwatch/install-memwatch.ps1
@@ -1,0 +1,32 @@
+# Installs the per-minute MuggleMemwatch scheduled task for the current user
+# (no elevation needed). Copies memwatch.ps1 to a stable path first so the task
+# survives deletion of the source checkout/worktree.
+[CmdletBinding()]
+param(
+    [string]$TaskName = "MuggleMemwatch"
+)
+
+$ErrorActionPreference = "Stop"
+
+$installDir = Join-Path $env:USERPROFILE ".muggle-ai\memwatch\bin"
+New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+$installedScript = Join-Path $installDir "memwatch.ps1"
+Copy-Item (Join-Path $PSScriptRoot "memwatch.ps1") $installedScript -Force
+
+$existingTask = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+if ($existingTask) { Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false }
+
+$taskAction = New-ScheduledTaskAction -Execute "powershell.exe" `
+    -Argument "-NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File `"$installedScript`""
+$taskTrigger = New-ScheduledTaskTrigger -Once -At (Get-Date).AddMinutes(1) `
+    -RepetitionInterval (New-TimeSpan -Minutes 1) -RepetitionDuration ([TimeSpan]::MaxValue)
+$taskSettings = New-ScheduledTaskSettingsSet -MultipleInstances IgnoreNew -StartWhenAvailable `
+    -ExecutionTimeLimit (New-TimeSpan -Minutes 5)
+Register-ScheduledTask -TaskName $TaskName -Action $taskAction -Trigger $taskTrigger `
+    -Settings $taskSettings -Description "Per-minute memory sampler + commit tripwire (muggle-ai-works ops/memwatch)" | Out-Null
+
+Start-ScheduledTask -TaskName $TaskName
+Start-Sleep -Seconds 5
+$taskInfo = Get-ScheduledTaskInfo -TaskName $TaskName
+"task $TaskName registered; state=$((Get-ScheduledTask -TaskName $TaskName).State) lastResult=$($taskInfo.LastTaskResult)"
+"sampler log dir: $(Join-Path $env:USERPROFILE '.muggle-ai\memwatch')"

--- a/ops/memwatch/memwatch.ps1
+++ b/ops/memwatch/memwatch.ps1
@@ -1,0 +1,104 @@
+# Per-minute memory sampler + commit tripwire. Runs from the MuggleMemwatch
+# scheduled task (see install-memwatch.ps1); PowerShell 5.1-compatible.
+[CmdletBinding()]
+param(
+    [string]$LogDir = (Join-Path $env:USERPROFILE ".muggle-ai\memwatch"),
+    [int]$TopN = 15,
+    [double]$TripCommitPct = 85,
+    [double]$RearmCommitPct = 75,
+    [int]$RetentionDays = 14,
+    [switch]$ForceTrip
+)
+
+$ErrorActionPreference = "Stop"
+New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
+$now = Get-Date
+
+$counterSamples = (Get-Counter '\Memory\% Committed Bytes In Use', '\Memory\Committed Bytes').CounterSamples
+$commitPct = [math]::Round(($counterSamples | Where-Object { $_.Path -like '*% committed*' })[0].CookedValue, 1)
+$commitGb = [math]::Round(($counterSamples | Where-Object { $_.Path -like '*committed bytes' })[0].CookedValue / 1GB, 2)
+$osInfo = Get-CimInstance Win32_OperatingSystem
+$freeRamGb = [math]::Round($osInfo.FreePhysicalMemory / 1MB, 2)
+
+$allProcesses = Get-CimInstance Win32_Process |
+    Select-Object ProcessId, ParentProcessId, Name, PrivatePageCount, WorkingSetSize, CommandLine
+$livePids = @{}
+foreach ($processRow in $allProcesses) { $livePids[[int]$processRow.ProcessId] = $true }
+
+function ConvertTo-ProcessEntry {
+    param($ProcessRow, [int]$CommandMaxChars)
+    $command = ""
+    if ($ProcessRow.CommandLine) {
+        $command = $ProcessRow.CommandLine.Substring(0, [Math]::Min($CommandMaxChars, $ProcessRow.CommandLine.Length))
+    }
+    return [ordered]@{
+        pid         = [int]$ProcessRow.ProcessId
+        ppid        = [int]$ProcessRow.ParentProcessId
+        parentAlive = [bool]$livePids[[int]$ProcessRow.ParentProcessId]
+        name        = $ProcessRow.Name
+        privMb      = [math]::Round($ProcessRow.PrivatePageCount / 1MB, 1)
+        wsMb        = [math]::Round($ProcessRow.WorkingSetSize / 1MB, 1)
+        cmd         = $command
+    }
+}
+
+$topProcesses = $allProcesses | Sort-Object PrivatePageCount -Descending | Select-Object -First $TopN
+$sampleLine = [ordered]@{
+    at        = $now.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+    commitPct = $commitPct
+    commitGb  = $commitGb
+    freeRamGb = $freeRamGb
+    top       = @(foreach ($processRow in $topProcesses) { ConvertTo-ProcessEntry $processRow 180 })
+}
+$sampleFile = Join-Path $LogDir ("memwatch-{0:yyyyMMdd}.jsonl" -f $now)
+Add-Content -Path $sampleFile -Value ($sampleLine | ConvertTo-Json -Compress -Depth 4)
+
+$tripStateFile = Join-Path $LogDir "trip-state.json"
+$armed = $true
+if (Test-Path $tripStateFile) {
+    try { $armed = [bool](Get-Content $tripStateFile -Raw | ConvertFrom-Json).armed } catch { $armed = $true }
+}
+
+if (($commitPct -ge $TripCommitPct -or $ForceTrip) -and $armed) {
+    $snapshot = [ordered]@{
+        at        = $sampleLine.at
+        commitPct = $commitPct
+        commitGb  = $commitGb
+        freeRamGb = $freeRamGb
+        processes = @(
+            foreach ($processRow in ($allProcesses | Sort-Object PrivatePageCount -Descending)) {
+                ConvertTo-ProcessEntry $processRow 400
+            }
+        )
+    }
+    $snapshotFile = Join-Path $LogDir ("memsnapshot-{0:yyyyMMdd-HHmmss}.json" -f $now)
+    Set-Content -Path $snapshotFile -Value ($snapshot | ConvertTo-Json -Depth 4)
+
+    try {
+        [Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null
+        $toastXml = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent(
+            [Windows.UI.Notifications.ToastTemplateType]::ToastText02)
+        $toastTextNodes = $toastXml.GetElementsByTagName("text")
+        $toastTextNodes.Item(0).AppendChild($toastXml.CreateTextNode("Memory tripwire: commit at $commitPct%")) | Out-Null
+        $toastTextNodes.Item(1).AppendChild($toastXml.CreateTextNode("Full process snapshot: $snapshotFile")) | Out-Null
+        [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier("MuggleMemwatch").Show(
+            [Windows.UI.Notifications.ToastNotification]::new($toastXml))
+    } catch {
+        # Toast is best-effort; the snapshot is the deliverable.
+    }
+    $armed = $false
+} elseif ($commitPct -lt $RearmCommitPct) {
+    $armed = $true
+}
+
+Set-Content -Path $tripStateFile -Value ([ordered]@{
+        armed      = $armed
+        updated_at = $sampleLine.at
+    } | ConvertTo-Json)
+
+$sampleCutoff = $now.AddDays(-$RetentionDays)
+Get-ChildItem $LogDir -Filter "memwatch-*.jsonl" | Where-Object { $_.LastWriteTime -lt $sampleCutoff } |
+    Remove-Item -Force -Confirm:$false
+$snapshotCutoff = $now.AddDays(-90)
+Get-ChildItem $LogDir -Filter "memsnapshot-*.json" | Where-Object { $_.LastWriteTime -lt $snapshotCutoff } |
+    Remove-Item -Force -Confirm:$false

--- a/ops/memwatch/toggle-memwatch.ps1
+++ b/ops/memwatch/toggle-memwatch.ps1
@@ -1,0 +1,40 @@
+# On/off switch for the MuggleMemwatch sampler task. Wraps Enable/Disable so the
+# tracker can be paused mid-investigation without unregistering it — samples and
+# trip-state survive, and -On resumes on the next minute. Unprivileged (the task
+# is registered per-user); PowerShell 5.1-compatible. The elevated flight-recorder
+# and audit pieces are not covered here — see README "Uninstall" for those.
+[CmdletBinding(DefaultParameterSetName = 'Status')]
+param(
+    [Parameter(ParameterSetName = 'On', Mandatory)][switch]$On,
+    [Parameter(ParameterSetName = 'Off', Mandatory)][switch]$Off,
+    [string]$TaskName = 'MuggleMemwatch'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+if ($null -eq $task) {
+    if ($On) {
+        Write-Warning "$TaskName is not installed — run install-memwatch.ps1 first to register it."
+        exit 1
+    }
+    Write-Output "$TaskName is not installed (nothing to toggle)."
+    exit 0
+}
+
+switch ($PSCmdlet.ParameterSetName) {
+    'On' {
+        Enable-ScheduledTask -TaskName $TaskName | Out-Null
+        Write-Output "$TaskName enabled — sampling resumes within a minute."
+    }
+    'Off' {
+        Disable-ScheduledTask -TaskName $TaskName | Out-Null
+        Write-Output "$TaskName disabled — sampler paused; samples and trip-state kept. Re-enable with -On."
+    }
+    'Status' {
+        $info = $task | Get-ScheduledTaskInfo
+        Write-Output "$TaskName state: $($task.State)"
+        Write-Output "  last run: $($info.LastRunTime) (result $($info.LastTaskResult))"
+        Write-Output "  next run: $($info.NextRunTime)"
+    }
+}


### PR DESCRIPTION
## What

Host-level memory-diagnostics tooling under `ops/memwatch/` — the standalone, watchdog-free half of #348, so we can actually debug the memory-exhaustion freezes on the fleet host.

- **`memwatch.ps1`** — per-minute sampler: `% Committed Bytes In Use` + committed/free GB + top-15 processes by private bytes → daily JSONL. At ≥85% commit it writes a full process snapshot (pid/ppid/parentAlive/priv/ws/cmd) and pops a toast, re-arming below 75%. 14-day sample retention, 90-day snapshot retention.
- **`install-memwatch.ps1`** — registers the unelevated `MuggleMemwatch` scheduled task and copies the script to `~/.muggle-ai/memwatch/bin` so it survives deleting the checkout/worktree.
- **`install-elevated.ps1`** — optional: perfmon circular flight recorder + boot autostart, and a 4688 process-creation audit with command lines.
- **`README.md`** — post-mortem reading guide.

## Why now

The 2026-07-27 22:45 host freeze hit 99% commit and hard-reset before Windows' RADAR could log a consumer; the sampler had been disabled, so the 40-minute runaway went uncaptured. This lands the tooling in-repo so it's tracked and improvable.

## Not shipped

`ops/` is outside the npm `files` whitelist (`dist`, `plugin`, `bin/muggle.js`, `scripts/postinstall.mjs`), so none of this reaches `@muggleai/works` end users. Internal host tooling only.

## Supersedes #348

#348's watchdog half (`src/watchdog`, orphan ledger) was removed upstream in `854729d` (session-scoped watching). This PR carries only the still-relevant host tooling; #348 will be closed.
