### PR TITLE
feat(ci): peak-RSS memory gate around the test suite (report-only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,11 @@ jobs:
       - name: Run lint
         run: pnpm run lint:check
 
-      - name: Run tests
-        run: pnpm test
+      # Peak-RSS report around the suite — surfaces a memory regression before it
+      # OOMs a runner. Report-only for now; set MEM_BUDGET_KB (+ MEM_GATE_BLOCKING=1)
+      # to enforce a ceiling once baselines are known. See scripts/mem-gate.sh.
+      - name: Run tests (memory-gated)
+        run: bash scripts/mem-gate.sh pnpm test
 
       - name: Build
         run: pnpm run build

--- a/scripts/mem-gate.sh
+++ b/scripts/mem-gate.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Runs a command under peak-RSS measurement and reports it, so a memory
+# regression in the evals/tests surfaces before it OOMs a CI runner. Report-only
+# by default; set a budget to turn it into a gate once baselines are known.
+#
+# Usage:  scripts/mem-gate.sh <command> [args...]
+# Env:
+#   MEM_BUDGET_KB       peak-RSS budget in KB. Unset (default) → report only.
+#   MEM_GATE_BLOCKING   "1" → fail the step when peak RSS exceeds MEM_BUDGET_KB.
+#                       Anything else → over-budget is a ::warning:: only.
+#
+# Peak RSS comes from GNU `/usr/bin/time -v` (present on the ubuntu runners).
+# Where it is unavailable the command still runs — the gate degrades to a no-op
+# rather than breaking the build.
+set -uo pipefail
+
+if [ "$#" -eq 0 ]; then
+  echo "mem-gate: no command given" >&2
+  exit 2
+fi
+
+if command -v /usr/bin/time >/dev/null 2>&1 && /usr/bin/time -v true >/dev/null 2>&1; then
+  timelog=$(mktemp)
+  /usr/bin/time -v -o "$timelog" "$@"
+  status=$?
+  peak_kb=$(awk -F': ' '/Maximum resident set size/ { gsub(/[^0-9]/, "", $2); print $2 }' "$timelog")
+  rm -f "$timelog"
+else
+  echo "mem-gate: GNU '/usr/bin/time -v' unavailable — running without memory measurement" >&2
+  "$@"
+  status=$?
+  peak_kb=""
+fi
+
+if [ -z "$peak_kb" ]; then
+  exit "$status"
+fi
+
+peak_mb=$(( peak_kb / 1024 ))
+report="mem-gate: peak RSS ${peak_mb} MB (${peak_kb} KB) — ${*}"
+echo "$report"
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  echo "- ${report}" >> "$GITHUB_STEP_SUMMARY"
+fi
+
+if [ -n "${MEM_BUDGET_KB:-}" ] && [ "$peak_kb" -gt "$MEM_BUDGET_KB" ]; then
+  over="peak RSS ${peak_kb} KB exceeds budget ${MEM_BUDGET_KB} KB"
+  if [ "${MEM_GATE_BLOCKING:-}" = "1" ]; then
+    echo "::error::mem-gate: ${over}"
+    exit 1
+  fi
+  echo "::warning::mem-gate: ${over} (report-only; set MEM_GATE_BLOCKING=1 to enforce)"
+fi
+
+exit "$status"


### PR DESCRIPTION
## What

Follow-up to #352 (the memwatch toolkit): a portable CI memory gate so an eval/test memory regression surfaces before it OOMs a runner. This is the CI-side answer to "can we bring memwatch into CI" — `memwatch.ps1` is Windows host telemetry (perf counters/WMI/toast) and won't run on the Linux jobs, so the gate is a separate, portable mechanism.

## How

- `scripts/mem-gate.sh <cmd>` runs the command under GNU `/usr/bin/time -v`, reports **peak RSS** to the log and the job summary, and — opt-in via `MEM_BUDGET_KB` (+ `MEM_GATE_BLOCKING=1`) — fails when peak exceeds the budget. It preserves the command's exit code, and degrades to a plain run where GNU time is absent so it can never break a runner that lacks it.
- Wired into the `lint-and-test` job's suite step (`bash scripts/mem-gate.sh pnpm test`), **report-only** — no budget set yet.

## Rollout (as agreed on #352)

Non-blocking first: land the mechanism, read a few baselines from the job summaries, then set `MEM_BUDGET_KB` and flip `MEM_GATE_BLOCKING=1` to enforce. Extensible to the `node-compat` / `platform-compat` / eval jobs the same way; a Windows-leg sampler can follow if we want the gate there too.

## Verification

`bash -n` clean; exit-code passthrough (0 / 7), no-command guard (exit 2), and the graceful no-GNU-time fallback all verified locally; `ci.yml` parses. The real peak-RSS line will show in this PR's `lint-and-test` job summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Szpvct8AHhVGgiSYFTohND
