### PR TITLE
feat(guardrails): block turn-end when an opened PR has no armed watcher

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -110,6 +110,12 @@
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/guardrail-terminal-gate.sh\"",
             "async": false,
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/guardrail-watch-gate.sh\"",
+            "async": false,
+            "timeout": 10
           }
         ]
       }

--- a/plugin/scripts/guardrail-watch-gate.sh
+++ b/plugin/scripts/guardrail-watch-gate.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# watcher-arm gate (Stop). When a PR was opened this session but no watcher was
+# armed for it, block the turn end and point at the Stage-8 hand-off (or the
+# MUGGLE_WATCH_SKIP escape hatch). Mirrors guardrail-e2e-gate.sh: synchronous
+# (only a sync Stop hook can block the turn end), fires on EVERY turn end, and
+# pre-filters in shell so Node spawns only when a PR was opened this session and
+# no skip was recorded. The real owed-vs-armed decision (a sessions/*/ slot scan)
+# runs in guardrails.mjs. On the overwhelming majority of turns no PR was opened,
+# so the state file is absent or prsHandled is empty and we return {} in-shell,
+# never paying Node cold-start. Degrades to {}.
+payload="$(cat)"
+
+raw_sid="$(printf '%s' "$payload" | grep -oE '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed -E 's/.*:[[:space:]]*"([^"]*)".*/\1/')"
+[ -n "$raw_sid" ] || raw_sid="unknown"
+sid="$(printf '%s' "$raw_sid" | sed 's/[^A-Za-z0-9_-]/_/g')"
+
+# Resolve the same home dir Node's os.homedir() uses. HOME is correct on
+# macOS/Linux and on most Git Bash setups; fall back to converting USERPROFILE
+# when HOME doesn't hold the state dir (some Windows shells point HOME elsewhere).
+home="${HOME:-}"
+if [ ! -d "$home/.muggle-ai" ] && command -v cygpath >/dev/null 2>&1 && [ -n "${USERPROFILE:-}" ]; then
+  home="$(cygpath -u "$USERPROFILE" 2>/dev/null || printf '%s' "$home")"
+fi
+
+# Empty array serializes as `"prsHandled": []` (one line); a non-empty array spans
+# lines, so the empty match reliably tells them apart. Skip Node unless a PR was
+# opened this session and no watcher skip was recorded.
+state_file="$home/.muggle-ai/guardrails/$sid.json"
+if [ ! -f "$state_file" ] \
+  || ! grep -q '"prsHandled"' "$state_file" \
+  || grep -q '"prsHandled": \[\]' "$state_file" \
+  || grep -q '"watchSkipped": true' "$state_file"; then
+  printf '{}'
+  exit 0
+fi
+
+root="${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-}}"
+printf '%s' "$payload" | node "${root}/scripts/guardrails.mjs" watch-gate 2>/dev/null || printf '{}'

--- a/plugin/scripts/guardrails.mjs
+++ b/plugin/scripts/guardrails.mjs
@@ -1,4 +1,4 @@
-import { readFileSync, existsSync, mkdirSync, writeFileSync } from 'fs';
+import { readFileSync, existsSync, mkdirSync, writeFileSync, readdirSync, statSync } from 'fs';
 import { isAbsolute, resolve, join } from 'path';
 import { homedir } from 'os';
 
@@ -45,6 +45,7 @@ var GH_PR_MERGED_LINE = /\b(?:Merged|Squashed and merged|Rebased and merged) pul
 var GH_PR_CLOSED_LINE = /\bClosed pull request [\w./-]*#(\d+)/;
 var PR_MONITOR_TERMINAL_LINE = /\bTERMINAL pr=(\d+): (MERGED|CLOSED)\b/;
 var MAX_PR_TERMINAL_BLOCKS = 3;
+var MAX_WATCH_BLOCKS = 3;
 var MUGGLE_SKILL_EMIT_TOOL = /muggle-local-telemetry-skill-emit/i;
 var MUGGLE_TEST_SKILL_NAME = "muggle-test";
 
@@ -142,6 +143,72 @@ function e2eGateDecision(state, maxBlocks = MAX_E2E_BLOCKS) {
   if (!shouldRunE2E(state)) return { action: "none" /* None */, blockCount };
   if (blockCount >= maxBlocks) return { action: "release" /* Release */, blockCount };
   return { action: "block" /* Block */, blockCount: blockCount + 1 };
+}
+var HEARTBEAT_FRESH_MS = 15 * 60 * 1e3;
+var WATCH_SKIP_MARKER = /^\s*echo\s+["']?MUGGLE_WATCH_SKIP\b/;
+function isWatchSkipMarker(cmd) {
+  return WATCH_SKIP_MARKER.test(cmd);
+}
+function applyWatchSkip(state, skipped) {
+  if (!skipped || state.watchSkipped === true) return state;
+  return { ...state, watchSkipped: true };
+}
+function slotHasArmedWatcher(slotDir) {
+  if (existsSync(join(slotDir, "result.md"))) return true;
+  const pidFile = join(slotDir, "watch.pid");
+  if (existsSync(pidFile)) {
+    const pid = Number.parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
+    if (Number.isInteger(pid) && pid > 0) {
+      try {
+        process.kill(pid, 0);
+        return true;
+      } catch (err) {
+        if (err.code === "EPERM") return true;
+      }
+    }
+  }
+  const beat = join(slotDir, "watch-heartbeat");
+  if (existsSync(beat)) {
+    try {
+      if (Date.now() - statSync(beat).mtimeMs < HEARTBEAT_FRESH_MS) return true;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+function findUnarmedHandledPrs(handledUrls, sessionsDirOverride) {
+  if (handledUrls.length === 0) return [];
+  const sessionsDir = join(homedir(), ".muggle-ai", "muggle-do", "sessions");
+  if (!existsSync(sessionsDir)) return [...handledUrls];
+  const watchedUrls = /* @__PURE__ */ new Set();
+  for (const slug of readdirSync(sessionsDir)) {
+    const slotDir = join(sessionsDir, slug);
+    const prsFile = join(slotDir, "prs.json");
+    if (!existsSync(prsFile)) continue;
+    let slotUrl;
+    try {
+      const parsed = JSON.parse(readFileSync(prsFile, "utf-8"));
+      const entry = Array.isArray(parsed) ? parsed[0] : parsed;
+      slotUrl = entry?.url;
+    } catch {
+      continue;
+    }
+    if (slotUrl && handledUrls.includes(slotUrl) && slotHasArmedWatcher(slotDir)) {
+      watchedUrls.add(slotUrl);
+    }
+  }
+  return handledUrls.filter((url) => !watchedUrls.has(url));
+}
+function watchGateDecision(state, owedUrls, maxBlocks = MAX_WATCH_BLOCKS) {
+  const blockCount = state.watchBlockCount ?? 0;
+  if (state.watchSkipped === true || owedUrls.length === 0) {
+    return { action: "none" /* None */, blockCount, owed: owedUrls };
+  }
+  if (blockCount >= maxBlocks) {
+    return { action: "release" /* Release */, blockCount, owed: owedUrls };
+  }
+  return { action: "block" /* Block */, blockCount: blockCount + 1, owed: owedUrls };
 }
 
 // src/guardrails/detectBuildIntent.ts
@@ -285,11 +352,12 @@ function terminalGate() {
 function recordTests() {
   const cmd = input.tool_input?.command ?? "";
   const state = readState(sessionId);
-  const next = applyRecordedRun(state, {
+  const recorded = applyRecordedRun(state, {
     unitTestPassed: isTestCommand(cmd) && testsPassed(input),
     e2eRan: isE2ERun(input),
     e2eSkipped: isE2ESkipMarker(cmd)
   });
+  const next = applyWatchSkip(recorded, isWatchSkipMarker(cmd));
   if (next !== state) writeState(next);
   return "{}";
 }
@@ -300,6 +368,19 @@ function e2eGate() {
   state.e2eBlockCount = decision.blockCount;
   writeState(state);
   const reason = decision.blockCount === 1 ? `Do not end the turn yet. Unit tests passed this session but no E2E acceptance run has happened. Per the autoE2ETest preference (default: always), run change-driven E2E now via /muggle:muggle-test, then finish. If E2E genuinely cannot run here (no app to drive, services down, no PR), tell the user why and run \`echo "MUGGLE_E2E_SKIP: <reason>"\` \u2014 that records the skip and keeps this gate quiet for the rest of the session.` : `E2E acceptance run still owed (reminder ${decision.blockCount}/${MAX_E2E_BLOCKS}): run /muggle:muggle-test, or record a legitimate skip via \`echo "MUGGLE_E2E_SKIP: <reason>"\`.`;
+  return blockStop(reason, host);
+}
+function watchGate() {
+  const state = readState(sessionId);
+  const owed = findUnarmedHandledPrs(state.prsHandled);
+  const decision = watchGateDecision(state, owed);
+  if (decision.action === "none" /* None */ || decision.action === "release" /* Release */) {
+    return "{}";
+  }
+  state.watchBlockCount = decision.blockCount;
+  writeState(state);
+  const prList = decision.owed.join(", ");
+  const reason = decision.blockCount === 1 ? `Do not end the turn yet. A PR was opened this session but has no armed watcher: ${prList}. muggle-do Stage 8 seeds the watcher slot and arms one watcher per opened PR \u2014 arm it now with /muggle:muggle-pr-followup ${decision.owed[0]} (or reconcile). If this PR should NOT be watched (autoWatchPR=never, a manually-opened PR, one handed off elsewhere, or already merged/closed), tell the user why and run \`echo "MUGGLE_WATCH_SKIP: <reason>"\` \u2014 that records the skip and keeps this gate quiet for the rest of the session.` : `Watcher hand-off still owed for ${prList} (reminder ${decision.blockCount}/${MAX_WATCH_BLOCKS}): arm via /muggle:muggle-pr-followup, or record a legitimate skip via \`echo "MUGGLE_WATCH_SKIP: <reason>"\`.`;
   return blockStop(reason, host);
 }
 function reportGate() {
@@ -323,6 +404,7 @@ var handlers = {
   "record-tests": recordTests,
   "e2e-gate": e2eGate,
   "terminal-gate": terminalGate,
+  "watch-gate": watchGate,
   "report-gate": reportGate,
   "build-router": buildRouter
 };

--- a/src/guardrails/cli.ts
+++ b/src/guardrails/cli.ts
@@ -7,13 +7,19 @@ import {
   applyNextOptionsOffered,
   prTerminalGateDecision,
 } from "./prTerminal.js";
-import { MAX_PR_TERMINAL_BLOCKS } from "./constants.js";
+import { MAX_PR_TERMINAL_BLOCKS, MAX_WATCH_BLOCKS } from "./constants.js";
 import { isTestCommand, testsPassed, isE2ERun, isE2ESkipMarker } from "./testsGreen.js";
 import { e2eGateDecision, E2eGateAction, MAX_E2E_BLOCKS, applyRecordedRun } from "./shouldRunE2E.js";
+import {
+  findUnarmedHandledPrs,
+  watchGateDecision,
+  isWatchSkipMarker,
+  applyWatchSkip,
+} from "./watchArmed.js";
 import { detectBuildIntent } from "./detectBuildIntent.js";
 import { evaluateReportPost } from "./reportGate.js";
 import { envelope, blockStop, denyTool, type Host } from "./emit.js";
-import { PrTerminalGateAction, type HookInput } from "./types.js";
+import { PrTerminalGateAction, WatchGateAction, type HookInput } from "./types.js";
 
 function readStdin(): HookInput {
   try {
@@ -85,11 +91,12 @@ function terminalGate(): string {
 function recordTests(): string {
   const cmd = input.tool_input?.command ?? "";
   const state = readState(sessionId);
-  const next = applyRecordedRun(state, {
+  const recorded = applyRecordedRun(state, {
     unitTestPassed: isTestCommand(cmd) && testsPassed(input),
     e2eRan: isE2ERun(input),
     e2eSkipped: isE2ESkipMarker(cmd),
   });
+  const next = applyWatchSkip(recorded, isWatchSkipMarker(cmd));
   if (next !== state) writeState(next);
   return "{}";
 }
@@ -111,6 +118,30 @@ function e2eGate(): string {
         `for the rest of the session.`
       : `E2E acceptance run still owed (reminder ${decision.blockCount}/${MAX_E2E_BLOCKS}): ` +
         `run /muggle:muggle-test, or record a legitimate skip via \`echo "MUGGLE_E2E_SKIP: <reason>"\`.`;
+  return blockStop(reason, host);
+}
+
+function watchGate(): string {
+  const state = readState(sessionId);
+  const owed = findUnarmedHandledPrs(state.prsHandled);
+  const decision = watchGateDecision(state, owed);
+  if (decision.action === WatchGateAction.None || decision.action === WatchGateAction.Release) {
+    return "{}";
+  }
+  state.watchBlockCount = decision.blockCount;
+  writeState(state);
+  const prList = decision.owed.join(", ");
+  // Full instruction once; repeats are one line — same rationale as e2eGate.
+  const reason =
+    decision.blockCount === 1
+      ? `Do not end the turn yet. A PR was opened this session but has no armed watcher: ${prList}. ` +
+        `muggle-do Stage 8 seeds the watcher slot and arms one watcher per opened PR — arm it now with ` +
+        `/muggle:muggle-pr-followup ${decision.owed[0]} (or reconcile). If this PR should NOT be watched ` +
+        `(autoWatchPR=never, a manually-opened PR, one handed off elsewhere, or already merged/closed), ` +
+        `tell the user why and run \`echo "MUGGLE_WATCH_SKIP: <reason>"\` — that records the skip and keeps ` +
+        `this gate quiet for the rest of the session.`
+      : `Watcher hand-off still owed for ${prList} (reminder ${decision.blockCount}/${MAX_WATCH_BLOCKS}): ` +
+        `arm via /muggle:muggle-pr-followup, or record a legitimate skip via \`echo "MUGGLE_WATCH_SKIP: <reason>"\`.`;
   return blockStop(reason, host);
 }
 
@@ -141,6 +172,7 @@ const handlers: Record<string, () => string> = {
   "record-tests": recordTests,
   "e2e-gate": e2eGate,
   "terminal-gate": terminalGate,
+  "watch-gate": watchGate,
   "report-gate": reportGate,
   "build-router": buildRouter,
 };

--- a/src/guardrails/constants.ts
+++ b/src/guardrails/constants.ts
@@ -17,6 +17,9 @@ export const PR_MONITOR_TERMINAL_LINE = /\bTERMINAL pr=(\d+): (MERGED|CLOSED)\b/
 
 export const MAX_PR_TERMINAL_BLOCKS = 3;
 
+/** How many times the watcher-arm Stop gate blocks a turn end before releasing, so a genuinely un-watchable PR can't trap the session. */
+export const MAX_WATCH_BLOCKS = 3;
+
 // The muggle-test skill's own first-step telemetry emit
 // (mcp__…muggle-local-telemetry-skill-emit with skillName "muggle-test").
 // Registering it as an E2E run covers the clean-SKIP verdict: the skill runs

--- a/src/guardrails/types.ts
+++ b/src/guardrails/types.ts
@@ -9,6 +9,22 @@ export interface GuardrailState {
   terminalPending?: number[];
   terminalHandled?: number[];
   terminalBlockCount?: number;
+  watchSkipped?: boolean;
+  watchBlockCount?: number;
+}
+
+/** Outcome of the watcher-arm Stop gate for a turn end. */
+export enum WatchGateAction {
+  Block = "block",
+  Release = "release",
+  None = "none",
+}
+
+/** A watcher-arm gate decision: the action, the running block count, and the opened-but-unwatched PR urls that drove it. */
+export interface WatchGateDecision {
+  action: WatchGateAction;
+  blockCount: number;
+  owed: string[];
 }
 
 export enum PrTerminalVerdict {

--- a/src/guardrails/watchArmed.ts
+++ b/src/guardrails/watchArmed.ts
@@ -1,0 +1,119 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+import { MAX_WATCH_BLOCKS } from "./constants.js";
+import { WatchGateAction, type GuardrailState, type WatchGateDecision } from "./types.js";
+
+// reconcile.md treats a watch-heartbeat older than this as a dead poller.
+const HEARTBEAT_FRESH_MS = 15 * 60 * 1000;
+
+// A deliberate "no watcher owed here" declaration: the model runs
+// `echo "MUGGLE_WATCH_SKIP: <reason>"` and the gate stays quiet for the session
+// (autoWatchPR=never, a manually-opened PR, one handed off elsewhere, an
+// already-terminal PR). Anchored to a leading echo for the same reason the E2E
+// skip marker is — a grep, commit, or skill edit that merely mentions the token
+// must not disarm the gate.
+const WATCH_SKIP_MARKER = /^\s*echo\s+["']?MUGGLE_WATCH_SKIP\b/;
+
+/** Whether a Bash command is the explicit watcher-skip declaration. */
+export function isWatchSkipMarker(cmd: string): boolean {
+  return WATCH_SKIP_MARKER.test(cmd);
+}
+
+/** Record a watcher skip into the gate state, returning the same reference when nothing changed so the caller can skip a redundant write. */
+export function applyWatchSkip(state: GuardrailState, skipped: boolean): GuardrailState {
+  if (!skipped || state.watchSkipped === true) return state;
+  return { ...state, watchSkipped: true };
+}
+
+// A slot counts as watched when its PR is terminal (result.md — nothing left to
+// watch), a live monitor owns it (watch.pid names a signalable process), or a
+// quiet monitor touched its heartbeat within reconcile's liveness window.
+function slotHasArmedWatcher(slotDir: string): boolean {
+  if (existsSync(join(slotDir, "result.md"))) return true;
+
+  const pidFile = join(slotDir, "watch.pid");
+  if (existsSync(pidFile)) {
+    const pid = Number.parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
+    if (Number.isInteger(pid) && pid > 0) {
+      try {
+        process.kill(pid, 0);
+        return true;
+      } catch (err) {
+        // ESRCH = the process is gone; EPERM = alive but owned by another user.
+        if ((err as NodeJS.ErrnoException).code === "EPERM") return true;
+      }
+    }
+  }
+
+  const beat = join(slotDir, "watch-heartbeat");
+  if (existsSync(beat)) {
+    try {
+      if (Date.now() - statSync(beat).mtimeMs < HEARTBEAT_FRESH_MS) return true;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+/**
+ * The PRs opened this session that have no armed watcher.
+ *
+ * Scans the muggle-do session slots and joins on the PR url (slot dirs are
+ * arbitrary slugs, so the url is the only stable key back to `prsHandled`). A
+ * handled url with no slot, or a slot with no armed watcher, is owed.
+ * `sessionsDirOverride` points the scan at a throwaway tree for tests.
+ */
+export function findUnarmedHandledPrs(
+  handledUrls: string[],
+  sessionsDirOverride?: string,
+): string[] {
+  if (handledUrls.length === 0) return [];
+  const sessionsDir =
+    sessionsDirOverride ?? join(homedir(), ".muggle-ai", "muggle-do", "sessions");
+  if (!existsSync(sessionsDir)) return [...handledUrls];
+
+  const watchedUrls = new Set<string>();
+  for (const slug of readdirSync(sessionsDir)) {
+    const slotDir = join(sessionsDir, slug);
+    const prsFile = join(slotDir, "prs.json");
+    if (!existsSync(prsFile)) continue;
+    let slotUrl: string | undefined;
+    try {
+      const parsed = JSON.parse(readFileSync(prsFile, "utf-8")) as unknown;
+      const entry = Array.isArray(parsed) ? parsed[0] : parsed;
+      slotUrl = (entry as { url?: string } | undefined)?.url;
+    } catch {
+      continue;
+    }
+    if (slotUrl && handledUrls.includes(slotUrl) && slotHasArmedWatcher(slotDir)) {
+      watchedUrls.add(slotUrl);
+    }
+  }
+  return handledUrls.filter((url) => !watchedUrls.has(url));
+}
+
+/**
+ * Decide what the Stop hook does about the watcher hand-off.
+ *
+ * Pure: the caller runs the sessions scan and passes the owed urls in.
+ * - `None`    — nothing owed (no PR opened, all watched, or a skip recorded).
+ * - `Block`   — a PR opened this session has no armed watcher; force the turn on.
+ * - `Release` — blocked `maxBlocks` times already; stop nagging so a legitimately
+ *               un-watchable PR can't trap the session.
+ */
+export function watchGateDecision(
+  state: GuardrailState,
+  owedUrls: string[],
+  maxBlocks: number = MAX_WATCH_BLOCKS,
+): WatchGateDecision {
+  const blockCount = state.watchBlockCount ?? 0;
+  if (state.watchSkipped === true || owedUrls.length === 0) {
+    return { action: WatchGateAction.None, blockCount: blockCount, owed: owedUrls };
+  }
+  if (blockCount >= maxBlocks) {
+    return { action: WatchGateAction.Release, blockCount: blockCount, owed: owedUrls };
+  }
+  return { action: WatchGateAction.Block, blockCount: blockCount + 1, owed: owedUrls };
+}

--- a/src/test/guardrails/hook-execution.test.ts
+++ b/src/test/guardrails/hook-execution.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { spawnSync } from "child_process";
 import { fileURLToPath } from "url";
-import { chmodSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from "fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { delimiter, dirname, join } from "path";
 
@@ -99,6 +99,71 @@ describe("guardrail hook execution (cli entry)", () => {
 
   it("e2e-gate: stays silent when no unit-test pass was recorded", () => {
     expect(runHook("e2e-gate", event({ session_id: "fresh" })).out).toBe("{}");
+  });
+
+  it("pr-opened -> watch-gate: an opened PR with no armed watcher blocks the Stop", () => {
+    const session = "watch-chain";
+    runHook(
+      "pr-opened",
+      event({
+        session_id: session,
+        tool_name: "Bash",
+        tool_input: { command: "gh pr create" },
+        tool_response: { stdout: "https://github.com/o/r/pull/77\n" },
+      }),
+    );
+    const gate = JSON.parse(runHook("watch-gate", event({ session_id: session })).out);
+    expect(gate.decision).toBe("block");
+    expect(gate.reason).toContain("no armed watcher");
+    expect(gate.reason).toContain("https://github.com/o/r/pull/77");
+    expect(gate.reason).toContain("MUGGLE_WATCH_SKIP");
+  });
+
+  it("watch-gate: silent once a watcher slot is armed for the opened PR", () => {
+    const session = "watch-armed";
+    const url = "https://github.com/o/r/pull/78";
+    runHook(
+      "pr-opened",
+      event({
+        session_id: session,
+        tool_name: "Bash",
+        tool_input: { command: "gh pr create" },
+        tool_response: { stdout: `${url}\n` },
+      }),
+    );
+    const slot = join(home, ".muggle-ai", "muggle-do", "sessions", "r-pr78");
+    mkdirSync(slot, { recursive: true });
+    writeFileSync(join(slot, "prs.json"), JSON.stringify([{ url: url }]));
+    writeFileSync(join(slot, "watch.pid"), String(process.pid));
+    expect(runHook("watch-gate", event({ session_id: session })).out).toBe("{}");
+  });
+
+  it("record-tests -> watch-gate: a MUGGLE_WATCH_SKIP marker releases the gate", () => {
+    const session = "watch-skip";
+    runHook(
+      "pr-opened",
+      event({
+        session_id: session,
+        tool_name: "Bash",
+        tool_input: { command: "gh pr create" },
+        tool_response: { stdout: "https://github.com/o/r/pull/79\n" },
+      }),
+    );
+    expect(JSON.parse(runHook("watch-gate", event({ session_id: session })).out).decision).toBe("block");
+    runHook(
+      "record-tests",
+      event({
+        session_id: session,
+        tool_name: "Bash",
+        tool_input: { command: 'echo "MUGGLE_WATCH_SKIP: manual PR, autoWatchPR=never"' },
+        tool_response: { stdout: "MUGGLE_WATCH_SKIP: manual PR, autoWatchPR=never" },
+      }),
+    );
+    expect(runHook("watch-gate", event({ session_id: session })).out).toBe("{}");
+  });
+
+  it("watch-gate: silent when no PR was opened this session", () => {
+    expect(runHook("watch-gate", event({ session_id: "no-pr" })).out).toBe("{}");
   });
 
   it("pr-terminal -> terminal-gate: a merged PR holds the Stop until the AskUserQuestion offer runs", () => {
@@ -379,6 +444,10 @@ describe.skipIf(process.platform === "win32")("guardrail wrapper pre-filter (no 
     expect(runWrapper("guardrail-e2e-gate.sh", event({ session_id: "no-state" }))).toBe("{}");
   });
 
+  it("watch-gate: skips Node when no PR was opened this session", () => {
+    expect(runWrapper("guardrail-watch-gate.sh", event({ session_id: "no-state" }))).toBe("{}");
+  });
+
   it("pr-terminal: skips Node on a plain command, spawns it on a merge success line", () => {
     expect(
       runWrapper("guardrail-pr-terminal.sh", event({ tool_name: "Bash", tool_input: { command: "git status" } })),
@@ -436,9 +505,10 @@ describe("hooks.json fan-out (Lazy-core tripwire)", () => {
     ]);
   });
 
-  it("runs both gates on Stop (e2e + post-merge handoff)", () => {
+  it("runs all three gates on Stop (e2e + post-merge handoff + watcher-arm)", () => {
     const stop = hooks.Stop[0].hooks.map((h) => h.command);
     expect(stop.some((c) => c.includes("guardrail-e2e-gate.sh"))).toBe(true);
     expect(stop.some((c) => c.includes("guardrail-terminal-gate.sh"))).toBe(true);
+    expect(stop.some((c) => c.includes("guardrail-watch-gate.sh"))).toBe(true);
   });
 });

--- a/src/test/guardrails/watchArmed.test.ts
+++ b/src/test/guardrails/watchArmed.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  isWatchSkipMarker,
+  applyWatchSkip,
+  findUnarmedHandledPrs,
+  watchGateDecision,
+} from "../../guardrails/watchArmed.js";
+import { WatchGateAction, type GuardrailState } from "../../guardrails/types.js";
+
+const base = (over: Partial<GuardrailState> = {}): GuardrailState => ({
+  sessionId: "s",
+  prsHandled: [],
+  ...over,
+});
+
+describe("isWatchSkipMarker", () => {
+  it("matches a leading MUGGLE_WATCH_SKIP echo", () => {
+    expect(isWatchSkipMarker('echo "MUGGLE_WATCH_SKIP: manual PR"')).toBe(true);
+    expect(isWatchSkipMarker("echo MUGGLE_WATCH_SKIP: x")).toBe(true);
+  });
+  it("ignores a mere mention (grep, commit, skill edit)", () => {
+    expect(isWatchSkipMarker('grep -r "MUGGLE_WATCH_SKIP" .')).toBe(false);
+    expect(isWatchSkipMarker("git commit -m 'add MUGGLE_WATCH_SKIP marker'")).toBe(false);
+  });
+});
+
+describe("applyWatchSkip", () => {
+  it("sets watchSkipped and returns a new object", () => {
+    const state = base();
+    const next = applyWatchSkip(state, true);
+    expect(next).not.toBe(state);
+    expect(next.watchSkipped).toBe(true);
+  });
+  it("returns the same reference when not skipping or already skipped", () => {
+    const state = base();
+    expect(applyWatchSkip(state, false)).toBe(state);
+    const skipped = base({ watchSkipped: true });
+    expect(applyWatchSkip(skipped, true)).toBe(skipped);
+  });
+});
+
+describe("watchGateDecision", () => {
+  it("None when nothing was opened this session", () => {
+    expect(watchGateDecision(base(), []).action).toBe(WatchGateAction.None);
+  });
+  it("None when a skip was recorded, even with owed PRs", () => {
+    const d = watchGateDecision(base({ watchSkipped: true }), ["https://x/pull/1"]);
+    expect(d.action).toBe(WatchGateAction.None);
+  });
+  it("Block and increments the count when a PR is owed", () => {
+    const d = watchGateDecision(base(), ["https://x/pull/1"]);
+    expect(d.action).toBe(WatchGateAction.Block);
+    expect(d.blockCount).toBe(1);
+    expect(d.owed).toEqual(["https://x/pull/1"]);
+  });
+  it("Release after the block budget is spent, so an un-watchable PR can't trap the session", () => {
+    const d = watchGateDecision(base({ watchBlockCount: 3 }), ["https://x/pull/1"]);
+    expect(d.action).toBe(WatchGateAction.Release);
+  });
+});
+
+describe("findUnarmedHandledPrs", () => {
+  let sessions: string;
+  const seedSlot = (slug: string, url: string, files: Record<string, string>): void => {
+    const dir = join(sessions, slug);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "prs.json"), JSON.stringify([{ url: url }]));
+    for (const [name, body] of Object.entries(files)) writeFileSync(join(dir, name), body);
+  };
+
+  beforeEach(() => {
+    sessions = mkdtempSync(join(tmpdir(), "watch-scan-"));
+  });
+
+  it("owes a handled url with no slot at all", () => {
+    expect(findUnarmedHandledPrs(["https://x/pull/1"], sessions)).toEqual(["https://x/pull/1"]);
+  });
+
+  it("owes a slot whose watch.pid is dead and heartbeat absent", () => {
+    seedSlot("s1", "https://x/pull/1", { "watch.pid": "999999999" });
+    expect(findUnarmedHandledPrs(["https://x/pull/1"], sessions)).toEqual(["https://x/pull/1"]);
+  });
+
+  it("does not owe a slot with a live watch.pid", () => {
+    seedSlot("s2", "https://x/pull/2", { "watch.pid": String(process.pid) });
+    expect(findUnarmedHandledPrs(["https://x/pull/2"], sessions)).toEqual([]);
+  });
+
+  it("does not owe a terminal slot (result.md present)", () => {
+    seedSlot("s3", "https://x/pull/3", { "result.md": "# done", "watch.pid": "999999999" });
+    expect(findUnarmedHandledPrs(["https://x/pull/3"], sessions)).toEqual([]);
+  });
+
+  it("does not owe a slot with a fresh heartbeat", () => {
+    seedSlot("s4", "https://x/pull/4", { "watch-heartbeat": "" });
+    expect(findUnarmedHandledPrs(["https://x/pull/4"], sessions)).toEqual([]);
+  });
+
+  it("returns only the owed subset across a mix", () => {
+    seedSlot("armed", "https://x/pull/10", { "watch.pid": String(process.pid) });
+    seedSlot("dead", "https://x/pull/11", { "watch.pid": "999999999" });
+    const owed = findUnarmedHandledPrs(
+      ["https://x/pull/10", "https://x/pull/11", "https://x/pull/12"],
+      sessions,
+    );
+    expect(owed.sort()).toEqual(["https://x/pull/11", "https://x/pull/12"]);
+  });
+
+  it("returns [] for no handled urls without scanning", () => {
+    expect(findUnarmedHandledPrs([], sessions)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Why

muggle-do's Stage-8 watcher hand-off (`open-prs/forward.md`) is mandated — "dispatch one watcher loop per opened PR … the LAST action this stage takes" — but it relied on **model discipline**, so it could be silently skipped: a PR gets opened and no watcher is ever armed. That just happened (a PR opened via /mdo with the hand-off skipped). The E2E gate already solves this class of problem deterministically — a Stop hook that blocks turn-end until the action runs or is explicitly skipped. This gives the watcher hand-off the same enforcement.

## The watcher-arm Stop gate (mirrors `guardrail-e2e-gate.sh`)

- **`watchArmed.ts`** — pure `watchGateDecision` + the impure `sessions/*/` slot scan (`findUnarmedHandledPrs`). A PR opened this session (`prsHandled`, recorded by the existing `pr-opened` hook) is **owed** unless some slot's `prs.json` url matches and the slot has a live `watch.pid`, a fresh `watch-heartbeat`, or a `result.md`.
- **`cli.ts`** — `watch-gate` subcommand; `recordTests` now also records the **`MUGGLE_WATCH_SKIP`** escape hatch (autoWatchPR=never, a manual PR, one handed off elsewhere, already terminal). Blocks up to `MAX_WATCH_BLOCKS` then releases, so a genuinely un-watchable PR can't trap the session.
- **`types.ts` / `constants.ts`** — `watchSkipped` + `watchBlockCount` state; `MAX_WATCH_BLOCKS`.
- **`guardrail-watch-gate.sh`** — Stop wrapper with the same in-shell pre-filter discipline (spawns Node only when a PR was opened this session and no skip recorded); wired as the third Stop hook in `hooks.json`.
- **`guardrails.mjs`** rebuilt (tsup) so the shipped bundle carries `watch-gate`.

## Deterministic CI coverage (vitest via `ci.yml` — not a probabilistic LLM eval)

- **`watchArmed.test.ts`** — unit-tests the decision (None/Block/Release/skip) and the scan (live pid / dead pid / heartbeat / result.md / no-slot / mixed).
- **`hook-execution.test.ts`** — adds the `pr-opened → watch-gate` **block** flow, the armed-slot and `MUGGLE_WATCH_SKIP` **release** paths, the cold-path Node-skip, and extends the `hooks.json` fan-out assertion to **require `guardrail-watch-gate.sh` on Stop**. Removing the gate or its wiring fails CI.

## Scope note

`prsHandled` records every `gh pr create|ready`, so a manually-opened PR under `autoWatchPR=never` trips the gate — that's what the `MUGGLE_WATCH_SKIP` hatch and the autoWatchPR-referencing reason text are for (a shell Stop hook can't cheaply read `preferences.json`), exactly how the E2E gate treats `autoE2ETest`.

## Verification

- Full vitest suite green (928 passed, 11 skipped), typecheck + lint clean, `check-skill-deps` OK, `verify:plugin` passed.
- Rebuilt `guardrails.mjs` dispatches `watch-gate` end-to-end (returns the block with the arm/skip instruction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
