### PR TITLE
feat(agent-gate-eval): behavioral scenarios for the acceptance-tester agent

### DIFF
--- a/internal/agent-gate-eval/README.md
+++ b/internal/agent-gate-eval/README.md
@@ -7,6 +7,7 @@ Behavioral contract eval for the pinned execution agents in `plugin/agents/`. La
 - System prompt = the agent's `.md` body; model = its `model:` pin resolved via `MODEL_ALIASES` (no override flag — the pin honoring the contract is what's under test).
 - `Read` is real, scoped to the plugin tree, so the stage files the agent links must resolve; the rest of the repo is denied (a lockfile-sized Read overflows the run's context).
 - `Bash` never executes: each call is denied with the scenario's scripted output (`bashResponses`, first `commandContains` match wins, `""` is the catch-all), keeping runs hermetic.
+- Muggle MCP is mocked when a scenario declares `fixtures`: the harness mounts the in-process mock server shared with `../skill-gate-eval` (`buildMockMcpServer`), so an agent whose contract runs through the tools — `acceptance-tester` — completes a run without auth, cloud, or Electron. A `mcp__eval_mock__*` call is recorded under its bare name (`muggle-local-execute-replay`) so `requireToolAttempts` matches it; a stray production `mcp__plugin_muggle_muggle__*` call is denied with a redirect. Bash-only agents omit `fixtures` and never mount it.
 - `AskUserQuestion` is denied and counted; any ask fails the verdict unless a scenario sets `forbidAskUserQuestion: false`.
 - Pool/throttle plumbing is imported from `../skill-gate-eval` (shared `ThrottleGate`, bounded concurrency, `PASS_THRESHOLD`).
 
@@ -21,6 +22,6 @@ pnpm run test:agents:behavioral -- --agent visual-walkthrough-builder --runs 5 -
 
 ## Scenarios
 
-`scenarios/<agent>.json` — `{ agent, scenarios: [{ name, prompt, bashResponses?, expect }] }`. `expect` supports `outputContains` / `outputMatches` / `outputNotContains` / `outputNotMatches` (regex sources), `requireToolAttempts` / `forbidToolAttempts` (`{tool, argContains}` against the serialized input), and `forbidAskUserQuestion`. Scenario files live in-repo (unlike skill-gate-eval's brain-hosted data) because the contract they gate is `plugin/agents/*.md` in this repo; `agent-contracts.test.ts` enforces that every agent has one.
+`scenarios/<agent>.json` — `{ agent, scenarios: [{ name, prompt, bashResponses?, fixtures?, expect }] }`. `expect` supports `outputContains` / `outputMatches` / `outputNotContains` / `outputNotMatches` (regex sources), `requireToolAttempts` / `forbidToolAttempts` (`{tool, argContains}` against the serialized input), and `forbidAskUserQuestion`. `fixtures` (shape from `../skill-gate-eval`) holds the canned muggle MCP responses for an MCP-driven agent — the dispatch `prompt` carries the run procedure the orchestrator would paste. Scenario files live in-repo (unlike skill-gate-eval's brain-hosted data) because the contract they gate is `plugin/agents/*.md` in this repo; `agent-contracts.test.ts` enforces that every execution agent has one.
 
 CI: the `agent-gate-eval` job in `.github/workflows/skill-eval.yml` — scoped to PRs touching `plugin/agents/`, this package, or the dispatching skills; full on nightly/dispatch/`run-full-eval`.

--- a/internal/agent-gate-eval/scenarios/acceptance-tester.json
+++ b/internal/agent-gate-eval/scenarios/acceptance-tester.json
@@ -1,0 +1,51 @@
+{
+  "agent": "acceptance-tester",
+  "scenarios": [
+    {
+      "name": "all-pass-returns-pass",
+      "prompt": "Run acceptance tests against http://localhost:3000 for the demo app.\n\nUse the muggle-test run loop: for EACH test case below, call `muggle-local-execute-replay` with that test case, then `muggle-local-run-result-get` for the returned runId; treat the tool results as the real run outcome. Then return your report per your output contract (Test Summary + Per-Test Highlights).\n\nTest cases (project proj-demo-1, already bound):\n- tc-101 \"Login flow\"\n- tc-102 \"View dashboard\"",
+      "fixtures": {
+        "lastProject": { "id": "proj-demo-1", "url": "http://localhost:3000" },
+        "executeResult": { "runId": "run-pass", "status": "passed", "viewUrl": "https://dashboard.muggle-ai.com/runs/run-pass" },
+        "runResult": { "runId": "run-pass", "status": "passed", "viewUrl": "https://dashboard.muggle-ai.com/runs/run-pass", "steps": [{ "summary": "Open page", "status": "passed" }, { "summary": "Assert content", "status": "passed" }] }
+      },
+      "expect": {
+        "outputContains": ["Test Summary"],
+        "outputMatches": ["Verdict:\\**\\s*PASS\\b"],
+        "outputNotMatches": ["Verdict:\\**\\s*FAIL\\b", "(^|\\n)[`*>#\\s-]*needs-input:"],
+        "requireToolAttempts": [{ "tool": "muggle-local-execute-replay", "argContains": "" }]
+      }
+    },
+    {
+      "name": "failure-reports-blocking-issue-and-fix",
+      "prompt": "Run acceptance tests against http://localhost:3000 for the demo app.\n\nUse the muggle-test run loop: for EACH test case below, call `muggle-local-execute-replay` with that test case, then `muggle-local-run-result-get` for the returned runId; treat the tool results as the real run outcome. Then return your report per your output contract — report every failing test, describe the problem from the user's perspective, and give a suggested fix.\n\nTest cases (project proj-demo-1, already bound):\n- tc-201 \"Add to cart\"\n- tc-202 \"Checkout\"",
+      "fixtures": {
+        "lastProject": { "id": "proj-demo-1", "url": "http://localhost:3000" },
+        "executeResult": { "runId": "run-fail", "status": "failed", "viewUrl": "https://dashboard.muggle-ai.com/runs/run-fail" },
+        "runResult": { "runId": "run-fail", "status": "failed", "viewUrl": "https://dashboard.muggle-ai.com/runs/run-fail", "steps": [{ "summary": "Add item to cart", "status": "passed" }, { "summary": "Click the checkout button", "status": "failed" }], "failureStepIndex": 1, "error": "The checkout button did not respond after an item was added to the cart; the page stayed on the cart view." }
+      },
+      "expect": {
+        "outputMatches": ["Verdict:\\**\\s*FAIL\\b"],
+        "outputContains": ["Blocking issue:", "Suggested fix:"],
+        "outputNotMatches": ["(^|\\n)[`*>#\\s-]*needs-input:"],
+        "requireToolAttempts": [{ "tool": "muggle-local-execute-replay", "argContains": "" }]
+      }
+    },
+    {
+      "name": "missing-project-binding-needs-input",
+      "prompt": "Run acceptance tests for the app.\n\nUse the muggle-test run loop. No project or test cases are named in this dispatch, and no last-project is recorded. If you cannot determine what to run, follow your no-user-channel contract.",
+      "fixtures": {
+        "projects": { "items": [] },
+        "lastProject": null
+      },
+      "expect": {
+        "outputMatches": ["(^|\\n)[`*>#\\s-]*needs-input:"],
+        "outputNotMatches": ["Verdict:\\**\\s*PASS\\b", "Verdict:\\**\\s*FAIL\\b"],
+        "forbidToolAttempts": [
+          { "tool": "muggle-local-execute-replay", "argContains": "" },
+          { "tool": "muggle-local-execute-test-generation", "argContains": "" }
+        ]
+      }
+    }
+  ]
+}

--- a/internal/agent-gate-eval/scenarios/acceptance-tester.json
+++ b/internal/agent-gate-eval/scenarios/acceptance-tester.json
@@ -6,8 +6,8 @@
       "prompt": "Run acceptance tests against http://localhost:3000 for the demo app.\n\nUse the muggle-test run loop: for EACH test case below, call `muggle-local-execute-replay` with that test case, then `muggle-local-run-result-get` for the returned runId; treat the tool results as the real run outcome. Then return your report per your output contract (Test Summary + Per-Test Highlights).\n\nTest cases (project proj-demo-1, already bound):\n- tc-101 \"Login flow\"\n- tc-102 \"View dashboard\"",
       "fixtures": {
         "lastProject": { "id": "proj-demo-1", "url": "http://localhost:3000" },
-        "executeResult": { "runId": "run-pass", "status": "passed", "viewUrl": "https://dashboard.muggle-ai.com/runs/run-pass" },
-        "runResult": { "runId": "run-pass", "status": "passed", "viewUrl": "https://dashboard.muggle-ai.com/runs/run-pass", "steps": [{ "summary": "Open page", "status": "passed" }, { "summary": "Assert content", "status": "passed" }] }
+        "executeResult": { "runId": "run-pass", "status": "passed", "viewUrl": "https://example.invalid/run/run-pass" },
+        "runResult": { "runId": "run-pass", "status": "passed", "viewUrl": "https://example.invalid/run/run-pass", "steps": [{ "summary": "Open page", "status": "passed" }, { "summary": "Assert content", "status": "passed" }] }
       },
       "expect": {
         "outputContains": ["Test Summary"],
@@ -21,8 +21,8 @@
       "prompt": "Run acceptance tests against http://localhost:3000 for the demo app.\n\nUse the muggle-test run loop: for EACH test case below, call `muggle-local-execute-replay` with that test case, then `muggle-local-run-result-get` for the returned runId; treat the tool results as the real run outcome. Then return your report per your output contract — report every failing test, describe the problem from the user's perspective, and give a suggested fix.\n\nTest cases (project proj-demo-1, already bound):\n- tc-201 \"Add to cart\"\n- tc-202 \"Checkout\"",
       "fixtures": {
         "lastProject": { "id": "proj-demo-1", "url": "http://localhost:3000" },
-        "executeResult": { "runId": "run-fail", "status": "failed", "viewUrl": "https://dashboard.muggle-ai.com/runs/run-fail" },
-        "runResult": { "runId": "run-fail", "status": "failed", "viewUrl": "https://dashboard.muggle-ai.com/runs/run-fail", "steps": [{ "summary": "Add item to cart", "status": "passed" }, { "summary": "Click the checkout button", "status": "failed" }], "failureStepIndex": 1, "error": "The checkout button did not respond after an item was added to the cart; the page stayed on the cart view." }
+        "executeResult": { "runId": "run-fail", "status": "failed", "viewUrl": "https://example.invalid/run/run-fail" },
+        "runResult": { "runId": "run-fail", "status": "failed", "viewUrl": "https://example.invalid/run/run-fail", "steps": [{ "summary": "Add item to cart", "status": "passed" }, { "summary": "Click the checkout button", "status": "failed" }], "failureStepIndex": 1, "error": "The checkout button did not respond after an item was added to the cart; the page stayed on the cart view." }
       },
       "expect": {
         "outputMatches": ["Verdict:\\**\\s*FAIL\\b"],

--- a/internal/agent-gate-eval/src/harness.ts
+++ b/internal/agent-gate-eval/src/harness.ts
@@ -15,6 +15,11 @@
  *   - Bash is intercepted: every call is denied with the scenario's scripted
  *     output for that command, so the run is hermetic (nothing executes) while
  *     the agent still "observes" ports, smoke results, and CLI output.
+ *   - Muggle MCP is mocked when the scenario declares `fixtures`: the in-process
+ *     mock server (shared with skill-gate-eval) mounts, canned handlers return
+ *     the fixtures, and each call is recorded so an agent whose contract runs
+ *     through the tools — acceptance-tester — completes a run without auth,
+ *     cloud, or Electron.
  *   - AskUserQuestion is denied and counted; the verdict fails any run that
  *     asks — agents return `needs-input:` instead of asking.
  */
@@ -28,13 +33,16 @@ import {
 } from "@anthropic-ai/claude-agent-sdk";
 
 import { ASK_QUESTION_TOOL } from "../../skill-gate-eval/src/constants.js";
+import { buildMockMcpServer } from "../../skill-gate-eval/src/mock-mcp.js";
 import type { AgentRunOptions, AgentRunVerdict, ToolAttempt } from "./types.js";
 import { judgeAgentRun } from "./verdict.js";
 
 const DEFAULT_MAX_TURNS = 60;
+const MOCK_MCP_PREFIX = "mcp__eval_mock__";
+const PRODUCTION_MUGGLE_PREFIX = "mcp__plugin_muggle_muggle__";
 
 function buildSystemPrompt(opts: AgentRunOptions): string {
-  return [
+  const lines = [
     opts.definition.body,
     "",
     "---",
@@ -49,7 +57,19 @@ function buildSystemPrompt(opts: AgentRunOptions): string {
     "",
     "There is no user. Follow your no-user-channel contract: a missing decision",
     "or input means returning a single `needs-input:` line, never a question.",
-  ].join("\n");
+  ];
+  if (opts.scenario.fixtures) {
+    lines.push(
+      "",
+      "The production `mcp__plugin_muggle_muggle__*` tools are NOT available;",
+      "call the matching `mcp__eval_mock__*` tools instead. They return canned",
+      "results so you can run and report without auth, cloud, or a real browser.",
+      "A bare tool name in your pasted skill text (e.g.",
+      "`muggle-local-execute-replay`) resolves to",
+      "`mcp__eval_mock__muggle-local-execute-replay`.",
+    );
+  }
+  return lines.join("\n");
 }
 
 function scriptedBashResponse(command: string, opts: AgentRunOptions): string {
@@ -71,11 +91,33 @@ export async function runAgentScenarioOnce(
     path.dirname(path.resolve(opts.definition.filePath)),
   );
 
+  const mock = opts.scenario.fixtures
+    ? buildMockMcpServer(opts.scenario.fixtures)
+    : null;
+
   const canUseTool: CanUseTool = async (
     toolName,
     input,
   ): Promise<PermissionResult> => {
+    // A mock MCP call is recorded under its bare name so `requireToolAttempts`
+    // and `forbidToolAttempts` match `muggle-local-execute-replay`, not the
+    // mounted `mcp__eval_mock__` alias.
+    if (toolName.startsWith(MOCK_MCP_PREFIX)) {
+      toolAttempts.push({ tool: toolName.slice(MOCK_MCP_PREFIX.length), args: input });
+      return { behavior: "allow", updatedInput: input };
+    }
+
     toolAttempts.push({ tool: toolName, args: input });
+
+    // The production muggle plugin loaded in the parent session bleeds into the
+    // SDK; steer the agent to the mock equivalents.
+    if (toolName.startsWith(PRODUCTION_MUGGLE_PREFIX)) {
+      const bare = toolName.slice(PRODUCTION_MUGGLE_PREFIX.length);
+      return {
+        behavior: "deny",
+        message: `[harness] the production muggle plugin is not available here — call \`${MOCK_MCP_PREFIX}${bare}\` instead.`,
+      };
+    }
 
     if (toolName === ASK_QUESTION_TOOL) {
       askQuestionCount++;
@@ -120,6 +162,7 @@ export async function runAgentScenarioOnce(
       model: opts.definition.model,
       maxTurns: opts.maxTurns ?? DEFAULT_MAX_TURNS,
       tools: ["Read", "Bash", "AskUserQuestion"],
+      ...(mock ? { mcpServers: { eval_mock: mock.config } } : {}),
       ...(process.env.CLAUDE_CODE_EXECUTABLE
         ? { pathToClaudeCodeExecutable: process.env.CLAUDE_CODE_EXECUTABLE }
         : {}),

--- a/internal/agent-gate-eval/src/types.ts
+++ b/internal/agent-gate-eval/src/types.ts
@@ -5,6 +5,8 @@
  * preference-gate side effects.
  */
 
+import type { Fixtures } from "../../skill-gate-eval/src/types.js";
+
 /** A canned response for an intercepted Bash command. First match wins; `commandContains: ""` is the catch-all. */
 export interface ScriptedBashResponse {
   commandContains: string;
@@ -43,6 +45,13 @@ export interface AgentScenario {
   prompt: string;
   /** Scripted results for intercepted Bash calls. */
   bashResponses?: ScriptedBashResponse[];
+  /**
+   * Canned muggle MCP responses. When present, the harness mounts the mock
+   * muggle server (shared with skill-gate-eval) so an agent whose contract runs
+   * through the MCP tools — acceptance-tester — can complete a run hermetically.
+   * Absent for the Bash/CLI-driven agents.
+   */
+  fixtures?: Fixtures;
   expect: AgentScenarioExpectation;
 }
 

--- a/src/test/agents/agent-contracts.test.ts
+++ b/src/test/agents/agent-contracts.test.ts
@@ -147,7 +147,7 @@ describe("agent behavioral eval coverage", () => {
     .readdirSync(scenariosDir)
     .filter((f) => f.endsWith(".json") && !f.endsWith(".results.json"));
 
-  it.each(["test-prepare-runner", "visual-walkthrough-builder"])(
+  it.each(["test-prepare-runner", "visual-walkthrough-builder", "acceptance-tester"])(
     "execution agent %s has behavioral scenarios",
     (agentName) => {
       expect(scenarioFiles).toContain(`${agentName}.json`);


### PR DESCRIPTION
Closes #346.

acceptance-tester (pinned sonnet) had no behavioral coverage because its contract runs through the muggle MCP tools, which the agent-gate-eval harness — Bash-interception only — couldn't script.

- Harness gains an optional **mock-MCP mode**: when a scenario declares `fixtures` it mounts the in-process mock muggle server shared with skill-gate-eval, so the agent completes a run without auth, cloud, or Electron. Mock calls are recorded under their bare names so `requireToolAttempts` matches them; a stray production muggle call is denied with a redirect.
- **3 scenarios**: all-pass → PASS, a failure → FAIL with a blocking issue + suggested fix, and a missing project binding → `needs-input:` (no fabricated run).
- acceptance-tester joins the required-scenarios list in `agent-contracts.test.ts`.

Verified: tsc + eslint clean, vitest 38/38 (incl. the 2 new coverage checks), and a live behavioral eval on sonnet at **9/9** (3/3 per scenario). muggle browser E2E = SKIPPED (repo tooling, no UI surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)