### PR TITLE
Make post-merge cleanup verify each step and report per step

### DIFF
--- a/plugin/skills/_shared/post-merge-cleanup.md
+++ b/plugin/skills/_shared/post-merge-cleanup.md
@@ -4,6 +4,86 @@ Gated by [`autoCleanup`](../muggle-preferences/preference-gates/autoCleanup.md).
 
 On `always`, the steps below run as one pre-authorized sequence (no per-step prompts). Stop on the first failure; do not force.
 
-1. **Remove the worktree — link-safe.** `git worktree remove {worktreePath}`, only if a worktree was used. A worktree's dependency dir (e.g. `node_modules`) is often a **link** (symlink, or a Windows junction) to a shared tree, not a real copy — and a forced/recursive delete follows the link and wipes that shared target, breaking every worktree. So never `--force`: unlink the dependency link first (remove the link only, using the host OS's unlink), then a plain `git worktree remove {worktreePath}`.
-2. `git branch -d {branch}` — **skip when no worktree was used**: the branch is the user's current live checkout (a bootstrap/auto-track watcher), and the checked-out branch must never be deleted. Then `git push origin --delete {branch}`.
-3. Clear `.muggle-ai/` session folders for this branch's runs and stale `/tmp/muggle-prepare-*.log` files. Cloud results stay.
+**Verify every step, assume none.** Each step states what proves it succeeded. A step whose side effect *usually* happens is not a step that ran — that assumption is how a branch survives a cleanup that reported success. The [report](#report) states verified state, never intent.
+
+## Preconditions
+
+Confirm the PR is `MERGED` from provider state. A closed-unmerged PR keeps its branch and worktree: the work never landed, so deleting it destroys it.
+
+## 1. Remove the worktree — link-safe
+
+Only if a worktree was used.
+
+A worktree's dependency dir (`node_modules`, and nested workspace copies) is often a **link** — a symlink or a Windows junction — to a shared tree rather than a real copy. A forced or recursive delete follows the link and wipes that shared target, breaking every other worktree.
+
+1. **Never `--force`.** It is the one flag that follows links.
+2. Clear the dependency and build dirs first, nested workspace ones included (`packages/*/node_modules`, `dist`). A plain `git worktree remove` fails with `Directory not empty` while they remain, and the obvious fix for that error is exactly the forbidden flag.
+   - A **link** → unlink it first with the host OS's unlink, removing the link only and never its target.
+   - A **real directory** → delete it in place.
+   Check which it is before deleting; the two are indistinguishable from a listing but not from a `rm -r`.
+3. Then plain `git worktree remove {worktreePath}`.
+4. `git worktree prune` to drop the administrative entry when the directory went away out from under git.
+
+**Verify:** the path is gone, it no longer appears in `git worktree list`, **and** the shared dependency tree the links pointed at still exists. That last check is the one that catches a link-follow.
+
+## 2. Delete the local branch
+
+**Skip entirely when no worktree was used** — the branch is then the user's live checkout, and a checked-out branch must never be deleted.
+
+`git branch -d` refuses after a **squash merge**, and always will: squashing mints a new commit carrying the same tree, so the branch tip is never an ancestor of the base. This is not a safety check that failed; it is one that cannot pass.
+
+Do not reach for `-D` on faith. Replace the ancestry check with a content check:
+
+1. Confirm the merged content is on the base — files the PR added exist at `origin/<base>`, and anything it removed is absent there.
+2. Only then `git branch -D {branch}`.
+
+**Verify:** the branch is absent from `git branch --list`.
+
+## 3. Delete the remote branch
+
+**A provider that auto-deletes the head branch on merge is a setting, not a guarantee.** It can be off for the repo, off for a fork, or simply not fire. Treat auto-delete as something to detect, never as this step having run.
+
+1. Query the ref. Already gone → record it deleted and move on.
+2. Still present → delete it explicitly.
+
+**Verify:** querying the ref returns not-found.
+
+## 4. Clear the session slot
+
+The slot is `~/.muggle-ai/muggle-do/sessions/<slug>/` — the home directory, not the project.
+
+Clear it only when `prs.json` records a terminal state. A slot for a still-open PR is live state that a watcher and [`reconcile`](../muggle-pr-followup/reconcile.md) both read. The merged PR is the durable record, so the slot's `result.md` is not lost history.
+
+**Verify:** the slot directory is gone, and no non-terminal slot was touched.
+
+## 5. Clear this run's prepare artifacts
+
+The PID tracker and per-service logs written during environment prep — `/tmp/muggle-test-prepare.json` and `/tmp/muggle-prepare-*.log`.
+
+**Only this run's.** Artifacts belonging to another session are not yours to delete; it may be mid-prepare with services running. When the tracker is absent no services are tracked, so any remaining logs are orphaned — report them rather than removing them.
+
+Cloud results always stay.
+
+**Verify:** this run's artifacts are gone; anything left is named in the report as out of scope.
+
+## Report
+
+Print as the last action, one row per step, filled from the verification checks — never from the fact that a command was issued:
+
+```
+Cleanup — <slug> (PR #<n>, merged)
+
+| Step                  | Result                                          |
+|:----------------------|:------------------------------------------------|
+| Worktree removed      | ✅ .claude/worktrees/<name> (shared deps intact) |
+| Local branch deleted  | ✅ users/<user>/<branch>                         |
+| Remote branch deleted | ✅ (already gone — provider auto-delete)         |
+| Session slot cleared  | ✅ <slug>                                        |
+| Prepare artifacts     | — none for this run                              |
+```
+
+Markers: `✅` verified done · `⚠️` done with a caveat worth reading · `❌` not done, with the reason · `—` nothing to do.
+
+Every step gets a row. A step that did not run is `❌` plus its reason — never omitted, and never `✅` when its verification did not actually run. A silent gap is worse than a visible one, because it is the version the user ends up believing.
+
+State anything deliberately left alone — another session's artifacts, a foreign worktree, an orphaned watcher — on a line below the table, so out-of-scope is declared rather than invisible.

--- a/src/test/skills/post-merge-cleanup-link-safe.test.ts
+++ b/src/test/skills/post-merge-cleanup-link-safe.test.ts
@@ -63,3 +63,66 @@ describe("post-merge cleanup is link-safe", () => {
     expect(doc).toMatch(/stop on the first failure/);
   });
 });
