### PR TITLE
chore(release): @muggleai/works 5.8.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "5.7.0"
+      "version": "5.8.0"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "5.7.0"
+      "version": "5.8.0"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@muggleai/works",
   "mcpName": "io.github.multiplex-ai/muggle",
-  "version": "5.7.0",
+  "version": "5.8.0",
   "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
   "type": "module",
   "main": "dist/index.js",
@@ -47,14 +47,14 @@
     "eval:studio-gen": "tsx internal/studio-gen-eval/src/run.ts"
   },
   "muggleConfig": {
-    "electronAppVersion": "1.6.10",
+    "electronAppVersion": "1.6.11",
     "downloadBaseUrl": "https://github.com/multiplex-ai/muggle-ai-works/releases/download",
     "runtimeTargetDefault": "dev",
     "checksums": {
-      "darwin-arm64": "11672d444a151125a4d2f3413a7f0f4f8cb2de64ecbd2a43eddca4f364743b13",
-      "darwin-x64": "6277246853cdcc3aa3fbbaae703d428cfbf85c53fda6720a71a0cadbe8f5a5f6",
-      "linux-x64": "9485e0f9f4a0fb90666e63e87bd83da3c4b865a8cff8da40dc4d1b0ad2aba242",
-      "win32-x64": "e68471bcbf4f00d501067a282e835d00bb2f4941dc42878a8f041a5dab06acdf"
+      "darwin-arm64": "97f7f5ba622dc3baf86457184bc44030c777d7dbac58b8c1c5418970662e7a07",
+      "darwin-x64": "c8c2745282583144b34110ef45c4745e03c03c4ac2e020c820daa51124c3fc50",
+      "linux-x64": "d85e14ed38cb8035b932aef26148934e3aec6e036b6bb80ff8927cbde901a935",
+      "win32-x64": "6e38a5b017ee5756985e1507def6c5a92d357a4bbd4e4032b6e490ad05dd09a2"
     }
   },
   "dependencies": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "5.7.0",
+  "version": "5.8.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "5.7.0",
+  "version": "5.8.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "5.7.0",
+  "version": "5.8.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "5.7.0",
+      "version": "5.8.0",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
## Release 5.8.0 (minor)

Baseline 5.7.0 → **5.8.0**. Two feats + the watchdog removal + pr-followup/skills fixes; **Electron bumped 1.6.10 → 1.6.11** (all 4 checksums, verified against the release).

### Shipping (10 commits since 5.7.0/#339)
- **#350** feat(guard-run): kernel-capped process-tree launcher — spawn-time storm guard
- **#351** feat(pr-post): sign every PR/review/comment muggle works posts
- **#347** remove out-of-session watchdog — pr-followup watching is now **session-scoped** (reverts #341); tick-line-only liveness beacon + live-watcher gate
- **#353** fix(pr-followup): watermark to the handled wave's snapshot, never a post-reply live-max
- **#349** fix(pr-followup): monitor-first recovery — crons deliver ticks, never the cadence
- **#345** fix(pr-followup): stop watcher/MCP process-leak freeze on Windows
- **#344** fix(skills): never push unsigned commits
- **#343** fix(pr-followup): keep an outdated thread actionable while unanswered
- **#342** fix(pr-followup): wake the watch monitor on settled-red CI

### Electron
1.6.10 → **1.6.11**; all four `muggleConfig.checksums` updated; `verify:electron-release-checksums` green.

### Manifests (by `sync:versions`)
marketplace.json (claude/cursor), plugin.json (claude/cursor), server.json.

### Verify (local, all green)
`lint:check` (0 errors) · `typecheck` · `test` 874 passed · `build` · `verify:plugin` · `verify:contracts` · `verify:electron-release-checksums`

Publish is CI-only (OIDC trusted publishing) via `publish-works-to-npm.yml` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sz9jfMQWttuyhCR5x3qJQ7