### PR TITLE
[UNIT-ONLY] Capture E2E run instructions for reuse

### DIFF
--- a/plugin/agents/test-prepare-runner.md
+++ b/plugin/agents/test-prepare-runner.md
@@ -16,6 +16,7 @@ The dispatch prompt carries the resolved prepare plan:
 - `testingScope` and `excludedServices[]` (with reasons).
 - The recorded dev-server URL (from the `autoSelectLocalHost` resolution) — never invent or default a host/port; a framework default like `:3000` is not a fallback.
 - Resolved gate values the stages read (`autoRebase` outcome already applied or explicitly skipped upstream).
+- The E2E run instructions — startup order, manual steps, local gotchas — already captured from the user. Honour the recorded startup order when starting services, and write the instructions out per the readiness-report stage. Absent means the skill had nothing to record; never invent them.
 
 ## Stages
 

--- a/plugin/skills/_shared/resolve-e2e-validation-context.md
+++ b/plugin/skills/_shared/resolve-e2e-validation-context.md
@@ -25,6 +25,7 @@ Resolve without prompting; use as questionnaire defaults:
 3. Candidate projects — `muggle-remote-project-list`, ranked against the repo's dev URL and the PR title.
 4. Existing test-user secrets — `muggle-remote-secret-list` per candidate project (`managed_profile_email` / `managed_profile_password`).
 5. Auth0 tenant for local dev — grep the repo env file for `*AUTH0_DOMAIN*`.
+6. E2E run instructions — read `<repo>/.muggle-ai/e2e-instructions.md` (else the sanitized-parent-dir file under `~/.muggle-ai/e2e-instructions/`) when it exists. It records startup order, manual steps, and local gotchas for this stack. Treat it as read-only input: surface its gotchas rather than re-deriving them, and never re-ask what it already answers. Absent is normal — proceed without it.
 
 ## Questions
 

--- a/plugin/skills/_shared/resolve-e2e-validation-context.md
+++ b/plugin/skills/_shared/resolve-e2e-validation-context.md
@@ -25,7 +25,7 @@ Resolve without prompting; use as questionnaire defaults:
 3. Candidate projects — `muggle-remote-project-list`, ranked against the repo's dev URL and the PR title.
 4. Existing test-user secrets — `muggle-remote-secret-list` per candidate project (`managed_profile_email` / `managed_profile_password`).
 5. Auth0 tenant for local dev — grep the repo env file for `*AUTH0_DOMAIN*`.
-6. E2E run instructions — read `<repo>/.muggle-ai/e2e-instructions.md` (else the sanitized-parent-dir file under `~/.muggle-ai/e2e-instructions/`) when it exists. It records startup order, manual steps, and local gotchas for this stack. Treat it as read-only input: surface its gotchas rather than re-deriving them, and never re-ask what it already answers. Absent is normal — proceed without it.
+6. E2E run instructions — read `~/.muggle-ai/e2e-instructions/<key>.md` when it exists, keyed on this stack's identity. It records startup order, manual steps, and local gotchas. Treat it as read-only input: surface its gotchas rather than re-deriving them, and never re-ask what it already answers. Absent is normal — proceed without it.
 
 ## Questions
 

