### PR TITLE
chore(release): @muggleai/works 5.9.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "5.8.1"
+      "version": "5.9.0"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "5.8.1"
+      "version": "5.9.0"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@muggleai/works",
   "mcpName": "io.github.multiplex-ai/muggle",
-  "version": "5.8.1",
+  "version": "5.9.0",
   "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
   "type": "module",
   "main": "dist/index.js",
@@ -48,14 +48,14 @@
     "eval:studio-gen": "tsx internal/studio-gen-eval/src/run.ts"
   },
   "muggleConfig": {
-    "electronAppVersion": "1.6.11",
+    "electronAppVersion": "1.6.12",
     "downloadBaseUrl": "https://github.com/multiplex-ai/muggle-ai-works/releases/download",
     "runtimeTargetDefault": "dev",
     "checksums": {
-      "darwin-arm64": "97f7f5ba622dc3baf86457184bc44030c777d7dbac58b8c1c5418970662e7a07",
-      "darwin-x64": "c8c2745282583144b34110ef45c4745e03c03c4ac2e020c820daa51124c3fc50",
-      "linux-x64": "d85e14ed38cb8035b932aef26148934e3aec6e036b6bb80ff8927cbde901a935",
-      "win32-x64": "6e38a5b017ee5756985e1507def6c5a92d357a4bbd4e4032b6e490ad05dd09a2"
+      "darwin-arm64": "d313b881b6f448b968c838a3b9bea4d8f226c60b703c377514d37f33d0dacd66",
+      "darwin-x64": "31f316bdcc97dbc764a9656fc3003a2640c613d6ce1f8ba1a73564987235f2f1",
+      "linux-x64": "1d06dfbf66ea97f55abfb6e3cd8a3edbea2c7c6bf75acbbd607039e7c6dae69b",
+      "win32-x64": "ff1150431afad2717e30d419d4ba15df79d20e10ae48a6293f71a723c7b3159a"
     }
   },
   "dependencies": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "5.8.1",
+  "version": "5.9.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "5.8.1",
+  "version": "5.9.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "5.8.1",
+  "version": "5.9.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "5.8.1",
+      "version": "5.9.0",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
## Version

`5.8.1` → **`5.9.0`** — minor. Three `feat` commits ship; no breaking changes.

## Shipping

| PR | Type | What |
|---|---|---|
| #360 | feat | pr-followup monitor wakes on **branch-behind/conflicting** (`REBASED` floor) and — while blocked — on **any CI-digest move** (`BLOCKED_CIDIGEST` floor), not only settled-red |
| #361 | feat | **watcher-arm Stop gate** — blocks turn-end when a PR was opened but no watcher armed; `MUGGLE_WATCH_SKIP` hatch + deterministic vitest coverage |
| #359 | feat | agent-gate-eval behavioral scenarios for the acceptance-tester agent |
| #362 | fix | pr-followup rides through GitHub API outages instead of dying after a few failed fetches |
| #358 | refactor | orphan-cron escalation gated on cancel-found-nothing, not a stale-fire count |

Together #360 + #361 close the loop this batch is about: the monitor now *sees* the states it was blind to, and the Stage-8 hand-off that arms it can no longer be silently skipped.

## Electron

`1.6.11` → **`1.6.12`**. All four `muggleConfig.checksums` refreshed from the `electron-app-v1.6.12` release and confirmed by `verify:electron-release-checksums`.

## Manifests (via `sync:versions`, not hand-edited)

`package.json`, `server.json`, `.claude-plugin/marketplace.json`, `.cursor-plugin/marketplace.json`, `plugin/.claude-plugin/plugin.json`, `plugin/.cursor-plugin/plugin.json`.

## Test plan

- [x] `lint:check` — 0 errors (17 pre-existing warnings)
- [x] `typecheck` — clean
- [x] `pnpm test` — 934 passed, 11 skipped
- [x] `build`
- [x] `verify:plugin`
- [x] `verify:contracts`
- [x] `verify:electron-release-checksums` — 1.6.12 verified

Publish is CI-only (`publish-works-to-npm.yml`, OIDC trusted publishing) — dispatched after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