+
+/**
+ * Each rule below pins a way the cleanup reported success while a step had not
+ * run. All three were observed in one session: a remote branch survived because
+ * the provider's auto-delete was treated as the step, the session slot and
+ * prepare artifacts were never cleared at all, and nothing in the output made
+ * either gap visible.
+ */
+describe("post-merge cleanup verifies rather than assumes", () => {
+  it("treats provider auto-delete as something to detect, not as the step", () => {
+    const doc = readCleanupDoc();
+    expect(doc).toMatch(/auto-delete[^.]*\bsetting\b[^.]*not a guarantee/i);
+    // The ref must be queried; "it usually gets deleted on merge" is the bug.
+    expect(doc.toLowerCase()).toMatch(/query the ref/);
+  });
+
+  it("explains that -d cannot pass after a squash merge, and gates -D on content", () => {
+    const doc = readCleanupDoc();
+    expect(doc).toMatch(/squash/i);
+    // A content check replaces the ancestry check `-d` performs.
+    expect(doc).toMatch(/exists at `?origin\/<base>`?|merged content is on the base/i);
+    expect(doc).toMatch(/not reach for `?-D`? on faith|only then `?git branch -D/i);
+  });
+
+  it("clears the session slot from the home directory, and only when terminal", () => {
+    const doc = readCleanupDoc();
+    expect(doc).toMatch(/~\/\.muggle-ai\/muggle-do\/sessions\//);
+    expect(doc).toMatch(/terminal state/i);
+    // A slot for an open PR is live state a watcher still reads.
+    expect(doc).toMatch(/still-open PR|non-terminal slot/i);
+  });
+
+  it("scopes prepare-artifact deletion to this run", () => {
+    const doc = readCleanupDoc();
+    expect(doc).toMatch(/only this run/i);
+    expect(doc).toMatch(/another session/i);
+  });
+
+  it("requires a per-step report built from verification, with no omitted rows", () => {
+    const doc = readCleanupDoc();
+    expect(doc).toMatch(/^## Report$/m);
+    for (const step of [
+      "Worktree removed",
+      "Local branch deleted",
+      "Remote branch deleted",
+      "Session slot cleared",
+      "Prepare artifacts",
+    ]) {
+      expect(doc, `report table missing row: ${step}`).toContain(step);
+    }
+    // A step that did not run must be visible, not dropped.
+    expect(doc).toMatch(/never omitted|Every step gets a row/i);
+    expect(doc).toMatch(/never from the fact that a command was issued/i);
+  });
+
+  it("gives every step an explicit verification", () => {
+    const doc = readCleanupDoc();
+    const stepHeadings = doc.match(/^## \d+\. /gm) ?? [];
+    const verifications = doc.match(/^\*\*Verify:\*\*/gm) ?? [];
+    expect(stepHeadings.length).toBeGreaterThanOrEqual(5);
+    expect(verifications.length).toBe(stepHeadings.length);
+  });
+});


### PR DESCRIPTION
## Goal

Make post-merge cleanup verify each step and report per step, so a cleanup cannot report success while a step silently didn't run.

## Why

The procedure listed three steps and asserted nothing about whether they happened. In practice a cleanup then reported success while two of them had not:

- the **remote branch survived** — the provider's auto-delete-on-merge was treated as being the step, and it fired for two PRs out of three
- the **session slot and prepare artifacts were never cleared** at all

Neither gap was visible in the output, so it stood as "cleanup complete" until someone audited it. That is the failure mode this change targets: not a step that fails loudly, but one that is skipped quietly.

## Changes

Every step now states what proves it succeeded, and the procedure ends by reporting per step from those checks rather than from the fact that a command was issued.

Three rules the old text did not have:

**Auto-delete is a setting, not a guarantee.** It can be off for the repo, off for a fork, or simply not fire. The ref is queried rather than assumed gone.

**`git branch -d` cannot pass after a squash merge.** Squashing mints a new commit carrying the same tree, so the branch tip is never an ancestor of the base. This is not a safety check failing — it is one that can never succeed — so the answer is a content check against the base before `-D`, not `-D` on faith.

**Scope is stated.** Session slots live in the home directory, not the project, and are cleared only when terminal — a slot for an open PR is live state a watcher reads. Prepare artifacts are limited to this run, since another session may be mid-prepare with services running; orphans get reported, not deleted.

Step 1 also now separates unlinking a dependency **link** from deleting a real **directory**. The two are indistinguishable in a listing and very much not in a `rm -r`.

## Reporting

The procedure ends by printing one row per step, each cell filled from that step's verification check. Markers distinguish verified-done, done-with-a-caveat, not-done-plus-reason, and nothing-to-do.

Every step gets a row. A step that did not run is never omitted, and a step whose verification did not actually happen is never marked done — a silent gap is worse than a visible one, because it is the version the user ends up believing. Anything deliberately left alone is stated below, so out-of-scope is declared rather than invisible.

See the `## Report` section of the diff for the exact shape.

## Lint

Extends `post-merge-cleanup-link-safe.test.ts` to pin the new rules, plus a structural check that every numbered step carries a `**Verify:**` line.

The existing lint earned its keep here: an earlier draft of this rewrite dropped the unlink instruction in favour of vaguer wording, and the test caught it. That is exactly the drift these prose lints exist for.

## Validation

Strategy is `unit-only` — this is a procedure document and a static prose lint, with no runtime surface to drive a browser against. The full vitest suite, `typecheck`, `check-skill-deps`, and `lint:check` all run green in the worktree; lint reports no errors, with 17 warnings pre-existing in `internal/*-gate-eval/src/run.ts`.

<!-- muggle-works:signature -->
🤖 _Posted by `/muggle-do` · [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works)_