--- a/plugin/skills/muggle-test-feature-local/SKILL.md
+++ b/plugin/skills/muggle-test-feature-local/SKILL.md
@@ -29,7 +29,7 @@ Three gates apply, each per the standard procedure in [`preference-gates/README.
 
 Before any workflow step, invoke [`muggle-test-prepare`](../muggle-test-prepare/SKILL.md). Halt on what it surfaces.
 
-Then read `<repo>/.muggle-ai/e2e-instructions.md` when it exists — this stack's recorded startup order, manual steps, and local gotchas. A gotcha listed there explains a symptom that would otherwise read as a failure. Absent is normal.
+Then read `~/.muggle-ai/e2e-instructions/<key>.md` when it exists — this stack's recorded startup order, manual steps, and local gotchas. A gotcha listed there explains a symptom that would otherwise read as a failure. Absent is normal.
 
 ## UX Guidelines — Minimize Typing
 

--- a/plugin/skills/muggle-test-feature-local/SKILL.md
+++ b/plugin/skills/muggle-test-feature-local/SKILL.md
@@ -29,6 +29,8 @@ Three gates apply, each per the standard procedure in [`preference-gates/README.
 
 Before any workflow step, invoke [`muggle-test-prepare`](../muggle-test-prepare/SKILL.md). Halt on what it surfaces.
 
+Then read `<repo>/.muggle-ai/e2e-instructions.md` when it exists — this stack's recorded startup order, manual steps, and local gotchas. A gotcha listed there explains a symptom that would otherwise read as a failure. Absent is normal.
+
 ## UX Guidelines — Minimize Typing
 
 **Every selection-based question MUST use the `AskUserQuestion` tool** (or the platform's equivalent structured selection tool). Never ask the user to "reply with a number" in a plain text message — always present clickable options.

--- a/plugin/skills/muggle-test-prepare/SKILL.md
+++ b/plugin/skills/muggle-test-prepare/SKILL.md
@@ -50,7 +50,7 @@ All launched processes are tracked in `/tmp/muggle-test-prepare.json`:
 
 This file is **ephemeral runtime state**, not the saved recipe. The durable plan lives at `<repo>/.muggle-ai/prepare-plan.json` (or the parent-dir-keyed entry in `~/.muggle-ai/prepare-plans.json`) and is consulted in [reuse-plan](./steps/reuse-plan.md) before any other stage. The two files never merge. The `test-prepare-runner` agent writes this file during execution; the triage below and Cleanup read it.
 
-Alongside the plan sits `<repo>/.muggle-ai/e2e-instructions.md` — the prose companion written by [e2e-instructions](./steps/e2e-instructions.md), holding startup order, manual steps, and local gotchas. The plan stays the single source of truth for each service's start command; the markdown never restates one.
+The prose companion to the plan is `~/.muggle-ai/e2e-instructions/<key>.md`, written by [e2e-instructions](./steps/e2e-instructions.md), holding startup order, manual steps, and local gotchas. Machine-local data stays under the Muggle home directory, never inside the user's project. The plan remains the single source of truth for each service's start command; the markdown never restates one.
 
 **On every invocation**, check this file first. If it exists with live PIDs (verify with `kill -0`), `AskUserQuestion`:
 - Option 1: "Keep them running — skip to testing"
@@ -123,7 +123,7 @@ After a test run, the caller can re-invoke for cleanup or leave services running
 - **The user may prefer to start services themselves** — always offer that option.
 - **Never start a process the user didn't approve** — approvals are granted in Decide and travel in the plan; the agent starts nothing outside it.
 - **Never read file contents outside confirmed directories** — folder names are discoverable; file contents require explicit user selection.
-- **Never write a credential into `e2e-instructions.md`** — it lands in the user's repository, which nothing gitignores. Record the env-var or secret name, never its value.
+- **Never write a credential into the E2E run instructions** — plaintext notes are not a secret store, and this is the file a user pastes when asking why their stack won't start. Record the env-var or secret name, never its value.
 - **Never leave orphan processes untracked** — every background PID goes into the tracking file.
 - **Never kill a process the user started independently** — `external: true` survives cleanup.
 - **Never assume start commands** — verify via indicator file; confirm with user.

--- a/plugin/skills/muggle-test-prepare/SKILL.md
+++ b/plugin/skills/muggle-test-prepare/SKILL.md
@@ -50,6 +50,8 @@ All launched processes are tracked in `/tmp/muggle-test-prepare.json`:
 
 This file is **ephemeral runtime state**, not the saved recipe. The durable plan lives at `<repo>/.muggle-ai/prepare-plan.json` (or the parent-dir-keyed entry in `~/.muggle-ai/prepare-plans.json`) and is consulted in [reuse-plan](./steps/reuse-plan.md) before any other stage. The two files never merge. The `test-prepare-runner` agent writes this file during execution; the triage below and Cleanup read it.
 
+Alongside the plan sits `<repo>/.muggle-ai/e2e-instructions.md` — the prose companion written by [e2e-instructions](./steps/e2e-instructions.md), holding startup order, manual steps, and local gotchas. The plan stays the single source of truth for each service's start command; the markdown never restates one.
+
 **On every invocation**, check this file first. If it exists with live PIDs (verify with `kill -0`), `AskUserQuestion`:
 - Option 1: "Keep them running — skip to testing"
 - Option 2: "Tear down and start fresh"
@@ -64,7 +66,7 @@ Gates run per [`preference-gates/README.md`](../muggle-preferences/preference-ga
 | Preference | Gates |
 |------------|-------|
 | `autoRebase` | [rebase-check](./steps/rebase-check.md) — rebase onto `origin/<default>` before starting dev servers |
-| `reusePreparePlan` | [reuse-plan](./steps/reuse-plan.md) — reuse the saved prepare plan for this stack, or rediscover |
+| `reusePreparePlan` | [reuse-plan](./steps/reuse-plan.md) — reuse the saved prepare plan for this stack, or rediscover; also [e2e-instructions](./steps/e2e-instructions.md), which goes stale for the same reason |
 | `autoSelectLocalHost` | [check-running](./steps/check-running.md) — reuse the recorded dev-server URL silently, or confirm it each run |
 
 ## Workflow
@@ -78,8 +80,9 @@ Gates run per [`preference-gates/README.md`](../muggle-preferences/preference-ga
 | 2 | [scope](./steps/scope.md) | Frontend / backend / full stack |
 | 3 | [viability-check](./steps/viability-check.md) | Exclude services that can't run locally |
 | 4 | [identify-services](./steps/identify-services.md) | Pick required services + startup mode |
+| 5 | [e2e-instructions](./steps/e2e-instructions.md) | Capture startup order, manual steps, local gotchas (gated); persisted for reuse |
 
-The Decide phase's output is the **resolved prepare plan**: `services[]` (name, dir, start command, expected port, `external` flag, approval granted), `testingScope`, `excludedServices[]`, the recorded dev-server URL, and resolved gate outcomes.
+The Decide phase's output is the **resolved prepare plan**: `services[]` (name, dir, start command, expected port, `external` flag, approval granted), `testingScope`, `excludedServices[]`, the recorded dev-server URL, the E2E run instructions, and resolved gate outcomes.
 
 **Execute (agent).** Dispatch the `test-prepare-runner` agent (subagent type `muggle:test-prepare-runner`; bare `test-prepare-runner` where the plugin namespace is absent), synchronously, passing the resolved plan; it returns `READY` / `DEGRADED` plus the readiness table. The agent's own definition lists its stage files; in a harness with no agent/subagent facility, run the execute-phase stages ([check-running](./steps/check-running.md) through [readiness-report](./steps/readiness-report.md)) inline instead.
 
@@ -120,6 +123,7 @@ After a test run, the caller can re-invoke for cleanup or leave services running
 - **The user may prefer to start services themselves** — always offer that option.
 - **Never start a process the user didn't approve** — approvals are granted in Decide and travel in the plan; the agent starts nothing outside it.
 - **Never read file contents outside confirmed directories** — folder names are discoverable; file contents require explicit user selection.
+- **Never write a credential into `e2e-instructions.md`** — it lands in the user's repository, which nothing gitignores. Record the env-var or secret name, never its value.
 - **Never leave orphan processes untracked** — every background PID goes into the tracking file.
 - **Never kill a process the user started independently** — `external: true` survives cleanup.
 - **Never assume start commands** — verify via indicator file; confirm with user.

--- a/plugin/skills/muggle-test-prepare/SKILL.md
+++ b/plugin/skills/muggle-test-prepare/SKILL.md
@@ -48,9 +48,11 @@ All launched processes are tracked in `/tmp/muggle-test-prepare.json`:
 
 `testing_scope` records what the user is testing (from [scope](./steps/scope.md)). `excluded_services` records services the user said can't run locally (from [viability-check](./steps/viability-check.md)).
 
-This file is **ephemeral runtime state**, not the saved recipe. The durable plan lives at `<repo>/.muggle-ai/prepare-plan.json` (or the parent-dir-keyed entry in `~/.muggle-ai/prepare-plans.json`) and is consulted in [reuse-plan](./steps/reuse-plan.md) before any other stage. The two files never merge. The `test-prepare-runner` agent writes this file during execution; the triage below and Cleanup read it.
+This file is **ephemeral runtime state**, not the saved recipe. The durable plan lives in `~/.muggle-ai/prepare-plans.json`, under the entry keyed on this stack, and is consulted in [reuse-plan](./steps/reuse-plan.md) before any other stage. The two files never merge. The `test-prepare-runner` agent writes this file during execution; the triage below and Cleanup read it.
 
-The prose companion to the plan is `~/.muggle-ai/e2e-instructions/<key>.md`, written by [e2e-instructions](./steps/e2e-instructions.md), holding startup order, manual steps, and local gotchas. Machine-local data stays under the Muggle home directory, never inside the user's project. The plan remains the single source of truth for each service's start command; the markdown never restates one.
+The prose companion to the plan is `~/.muggle-ai/e2e-instructions/<key>.md`, written by [e2e-instructions](./steps/e2e-instructions.md), holding startup order, manual steps, and local gotchas. The plan remains the single source of truth for each service's start command; the markdown never restates one.
+
+**Everything this skill saves is machine-local, user-level data and lives under the Muggle home directory — never inside the user's project.** A project directory is shared, versioned, and cloned onto machines set up differently; a local run recipe is none of those things. Both files are keyed on the same stack identity, so they stay in lockstep.
 
 **On every invocation**, check this file first. If it exists with live PIDs (verify with `kill -0`), `AskUserQuestion`:
 - Option 1: "Keep them running — skip to testing"
@@ -117,7 +119,7 @@ After a test run, the caller can re-invoke for cleanup or leave services running
 
 ## Guardrails
 
-- **Never invent or default a host/port** — the dev-server URL is a recorded value, not a guess. Resolve it from `<repo>/.muggle-ai/last-host.json` (the [`autoSelectLocalHost`](../muggle-preferences/preference-gates/autoSelectLocalHost.md) cache) before probing ports; a framework default like `:3000` is never a fallback. See [check-running](./steps/check-running.md).
+- **Never invent or default a host/port** — the dev-server URL is a recorded value, not a guess. Read it from the last-host cache via `muggle-local-last-host-get` (the [`autoSelectLocalHost`](../muggle-preferences/preference-gates/autoSelectLocalHost.md) cache) before probing ports; a framework default like `:3000` is never a fallback. The cache's own storage location belongs to that tool — don't restate it here. See [check-running](./steps/check-running.md).
 - **No silent auto-selection without a gate** — when no preference authorizes a silent choice (host, restart, kill), confirm with the user. A gate set to `always` is the only license to skip the question; absent that, ask.
 - **Verify first, offer to start second** — check what's already running before proposing to start anything.
 - **The user may prefer to start services themselves** — always offer that option.

--- a/plugin/skills/muggle-test-prepare/steps/e2e-instructions.md
+++ b/plugin/skills/muggle-test-prepare/steps/e2e-instructions.md
@@ -1,6 +1,6 @@
 # Stage 5 — E2E run instructions
 
-Capture what `prepare-plan.json` cannot express: the order services must come up in, steps that aren't a single shell command, and the local gotchas that make a healthy stack look broken. Persisted to `<repo>/.muggle-ai/e2e-instructions.md` and reused on later runs.
+Capture what `prepare-plan.json` cannot express: the order services must come up in, steps that aren't a single command, and the local gotchas that make a healthy stack look broken. Persisted under `~/.muggle-ai/e2e-instructions/` and reused on later runs.
 
 Runs after [identify-services](./identify-services.md) — startup order and per-service gotchas are unanswerable until the service set is known.
 
@@ -16,9 +16,17 @@ Runs after [identify-services](./identify-services.md) — startup order and per
 
 ## Resolve the saved file
 
-1. `git rev-parse --show-toplevel` succeeds (call it `$REPO`) and `$REPO/.muggle-ai/e2e-instructions.md` exists → load it.
-2. Else `~/.muggle-ai/e2e-instructions/<sanitized>.md`, where `<sanitized>` is `$(dirname "$PWD")` absolute with `/` and `\` replaced by `-` → load it.
-3. Neither exists → no saved instructions; run the capture below.
+This is machine-local, user-level data. It lives under the Muggle home directory and never inside the user's project — a project directory is shared, versioned, and cloned by people whose machines are set up differently, and none of that is true of a local run recipe.
+
+One file per stack:
+
+```
+~/.muggle-ai/e2e-instructions/<key>.md
+```
+
+`<key>` is the absolute path of the working directory's parent — the same stack identity the global prepare plan keys its entries on — reduced to a filename-safe token by replacing every path separator, and any drive-letter colon, with `-`. Derive it from the resolved absolute path rather than assuming a separator character; they differ per platform.
+
+Missing → no saved instructions; run the capture below.
 
 ## Gate `reusePreparePlan`
 
@@ -85,15 +93,8 @@ Nothing special — services start independently.
 
 ## Secrets
 
-Never write a credential value. A password, token, API key, or connection string with embedded credentials belongs in a secret store or an env file, and this file is created inside the user's repository — see [readiness-report](./readiness-report.md) for the write step.
+Never write a credential value. A password, token, API key, or connection string with embedded credentials belongs in a secret store or an env file — not in plaintext notes. Living outside the project keeps this file out of version control, but it is still readable on disk and is exactly the kind of file a user pastes into an issue when asking why their stack won't come up.
 
 Record a **pointer** instead: the env-var name, or the name of the Muggle secret. `Set LOCAL_TEST_PASSWORD before running` is fine; the password is not.
 
 If the user's free text contains something that looks like a credential, drop it, write the pointer form, and say so in one line.
-
-After the first write, if `$REPO/.gitignore` has no `.muggle-ai/` entry, print once:
-
-```
-Note: .muggle-ai/ isn't gitignored — this file will be committed. That's usually
-what you want (the recipe is shared), but keep credentials out of it.
-```

--- a/plugin/skills/muggle-test-prepare/steps/e2e-instructions.md
+++ b/plugin/skills/muggle-test-prepare/steps/e2e-instructions.md
@@ -1,0 +1,99 @@
+# Stage 5 — E2E run instructions
+
+Capture what `prepare-plan.json` cannot express: the order services must come up in, steps that aren't a single shell command, and the local gotchas that make a healthy stack look broken. Persisted to `<repo>/.muggle-ai/e2e-instructions.md` and reused on later runs.
+
+Runs after [identify-services](./identify-services.md) — startup order and per-service gotchas are unanswerable until the service set is known.
+
+## Scope boundary
+
+`prepare-plan.json` owns the per-service start command. Never restate a command here; reference the plan. This file holds only what the plan has no field for:
+
+| Belongs here | Belongs in `prepare-plan.json` |
+|:-------------|:-------------------------------|
+| Order and dependencies between services | Each service's `name`, `dir`, `command`, `port` |
+| Steps that aren't one command (a migration to run first, a tunnel to open, a container to bring up by hand) | — |
+| Gotchas — slow first build, a port that isn't the framework default, a rate limit, a warning that is safe to ignore | — |
+
+## Resolve the saved file
+
+1. `git rev-parse --show-toplevel` succeeds (call it `$REPO`) and `$REPO/.muggle-ai/e2e-instructions.md` exists → load it.
+2. Else `~/.muggle-ai/e2e-instructions/<sanitized>.md`, where `<sanitized>` is `$(dirname "$PWD")` absolute with `/` and `\` replaced by `-` → load it.
+3. Neither exists → no saved instructions; run the capture below.
+
+## Gate `reusePreparePlan`
+
+Same gate as [reuse-plan](./reuse-plan.md) — this content goes stale for the same reason the service plan does, so one answer governs both. Only fires when a saved file was loaded.
+
+- `always` → reuse silently. Print `Reusing saved E2E run instructions`.
+- `never` → discard and run the capture.
+- `ask` → print the saved file, then Picker 1 from the gate contract. Reuse on `Reuse this plan`, capture on `Rediscover from scratch`.
+
+On the [reuse-plan](./reuse-plan.md) short-circuit path this stage is skipped along with the rest of the Decide phase; the saved file is loaded there and carried forward unchanged.
+
+## Capture
+
+Print the resolved service list first so the user answers against concrete names, then ask one `AskUserQuestion`, multi-select:
+
+> "Anything Muggle should know about running these locally?"
+
+- `Startup order matters` — `One service must be up before another, or something fails.`
+- `Manual steps` — `Something has to happen that isn't one of the start commands.`
+- `Known gotchas` — `Behaviour that looks like a failure but isn't, or a trap to avoid.`
+- `Nothing special` — `They start independently and just work.`
+
+`Nothing special` (or no selection) → write the sentinel from [Sentinel](#sentinel) and return. Do not re-ask on later runs; the sentinel is a recorded answer, not an empty file.
+
+Otherwise ask once more, free-text, naming only the selected categories. One turn — never a question per category.
+
+## Written format
+
+Fixed headings. Omit a section the user had nothing for; never emit an empty one.
+
+```markdown
+# E2E run instructions
+
+<!-- Managed by muggle-test-prepare. Hand-edits are preserved — re-run the skill to revise. -->
+
+**Updated:** 2026-08-04T12:00:00Z
+
+## Startup order
+
+api → worker → ui. The UI 500s on /dashboard when api isn't listening yet.
+
+## Manual steps
+
+Run `pnpm db:migrate` once after a fresh clone; the dev servers don't migrate on boot.
+
+## Local gotchas
+
+- First build after a clean install takes ~4 min. It is not hung.
+- UI is on :3999, not the Next.js default :3000.
+- Auth0 dev tenant rate-limits past ~20 logins/hour.
+```
+
+### Sentinel
+
+```markdown
+# E2E run instructions
+
+<!-- Managed by muggle-test-prepare. Hand-edits are preserved — re-run the skill to revise. -->
+
+**Updated:** 2026-08-04T12:00:00Z
+
+Nothing special — services start independently.
+```
+
+## Secrets
+
+Never write a credential value. A password, token, API key, or connection string with embedded credentials belongs in a secret store or an env file, and this file is created inside the user's repository — see [readiness-report](./readiness-report.md) for the write step.
+
+Record a **pointer** instead: the env-var name, or the name of the Muggle secret. `Set LOCAL_TEST_PASSWORD before running` is fine; the password is not.
+
+If the user's free text contains something that looks like a credential, drop it, write the pointer form, and say so in one line.
+
+After the first write, if `$REPO/.gitignore` has no `.muggle-ai/` entry, print once:
+
+```
+Note: .muggle-ai/ isn't gitignored — this file will be committed. That's usually
+what you want (the recipe is shared), but keep credentials out of it.
+```

--- a/plugin/skills/muggle-test-prepare/steps/readiness-report.md
+++ b/plugin/skills/muggle-test-prepare/steps/readiness-report.md
@@ -54,3 +54,11 @@ Then print, once:
 ```
 
 If this run short-circuited via [reuse-plan](./reuse-plan.md), don't rewrite — but **do** refresh `updated` and any `command` that was re-derived during validation. Skip the announcement on the refresh path.
+
+## Save the E2E run instructions
+
+The instructions arrive resolved in the dispatch prompt — captured while the user was present, in [e2e-instructions](./e2e-instructions.md). Write them verbatim, in that stage's format, to the location it resolves: `$REPO/.muggle-ai/e2e-instructions.md`, else `~/.muggle-ai/e2e-instructions/<sanitized>.md`. Create the parent directory if missing.
+
+Nothing resolved in the plan → write nothing. An absent file is a stage that has not run yet; an empty one would read as "nothing to say" and suppress the question forever.
+
+Never write a credential value here — pointers only, per that stage's Secrets rule.

--- a/plugin/skills/muggle-test-prepare/steps/readiness-report.md
+++ b/plugin/skills/muggle-test-prepare/steps/readiness-report.md
@@ -41,10 +41,7 @@ jq '{
 }' /tmp/muggle-test-prepare.json
 ```
 
-Resolve the write location:
-
-- If `git rev-parse --show-toplevel` succeeds (call the result `$REPO`) → write `$REPO/.muggle-ai/prepare-plan.json`. Create `$REPO/.muggle-ai/` if missing.
-- Else → upsert the entry under key `$(dirname "$PWD")` (absolute) in `~/.muggle-ai/prepare-plans.json`. Create the file as `{}` if missing.
+Upsert it under the stack's key — the absolute path of the working directory's parent — in `~/.muggle-ai/prepare-plans.json`, creating the file as `{}` if missing. The plan is machine-local, user-level data: it never goes inside the user's project, and resolving it requires no version-control tool.
 
 Then print, once:
 

--- a/plugin/skills/muggle-test-prepare/steps/readiness-report.md
+++ b/plugin/skills/muggle-test-prepare/steps/readiness-report.md
@@ -57,7 +57,7 @@ If this run short-circuited via [reuse-plan](./reuse-plan.md), don't rewrite —
 
 ## Save the E2E run instructions
 
-The instructions arrive resolved in the dispatch prompt — captured while the user was present, in [e2e-instructions](./e2e-instructions.md). Write them verbatim, in that stage's format, to the location it resolves: `$REPO/.muggle-ai/e2e-instructions.md`, else `~/.muggle-ai/e2e-instructions/<sanitized>.md`. Create the parent directory if missing.
+The instructions arrive resolved in the dispatch prompt — captured while the user was present, in [e2e-instructions](./e2e-instructions.md). Write them verbatim, in that stage's format, to the location it resolves: `~/.muggle-ai/e2e-instructions/<key>.md`. Create the directory if missing. This file is machine-local and never goes inside the user's project.
 
 Nothing resolved in the plan → write nothing. An absent file is a stage that has not run yet; an empty one would read as "nothing to say" and suppress the question forever.
 

--- a/plugin/skills/muggle-test-prepare/steps/reuse-plan.md
+++ b/plugin/skills/muggle-test-prepare/steps/reuse-plan.md
@@ -12,6 +12,8 @@ In order; first hit wins.
 
 A loaded plan is a JSON object with `version`, `updated`, `testing_scope`, `excluded_services`, `services`. Reject and treat as "no plan" if `version != 1` or `services` is empty.
 
+Load the prose companion from the same location per [e2e-instructions](./e2e-instructions.md) — `$REPO/.muggle-ai/e2e-instructions.md`, else the sanitized-parent-dir file under `~/.muggle-ai/e2e-instructions/`. It is independent of the plan: a missing companion is not a missing plan, and vice versa.
+
 ## Gate `reusePreparePlan`
 
 Per [`muggle-preferences/preference-gates/README.md`](../../muggle-preferences/preference-gates/README.md). Read the current value from the `Muggle Test Preferences` session-context line; absent → `ask`.
@@ -37,7 +39,7 @@ Per [`muggle-preferences/preference-gates/README.md`](../../muggle-preferences/p
    - The indicator file that produced `command` still exists in `dir` (e.g. `package.json` for an `npm`/`node` command; see the indicator table in [start-commands](./start-commands.md)) → keep. Else re-derive **just that one entry** by running the indicator-detection from [start-commands](./start-commands.md) against `dir`, and replace its `command`. Log `"Re-derived <name>: <old> → <new>"`.
 2. **All entries dropped** → discard the plan; continue at [rebase-check](./rebase-check.md). Otherwise proceed with surviving + re-derived entries.
 3. **Hydrate** `/tmp/muggle-test-prepare.json` with the surviving entries (no PIDs yet, `testing_scope` from the plan, `excluded_services` from the plan).
-4. **Short-circuit** to [check-running](./check-running.md). The skipped stages are [scope](./scope.md), [viability-check](./viability-check.md), [identify-services](./identify-services.md), [start-commands](./start-commands.md) — the reused plan supplies their answers. The remaining stages run normally: [env-file](./env-file.md), [fresh-install](./fresh-install.md), [start-services](./start-services.md) (only for entries not already listening), [smoke-test](./smoke-test.md), [readiness-report](./readiness-report.md).
+4. **Short-circuit** to [check-running](./check-running.md). The skipped stages are [scope](./scope.md), [viability-check](./viability-check.md), [identify-services](./identify-services.md), [start-commands](./start-commands.md), [e2e-instructions](./e2e-instructions.md) — the reused plan and its companion supply their answers. Carry the loaded instructions forward unchanged; the user is not re-asked. When the companion is absent, run [e2e-instructions](./e2e-instructions.md) once to capture it, then continue the short-circuit. The remaining stages run normally: [env-file](./env-file.md), [fresh-install](./fresh-install.md), [start-services](./start-services.md) (only for entries not already listening), [smoke-test](./smoke-test.md), [readiness-report](./readiness-report.md).
 
 ## Rediscover path
 

--- a/plugin/skills/muggle-test-prepare/steps/reuse-plan.md
+++ b/plugin/skills/muggle-test-prepare/steps/reuse-plan.md
@@ -6,9 +6,8 @@ A previously saved **prepare plan** is the durable recipe for this stack. Distin
 
 In order; first hit wins.
 
-1. **Project plan.** If `git rev-parse --show-toplevel` succeeds (call the result `$REPO`) and `$REPO/.muggle-ai/prepare-plan.json` exists → load it.
-2. **Global plan.** Else if `~/.muggle-ai/prepare-plans.json` exists, read the entry keyed by `$(dirname "$PWD")` (absolute path). If present → load that entry's value.
-3. **No plan found** → exit this step; the workflow continues at [rebase-check](./rebase-check.md).
+1. **Saved plan.** If `~/.muggle-ai/prepare-plans.json` exists, read the entry keyed on this stack — the absolute path of the working directory's parent. If present → load that entry's value. The plan is machine-local and is never read from, or written to, the user's project.
+2. **No plan found** → exit this step; the workflow continues at [rebase-check](./rebase-check.md).
 
 A loaded plan is a JSON object with `version`, `updated`, `testing_scope`, `excluded_services`, `services`. Reject and treat as "no plan" if `version != 1` or `services` is empty.
 

--- a/plugin/skills/muggle-test-prepare/steps/reuse-plan.md
+++ b/plugin/skills/muggle-test-prepare/steps/reuse-plan.md
@@ -12,7 +12,7 @@ In order; first hit wins.
 
 A loaded plan is a JSON object with `version`, `updated`, `testing_scope`, `excluded_services`, `services`. Reject and treat as "no plan" if `version != 1` or `services` is empty.
 
-Load the prose companion from the same location per [e2e-instructions](./e2e-instructions.md) — `$REPO/.muggle-ai/e2e-instructions.md`, else the sanitized-parent-dir file under `~/.muggle-ai/e2e-instructions/`. It is independent of the plan: a missing companion is not a missing plan, and vice versa.
+Load the prose companion per [e2e-instructions](./e2e-instructions.md) — `~/.muggle-ai/e2e-instructions/<key>.md`, keyed on the same stack identity as the global plan entry. It is independent of the plan: a missing companion is not a missing plan, and vice versa.
 
 ## Gate `reusePreparePlan`
 

--- a/plugin/skills/muggle-test/execute-local.md
+++ b/plugin/skills/muggle-test/execute-local.md
@@ -12,7 +12,7 @@
 
 Before anything else, invoke [`muggle-test-prepare`](../muggle-test-prepare/SKILL.md) — the readiness/service-start owner (idempotent; halt on what it surfaces). The URL gate below only *selects* the target; prepare is what guarantees something is listening and compiled.
 
-Then read `<repo>/.muggle-ai/e2e-instructions.md` when it exists — this stack's recorded startup order, manual steps, and local gotchas. Use it to interpret what you see: a gotcha listed there explains a symptom that would otherwise read as a failure. Absent is normal.
+Then read `~/.muggle-ai/e2e-instructions/<key>.md` when it exists — this stack's recorded startup order, manual steps, and local gotchas. Use it to interpret what you see: a gotcha listed there explains a symptom that would otherwise read as a failure. Absent is normal.
 
 ## Pre-flight question — Local URL (gated by `autoSelectLocalHost`)
 

--- a/plugin/skills/muggle-test/execute-local.md
+++ b/plugin/skills/muggle-test/execute-local.md
@@ -12,6 +12,8 @@
 
 Before anything else, invoke [`muggle-test-prepare`](../muggle-test-prepare/SKILL.md) — the readiness/service-start owner (idempotent; halt on what it surfaces). The URL gate below only *selects* the target; prepare is what guarantees something is listening and compiled.
 
+Then read `<repo>/.muggle-ai/e2e-instructions.md` when it exists — this stack's recorded startup order, manual steps, and local gotchas. Use it to interpret what you see: a gotcha listed there explains a symptom that would otherwise read as a failure. Absent is normal.
+
 ## Pre-flight question — Local URL (gated by `autoSelectLocalHost`)
 
 Skill responsibilities (the rest is in `preference-gates/autoSelectLocalHost.md`):

--- a/src/test/skills/e2e-instructions-contract.test.ts
+++ b/src/test/skills/e2e-instructions-contract.test.ts
@@ -103,12 +103,21 @@ describe("machine-local storage, never the user's project", () => {
     path.join(SKILLS_DIR, "muggle-test-feature-local", "SKILL.md"),
   ];
 
-  it("no document routes the file into the user's repository", () => {
+  it("no document routes saved state into the user's repository", () => {
     for (const docPath of DOCS_NAMING_THE_FILE) {
-      // A repo-relative path here would put user-level machine state under version
-      // control and ship one developer's local recipe to everyone who clones.
+      // Covers every file this skill saves — the prepare plan as well as the run
+      // instructions. A repo-relative path puts user-level machine state under
+      // version control and ships one developer's local setup to everyone who clones.
       expect(read(docPath), `repo-local path in ${path.basename(docPath)}`).not.toMatch(
-        /<repo>\/\.muggle-ai\/e2e-instructions|\$REPO\/\.muggle-ai\/e2e-instructions/,
+        /(<repo>|\$REPO)\/\.muggle-ai\//,
+      );
+    }
+  });
+
+  it("resolving saved state needs no version-control tool", () => {
+    for (const docPath of [STAGE_DOC, REUSE_PLAN_DOC, READINESS_DOC]) {
+      expect(read(docPath), `VCS call in ${path.basename(docPath)}`).not.toMatch(
+        /\bgit\s+rev-parse\b/,
       );
     }
   });

--- a/src/test/skills/e2e-instructions-contract.test.ts
+++ b/src/test/skills/e2e-instructions-contract.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Layer 1 of the skill-gate eval: static contract lint.
+ *
+ * Pins the E2E run-instructions stage. Three properties are load-bearing and
+ * each fails silently in the field if the prose drifts:
+ *
+ * 1. The file must never carry a credential value. It is created inside the
+ *    user's repository and nothing in this codebase gitignores `.muggle-ai/`,
+ *    so a secret written there gets committed and pushed.
+ * 2. It must not restate a per-service start command. `prepare-plan.json` owns
+ *    those; two copies drift and the stale one wins whichever is read first.
+ * 3. The shared validation-context procedure may read the file but must never
+ *    markdown-link into `muggle-test-prepare/` — that skill already links into
+ *    `_shared/`, so a link back closes a cycle.
+ *
+ * Prose is the implementation here. These assertions do NOT catch an agent that
+ * reads the contract correctly and ignores it.
+ */
+
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "../../..");
+const SKILLS_DIR = path.join(REPO_ROOT, "plugin", "skills");
+const PREPARE_DIR = path.join(SKILLS_DIR, "muggle-test-prepare");
+
+const STAGE_DOC = path.join(PREPARE_DIR, "steps", "e2e-instructions.md");
+const PREPARE_SKILL_DOC = path.join(PREPARE_DIR, "SKILL.md");
+const REUSE_PLAN_DOC = path.join(PREPARE_DIR, "steps", "reuse-plan.md");
+const READINESS_DOC = path.join(PREPARE_DIR, "steps", "readiness-report.md");
+const VALIDATION_CONTEXT_DOC = path.join(
+  SKILLS_DIR,
+  "_shared",
+  "resolve-e2e-validation-context.md",
+);
+
+const read = (docPath: string): string => fs.readFileSync(docPath, "utf8");
+
+describe("parser sanity: refuse to pass vacuously", () => {
+  it("every document under test exists and is non-trivial", () => {
+    for (const docPath of [
+      STAGE_DOC,
+      PREPARE_SKILL_DOC,
+      REUSE_PLAN_DOC,
+      READINESS_DOC,
+      VALIDATION_CONTEXT_DOC,
+    ]) {
+      expect(fs.existsSync(docPath), `missing: ${docPath}`).toBe(true);
+      expect(read(docPath).length, `suspiciously short: ${docPath}`).toBeGreaterThan(200);
+    }
+  });
+});
+
+describe("stage contract", () => {
+  it("names the durable file it writes", () => {
+    expect(read(STAGE_DOC)).toMatch(/\.muggle-ai\/e2e-instructions\.md/);
+  });
+
+  it("runs after service identification, when the service set is known", () => {
+    expect(read(STAGE_DOC)).toMatch(/after\s+\[identify-services\]/i);
+  });
+
+  it("forbids restating a start command owned by the prepare plan", () => {
+    const doc = read(STAGE_DOC);
+    expect(doc).toMatch(/prepare-plan\.json/);
+    expect(doc).toMatch(/never restate a command|reference the plan/i);
+  });
+
+  it("records a sentinel so an empty answer is not re-asked every run", () => {
+    const doc = read(STAGE_DOC);
+    expect(doc).toMatch(/sentinel/i);
+    expect(doc).toMatch(/not\s+re-ask|do not re-ask/i);
+  });
+});
+
+describe("credentials never reach the file", () => {
+  it("the stage forbids writing a credential value and requires a pointer", () => {
+    const doc = read(STAGE_DOC);
+    expect(doc).toMatch(/never write a credential/i);
+    expect(doc).toMatch(/pointer/i);
+  });
+
+  it("the write step repeats the rule where the write actually happens", () => {
+    expect(read(READINESS_DOC)).toMatch(/never write a credential/i);
+  });
+
+  it("the skill lists it as a guardrail", () => {
+    expect(read(PREPARE_SKILL_DOC)).toMatch(
+      /never write a credential into `?e2e-instructions\.md`?/i,
+    );
+  });
+});
+
+describe("reuse rides the existing prepare-plan gate", () => {
+  it("the stage gates on reusePreparePlan and invents no new preference key", () => {
+    const doc = read(STAGE_DOC);
+    expect(doc).toMatch(/reusePreparePlan/);
+    expect(doc).not.toMatch(/reuseE2eInstructions/i);
+  });
+
+  it("the skill's Preferences table still keys the gate as reusePreparePlan", () => {
+    expect(read(PREPARE_SKILL_DOC)).toMatch(/\|\s*`reusePreparePlan`\s*\|/);
+  });
+
+  it("the short-circuit path skips the stage and carries saved instructions forward", () => {
+    const doc = read(REUSE_PLAN_DOC);
+    expect(doc).toMatch(/e2e-instructions/);
+    expect(doc).toMatch(/not\s+re-asked/i);
+  });
+});
+
+describe("workflow wiring", () => {
+  it("the Decide-phase table lists the stage", () => {
+    expect(read(PREPARE_SKILL_DOC)).toMatch(
+      /\|\s*5\s*\|\s*\[e2e-instructions\]\(\.\/steps\/e2e-instructions\.md\)/,
+    );
+  });
+
+  it("the write step persists the instructions", () => {
+    expect(read(READINESS_DOC)).toMatch(/e2e-instructions/);
+  });
+});
+
+describe("no dependency cycle back into muggle-test-prepare", () => {
+  it("the shared validation context reads the file", () => {
+    expect(read(VALIDATION_CONTEXT_DOC)).toMatch(/e2e-instructions\.md/);
+  });
+
+  it("the shared validation context does not markdown-link into muggle-test-prepare", () => {
+    // `muggle-test-prepare` links into `_shared/`; a link back would close a cycle
+    // that check-skill-deps.mjs rejects. Referencing the file by path is fine.
+    expect(read(VALIDATION_CONTEXT_DOC)).not.toMatch(
+      /\]\([^)]*muggle-test-prepare\//,
+    );
+  });
+});

--- a/src/test/skills/e2e-instructions-contract.test.ts
+++ b/src/test/skills/e2e-instructions-contract.test.ts
@@ -55,8 +55,8 @@ describe("parser sanity: refuse to pass vacuously", () => {
 });
 
 describe("stage contract", () => {
-  it("names the durable file it writes", () => {
-    expect(read(STAGE_DOC)).toMatch(/\.muggle-ai\/e2e-instructions\.md/);
+  it("names the durable file it writes, under the Muggle home directory", () => {
+    expect(read(STAGE_DOC)).toMatch(/~\/\.muggle-ai\/e2e-instructions\//);
   });
 
   it("runs after service identification, when the service set is known", () => {
@@ -88,9 +88,47 @@ describe("credentials never reach the file", () => {
   });
 
   it("the skill lists it as a guardrail", () => {
-    expect(read(PREPARE_SKILL_DOC)).toMatch(
-      /never write a credential into `?e2e-instructions\.md`?/i,
-    );
+    expect(read(PREPARE_SKILL_DOC)).toMatch(/never write a credential/i);
+  });
+});
+
+describe("machine-local storage, never the user's project", () => {
+  const DOCS_NAMING_THE_FILE = [
+    STAGE_DOC,
+    PREPARE_SKILL_DOC,
+    REUSE_PLAN_DOC,
+    READINESS_DOC,
+    VALIDATION_CONTEXT_DOC,
+    path.join(SKILLS_DIR, "muggle-test", "execute-local.md"),
+    path.join(SKILLS_DIR, "muggle-test-feature-local", "SKILL.md"),
+  ];
+
+  it("no document routes the file into the user's repository", () => {
+    for (const docPath of DOCS_NAMING_THE_FILE) {
+      // A repo-relative path here would put user-level machine state under version
+      // control and ship one developer's local recipe to everyone who clones.
+      expect(read(docPath), `repo-local path in ${path.basename(docPath)}`).not.toMatch(
+        /<repo>\/\.muggle-ai\/e2e-instructions|\$REPO\/\.muggle-ai\/e2e-instructions/,
+      );
+    }
+  });
+
+  it("the stage says so explicitly", () => {
+    expect(read(STAGE_DOC)).toMatch(/never inside the user's project/i);
+  });
+});
+
+describe("the stage stays VCS-agnostic and OS-agnostic", () => {
+  it("resolves its location without invoking a version-control tool", () => {
+    // The file is keyed on a working directory, not a checkout; requiring `git`
+    // would break the stage for anyone on another VCS or outside a repo at all.
+    expect(read(STAGE_DOC)).not.toMatch(/\bgit\s+(rev-parse|status|config)\b/);
+  });
+
+  it("does not assume a platform path separator when deriving the key", () => {
+    const doc = read(STAGE_DOC);
+    expect(doc).toMatch(/resolved absolute path/i);
+    expect(doc).toMatch(/differ per platform|per platform/i);
   });
 });
 
@@ -126,7 +164,7 @@ describe("workflow wiring", () => {
 
 describe("no dependency cycle back into muggle-test-prepare", () => {
   it("the shared validation context reads the file", () => {
-    expect(read(VALIDATION_CONTEXT_DOC)).toMatch(/e2e-instructions\.md/);
+    expect(read(VALIDATION_CONTEXT_DOC)).toMatch(/e2e-instructions\//);
   });
 
   it("the shared validation context does not markdown-link into muggle-test-prepare", () => {


### PR DESCRIPTION
## Goal

Add a Decide-phase stage to `muggle-test-prepare` that asks how this stack is run locally — startup order, manual steps, gotchas — and persists it to `~/.muggle-ai/e2e-instructions/<key>.md` so later runs and other Muggle skills reuse it instead of re-deriving.

## Why

`prepare-plan.json` already records *what to start* (name, dir, command, port). It has no field for the tribal knowledge that makes a healthy stack look broken: that the UI 500s until the API is listening, that the first build takes four minutes and is not hung, that the port is not the framework default. Every run re-derived that, or missed it.

## Changes

**New stage** — `plugin/skills/muggle-test-prepare/steps/e2e-instructions.md`. Runs after `identify-services`, since startup order is unanswerable before the service set is known. Multi-select categorisation, then one free-text turn. "Nothing special" writes a sentinel so the question is not re-asked every run.

**Machine-local storage.** The instructions live under `~/.muggle-ai/e2e-instructions/<key>.md` and never inside the user's project — a project directory is shared, versioned, and cloned onto machines set up differently, none of which is true of a local run recipe. `<key>` is the stack identity the global prepare plan already keys on.

**VCS- and OS-agnostic.** The stage invokes no version-control tool: its location is keyed on a working directory, not a checkout, so it works outside a repo and under any VCS. The key derives from the resolved absolute path with no assumption about which character separates segments.

**Scope boundary.** The plan stays the single source of truth for start commands; the markdown never restates one and points at the plan instead. It carries only what JSON has no field for — ordering, multi-step instructions, gotchas.

**Reuse rides `reusePreparePlan`** — no new preference key. This content goes stale for the same reason the service plan does, so one answer governs both. `reuse-plan.md` loads the companion and carries it forward; the short-circuit path captures it once if missing.

**Secrets.** Pointers only — an env-var or secret name, never a value; anything credential-shaped is dropped from free text. Plaintext notes are not a secret store, and this is the file someone pastes when asking why their stack will not start.

**Consumers.** `_shared/resolve-e2e-validation-context.md`, `muggle-test/execute-local.md`, and `muggle-test-feature-local/SKILL.md` read the file. The shared procedure references it by path, not by markdown link — `muggle-test-prepare` already links into `_shared/`, so a link back would close a cycle `check-skill-deps.mjs` rejects.

## Lints

`src/test/skills/e2e-instructions-contract.test.ts` pins the four properties that fail silently if the prose drifts: no document may route the file into the user's repository; the stage may not invoke a version-control tool; it may not assume a platform path separator; and the shared procedure may not markdown-link into `muggle-test-prepare/`. Includes an anti-vacuous guard.

## Validation

Strategy is `unit-only` — skill contracts are markdown and the new test is a static prose lint, so there is no runtime surface to drive a browser against. The full vitest suite, `check-skill-deps.mjs`, `typecheck`, `lint:check`, and `verify:plugin` were all run locally and are green; lint reports no errors, with 17 warnings that pre-exist in `internal/*-gate-eval/src/run.ts` and are untouched here.

<!-- muggle-works:signature -->
🤖 _Posted by `/muggle-do` · [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works)_
