### PR TITLE
Store last-host and last-project caches in the home directory

### DIFF
--- a/packages/mcps/src/mcp/tools/local/tool-registry.ts
+++ b/packages/mcps/src/mcp/tools/local/tool-registry.ts
@@ -46,6 +46,7 @@ import {
   clearLastHost,
   LAST_HOST_FILE_NAME,
 } from "../../../shared/last-host.js";
+import { MUGGLE_HOME_DISPLAY_DIR } from "../../../shared/cwd-keyed-cache-constants.js";
 import {
   cancelExecution,
   executeReplay,
@@ -462,7 +463,7 @@ const preferencesSetTool: ILocalMcpTool = {
 const lastProjectGetTool: ILocalMcpTool = {
   name: "muggle-local-last-project-get",
   description:
-    "Get the cached last-used Muggle Test project for a repo (read from the entry keyed on <cwd> in ~/.muggle-ai/last-project.json). " +
+    `Get the cached last-used Muggle Test project for a repo (read from the entry keyed on <cwd> in ${MUGGLE_HOME_DISPLAY_DIR}/${LAST_PROJECT_FILE_NAME}). ` +
     "Returns the project ID, URL, name, and saved-at timestamp, or null if no cache exists. " +
     "Skills consult this when 'autoSelectProject = always' to silently reuse the project the user picked previously, instead of presenting the project picker every time.",
   inputSchema: LastProjectGetInputSchema,
@@ -500,7 +501,7 @@ const lastProjectSetTool: ILocalMcpTool = {
   name: "muggle-local-last-project-set",
   description:
     "Save the user's selected Muggle Test project as the cached last-used project for this repo. " +
-    "Writes the entry keyed on <cwd> in ~/.muggle-ai/last-project.json. Subsequent skill invocations honor 'autoSelectProject = always' " +
+    `Writes the entry keyed on <cwd> in ${MUGGLE_HOME_DISPLAY_DIR}/${LAST_PROJECT_FILE_NAME}. Subsequent skill invocations honor 'autoSelectProject = always' ` +
     "by silently reusing this entry — no project picker shown. Always pair this call with " +
     "'muggle-local-preferences-set autoSelectProject=always' when the user chose 'Yes, save it'.",
   inputSchema: LastProjectSetInputSchema,
@@ -552,7 +553,7 @@ const lastProjectClearTool: ILocalMcpTool = {
 const lastHostGetTool: ILocalMcpTool = {
   name: "muggle-local-last-host-get",
   description:
-    "Get the cached last-used local dev server URL for a repo (read from the entry keyed on <cwd> in ~/.muggle-ai/last-host.json). " +
+    `Get the cached last-used local dev server URL for a repo (read from the entry keyed on <cwd> in ${MUGGLE_HOME_DISPLAY_DIR}/${LAST_HOST_FILE_NAME}). ` +
     "Returns the URL and saved-at timestamp, or null if no cache exists. " +
     "Skills consult this when 'autoSelectLocalHost = always' to silently reuse the URL the user used previously.",
   inputSchema: LastHostGetInputSchema,
@@ -586,7 +587,7 @@ const lastHostSetTool: ILocalMcpTool = {
   name: "muggle-local-last-host-set",
   description:
     "Save the user's chosen local dev server URL as the cached last-used host for this repo. " +
-    "Writes the entry keyed on <cwd> in ~/.muggle-ai/last-host.json. Call this on every host pick (independent of 'Remember this URL?' Picker 2) " +
+    `Writes the entry keyed on <cwd> in ${MUGGLE_HOME_DISPLAY_DIR}/${LAST_HOST_FILE_NAME}. Call this on every host pick (independent of 'Remember this URL?' Picker 2) ` +
     "so future runs can offer 'Use {lastHost}' regardless of whether the user opted to set autoSelectLocalHost=always.",
   inputSchema: LastHostSetInputSchema,
   execute: async (ctx) => {

--- a/packages/mcps/src/mcp/tools/local/tool-registry.ts
+++ b/packages/mcps/src/mcp/tools/local/tool-registry.ts
@@ -462,7 +462,7 @@ const preferencesSetTool: ILocalMcpTool = {
 const lastProjectGetTool: ILocalMcpTool = {
   name: "muggle-local-last-project-get",
   description:
-    "Get the cached last-used Muggle Test project for a repo (read from <cwd>/.muggle-ai/last-project.json). " +
+    "Get the cached last-used Muggle Test project for a repo (read from the entry keyed on <cwd> in ~/.muggle-ai/last-project.json). " +
     "Returns the project ID, URL, name, and saved-at timestamp, or null if no cache exists. " +
     "Skills consult this when 'autoSelectProject = always' to silently reuse the project the user picked previously, instead of presenting the project picker every time.",
   inputSchema: LastProjectGetInputSchema,
@@ -477,7 +477,7 @@ const lastProjectGetTool: ILocalMcpTool = {
       const content = [
         "No cached last-used project for this repo.",
         "",
-        `Looked at: \`${input.cwd}/.muggle-ai/${LAST_PROJECT_FILE_NAME}\``,
+        `Looked at: \`~/.muggle-ai/${LAST_PROJECT_FILE_NAME}\` (entry for \`${input.cwd}\`)`,
         "",
         "The cache is populated when a user picks an existing project AND chooses 'Yes, save it' on the memory picker (the autoSelectProject preference).",
       ].join("\n");
@@ -500,7 +500,7 @@ const lastProjectSetTool: ILocalMcpTool = {
   name: "muggle-local-last-project-set",
   description:
     "Save the user's selected Muggle Test project as the cached last-used project for this repo. " +
-    "Writes to <cwd>/.muggle-ai/last-project.json. Subsequent skill invocations honor 'autoSelectProject = always' " +
+    "Writes the entry keyed on <cwd> in ~/.muggle-ai/last-project.json. Subsequent skill invocations honor 'autoSelectProject = always' " +
     "by silently reusing this entry — no project picker shown. Always pair this call with " +
     "'muggle-local-preferences-set autoSelectProject=always' when the user chose 'Yes, save it'.",
   inputSchema: LastProjectSetInputSchema,
@@ -518,7 +518,7 @@ const lastProjectSetTool: ILocalMcpTool = {
     const content = [
       `Cached **${input.projectName}** as the last-used project for this repo.`,
       "",
-      `Written to: \`${input.cwd}/.muggle-ai/${LAST_PROJECT_FILE_NAME}\``,
+      `Written to: \`~/.muggle-ai/${LAST_PROJECT_FILE_NAME}\` (entry for \`${input.cwd}\`)`,
       "",
       "Skills will silently reuse this project on future runs when `autoSelectProject = always`.",
     ].join("\n");
@@ -542,7 +542,7 @@ const lastProjectClearTool: ILocalMcpTool = {
     const content = [
       "Cleared the cached last-used project for this repo.",
       "",
-      `Path: \`${input.cwd}/.muggle-ai/${LAST_PROJECT_FILE_NAME}\``,
+      `Path: \`~/.muggle-ai/${LAST_PROJECT_FILE_NAME}\` (entry for \`${input.cwd}\`)`,
     ].join("\n");
     return { content: content, isError: false };
   },
@@ -552,7 +552,7 @@ const lastProjectClearTool: ILocalMcpTool = {
 const lastHostGetTool: ILocalMcpTool = {
   name: "muggle-local-last-host-get",
   description:
-    "Get the cached last-used local dev server URL for a repo (read from <cwd>/.muggle-ai/last-host.json). " +
+    "Get the cached last-used local dev server URL for a repo (read from the entry keyed on <cwd> in ~/.muggle-ai/last-host.json). " +
     "Returns the URL and saved-at timestamp, or null if no cache exists. " +
     "Skills consult this when 'autoSelectLocalHost = always' to silently reuse the URL the user used previously.",
   inputSchema: LastHostGetInputSchema,
@@ -567,7 +567,7 @@ const lastHostGetTool: ILocalMcpTool = {
       const content = [
         "No cached last-used host for this repo.",
         "",
-        `Looked at: \`${input.cwd}/.muggle-ai/${LAST_HOST_FILE_NAME}\``,
+        `Looked at: \`~/.muggle-ai/${LAST_HOST_FILE_NAME}\` (entry for \`${input.cwd}\`)`,
       ].join("\n");
       return { content: content, isError: false };
     }
@@ -586,7 +586,7 @@ const lastHostSetTool: ILocalMcpTool = {
   name: "muggle-local-last-host-set",
   description:
     "Save the user's chosen local dev server URL as the cached last-used host for this repo. " +
-    "Writes to <cwd>/.muggle-ai/last-host.json. Call this on every host pick (independent of 'Remember this URL?' Picker 2) " +
+    "Writes the entry keyed on <cwd> in ~/.muggle-ai/last-host.json. Call this on every host pick (independent of 'Remember this URL?' Picker 2) " +
     "so future runs can offer 'Use {lastHost}' regardless of whether the user opted to set autoSelectLocalHost=always.",
   inputSchema: LastHostSetInputSchema,
   execute: async (ctx) => {

--- a/packages/mcps/src/shared/cwd-keyed-cache-constants.ts
+++ b/packages/mcps/src/shared/cwd-keyed-cache-constants.ts
@@ -5,3 +5,10 @@ export const CWD_KEYED_CACHE_VERSION = 1;
 
 /** Directory holding the superseded in-project cache files. */
 export const LEGACY_CACHE_DIR_NAME = ".muggle-ai";
+
+/**
+ * Home location as written for humans, for tool descriptions and result lines.
+ * The resolved path comes from `getDataDir()`; this is the tilde form a user
+ * reads, and it is a constant so the two never drift apart across call sites.
+ */
+export const MUGGLE_HOME_DISPLAY_DIR = "~/.muggle-ai";

--- a/packages/mcps/src/shared/cwd-keyed-cache-constants.ts
+++ b/packages/mcps/src/shared/cwd-keyed-cache-constants.ts
@@ -1,0 +1,7 @@
+/** Constants shared by every cwd-keyed cache. */
+
+/** Schema version stamped on cwd-keyed cache files. */
+export const CWD_KEYED_CACHE_VERSION = 1;
+
+/** Directory holding the superseded in-project cache files. */
+export const LEGACY_CACHE_DIR_NAME = ".muggle-ai";

--- a/packages/mcps/src/shared/cwd-keyed-cache-types.ts
+++ b/packages/mcps/src/shared/cwd-keyed-cache-types.ts
@@ -1,0 +1,22 @@
+/**
+ * Shapes for caches stored in the Muggle home directory and keyed by working
+ * directory.
+ */
+
+/** Identifies one cwd-keyed cache and the in-project file it superseded. */
+export interface ICwdKeyedCache {
+  /** File name under the Muggle home directory. */
+  fileName: string;
+  /** Property that held the entry in the superseded in-project file. */
+  legacyEntryKey: string;
+}
+
+/**
+ * On-disk shape of a cwd-keyed cache file.
+ *
+ * Output shape: `{ version: 1, entries: { "C:\\repo": { host, savedAt } } }`
+ */
+export interface ICwdKeyedCacheFile<TEntry> {
+  version: number;
+  entries: Record<string, TEntry>;
+}

--- a/packages/mcps/src/shared/cwd-keyed-cache.ts
+++ b/packages/mcps/src/shared/cwd-keyed-cache.ts
@@ -1,0 +1,136 @@
+/**
+ * Home-directory storage for caches keyed by working directory.
+ *
+ * Each cache is a single `{ version, entries }` map file in the Muggle home
+ * directory, mirroring the `prepare-plans.json` convention, so nothing is
+ * written inside the user's project. A read that misses falls back to the
+ * superseded in-project file and copies that entry forward, so an existing
+ * project cache survives the move.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { CWD_KEYED_CACHE_VERSION, LEGACY_CACHE_DIR_NAME } from "./cwd-keyed-cache-constants.js";
+import type { ICwdKeyedCache, ICwdKeyedCacheFile } from "./cwd-keyed-cache-types.js";
+import { getDataDir } from "./data-dir.js";
+import { getLogger } from "./logger.js";
+
+function resolveHomeFilePath(cache: ICwdKeyedCache): string {
+  return path.join(getDataDir(), cache.fileName);
+}
+
+function resolveLegacyFilePath(cache: ICwdKeyedCache, cwd: string): string {
+  return path.join(cwd, LEGACY_CACHE_DIR_NAME, cache.fileName);
+}
+
+function parseJsonFile<TParsed>(filePath: string): TParsed | null {
+  try {
+    if (!fs.existsSync(filePath)) {
+      return null;
+    }
+    return JSON.parse(fs.readFileSync(filePath, "utf-8")) as TParsed;
+  } catch (error) {
+    getLogger().warn("Failed to read cache file", {
+      path: filePath,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+function readHomeEntries<TEntry>(cache: ICwdKeyedCache): Record<string, TEntry> {
+  const parsed = parseJsonFile<ICwdKeyedCacheFile<TEntry>>(resolveHomeFilePath(cache));
+  return parsed?.entries ?? {};
+}
+
+function writeHomeEntries<TEntry>(
+  cache: ICwdKeyedCache,
+  entries: Record<string, TEntry>,
+): void {
+  fs.mkdirSync(getDataDir(), { recursive: true });
+  const file: ICwdKeyedCacheFile<TEntry> = {
+    version: CWD_KEYED_CACHE_VERSION,
+    entries: entries,
+  };
+  fs.writeFileSync(
+    resolveHomeFilePath(cache),
+    `${JSON.stringify(file, null, 2)}\n`,
+    "utf-8",
+  );
+}
+
+function readLegacyEntry<TEntry>(cache: ICwdKeyedCache, cwd: string): TEntry | null {
+  const parsed = parseJsonFile<Record<string, TEntry | undefined>>(
+    resolveLegacyFilePath(cache, cwd),
+  );
+  return parsed?.[cache.legacyEntryKey] ?? null;
+}
+
+/**
+ * Read the entry for a working directory, migrating a superseded in-project
+ * entry into the home file on the way.
+ * @param cache - Cache descriptor.
+ * @param cwd - Working directory the entry is keyed on.
+ * @returns The entry, or null when neither file holds one.
+ */
+export function readCwdEntry<TEntry>(cache: ICwdKeyedCache, cwd: string): TEntry | null {
+  const cwdKey = path.resolve(cwd);
+  const entries = readHomeEntries<TEntry>(cache);
+  const homeEntry = entries[cwdKey];
+  if (homeEntry) {
+    return homeEntry;
+  }
+
+  const legacyEntry = readLegacyEntry<TEntry>(cache, cwd);
+  if (!legacyEntry) {
+    return null;
+  }
+
+  try {
+    writeHomeEntries<TEntry>(cache, { ...entries, [cwdKey]: legacyEntry });
+  } catch (error) {
+    // A home directory that cannot be written still yields a usable entry.
+    getLogger().warn("Failed to migrate cache entry to the home directory", {
+      path: resolveHomeFilePath(cache),
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+  return legacyEntry;
+}
+
+/**
+ * Write the entry for a working directory into the home file.
+ * @param cache - Cache descriptor.
+ * @param cwd - Working directory the entry is keyed on.
+ * @param entry - Entry to store.
+ */
+export function writeCwdEntry<TEntry>(
+  cache: ICwdKeyedCache,
+  cwd: string,
+  entry: TEntry,
+): void {
+  const entries = readHomeEntries<TEntry>(cache);
+  writeHomeEntries<TEntry>(cache, { ...entries, [path.resolve(cwd)]: entry });
+}
+
+/**
+ * Remove the entry for a working directory from the home file and delete the
+ * superseded in-project file.
+ * @param cache - Cache descriptor.
+ * @param cwd - Working directory the entry is keyed on.
+ */
+export function clearCwdEntry(cache: ICwdKeyedCache, cwd: string): void {
+  const entries = readHomeEntries<unknown>(cache);
+  const cwdKey = path.resolve(cwd);
+  if (cwdKey in entries) {
+    delete entries[cwdKey];
+    writeHomeEntries<unknown>(cache, entries);
+  }
+
+  // Left in place, the in-project file would be migrated back on the next read.
+  const legacyFilePath = resolveLegacyFilePath(cache, cwd);
+  if (fs.existsSync(legacyFilePath)) {
+    fs.unlinkSync(legacyFilePath);
+  }
+}

--- a/packages/mcps/src/shared/last-host-constants.ts
+++ b/packages/mcps/src/shared/last-host-constants.ts
@@ -1,0 +1,22 @@
+/** Constants for the last-used local dev server URL cache. */
+
+import {
+  CWD_KEYED_CACHE_VERSION,
+  LEGACY_CACHE_DIR_NAME,
+} from "./cwd-keyed-cache-constants.js";
+import type { ICwdKeyedCache } from "./cwd-keyed-cache-types.js";
+
+/** Cache file name, in the Muggle home directory. */
+export const LAST_HOST_FILE_NAME = "last-host.json";
+
+/** Directory of the superseded in-project cache. */
+export const LAST_HOST_DIR_NAME = LEGACY_CACHE_DIR_NAME;
+
+/** Schema version for future migrations. */
+export const LAST_HOST_VERSION = CWD_KEYED_CACHE_VERSION;
+
+/** Descriptor passed to the cwd-keyed cache store. */
+export const LAST_HOST_CACHE: ICwdKeyedCache = {
+  fileName: LAST_HOST_FILE_NAME,
+  legacyEntryKey: "lastHost",
+};

--- a/packages/mcps/src/shared/last-host-types.ts
+++ b/packages/mcps/src/shared/last-host-types.ts
@@ -1,0 +1,14 @@
+/** Shapes for the last-used local dev server URL cache. */
+
+/** A cached "last used host" record for a single working directory. */
+export interface ILastHost {
+  host: string;
+  /** ISO-8601 timestamp of when this entry was last written. */
+  savedAt: string;
+}
+
+/** Shape of the superseded in-project cache file. */
+export interface ILastHostFile {
+  version: number;
+  lastHost: ILastHost;
+}

--- a/packages/mcps/src/shared/last-host.ts
+++ b/packages/mcps/src/shared/last-host.ts
@@ -1,68 +1,42 @@
 /**
- * Per-repo last-used local dev server URL cache.
+ * Last-used local dev server URL, cached per working directory.
  *
- * Lives at `<repo>/.muggle-ai/last-host.json`. Honors `autoSelectLocalHost = always`:
- * when set, skills silently reuse the URL the user used last time in this repo
- * instead of prompting again. Cache is updated on every pick — independent of
- * the "Remember this URL?" Picker 2 — so `Use {lastHost}` always shows the
- * most recent run's URL.
+ * Stored in the Muggle home directory under the absolute working directory, so
+ * the user's project stays untouched. Honors `autoSelectLocalHost = always`:
+ * when set, skills silently reuse the URL the user used last time in this
+ * directory instead of prompting again. The cache is updated on every pick —
+ * independent of the "Remember this URL?" Picker 2 — so `Use {lastHost}` always
+ * shows the most recent run's URL.
  */
 
-import * as fs from "node:fs";
-import * as path from "node:path";
+import { clearCwdEntry, readCwdEntry, writeCwdEntry } from "./cwd-keyed-cache.js";
+import { LAST_HOST_CACHE } from "./last-host-constants.js";
+import type { ILastHost } from "./last-host-types.js";
 
-import { getLogger } from "./logger.js";
-
-export const LAST_HOST_FILE_NAME = "last-host.json";
-export const LAST_HOST_DIR_NAME = ".muggle-ai";
-export const LAST_HOST_VERSION = 1;
-
-export interface ILastHost {
-  host: string;
-  savedAt: string;
-}
-
-export interface ILastHostFile {
-  version: number;
-  lastHost: ILastHost;
-}
+export {
+  LAST_HOST_CACHE,
+  LAST_HOST_DIR_NAME,
+  LAST_HOST_FILE_NAME,
+  LAST_HOST_VERSION,
+} from "./last-host-constants.js";
+export type { ILastHost, ILastHostFile } from "./last-host-types.js";
 
 /** Read the cached last host. Null if missing or unparseable. */
 export function readLastHost(cwd: string): ILastHost | null {
-  const filePath = path.join(cwd, LAST_HOST_DIR_NAME, LAST_HOST_FILE_NAME);
-  try {
-    if (!fs.existsSync(filePath)) {
-      return null;
-    }
-    const raw = JSON.parse(fs.readFileSync(filePath, "utf-8")) as ILastHostFile;
-    return raw.lastHost ?? null;
-  } catch (error) {
-    getLogger().warn("Failed to read last-host file", {
-      path: filePath,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return null;
-  }
+  return readCwdEntry<ILastHost>(LAST_HOST_CACHE, cwd);
 }
 
-/** Write the cached last host. Creates the `.muggle-ai/` dir if needed. */
+/** Write the cached last host. Creates the Muggle home directory if needed. */
 export function writeLastHost(cwd: string, host: string): void {
-  const dir = path.join(cwd, LAST_HOST_DIR_NAME);
-  fs.mkdirSync(dir, { recursive: true });
-  const filePath = path.join(dir, LAST_HOST_FILE_NAME);
-  const file: ILastHostFile = {
-    version: LAST_HOST_VERSION,
-    lastHost: { host, savedAt: new Date().toISOString() },
-  };
-  fs.writeFileSync(filePath, `${JSON.stringify(file, null, 2)}\n`, "utf-8");
+  writeCwdEntry<ILastHost>(LAST_HOST_CACHE, cwd, {
+    host: host,
+    savedAt: new Date().toISOString(),
+  });
 }
 
-/** Remove the cached last host. No-op if missing. */
+/** Remove the cached last host, including any superseded in-project file. */
 export function clearLastHost(cwd: string): void {
-  const filePath = path.join(cwd, LAST_HOST_DIR_NAME, LAST_HOST_FILE_NAME);
-  if (fs.existsSync(filePath)) {
-    fs.unlinkSync(filePath);
-  }
+  clearCwdEntry(LAST_HOST_CACHE, cwd);
 }
 
 /** Compact one-liner for session context. Empty string if no cache. */

--- a/packages/mcps/src/shared/last-project-constants.ts
+++ b/packages/mcps/src/shared/last-project-constants.ts
@@ -1,0 +1,22 @@
+/** Constants for the last-used Muggle Test project cache. */
+
+import {
+  CWD_KEYED_CACHE_VERSION,
+  LEGACY_CACHE_DIR_NAME,
+} from "./cwd-keyed-cache-constants.js";
+import type { ICwdKeyedCache } from "./cwd-keyed-cache-types.js";
+
+/** Cache file name, in the Muggle home directory. */
+export const LAST_PROJECT_FILE_NAME = "last-project.json";
+
+/** Directory of the superseded in-project cache. */
+export const LAST_PROJECT_DIR_NAME = LEGACY_CACHE_DIR_NAME;
+
+/** Schema version for future migrations. */
+export const LAST_PROJECT_VERSION = CWD_KEYED_CACHE_VERSION;
+
+/** Descriptor passed to the cwd-keyed cache store. */
+export const LAST_PROJECT_CACHE: ICwdKeyedCache = {
+  fileName: LAST_PROJECT_FILE_NAME,
+  legacyEntryKey: "lastProject",
+};

--- a/packages/mcps/src/shared/last-project-types.ts
+++ b/packages/mcps/src/shared/last-project-types.ts
@@ -1,0 +1,16 @@
+/** Shapes for the last-used Muggle Test project cache. */
+
+/** A cached "last used project" record for a single working directory. */
+export interface ILastProject {
+  projectId: string;
+  projectUrl: string;
+  projectName: string;
+  /** ISO-8601 timestamp of when this entry was last written. */
+  savedAt: string;
+}
+
+/** Shape of the superseded in-project cache file. */
+export interface ILastProjectFile {
+  version: number;
+  lastProject: ILastProject;
+}

--- a/packages/mcps/src/shared/last-project.ts
+++ b/packages/mcps/src/shared/last-project.ts
@@ -1,93 +1,60 @@
 /**
- * Per-repo last-used Muggle Test project cache.
+ * Last-used Muggle Test project, cached per working directory.
  *
- * Stored at `<repo>/.muggle-ai/last-project.json`. Honors the
- * `autoSelectProject = always` preference: when set, skills can silently reuse
- * the project that the user most recently picked for this repo, instead of
- * presenting the project picker every time.
+ * Stored in the Muggle home directory under the absolute working directory, so
+ * the user's project stays untouched. Honors the `autoSelectProject = always`
+ * preference: when set, skills can silently reuse the project that the user
+ * most recently picked for this directory, instead of presenting the project
+ * picker every time.
  *
- * Skills consume this via the `Muggle Test Last Project` line injected into session
- * context by the SessionStart hook (zero tokens). MCP tools import this module
- * directly (zero tokens).
+ * Skills consume this via the `Muggle Test Last Project` line injected into
+ * session context by the SessionStart hook (zero tokens). MCP tools import this
+ * module directly (zero tokens).
  */
 
-import * as fs from "node:fs";
-import * as path from "node:path";
+import { clearCwdEntry, readCwdEntry, writeCwdEntry } from "./cwd-keyed-cache.js";
+import { LAST_PROJECT_CACHE } from "./last-project-constants.js";
+import type { ILastProject } from "./last-project-types.js";
 
-import { getLogger } from "./logger.js";
-
-/** Per-repo cache file name. */
-export const LAST_PROJECT_FILE_NAME = "last-project.json";
-/** Per-repo cache directory name (shared with project preferences). */
-export const LAST_PROJECT_DIR_NAME = ".muggle-ai";
-/** Schema version for future migrations. */
-export const LAST_PROJECT_VERSION = 1;
-
-/** A cached "last used project" record for a single repo. */
-export interface ILastProject {
-  projectId: string;
-  projectUrl: string;
-  projectName: string;
-  /** ISO-8601 timestamp of when this entry was last written. */
-  savedAt: string;
-}
-
-/** On-disk file shape. */
-export interface ILastProjectFile {
-  version: number;
-  lastProject: ILastProject;
-}
+export {
+  LAST_PROJECT_CACHE,
+  LAST_PROJECT_DIR_NAME,
+  LAST_PROJECT_FILE_NAME,
+  LAST_PROJECT_VERSION,
+} from "./last-project-constants.js";
+export type { ILastProject, ILastProjectFile } from "./last-project-types.js";
 
 /**
- * Read the cached last project for a repo.
+ * Read the cached last project for a working directory.
  *
- * Returns null if the file does not exist or fails to parse.
+ * Returns null if no entry exists or the cache fails to parse.
  */
 export function readLastProject(cwd: string): ILastProject | null {
-  const filePath = path.join(cwd, LAST_PROJECT_DIR_NAME, LAST_PROJECT_FILE_NAME);
-  try {
-    if (!fs.existsSync(filePath)) {
-      return null;
-    }
-    const raw = JSON.parse(fs.readFileSync(filePath, "utf-8")) as ILastProjectFile;
-    return raw.lastProject ?? null;
-  } catch (error) {
-    getLogger().warn("Failed to read last-project file", {
-      path: filePath,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return null;
-  }
+  return readCwdEntry<ILastProject>(LAST_PROJECT_CACHE, cwd);
 }
 
 /**
- * Write the cached last project for a repo.
+ * Write the cached last project for a working directory.
  *
- * Creates the `.muggle-ai/` directory if it doesn't exist. `savedAt` is set
+ * Creates the Muggle home directory if it doesn't exist. `savedAt` is set
  * automatically; the caller only provides project identity fields.
  */
 export function writeLastProject(
   cwd: string,
   lastProject: Omit<ILastProject, "savedAt">,
 ): void {
-  const dir = path.join(cwd, LAST_PROJECT_DIR_NAME);
-  fs.mkdirSync(dir, { recursive: true });
-  const filePath = path.join(dir, LAST_PROJECT_FILE_NAME);
-  const file: ILastProjectFile = {
-    version: LAST_PROJECT_VERSION,
-    lastProject: { ...lastProject, savedAt: new Date().toISOString() },
-  };
-  fs.writeFileSync(filePath, `${JSON.stringify(file, null, 2)}\n`, "utf-8");
+  writeCwdEntry<ILastProject>(LAST_PROJECT_CACHE, cwd, {
+    ...lastProject,
+    savedAt: new Date().toISOString(),
+  });
 }
 
 /**
- * Remove the cached last project for a repo. No-op if the file does not exist.
+ * Remove the cached last project for a working directory, including any
+ * superseded in-project file.
  */
 export function clearLastProject(cwd: string): void {
-  const filePath = path.join(cwd, LAST_PROJECT_DIR_NAME, LAST_PROJECT_FILE_NAME);
-  if (fs.existsSync(filePath)) {
-    fs.unlinkSync(filePath);
-  }
+  clearCwdEntry(LAST_PROJECT_CACHE, cwd);
 }
 
 /**

--- a/packages/mcps/src/test/__snapshots__/mcp-tool-surface.test.ts.snap
+++ b/packages/mcps/src/test/__snapshots__/mcp-tool-surface.test.ts.snap
@@ -23,11 +23,11 @@ exports[`MCP tool surface (Lazy-core parity oracle) > advertises the exact name 
     "name": "muggle-local-last-host-clear",
   },
   {
-    "description": "Get the cached last-used local dev server URL for a repo (read from <cwd>/.muggle-ai/last-host.json). Returns the URL and saved-at timestamp, or null if no cache exists. Skills consult this when 'autoSelectLocalHost = always' to silently reuse the URL the user used previously.",
+    "description": "Get the cached last-used local dev server URL for a repo (read from the entry keyed on <cwd> in ~/.muggle-ai/last-host.json). Returns the URL and saved-at timestamp, or null if no cache exists. Skills consult this when 'autoSelectLocalHost = always' to silently reuse the URL the user used previously.",
     "name": "muggle-local-last-host-get",
   },
   {
-    "description": "Save the user's chosen local dev server URL as the cached last-used host for this repo. Writes to <cwd>/.muggle-ai/last-host.json. Call this on every host pick (independent of 'Remember this URL?' Picker 2) so future runs can offer 'Use {lastHost}' regardless of whether the user opted to set autoSelectLocalHost=always.",
+    "description": "Save the user's chosen local dev server URL as the cached last-used host for this repo. Writes the entry keyed on <cwd> in ~/.muggle-ai/last-host.json. Call this on every host pick (independent of 'Remember this URL?' Picker 2) so future runs can offer 'Use {lastHost}' regardless of whether the user opted to set autoSelectLocalHost=always.",
     "name": "muggle-local-last-host-set",
   },
   {
@@ -35,11 +35,11 @@ exports[`MCP tool surface (Lazy-core parity oracle) > advertises the exact name 
     "name": "muggle-local-last-project-clear",
   },
   {
-    "description": "Get the cached last-used Muggle Test project for a repo (read from <cwd>/.muggle-ai/last-project.json). Returns the project ID, URL, name, and saved-at timestamp, or null if no cache exists. Skills consult this when 'autoSelectProject = always' to silently reuse the project the user picked previously, instead of presenting the project picker every time.",
+    "description": "Get the cached last-used Muggle Test project for a repo (read from the entry keyed on <cwd> in ~/.muggle-ai/last-project.json). Returns the project ID, URL, name, and saved-at timestamp, or null if no cache exists. Skills consult this when 'autoSelectProject = always' to silently reuse the project the user picked previously, instead of presenting the project picker every time.",
     "name": "muggle-local-last-project-get",
   },
   {
-    "description": "Save the user's selected Muggle Test project as the cached last-used project for this repo. Writes to <cwd>/.muggle-ai/last-project.json. Subsequent skill invocations honor 'autoSelectProject = always' by silently reusing this entry — no project picker shown. Always pair this call with 'muggle-local-preferences-set autoSelectProject=always' when the user chose 'Yes, save it'.",
+    "description": "Save the user's selected Muggle Test project as the cached last-used project for this repo. Writes the entry keyed on <cwd> in ~/.muggle-ai/last-project.json. Subsequent skill invocations honor 'autoSelectProject = always' by silently reusing this entry — no project picker shown. Always pair this call with 'muggle-local-preferences-set autoSelectProject=always' when the user chose 'Yes, save it'.",
     "name": "muggle-local-last-project-set",
   },
   {

--- a/packages/mcps/src/test/last-host.test.ts
+++ b/packages/mcps/src/test/last-host.test.ts
@@ -1,9 +1,31 @@
-/** Tests for the per-repo last-host cache. */
+/** Tests for the last-host cache. */
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+
+const homeDirState = vi.hoisted(() => ({ path: "" }));
+
+vi.mock("../shared/data-dir.js", () => ({
+  getDataDir: () => homeDirState.path,
+}));
+
+vi.mock("../shared/logger.js", () => {
+  const noop = (): undefined => undefined;
+  const silentLogger = {
+    info: noop,
+    warn: noop,
+    error: noop,
+    debug: noop,
+    child: () => silentLogger,
+  };
+  return {
+    getLogger: () => silentLogger,
+    createChildLogger: () => silentLogger,
+    resetLogger: noop,
+  };
+});
 
 import {
   LAST_HOST_FILE_NAME,
@@ -13,6 +35,7 @@ import {
   formatLastHostOneLiner,
   readLastHost,
   writeLastHost,
+  type ILastHostFile,
 } from "../shared/last-host.js";
 import {
   LastHostGetInputSchema,
@@ -36,13 +59,32 @@ describe("last-host constants", () => {
 
 describe("last-host cache", () => {
   let projectDir: string;
+  let otherProjectDir: string;
+
+  const homeFilePath = (): string => path.join(homeDirState.path, LAST_HOST_FILE_NAME);
+
+  const legacyFilePath = (cwd: string): string =>
+    path.join(cwd, LAST_HOST_DIR_NAME, LAST_HOST_FILE_NAME);
+
+  const writeLegacyFile = (cwd: string, host: string): void => {
+    fs.mkdirSync(path.join(cwd, LAST_HOST_DIR_NAME), { recursive: true });
+    const legacy: ILastHostFile = {
+      version: LAST_HOST_VERSION,
+      lastHost: { host: host, savedAt: "2020-01-01T00:00:00.000Z" },
+    };
+    fs.writeFileSync(legacyFilePath(cwd), JSON.stringify(legacy), "utf-8");
+  };
 
   beforeEach(() => {
     projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "muggle-last-host-test-"));
+    otherProjectDir = fs.mkdtempSync(path.join(os.tmpdir(), "muggle-last-host-other-"));
+    homeDirState.path = fs.mkdtempSync(path.join(os.tmpdir(), "muggle-last-host-home-"));
   });
 
   afterEach(() => {
     fs.rmSync(projectDir, { recursive: true, force: true });
+    fs.rmSync(otherProjectDir, { recursive: true, force: true });
+    fs.rmSync(homeDirState.path, { recursive: true, force: true });
   });
 
   describe("readLastHost", () => {
@@ -57,34 +99,83 @@ describe("last-host cache", () => {
       expect(cached?.host).toBe("http://localhost:3000");
       expect(cached?.savedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     });
+
+    it("returns null for an unparseable home file", () => {
+      fs.writeFileSync(homeFilePath(), "{ not json", "utf-8");
+      expect(readLastHost(projectDir)).toBeNull();
+    });
+
+    it("migrates a superseded in-project cache into the home file", () => {
+      writeLegacyFile(projectDir, "http://localhost:4200");
+
+      expect(readLastHost(projectDir)?.host).toBe("http://localhost:4200");
+
+      const stored = JSON.parse(fs.readFileSync(homeFilePath(), "utf-8"));
+      expect(stored.entries[path.resolve(projectDir)].host).toBe("http://localhost:4200");
+    });
+
+    it("prefers the home entry over a superseded in-project cache", () => {
+      writeLegacyFile(projectDir, "http://localhost:4200");
+      writeLastHost(projectDir, "http://localhost:3000");
+      expect(readLastHost(projectDir)?.host).toBe("http://localhost:3000");
+    });
   });
 
   describe("writeLastHost", () => {
-    it("creates the .muggle-ai directory if missing", () => {
+    it("writes nothing inside the project directory", () => {
       writeLastHost(projectDir, "http://localhost:3000");
-      expect(fs.existsSync(path.join(projectDir, LAST_HOST_DIR_NAME))).toBe(true);
+      expect(fs.existsSync(path.join(projectDir, LAST_HOST_DIR_NAME))).toBe(false);
     });
 
-    it("writes a versioned file shape", () => {
+    it("creates the home directory if missing", () => {
+      fs.rmSync(homeDirState.path, { recursive: true, force: true });
       writeLastHost(projectDir, "http://localhost:3000");
-      const filePath = path.join(projectDir, LAST_HOST_DIR_NAME, LAST_HOST_FILE_NAME);
-      const raw = JSON.parse(fs.readFileSync(filePath, "utf-8"));
-      expect(raw.version).toBe(1);
-      expect(raw.lastHost.host).toBe("http://localhost:3000");
+      expect(fs.existsSync(homeFilePath())).toBe(true);
     });
 
-    it("overwrites an existing cache file", () => {
+    it("writes a versioned map keyed by absolute working directory", () => {
+      writeLastHost(projectDir, "http://localhost:3000");
+      const stored = JSON.parse(fs.readFileSync(homeFilePath(), "utf-8"));
+      expect(stored.version).toBe(1);
+      expect(stored.entries[path.resolve(projectDir)].host).toBe("http://localhost:3000");
+    });
+
+    it("overwrites the entry for the same working directory", () => {
       writeLastHost(projectDir, "http://localhost:3000");
       writeLastHost(projectDir, "http://localhost:5173");
       expect(readLastHost(projectDir)?.host).toBe("http://localhost:5173");
     });
+
+    it("keeps entries for different working directories apart", () => {
+      writeLastHost(projectDir, "http://localhost:3000");
+      writeLastHost(otherProjectDir, "http://localhost:5173");
+      expect(readLastHost(projectDir)?.host).toBe("http://localhost:3000");
+      expect(readLastHost(otherProjectDir)?.host).toBe("http://localhost:5173");
+    });
   });
 
   describe("clearLastHost", () => {
-    it("removes the cache file", () => {
+    it("removes the cached entry", () => {
       writeLastHost(projectDir, "http://localhost:3000");
       clearLastHost(projectDir);
       expect(readLastHost(projectDir)).toBeNull();
+    });
+
+    it("removes the superseded in-project file so it cannot resurrect the entry", () => {
+      writeLegacyFile(projectDir, "http://localhost:4200");
+      writeLastHost(projectDir, "http://localhost:3000");
+
+      clearLastHost(projectDir);
+
+      expect(fs.existsSync(legacyFilePath(projectDir))).toBe(false);
+      expect(readLastHost(projectDir)).toBeNull();
+    });
+
+    it("leaves other working directories untouched", () => {
+      writeLastHost(projectDir, "http://localhost:3000");
+      writeLastHost(otherProjectDir, "http://localhost:5173");
+      clearLastHost(projectDir);
+      expect(readLastHost(otherProjectDir)?.host).toBe("http://localhost:5173");
     });
 
     it("is a no-op when no cache exists", () => {
@@ -127,8 +218,11 @@ describe("LastHostSetInputSchema", () => {
   });
 
   it("accepts a valid input", () => {
-    const r = LastHostSetInputSchema.parse({ cwd: "/repo", host: "http://localhost:3000" });
-    expect(r.host).toBe("http://localhost:3000");
+    const parsed = LastHostSetInputSchema.parse({
+      cwd: "/repo",
+      host: "http://localhost:3000",
+    });
+    expect(parsed.host).toBe("http://localhost:3000");
   });
 });
 

--- a/packages/mcps/src/test/last-project.test.ts
+++ b/packages/mcps/src/test/last-project.test.ts
@@ -1,11 +1,31 @@
-/**
- * Tests for the per-repo last-project cache.
- */
+/** Tests for the last-project cache. */
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+
+const homeDirState = vi.hoisted(() => ({ path: "" }));
+
+vi.mock("../shared/data-dir.js", () => ({
+  getDataDir: () => homeDirState.path,
+}));
+
+vi.mock("../shared/logger.js", () => {
+  const noop = (): undefined => undefined;
+  const silentLogger = {
+    info: noop,
+    warn: noop,
+    error: noop,
+    debug: noop,
+    child: () => silentLogger,
+  };
+  return {
+    getLogger: () => silentLogger,
+    createChildLogger: () => silentLogger,
+    resetLogger: noop,
+  };
+});
 
 import {
   LAST_PROJECT_FILE_NAME,
@@ -15,6 +35,7 @@ import {
   formatLastProjectOneLiner,
   readLastProject,
   writeLastProject,
+  type ILastProjectFile,
 } from "../shared/last-project.js";
 import {
   LastProjectGetInputSchema,
@@ -38,13 +59,37 @@ describe("last-project constants", () => {
 
 describe("last-project cache", () => {
   let projectDir: string;
+  let otherProjectDir: string;
+
+  const homeFilePath = (): string => path.join(homeDirState.path, LAST_PROJECT_FILE_NAME);
+
+  const legacyFilePath = (cwd: string): string =>
+    path.join(cwd, LAST_PROJECT_DIR_NAME, LAST_PROJECT_FILE_NAME);
+
+  const writeLegacyFile = (cwd: string, projectId: string): void => {
+    fs.mkdirSync(path.join(cwd, LAST_PROJECT_DIR_NAME), { recursive: true });
+    const legacy: ILastProjectFile = {
+      version: LAST_PROJECT_VERSION,
+      lastProject: {
+        projectId: projectId,
+        projectUrl: "https://legacy.example.com",
+        projectName: "Legacy",
+        savedAt: "2020-01-01T00:00:00.000Z",
+      },
+    };
+    fs.writeFileSync(legacyFilePath(cwd), JSON.stringify(legacy), "utf-8");
+  };
 
   beforeEach(() => {
     projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "muggle-last-project-test-"));
+    otherProjectDir = fs.mkdtempSync(path.join(os.tmpdir(), "muggle-last-project-other-"));
+    homeDirState.path = fs.mkdtempSync(path.join(os.tmpdir(), "muggle-last-project-home-"));
   });
 
   afterEach(() => {
     fs.rmSync(projectDir, { recursive: true, force: true });
+    fs.rmSync(otherProjectDir, { recursive: true, force: true });
+    fs.rmSync(homeDirState.path, { recursive: true, force: true });
   });
 
   describe("readLastProject", () => {
@@ -65,43 +110,107 @@ describe("last-project cache", () => {
       expect(cached?.projectName).toBe("Example");
       expect(cached?.savedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     });
+
+    it("returns null for an unparseable home file", () => {
+      fs.writeFileSync(homeFilePath(), "{ not json", "utf-8");
+      expect(readLastProject(projectDir)).toBeNull();
+    });
+
+    it("migrates a superseded in-project cache into the home file", () => {
+      writeLegacyFile(projectDir, "legacy-1");
+
+      expect(readLastProject(projectDir)?.projectId).toBe("legacy-1");
+
+      const stored = JSON.parse(fs.readFileSync(homeFilePath(), "utf-8"));
+      expect(stored.entries[path.resolve(projectDir)].projectId).toBe("legacy-1");
+    });
+
+    it("prefers the home entry over a superseded in-project cache", () => {
+      writeLegacyFile(projectDir, "legacy-1");
+      writeLastProject(projectDir, {
+        projectId: "p1",
+        projectUrl: "https://x.com",
+        projectName: "X",
+      });
+      expect(readLastProject(projectDir)?.projectId).toBe("p1");
+    });
   });
 
   describe("writeLastProject", () => {
-    it("creates the .muggle-ai directory if missing", () => {
+    it("writes nothing inside the project directory", () => {
       writeLastProject(projectDir, {
         projectId: "p1",
         projectUrl: "https://x.com",
         projectName: "X",
       });
-      expect(fs.existsSync(path.join(projectDir, LAST_PROJECT_DIR_NAME))).toBe(true);
+      expect(fs.existsSync(path.join(projectDir, LAST_PROJECT_DIR_NAME))).toBe(false);
     });
 
-    it("writes a versioned file shape", () => {
+    it("creates the home directory if missing", () => {
+      fs.rmSync(homeDirState.path, { recursive: true, force: true });
       writeLastProject(projectDir, {
         projectId: "p1",
         projectUrl: "https://x.com",
         projectName: "X",
       });
-      const filePath = path.join(projectDir, LAST_PROJECT_DIR_NAME, LAST_PROJECT_FILE_NAME);
-      const raw = JSON.parse(fs.readFileSync(filePath, "utf-8"));
-      expect(raw.version).toBe(1);
-      expect(raw.lastProject.projectId).toBe("p1");
+      expect(fs.existsSync(homeFilePath())).toBe(true);
     });
 
-    it("overwrites an existing cache file", () => {
+    it("writes a versioned map keyed by absolute working directory", () => {
+      writeLastProject(projectDir, {
+        projectId: "p1",
+        projectUrl: "https://x.com",
+        projectName: "X",
+      });
+      const stored = JSON.parse(fs.readFileSync(homeFilePath(), "utf-8"));
+      expect(stored.version).toBe(1);
+      expect(stored.entries[path.resolve(projectDir)].projectId).toBe("p1");
+    });
+
+    it("overwrites the entry for the same working directory", () => {
       writeLastProject(projectDir, { projectId: "p1", projectUrl: "u1", projectName: "n1" });
       writeLastProject(projectDir, { projectId: "p2", projectUrl: "u2", projectName: "n2" });
-      const cached = readLastProject(projectDir);
-      expect(cached?.projectId).toBe("p2");
+      expect(readLastProject(projectDir)?.projectId).toBe("p2");
+    });
+
+    it("keeps entries for different working directories apart", () => {
+      writeLastProject(projectDir, { projectId: "p1", projectUrl: "u1", projectName: "n1" });
+      writeLastProject(otherProjectDir, {
+        projectId: "p2",
+        projectUrl: "u2",
+        projectName: "n2",
+      });
+      expect(readLastProject(projectDir)?.projectId).toBe("p1");
+      expect(readLastProject(otherProjectDir)?.projectId).toBe("p2");
     });
   });
 
   describe("clearLastProject", () => {
-    it("removes the cache file", () => {
+    it("removes the cached entry", () => {
       writeLastProject(projectDir, { projectId: "p1", projectUrl: "u", projectName: "n" });
       clearLastProject(projectDir);
       expect(readLastProject(projectDir)).toBeNull();
+    });
+
+    it("removes the superseded in-project file so it cannot resurrect the entry", () => {
+      writeLegacyFile(projectDir, "legacy-1");
+      writeLastProject(projectDir, { projectId: "p1", projectUrl: "u", projectName: "n" });
+
+      clearLastProject(projectDir);
+
+      expect(fs.existsSync(legacyFilePath(projectDir))).toBe(false);
+      expect(readLastProject(projectDir)).toBeNull();
+    });
+
+    it("leaves other working directories untouched", () => {
+      writeLastProject(projectDir, { projectId: "p1", projectUrl: "u1", projectName: "n1" });
+      writeLastProject(otherProjectDir, {
+        projectId: "p2",
+        projectUrl: "u2",
+        projectName: "n2",
+      });
+      clearLastProject(projectDir);
+      expect(readLastProject(otherProjectDir)?.projectId).toBe("p2");
     });
 
     it("is a no-op when no cache exists", () => {
@@ -144,8 +253,8 @@ describe("LastProjectGetInputSchema", () => {
   });
 
   it("accepts a valid input", () => {
-    const r = LastProjectGetInputSchema.parse({ cwd: "/some/repo" });
-    expect(r.cwd).toBe("/some/repo");
+    const parsed = LastProjectGetInputSchema.parse({ cwd: "/some/repo" });
+    expect(parsed.cwd).toBe("/some/repo");
   });
 });
 
@@ -162,13 +271,13 @@ describe("LastProjectSetInputSchema", () => {
   });
 
   it("accepts a valid input", () => {
-    const r = LastProjectSetInputSchema.parse({
+    const parsed = LastProjectSetInputSchema.parse({
       cwd: "/repo",
       projectId: "p1",
       projectUrl: "https://x.com",
       projectName: "n",
     });
-    expect(r.projectId).toBe("p1");
+    expect(parsed.projectId).toBe("p1");
   });
 
   it("rejects empty strings", () => {
@@ -189,7 +298,7 @@ describe("LastProjectClearInputSchema", () => {
   });
 
   it("accepts a valid input", () => {
-    const r = LastProjectClearInputSchema.parse({ cwd: "/some/repo" });
-    expect(r.cwd).toBe("/some/repo");
+    const parsed = LastProjectClearInputSchema.parse({ cwd: "/some/repo" });
+    expect(parsed.cwd).toBe("/some/repo");
   });
 });

--- a/plugin/scripts/ensure-electron-app.sh
+++ b/plugin/scripts/ensure-electron-app.sh
@@ -149,53 +149,44 @@ else
   prefs_file_note="\\n\\nMuggle Test Preferences: not configured. Run \\\`muggle setup\\\` or tell the agent to set preferences."
 fi
 
-# --- Last-project cache injection ---
-# Per-repo "last used Muggle Test project" cache. Lives at <cwd>/.muggle-ai/last-project.json
-# and is honored by skills when autoSelectProject = always.
-last_project_line=""
-last_project_note=""
-last_project_line=$(node -e "
+# --- Last-used cache injection ---
+# The "last used Muggle Test project" and "last used local dev server URL"
+# caches live in ~/.muggle-ai/, keyed by working directory, and are honored by
+# skills when autoSelectProject / autoSelectLocalHost = always. A cache written
+# before the move to the home directory still sits in <cwd>/.muggle-ai/ and is
+# read as a fallback, so those sessions keep their context lines.
+last_cache_notes=""
+last_cache_notes=$(node -e "
   const fs = require('fs');
+  const os = require('os');
   const path = require('path');
   try {
     const cwd = process.env.CLAUDE_CWD || process.env.CURSOR_CWD || process.cwd();
-    const lpPath = path.join(cwd, '.muggle-ai', 'last-project.json');
-    if (!fs.existsSync(lpPath)) { console.log(''); return; }
-    const raw = JSON.parse(fs.readFileSync(lpPath, 'utf-8'));
-    const lp = raw && raw.lastProject;
-    if (!lp || !lp.projectId) { console.log(''); return; }
-    const safeName = String(lp.projectName || '').replace(/\"/g, '\\\\\"');
-    console.log('Muggle Test Last Project: id=' + lp.projectId + ' url=' + lp.projectUrl + ' name=\"' + safeName + '\"');
+    const parseFile = (filePath) => {
+      try { return JSON.parse(fs.readFileSync(filePath, 'utf-8')); } catch { return null; }
+    };
+    const readEntry = (fileName, legacyEntryKey) => {
+      const home = parseFile(path.join(os.homedir(), '.muggle-ai', fileName));
+      const homeEntry = home && home.entries && home.entries[path.resolve(cwd)];
+      if (homeEntry) { return homeEntry; }
+      const legacy = parseFile(path.join(cwd, '.muggle-ai', fileName));
+      return (legacy && legacy[legacyEntryKey]) || null;
+    };
+    const lines = [];
+    const lastProject = readEntry('last-project.json', 'lastProject');
+    if (lastProject && lastProject.projectId) {
+      const safeName = String(lastProject.projectName || '').replace(/\"/g, '\\\\\"');
+      lines.push('Muggle Test Last Project: id=' + lastProject.projectId + ' url=' + lastProject.projectUrl + ' name=\"' + safeName + '\"');
+    }
+    const lastHost = readEntry('last-host.json', 'lastHost');
+    if (lastHost && lastHost.host) {
+      lines.push('Muggle Test Last Host: ' + lastHost.host);
+    }
+    console.log(lines.map((line) => '\\\\n\\\\n' + line).join(''));
   } catch { console.log(''); }
 " 2>/dev/null || true)
-if [ -n "$last_project_line" ]; then
-  last_project_note="\\n\\n${last_project_line}"
-fi
 
-# --- Last-host cache injection ---
-# Per-repo cache of the local dev server URL the user picked on the previous
-# run. Lives at <cwd>/.muggle-ai/last-host.json. Skills silently reuse it
-# when the user has set the autoSelectLocalHost preference to "always".
-last_host_line=""
-last_host_note=""
-last_host_line=$(node -e "
-  const fs = require('fs');
-  const path = require('path');
-  try {
-    const cwd = process.env.CLAUDE_CWD || process.env.CURSOR_CWD || process.cwd();
-    const lhPath = path.join(cwd, '.muggle-ai', 'last-host.json');
-    if (!fs.existsSync(lhPath)) { console.log(''); return; }
-    const raw = JSON.parse(fs.readFileSync(lhPath, 'utf-8'));
-    const lh = raw && raw.lastHost;
-    if (!lh || !lh.host) { console.log(''); return; }
-    console.log('Muggle Test Last Host: ' + lh.host);
-  } catch { console.log(''); }
-" 2>/dev/null || true)
-if [ -n "$last_host_line" ]; then
-  last_host_note="\\n\\n${last_host_line}"
-fi
-
-context="<EXTREMELY_IMPORTANT>\nYou have access to Muggle AI — a real-browser E2E acceptance testing tool.\n\nWhenever the user asks you to test, validate, verify, or check if their web app works — use the muggle MCP tools. This includes:\n- Testing user flows (signup, login, checkout, forms, dashboards)\n- Verifying UI changes didn't break anything\n- Running regression tests after code changes\n- Validating frontend behavior on localhost or a dev server\n- Checking if a feature works before merging a PR\n\nMuggle Test launches a real Electron browser that clicks buttons, fills forms, navigates pages, and captures screenshots. It generates replayable test scripts that persist across sessions.\n\nDo NOT write test code (Playwright, Cypress, Selenium) or try to test UI manually when muggle tools are available. Use the muggle skill or muggle MCP tools instead — they are faster, capture visual evidence, and produce reusable test scripts.\n\nTrigger phrases: 'test my app', 'check if it works', 'run E2E acceptance tests', 'validate the UI', 'verify the flow', 'regression test', 'make sure it still works', 'test before merging'.\n</EXTREMELY_IMPORTANT>${upgrade_notice}${prefs_file_note}${last_project_note}${last_host_note}"
+context="<EXTREMELY_IMPORTANT>\nYou have access to Muggle AI — a real-browser E2E acceptance testing tool.\n\nWhenever the user asks you to test, validate, verify, or check if their web app works — use the muggle MCP tools. This includes:\n- Testing user flows (signup, login, checkout, forms, dashboards)\n- Verifying UI changes didn't break anything\n- Running regression tests after code changes\n- Validating frontend behavior on localhost or a dev server\n- Checking if a feature works before merging a PR\n\nMuggle Test launches a real Electron browser that clicks buttons, fills forms, navigates pages, and captures screenshots. It generates replayable test scripts that persist across sessions.\n\nDo NOT write test code (Playwright, Cypress, Selenium) or try to test UI manually when muggle tools are available. Use the muggle skill or muggle MCP tools instead — they are faster, capture visual evidence, and produce reusable test scripts.\n\nTrigger phrases: 'test my app', 'check if it works', 'run E2E acceptance tests', 'validate the UI', 'verify the flow', 'regression test', 'make sure it still works', 'test before merging'.\n</EXTREMELY_IMPORTANT>${upgrade_notice}${prefs_file_note}${last_cache_notes}"
 
 escaped_context=$(escape_for_json "$context")
 

--- a/plugin/skills/muggle-preferences/preference-gates/autoSelectLocalHost.md
+++ b/plugin/skills/muggle-preferences/preference-gates/autoSelectLocalHost.md
@@ -2,7 +2,7 @@
 
 Reuse the saved local dev server URL for this repo, or pick one each run. Substitute `{lastHost}` (the URL used in the previous run for this repo — omit the option entirely when no cache exists) and `{suggestedHost}` (auto-detected from running ports, e.g. `http://localhost:3000`).
 
-Cache lives at `<cwd>/.muggle-ai/last-host.json`. The calling skill **always** updates the cache after the user picks/types a URL — independent of Picker 2 — so `Use {lastHost}` reflects the most recent run.
+Cache lives in `~/.muggle-ai/last-host.json`, in the entry keyed on `<cwd>`. The calling skill **always** updates the cache after the user picks/types a URL — independent of Picker 2 — so `Use {lastHost}` reflects the most recent run.
 
 **Picker 1** — header `Local server`, question `"Which local URL should the test target?"`
 - `Use {lastHost}` — `From your last run in this repo.` → reuse cached URL. *Skip this option when no cache exists.*

--- a/plugin/skills/muggle-test-feature-local/SKILL.md
+++ b/plugin/skills/muggle-test-feature-local/SKILL.md
@@ -69,7 +69,7 @@ Gates run per `preference-gates/README.md`.
 
 ### 2. Targets (user must confirm)
 
-The per-repo project cache lives at `<cwd>/.muggle-ai/last-project.json` (via the `muggle-local-last-project-get` / `muggle-local-last-project-set` MCP tools). Look for `Muggle Test Last Project: id=… url=… name="…"` in session context.
+The per-repo project cache lives in `~/.muggle-ai/last-project.json`, in the entry keyed on `<cwd>` (via the `muggle-local-last-project-get` / `muggle-local-last-project-set` MCP tools). Look for `Muggle Test Last Project: id=… url=… name="…"` in session context.
 
 Gate `autoSelectProject` (per `preference-gates/README.md`). Cache: `Muggle Test Last Project` session line.
 - `always` + cache → use cached `projectId`, skip to use case selection. No cache → fall through to `ask`.

--- a/plugin/skills/muggle-test-import/SKILL.md
+++ b/plugin/skills/muggle-test-import/SKILL.md
@@ -151,7 +151,7 @@ If **not authenticated**:
 
 A **project** is where all your imported use cases, test cases, and future test results are grouped on the Muggle AI dashboard.
 
-The per-repo project cache lives at `<cwd>/.muggle-ai/last-project.json` (via the `muggle-local-last-project-get` / `muggle-local-last-project-set` MCP tools). Look for `Muggle Test Last Project: id=… url=… name="…"` in session context.
+The per-repo project cache lives in `~/.muggle-ai/last-project.json`, in the entry keyed on `<cwd>` (via the `muggle-local-last-project-get` / `muggle-local-last-project-set` MCP tools). Look for `Muggle Test Last Project: id=… url=… name="…"` in session context.
 
 Gate `autoSelectProject` (per `preference-gates/README.md`). Cache: `Muggle Test Last Project` session line.
 - `always` + cache → use cached `projectId`, skip to Step 6. No cache → fall through to `ask`.

--- a/plugin/skills/muggle-test-prepare/steps/check-running.md
+++ b/plugin/skills/muggle-test-prepare/steps/check-running.md
@@ -4,7 +4,7 @@
 
 The dev-server URL the tests will hit is a **recorded value, not a guess** — resolve it before probing anything.
 
-1. Read the cached host with `muggle-local-last-host-get`. It reads `<cwd>/.muggle-ai/last-host.json`; a worktree usually has **no cache of its own**, so when the worktree returns nothing, pass the **main** working-tree root as `cwd` — `git rev-parse --git-common-dir`, then its parent directory.
+1. Read the cached host with `muggle-local-last-host-get`. It reads the entry keyed on `<cwd>` in `~/.muggle-ai/last-host.json`; a worktree usually has **no cache of its own**, so when the worktree returns nothing, pass the **main** working-tree root as `cwd` — `git rev-parse --git-common-dir`, then its parent directory.
 2. Apply the [`autoSelectLocalHost`](../../muggle-preferences/preference-gates/autoSelectLocalHost.md) gate (read its value from the `Muggle Test Preferences` session-context line; absent → `ask`):
    - `always` **and** a cache exists → use it silently: `Using saved local URL {lastHost}`.
    - otherwise (`ask` / `never`, or no cache) → **confirm before using any host.** Run the gate's Picker 1 with `{lastHost}` (cached URL, omitted when absent) and `{suggestedHost}` (a port you actually detect listening). Never auto-pick, and never fall back to a framework default like `:3000`; if nothing is cached or detected, ask the user to type the URL.

--- a/plugin/skills/muggle-test-regenerate-missing/SKILL.md
+++ b/plugin/skills/muggle-test-regenerate-missing/SKILL.md
@@ -65,7 +65,7 @@ If auth keeps failing, suggest the user run `muggle logout && muggle login` from
 
 A **project** is the unit on the Muggle AI dashboard that groups test cases, scripts, and runs. The user must pick the one to scan — never auto-select from repo name, branch, or URL heuristics.
 
-The per-repo project cache lives at `<cwd>/.muggle-ai/last-project.json` (via the `muggle-local-last-project-get` / `muggle-local-last-project-set` MCP tools). Look for `Muggle Test Last Project: id=… url=… name="…"` in session context.
+The per-repo project cache lives in `~/.muggle-ai/last-project.json`, in the entry keyed on `<cwd>` (via the `muggle-local-last-project-get` / `muggle-local-last-project-set` MCP tools). Look for `Muggle Test Last Project: id=… url=… name="…"` in session context.
 
 Gate `autoSelectProject` (per `preference-gates/README.md`). Cache: `Muggle Test Last Project` session line.
 - `always` + cache → use cached `projectId`, proceed to Step 3. No cache → fall through to `ask`.

--- a/plugin/skills/muggle-test/SKILL.md
+++ b/plugin/skills/muggle-test/SKILL.md
@@ -128,7 +128,7 @@ If auth fails repeatedly, suggest: `muggle logout && muggle login` from terminal
 
 A **project** is where all your test results, use cases, and test scripts are grouped on the Muggle AI dashboard. Pick the project that matches what you're working on.
 
-The per-repo cache lives at `<cwd>/.muggle-ai/last-project.json` (managed via the `muggle-local-last-project-get` / `muggle-local-last-project-set` MCP tools). Look for the `Muggle Test Last Project: id=… url=… name="…"` line in session context — if present, that's this repo's cached pick.
+The per-repo cache lives in `~/.muggle-ai/last-project.json`, in the entry keyed on `<cwd>` (managed via the `muggle-local-last-project-get` / `muggle-local-last-project-set` MCP tools). Look for the `Muggle Test Last Project: id=… url=… name="…"` line in session context — if present, that's this repo's cached pick.
 
 Gate `autoSelectProject` (per `preference-gates/README.md`). Cache: `Muggle Test Last Project` session line.
 - `always` + cache → use cached `projectId`, skip to Step 5. No cache → fall through to `ask`.


### PR DESCRIPTION
Follow-up to #365, agreed in review there.

## Goal

Move the `last-host` and `last-project` caches out of the user's project and into `~/.muggle-ai/`, with a migration that loses nothing.

## Why

Both caches wrote to `<cwd>/.muggle-ai/`. They are machine-local, user-level data — a project directory is shared, versioned, and cloned onto machines set up differently, and a cached dev-server URL is none of those things. #365 moved the prepare plan and the E2E run instructions for the same reason; these were left behind because they are code-backed rather than prose, and needed a migration story first.

## Storage

One `{ version, entries }` map per cache in the Muggle home directory, keyed on the resolved working directory — mirroring the existing `prepare-plans.json` convention. Per-directory semantics are unchanged.

```
~/.muggle-ai/last-host.json     { "version": 1, "entries": { "<resolved-cwd>": { host, savedAt } } }
~/.muggle-ai/last-project.json  { "version": 1, "entries": { "<resolved-cwd>": { projectId, projectUrl, projectName, savedAt } } }
```

## Migration — copy-on-read

A home lookup that misses falls back to the in-project file and copies that entry forward. No flag day, no separate migration step, nobody loses a cached host or project. The copy-forward write is guarded: a home directory that cannot be written still returns a usable entry instead of making a read throw.

**Clear deletes the in-project file too.** This is the non-obvious part. Removing only the home entry would let the very next read migrate the old value straight back — silently resurrecting the entry the user just cleared. A test in each suite pins it.

## Shape of the change

The read/write/clear/migrate logic was identical between the two caches apart from a file name and a property name, so it lives once in `shared/cwd-keyed-cache.ts`, with types and constants split out per the `preferences.ts` precedent already in that folder.

**The public surface is unchanged** — same functions, interfaces, and constants, re-exported from `last-host.ts` / `last-project.ts`. No caller moved.

The SessionStart hook reads both caches directly to emit its `Muggle Test Last Host:` / `Muggle Test Last Project:` context lines. It now reads the home files, falling back to the in-project file **without** migrating — a hook should not write. Its node block was checked against fixture directories for the home-entry, legacy-only, and empty cases.

## Validation

Strategy is `unit-only`: this is storage plumbing with no runtime UI surface to drive a browser against. The full vitest suite, `typecheck`, `check-skill-deps`, and `lint:check` were all run locally in the worktree and are green; lint reports no errors, with 17 warnings that pre-exist in `internal/*-gate-eval/src/run.ts` and are untouched here.

Coverage was added for the behaviours that would otherwise fail silently: home-directory storage, the copy-forward migration, home-entry-beats-legacy precedence, clear removing the superseded in-project file, isolation between two working directories sharing one map, and a corrupt home file degrading to null rather than throwing.

## Note

`packages/mcps/src/mcp/tools/local/tool-registry.ts` has four pre-existing `const result` locals (lines 178, 331, 378, 747) that trip the `code-standards` hook. They are unrelated to this change and I left them alone to keep the diff honest — say the word if you want them renamed here.

<!-- muggle-works:signature -->
🤖 _Posted by `/muggle-do` · [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works)_
