### PR TITLE
fix(guardrails): accept a seeded slot as the watcher hand-off

### DIFF
--- a/plugin/scripts/guardrails.mjs
+++ b/plugin/scripts/guardrails.mjs
@@ -1,4 +1,4 @@
-import { readFileSync, existsSync, mkdirSync, writeFileSync, readdirSync, statSync } from 'fs';
+import { readFileSync, existsSync, mkdirSync, writeFileSync, readdirSync } from 'fs';
 import { isAbsolute, resolve, join } from 'path';
 import { homedir } from 'os';
 
@@ -144,7 +144,6 @@ function e2eGateDecision(state, maxBlocks = MAX_E2E_BLOCKS) {
   if (blockCount >= maxBlocks) return { action: "release" /* Release */, blockCount };
   return { action: "block" /* Block */, blockCount: blockCount + 1 };
 }
-var HEARTBEAT_FRESH_MS = 15 * 60 * 1e3;
 var WATCH_SKIP_MARKER = /^\s*echo\s+["']?MUGGLE_WATCH_SKIP\b/;
 function isWatchSkipMarker(cmd) {
   return WATCH_SKIP_MARKER.test(cmd);
@@ -153,38 +152,13 @@ function applyWatchSkip(state, skipped) {
   if (!skipped || state.watchSkipped === true) return state;
   return { ...state, watchSkipped: true };
 }
-function slotHasArmedWatcher(slotDir) {
-  if (existsSync(join(slotDir, "result.md"))) return true;
-  const pidFile = join(slotDir, "watch.pid");
-  if (existsSync(pidFile)) {
-    const pid = Number.parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
-    if (Number.isInteger(pid) && pid > 0) {
-      try {
-        process.kill(pid, 0);
-        return true;
-      } catch (err) {
-        if (err.code === "EPERM") return true;
-      }
-    }
-  }
-  const beat = join(slotDir, "watch-heartbeat");
-  if (existsSync(beat)) {
-    try {
-      if (Date.now() - statSync(beat).mtimeMs < HEARTBEAT_FRESH_MS) return true;
-    } catch {
-      return false;
-    }
-  }
-  return false;
-}
-function findUnarmedHandledPrs(handledUrls, sessionsDirOverride) {
+function findUntrackedHandledPrs(handledUrls, sessionsDirOverride) {
   if (handledUrls.length === 0) return [];
   const sessionsDir = join(homedir(), ".muggle-ai", "muggle-do", "sessions");
   if (!existsSync(sessionsDir)) return [...handledUrls];
-  const watchedUrls = /* @__PURE__ */ new Set();
+  const trackedUrls = /* @__PURE__ */ new Set();
   for (const slug of readdirSync(sessionsDir)) {
-    const slotDir = join(sessionsDir, slug);
-    const prsFile = join(slotDir, "prs.json");
+    const prsFile = join(sessionsDir, slug, "prs.json");
     if (!existsSync(prsFile)) continue;
     let slotUrl;
     try {
@@ -194,21 +168,23 @@ function findUnarmedHandledPrs(handledUrls, sessionsDirOverride) {
     } catch {
       continue;
     }
-    if (slotUrl && handledUrls.includes(slotUrl) && slotHasArmedWatcher(slotDir)) {
-      watchedUrls.add(slotUrl);
-    }
+    if (slotUrl) trackedUrls.add(slotUrl);
   }
-  return handledUrls.filter((url) => !watchedUrls.has(url));
+  return handledUrls.filter((url) => !trackedUrls.has(url));
 }
-function watchGateDecision(state, owedUrls, maxBlocks = MAX_WATCH_BLOCKS) {
+function watchGateDecision(state, untrackedPrUrls, maxBlocks = MAX_WATCH_BLOCKS) {
   const blockCount = state.watchBlockCount ?? 0;
-  if (state.watchSkipped === true || owedUrls.length === 0) {
-    return { action: "none" /* None */, blockCount, owed: owedUrls };
+  if (state.watchSkipped === true || untrackedPrUrls.length === 0) {
+    return { action: "none" /* None */, blockCount, untracked: untrackedPrUrls };
   }
   if (blockCount >= maxBlocks) {
-    return { action: "release" /* Release */, blockCount, owed: owedUrls };
+    return { action: "release" /* Release */, blockCount, untracked: untrackedPrUrls };
   }
-  return { action: "block" /* Block */, blockCount: blockCount + 1, owed: owedUrls };
+  return {
+    action: "block" /* Block */,
+    blockCount: blockCount + 1,
+    untracked: untrackedPrUrls
+  };
 }
 
 // src/guardrails/detectBuildIntent.ts
@@ -372,21 +348,21 @@ function e2eGate() {
 }
 function watchGate() {
   const state = readState(sessionId);
-  const owed = findUnarmedHandledPrs(state.prsHandled);
-  const decision = watchGateDecision(state, owed);
+  const untrackedPrUrls = findUntrackedHandledPrs(state.prsHandled);
+  const decision = watchGateDecision(state, untrackedPrUrls);
   if (decision.action === "none" /* None */ || decision.action === "release" /* Release */) {
     return "{}";
   }
   state.watchBlockCount = decision.blockCount;
   writeState(state);
-  const prList = decision.owed.join(", ");
-  const reason = decision.blockCount === 1 ? `Do not end the turn yet. A PR was opened this session but has no armed watcher: ${prList}. muggle-do Stage 8 seeds the watcher slot and arms one watcher per opened PR \u2014 arm it now with /muggle:muggle-pr-followup ${decision.owed[0]} (or reconcile). If this PR should NOT be watched (autoWatchPR=never, a manually-opened PR, one handed off elsewhere, or already merged/closed), tell the user why and run \`echo "MUGGLE_WATCH_SKIP: <reason>"\` \u2014 that records the skip and keeps this gate quiet for the rest of the session.` : `Watcher hand-off still owed for ${prList} (reminder ${decision.blockCount}/${MAX_WATCH_BLOCKS}): arm via /muggle:muggle-pr-followup, or record a legitimate skip via \`echo "MUGGLE_WATCH_SKIP: <reason>"\`.`;
+  const prList = decision.untracked.join(", ");
+  const reason = decision.blockCount === 1 ? `Do not end the turn yet. A PR was opened this session but no muggle-do session slot tracks it: ${prList}. Seed the slot and hand off per muggle-do Stage 8 \u2014 /muggle:muggle-pr-followup ${decision.untracked[0]} does both. Seeding is what matters: once a slot exists, reconcile arms it at the next session start and finalizes it when the PR goes terminal, so an unarmed slot is fine but no slot means nothing ever picks this PR up. If it genuinely should not be tracked (autoWatchPR=never, handed off elsewhere), tell the user why and run \`echo "MUGGLE_WATCH_SKIP: <reason>"\` \u2014 that records the skip and keeps this gate quiet for the rest of the session.` : `PR hand-off still owed for ${prList} (reminder ${decision.blockCount}/${MAX_WATCH_BLOCKS}): seed a slot via /muggle:muggle-pr-followup, or record a legitimate skip via \`echo "MUGGLE_WATCH_SKIP: <reason>"\`.`;
   return blockStop(reason, host);
 }
 function reportGate() {
-  const result = evaluateReportPost(input);
-  if (!result.deny || !result.reason) return "{}";
-  return denyTool(result.reason, host);
+  const reportPostVerdict = evaluateReportPost(input);
+  if (!reportPostVerdict.deny || !reportPostVerdict.reason) return "{}";
+  return denyTool(reportPostVerdict.reason, host);
 }
 function buildRouter() {
   if (!detectBuildIntent(input.prompt ?? "")) return "{}";

--- a/src/guardrails/cli.ts
+++ b/src/guardrails/cli.ts
@@ -11,7 +11,7 @@ import { MAX_PR_TERMINAL_BLOCKS, MAX_WATCH_BLOCKS } from "./constants.js";
 import { isTestCommand, testsPassed, isE2ERun, isE2ESkipMarker } from "./testsGreen.js";
 import { e2eGateDecision, E2eGateAction, MAX_E2E_BLOCKS, applyRecordedRun } from "./shouldRunE2E.js";
 import {
-  findUnarmedHandledPrs,
+  findUntrackedHandledPrs,
   watchGateDecision,
   isWatchSkipMarker,
   applyWatchSkip,
@@ -123,32 +123,33 @@ function e2eGate(): string {
 
 function watchGate(): string {
   const state = readState(sessionId);
-  const owed = findUnarmedHandledPrs(state.prsHandled);
-  const decision = watchGateDecision(state, owed);
+  const untrackedPrUrls = findUntrackedHandledPrs(state.prsHandled);
+  const decision = watchGateDecision(state, untrackedPrUrls);
   if (decision.action === WatchGateAction.None || decision.action === WatchGateAction.Release) {
     return "{}";
   }
   state.watchBlockCount = decision.blockCount;
   writeState(state);
-  const prList = decision.owed.join(", ");
+  const prList = decision.untracked.join(", ");
   // Full instruction once; repeats are one line — same rationale as e2eGate.
   const reason =
     decision.blockCount === 1
-      ? `Do not end the turn yet. A PR was opened this session but has no armed watcher: ${prList}. ` +
-        `muggle-do Stage 8 seeds the watcher slot and arms one watcher per opened PR — arm it now with ` +
-        `/muggle:muggle-pr-followup ${decision.owed[0]} (or reconcile). If this PR should NOT be watched ` +
-        `(autoWatchPR=never, a manually-opened PR, one handed off elsewhere, or already merged/closed), ` +
+      ? `Do not end the turn yet. A PR was opened this session but no muggle-do session slot tracks it: ${prList}. ` +
+        `Seed the slot and hand off per muggle-do Stage 8 — /muggle:muggle-pr-followup ${decision.untracked[0]} ` +
+        `does both. Seeding is what matters: once a slot exists, reconcile arms it at the next session start ` +
+        `and finalizes it when the PR goes terminal, so an unarmed slot is fine but no slot means nothing ever ` +
+        `picks this PR up. If it genuinely should not be tracked (autoWatchPR=never, handed off elsewhere), ` +
         `tell the user why and run \`echo "MUGGLE_WATCH_SKIP: <reason>"\` — that records the skip and keeps ` +
         `this gate quiet for the rest of the session.`
-      : `Watcher hand-off still owed for ${prList} (reminder ${decision.blockCount}/${MAX_WATCH_BLOCKS}): ` +
-        `arm via /muggle:muggle-pr-followup, or record a legitimate skip via \`echo "MUGGLE_WATCH_SKIP: <reason>"\`.`;
+      : `PR hand-off still owed for ${prList} (reminder ${decision.blockCount}/${MAX_WATCH_BLOCKS}): ` +
+        `seed a slot via /muggle:muggle-pr-followup, or record a legitimate skip via \`echo "MUGGLE_WATCH_SKIP: <reason>"\`.`;
   return blockStop(reason, host);
 }
 
 function reportGate(): string {
-  const result = evaluateReportPost(input);
-  if (!result.deny || !result.reason) return "{}";
-  return denyTool(result.reason, host);
+  const reportPostVerdict = evaluateReportPost(input);
+  if (!reportPostVerdict.deny || !reportPostVerdict.reason) return "{}";
+  return denyTool(reportPostVerdict.reason, host);
 }
 
 function buildRouter(): string {

--- a/src/guardrails/types.ts
+++ b/src/guardrails/types.ts
@@ -20,11 +20,11 @@ export enum WatchGateAction {
   None = "none",
 }
 
-/** A watcher-arm gate decision: the action, the running block count, and the opened-but-unwatched PR urls that drove it. */
+/** A watcher-arm gate decision: the action, the running block count, and the opened-but-untracked PR urls that drove it. */
 export interface WatchGateDecision {
   action: WatchGateAction;
   blockCount: number;
-  owed: string[];
+  untracked: string[];
 }
 
 export enum PrTerminalVerdict {

--- a/src/guardrails/watchArmed.ts
+++ b/src/guardrails/watchArmed.ts
@@ -1,18 +1,15 @@
-import { existsSync, readdirSync, readFileSync, statSync } from "fs";
+import { existsSync, readdirSync, readFileSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
 import { MAX_WATCH_BLOCKS } from "./constants.js";
 import { WatchGateAction, type GuardrailState, type WatchGateDecision } from "./types.js";
 
-// reconcile.md treats a watch-heartbeat older than this as a dead poller.
-const HEARTBEAT_FRESH_MS = 15 * 60 * 1000;
-
 // A deliberate "no watcher owed here" declaration: the model runs
 // `echo "MUGGLE_WATCH_SKIP: <reason>"` and the gate stays quiet for the session
-// (autoWatchPR=never, a manually-opened PR, one handed off elsewhere, an
-// already-terminal PR). Anchored to a leading echo for the same reason the E2E
-// skip marker is — a grep, commit, or skill edit that merely mentions the token
-// must not disarm the gate.
+// (autoWatchPR=never, a PR handed off elsewhere, a repo nobody watches).
+// Anchored to a leading echo for the same reason the E2E skip marker is — a
+// grep, commit, or skill edit that merely mentions the token must not disarm
+// the gate.
 const WATCH_SKIP_MARKER = /^\s*echo\s+["']?MUGGLE_WATCH_SKIP\b/;
 
 /** Whether a Bash command is the explicit watcher-skip declaration. */
@@ -26,46 +23,26 @@ export function applyWatchSkip(state: GuardrailState, skipped: boolean): Guardra
   return { ...state, watchSkipped: true };
 }
 
-// A slot counts as watched when its PR is terminal (result.md — nothing left to
-// watch), a live monitor owns it (watch.pid names a signalable process), or a
-// quiet monitor touched its heartbeat within reconcile's liveness window.
-function slotHasArmedWatcher(slotDir: string): boolean {
-  if (existsSync(join(slotDir, "result.md"))) return true;
-
-  const pidFile = join(slotDir, "watch.pid");
-  if (existsSync(pidFile)) {
-    const pid = Number.parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
-    if (Number.isInteger(pid) && pid > 0) {
-      try {
-        process.kill(pid, 0);
-        return true;
-      } catch (err) {
-        // ESRCH = the process is gone; EPERM = alive but owned by another user.
-        if ((err as NodeJS.ErrnoException).code === "EPERM") return true;
-      }
-    }
-  }
-
-  const beat = join(slotDir, "watch-heartbeat");
-  if (existsSync(beat)) {
-    try {
-      if (Date.now() - statSync(beat).mtimeMs < HEARTBEAT_FRESH_MS) return true;
-    } catch {
-      return false;
-    }
-  }
-  return false;
-}
-
 /**
- * The PRs opened this session that have no armed watcher.
+ * The PRs opened this session that no session slot tracks.
  *
- * Scans the muggle-do session slots and joins on the PR url (slot dirs are
- * arbitrary slugs, so the url is the only stable key back to `prsHandled`). A
- * handled url with no slot, or a slot with no armed watcher, is owed.
+ * Scans the muggle-do session slots and joins on the PR url — slot dirs are
+ * arbitrary slugs, so the url is the only stable key back to `prsHandled`.
+ *
+ * A slot's **existence** is the bar, not whether a watcher is live right now.
+ * Watchers are session-scoped: the monitor and any recovery cron both die with
+ * the session that started them, so "a poller is running" is never the durable
+ * guarantee. The slot on disk is — reconcile re-arms every open slot whose
+ * poller went silent and finalizes it once the PR goes terminal. So a seeded
+ * slot means the PR is followed, while a PR with no slot is the one nothing
+ * will ever pick up, and that is what this gate exists to catch. Requiring a
+ * live poller instead made the gate fire on the seeded-but-not-yet-armed state
+ * that a background job legitimately ends in, pushing the caller toward the
+ * skip hatch the gate exists to make unnecessary.
+ *
  * `sessionsDirOverride` points the scan at a throwaway tree for tests.
  */
-export function findUnarmedHandledPrs(
+export function findUntrackedHandledPrs(
   handledUrls: string[],
   sessionsDirOverride?: string,
 ): string[] {
@@ -74,10 +51,9 @@ export function findUnarmedHandledPrs(
     sessionsDirOverride ?? join(homedir(), ".muggle-ai", "muggle-do", "sessions");
   if (!existsSync(sessionsDir)) return [...handledUrls];
 
-  const watchedUrls = new Set<string>();
+  const trackedUrls = new Set<string>();
   for (const slug of readdirSync(sessionsDir)) {
-    const slotDir = join(sessionsDir, slug);
-    const prsFile = join(slotDir, "prs.json");
+    const prsFile = join(sessionsDir, slug, "prs.json");
     if (!existsSync(prsFile)) continue;
     let slotUrl: string | undefined;
     try {
@@ -87,33 +63,35 @@ export function findUnarmedHandledPrs(
     } catch {
       continue;
     }
-    if (slotUrl && handledUrls.includes(slotUrl) && slotHasArmedWatcher(slotDir)) {
-      watchedUrls.add(slotUrl);
-    }
+    if (slotUrl) trackedUrls.add(slotUrl);
   }
-  return handledUrls.filter((url) => !watchedUrls.has(url));
+  return handledUrls.filter((url) => !trackedUrls.has(url));
 }
 
 /**
  * Decide what the Stop hook does about the watcher hand-off.
  *
- * Pure: the caller runs the sessions scan and passes the owed urls in.
- * - `None`    — nothing owed (no PR opened, all watched, or a skip recorded).
- * - `Block`   — a PR opened this session has no armed watcher; force the turn on.
+ * Pure: the caller runs the sessions scan and passes the untracked urls in.
+ * - `None`    — nothing owed (no PR opened, all tracked, or a skip recorded).
+ * - `Block`   — a PR opened this session has no session slot; force the turn on.
  * - `Release` — blocked `maxBlocks` times already; stop nagging so a legitimately
- *               un-watchable PR can't trap the session.
+ *               unwatchable PR can't trap the session.
  */
 export function watchGateDecision(
   state: GuardrailState,
-  owedUrls: string[],
+  untrackedPrUrls: string[],
   maxBlocks: number = MAX_WATCH_BLOCKS,
 ): WatchGateDecision {
   const blockCount = state.watchBlockCount ?? 0;
-  if (state.watchSkipped === true || owedUrls.length === 0) {
-    return { action: WatchGateAction.None, blockCount: blockCount, owed: owedUrls };
+  if (state.watchSkipped === true || untrackedPrUrls.length === 0) {
+    return { action: WatchGateAction.None, blockCount: blockCount, untracked: untrackedPrUrls };
   }
   if (blockCount >= maxBlocks) {
-    return { action: WatchGateAction.Release, blockCount: blockCount, owed: owedUrls };
+    return { action: WatchGateAction.Release, blockCount: blockCount, untracked: untrackedPrUrls };
   }
-  return { action: WatchGateAction.Block, blockCount: blockCount + 1, owed: owedUrls };
+  return {
+    action: WatchGateAction.Block,
+    blockCount: blockCount + 1,
+    untracked: untrackedPrUrls,
+  };
 }

--- a/src/test/guardrails/hook-execution.test.ts
+++ b/src/test/guardrails/hook-execution.test.ts
@@ -101,7 +101,7 @@ describe("guardrail hook execution (cli entry)", () => {
     expect(runHook("e2e-gate", event({ session_id: "fresh" })).out).toBe("{}");
   });
 
-  it("pr-opened -> watch-gate: an opened PR with no armed watcher blocks the Stop", () => {
+  it("pr-opened -> watch-gate: an opened PR that no slot tracks blocks the Stop", () => {
     const session = "watch-chain";
     runHook(
       "pr-opened",
@@ -114,13 +114,16 @@ describe("guardrail hook execution (cli entry)", () => {
     );
     const gate = JSON.parse(runHook("watch-gate", event({ session_id: session })).out);
     expect(gate.decision).toBe("block");
-    expect(gate.reason).toContain("no armed watcher");
+    expect(gate.reason).toContain("no muggle-do session slot tracks it");
     expect(gate.reason).toContain("https://github.com/o/r/pull/77");
     expect(gate.reason).toContain("MUGGLE_WATCH_SKIP");
   });
 
-  it("watch-gate: silent once a watcher slot is armed for the opened PR", () => {
-    const session = "watch-armed";
+  // Seeding the slot is the hand-off the gate asks for; arming is reconcile's
+  // job from there. A background job legitimately ends seeded-but-unarmed, and
+  // the gate firing on that state pushed the caller into the skip hatch.
+  it("watch-gate: silent once a slot tracks the opened PR, even with no watcher armed", () => {
+    const session = "watch-seeded";
     const url = "https://github.com/o/r/pull/78";
     runHook(
       "pr-opened",
@@ -131,10 +134,11 @@ describe("guardrail hook execution (cli entry)", () => {
         tool_response: { stdout: `${url}\n` },
       }),
     );
+    expect(JSON.parse(runHook("watch-gate", event({ session_id: session })).out).decision).toBe("block");
+
     const slot = join(home, ".muggle-ai", "muggle-do", "sessions", "r-pr78");
     mkdirSync(slot, { recursive: true });
     writeFileSync(join(slot, "prs.json"), JSON.stringify([{ url: url }]));
-    writeFileSync(join(slot, "watch.pid"), String(process.pid));
     expect(runHook("watch-gate", event({ session_id: session })).out).toBe("{}");
   });
 

--- a/src/test/guardrails/watchArmed.test.ts
+++ b/src/test/guardrails/watchArmed.test.ts
@@ -5,7 +5,7 @@ import { join } from "path";
 import {
   isWatchSkipMarker,
   applyWatchSkip,
-  findUnarmedHandledPrs,
+  findUntrackedHandledPrs,
   watchGateDecision,
 } from "../../guardrails/watchArmed.js";
 import { WatchGateAction, type GuardrailState } from "../../guardrails/types.js";
@@ -18,7 +18,7 @@ const base = (over: Partial<GuardrailState> = {}): GuardrailState => ({
 
 describe("isWatchSkipMarker", () => {
   it("matches a leading MUGGLE_WATCH_SKIP echo", () => {
-    expect(isWatchSkipMarker('echo "MUGGLE_WATCH_SKIP: manual PR"')).toBe(true);
+    expect(isWatchSkipMarker('echo "MUGGLE_WATCH_SKIP: handed off"')).toBe(true);
     expect(isWatchSkipMarker("echo MUGGLE_WATCH_SKIP: x")).toBe(true);
   });
   it("ignores a mere mention (grep, commit, skill edit)", () => {
@@ -46,25 +46,25 @@ describe("watchGateDecision", () => {
   it("None when nothing was opened this session", () => {
     expect(watchGateDecision(base(), []).action).toBe(WatchGateAction.None);
   });
-  it("None when a skip was recorded, even with owed PRs", () => {
-    const d = watchGateDecision(base({ watchSkipped: true }), ["https://x/pull/1"]);
-    expect(d.action).toBe(WatchGateAction.None);
+  it("None when a skip was recorded, even with untracked PRs", () => {
+    const decision = watchGateDecision(base({ watchSkipped: true }), ["https://x/pull/1"]);
+    expect(decision.action).toBe(WatchGateAction.None);
   });
-  it("Block and increments the count when a PR is owed", () => {
-    const d = watchGateDecision(base(), ["https://x/pull/1"]);
-    expect(d.action).toBe(WatchGateAction.Block);
-    expect(d.blockCount).toBe(1);
-    expect(d.owed).toEqual(["https://x/pull/1"]);
+  it("Block and increments the count when a PR is untracked", () => {
+    const decision = watchGateDecision(base(), ["https://x/pull/1"]);
+    expect(decision.action).toBe(WatchGateAction.Block);
+    expect(decision.blockCount).toBe(1);
+    expect(decision.untracked).toEqual(["https://x/pull/1"]);
   });
-  it("Release after the block budget is spent, so an un-watchable PR can't trap the session", () => {
-    const d = watchGateDecision(base({ watchBlockCount: 3 }), ["https://x/pull/1"]);
-    expect(d.action).toBe(WatchGateAction.Release);
+  it("Release after the block budget is spent, so an untrackable PR can't trap the session", () => {
+    const decision = watchGateDecision(base({ watchBlockCount: 3 }), ["https://x/pull/1"]);
+    expect(decision.action).toBe(WatchGateAction.Release);
   });
 });
 
-describe("findUnarmedHandledPrs", () => {
+describe("findUntrackedHandledPrs", () => {
   let sessions: string;
-  const seedSlot = (slug: string, url: string, files: Record<string, string>): void => {
+  const seedSlot = (slug: string, url: string, files: Record<string, string> = {}): void => {
     const dir = join(sessions, slug);
     mkdirSync(dir, { recursive: true });
     writeFileSync(join(dir, "prs.json"), JSON.stringify([{ url: url }]));
@@ -75,41 +75,46 @@ describe("findUnarmedHandledPrs", () => {
     sessions = mkdtempSync(join(tmpdir(), "watch-scan-"));
   });
 
-  it("owes a handled url with no slot at all", () => {
-    expect(findUnarmedHandledPrs(["https://x/pull/1"], sessions)).toEqual(["https://x/pull/1"]);
+  it("reports a handled url with no slot at all", () => {
+    expect(findUntrackedHandledPrs(["https://x/pull/1"], sessions)).toEqual(["https://x/pull/1"]);
   });
 
-  it("owes a slot whose watch.pid is dead and heartbeat absent", () => {
-    seedSlot("s1", "https://x/pull/1", { "watch.pid": "999999999" });
-    expect(findUnarmedHandledPrs(["https://x/pull/1"], sessions)).toEqual(["https://x/pull/1"]);
+  // The seeded-but-not-yet-armed slot is the state a background job legitimately
+  // ends in. Reconcile arms it at the next session start, so the gate must not
+  // fire and push the caller toward the skip hatch.
+  it("accepts a seeded slot with no watcher yet", () => {
+    seedSlot("seeded", "https://x/pull/2");
+    expect(findUntrackedHandledPrs(["https://x/pull/2"], sessions)).toEqual([]);
   });
 
-  it("does not owe a slot with a live watch.pid", () => {
-    seedSlot("s2", "https://x/pull/2", { "watch.pid": String(process.pid) });
-    expect(findUnarmedHandledPrs(["https://x/pull/2"], sessions)).toEqual([]);
+  it("accepts a slot whose watcher died (stale pid, no heartbeat)", () => {
+    seedSlot("dead", "https://x/pull/3", { "watch.pid": "999999999" });
+    expect(findUntrackedHandledPrs(["https://x/pull/3"], sessions)).toEqual([]);
   });
 
-  it("does not owe a terminal slot (result.md present)", () => {
-    seedSlot("s3", "https://x/pull/3", { "result.md": "# done", "watch.pid": "999999999" });
-    expect(findUnarmedHandledPrs(["https://x/pull/3"], sessions)).toEqual([]);
+  it("accepts a live-monitor slot and a terminal slot alike", () => {
+    seedSlot("live", "https://x/pull/4", { "watch.pid": String(process.pid) });
+    seedSlot("done", "https://x/pull/5", { "result.md": "# merged" });
+    expect(findUntrackedHandledPrs(["https://x/pull/4", "https://x/pull/5"], sessions)).toEqual([]);
   });
 
-  it("does not owe a slot with a fresh heartbeat", () => {
-    seedSlot("s4", "https://x/pull/4", { "watch-heartbeat": "" });
-    expect(findUnarmedHandledPrs(["https://x/pull/4"], sessions)).toEqual([]);
-  });
-
-  it("returns only the owed subset across a mix", () => {
-    seedSlot("armed", "https://x/pull/10", { "watch.pid": String(process.pid) });
-    seedSlot("dead", "https://x/pull/11", { "watch.pid": "999999999" });
-    const owed = findUnarmedHandledPrs(
+  it("reports only the urls no slot tracks", () => {
+    seedSlot("tracked", "https://x/pull/10");
+    const untracked = findUntrackedHandledPrs(
       ["https://x/pull/10", "https://x/pull/11", "https://x/pull/12"],
       sessions,
     );
-    expect(owed.sort()).toEqual(["https://x/pull/11", "https://x/pull/12"]);
+    expect(untracked.sort()).toEqual(["https://x/pull/11", "https://x/pull/12"]);
+  });
+
+  it("ignores a slot dir with no prs.json and one with malformed json", () => {
+    mkdirSync(join(sessions, "empty"), { recursive: true });
+    mkdirSync(join(sessions, "broken"), { recursive: true });
+    writeFileSync(join(sessions, "broken", "prs.json"), "{not json");
+    expect(findUntrackedHandledPrs(["https://x/pull/20"], sessions)).toEqual(["https://x/pull/20"]);
   });
 
   it("returns [] for no handled urls without scanning", () => {
-    expect(findUnarmedHandledPrs([], sessions)).toEqual([]);
+    expect(findUntrackedHandledPrs([], sessions)).toEqual([]);
   });
 });


### PR DESCRIPTION
## The bug

The watcher-arm gate (#361) required a **live poller** — a signalable `watch.pid`, a fresh heartbeat, or `result.md` — to consider a PR handled. That made it fire on the **seeded-but-not-yet-armed** slot, which is the state a background job legitimately ends in, and the only way past it was the `MUGGLE_WATCH_SKIP` hatch.

A gate that manufactures the skip it exists to prevent is worse than no gate: it trains the caller to reach for the escape valve. That is exactly what happened on muggle-ai-brain#146 in the session that wrote this fix.

## Why liveness was the wrong bar

Watchers are **session-scoped** — the monitor and any recovery cron both die with the session that started them — so *"a poller is running right now"* is never the durable guarantee. The **slot on disk** is: reconcile re-arms every open slot whose poller went silent, and finalizes it once the PR goes terminal.

Observed end to end: **muggle-ai-brain#146** was seeded but never armed, merged on 2026-08-05, and was finalized by a later session's reconcile on 2026-08-06 (`result.md` written, state → `merged`) with **no watcher ever running**. The seeded slot did its job.

## The change

The gate now blocks only when a handled PR has **no session slot at all** — the genuine *"Stage 8 never ran, nothing will ever pick this up"* case — and accepts any slot that tracks the url, armed or not.

- `findUnarmedHandledPrs` → **`findUntrackedHandledPrs`**; the pid/heartbeat liveness probe is gone.
- `WatchGateDecision.owed` → **`.untracked`**.
- Block message now says seeding is what matters and that reconcile arms it from there, instead of demanding a live watcher.

## Tests

Pin the regression directly:
- a **seeded slot with no watcher** leaves the gate silent (blocks before seeding, silent after — asserted in the same test),
- a slot whose **watcher died** (stale pid, no heartbeat) is likewise accepted,
- a handled url with **no slot** still blocks,
- malformed / missing `prs.json` slots are ignored.

## Verification

- Full suite **981 passed**, 11 skipped, 72 files.
- `typecheck` clean, `lint:check` 0 errors, `check-skill-deps` OK (344 links).
- Rebuilt `guardrails.mjs` verified end-to-end: **blocks** with no slot, **silent** with a seeded slot.

Also renames a vague `result` binding in `reportGate` that the code-standards hook flagged on touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
