### PR TITLE
docs(readme): complete the command table with every skill and its shorthand

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,18 @@ This installs:
 - `/muggle:muggle-do` — autonomous dev pipeline (requirements to PR)
 - `/muggle:muggle-test` — change-driven E2E acceptance testing (local or remote, with PR posting)
 - `/muggle:muggle-test-feature-local` — local quick E2E acceptance testing
+- `/muggle:muggle-test-prepare` — verify and start the dev servers a test run needs
+- `/muggle:muggle-test-import` — import existing Playwright/Cypress specs, PRDs, or feature files
 - `/muggle:muggle-test-regenerate-missing` — bulk-regenerate test scripts for every test case that has no active script
+- `/muggle:muggle-browser-task` — perform a real action on a website from plain English
+- `/muggle:muggle-pr-visual-walkthrough` — post screenshots and a pass/fail summary to a PR
+- `/muggle:muggle-pr-followup` — watch a PR's review thread and address incoming feedback
+- `/muggle:muggle-feedback` — flag a generated action script or step as wrong
+- `/muggle:muggle-preferences` — view, set, or reset Muggle Test preferences
 - `/muggle:muggle-status` — health check for muggle-works plugins (Electron app, MCP server, and auth)
 - `/muggle:muggle-repair` — diagnose and fix broken installation
 - `/muggle:muggle-upgrade` — update to the latest version
+- short aliases for every command above — `/m`, `/mdo`, `/mtest`, `/mtestlocal`, `/mtestprep`, `/mimport`, `/mregen`, `/mbt`, `/mpr`, `/mprfollowup`, `/mfeedback`, `/mprefs`, `/mstatus`, `/mrepair`, `/mupgrade`
 - MCP server with 70+ tools (auto-started)
 - Electron browser test runner provisioning (via session hook)
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -21,19 +21,25 @@ This updates the CLI, configures Cursor MCP (`~/.cursor/mcp.json`), and syncs `m
 
 Type `muggle` to discover the full command family.
 
-| Skill | What it does |
-|:---|:---|
-| `/muggle:muggle` | Router and menu for all Muggle Test commands. |
-| `/muggle:muggle-do` | Autonomous dev pipeline: requirements, code, unit tests, E2E acceptance tests, PR. |
-| `/muggle:muggle-test` | Change-driven E2E acceptance router: detects code changes, maps to use cases, runs test generation locally or remotely, publishes to dashboard, opens in browser, posts E2E acceptance results to PR. |
-| `/muggle:muggle-test-feature-local` | Test a feature on localhost with AI-driven browser automation. Offers publish to cloud after each run. |
-| `/muggle:muggle-test-import` | Import existing tests into Muggle Test — from Playwright/Cypress specs, PRDs, Gherkin feature files, test plan docs, or any test artifact. |
-| `/muggle:muggle-test-regenerate-missing` | Bulk-regenerate test scripts for every test case in a project that doesn't currently have an active script. Scans DRAFT + GENERATION_PENDING, confirms the list with the user, and dispatches remote generation workflows for each. |
-| `/muggle:muggle-status` | Health check for Electron browser test runner, MCP server, and authentication. |
-| `/muggle:muggle-repair` | Diagnose and fix broken installation automatically. |
-| `/muggle:muggle-upgrade` | Update Electron browser test runner and MCP server to latest version. |
+| Skill | Shorthand | What it does |
+|:---|:---|:---|
+| `/muggle:muggle` | `/m` | Router and menu for all Muggle Test commands. |
+| `/muggle:muggle-do` | `/mdo` | Autonomous dev pipeline: requirements, code, unit tests, E2E acceptance tests, PR. |
+| `/muggle:muggle-test` | `/mtest` | Change-driven E2E acceptance router: detects code changes, maps to use cases, runs test generation locally or remotely, publishes to dashboard, opens in browser, posts E2E acceptance results to PR. |
+| `/muggle:muggle-test-feature-local` | `/mtestlocal` | Test a feature on localhost with AI-driven browser automation. Offers publish to cloud after each run. |
+| `/muggle:muggle-test-prepare` | `/mtestprep` | Verify the dev servers and sibling services a test run needs, and start whatever is missing. |
+| `/muggle:muggle-test-import` | `/mimport` | Import existing tests into Muggle Test — from Playwright/Cypress specs, PRDs, Gherkin feature files, test plan docs, or any test artifact. |
+| `/muggle:muggle-test-regenerate-missing` | `/mregen` | Bulk-regenerate test scripts for every test case in a project that doesn't currently have an active script. Scans DRAFT + GENERATION_PENDING, confirms the list with the user, and dispatches remote generation workflows for each. |
+| `/muggle:muggle-browser-task` | `/mbt` | Perform a real action on a website from plain English — log in and submit the form, create the ticket, refund the charge. |
+| `/muggle:muggle-pr-visual-walkthrough` | `/mpr` | Post per-test-case dashboard links, step-by-step screenshots, and a pass/fail summary to a PR. |
+| `/muggle:muggle-pr-followup` | `/mprfollowup` | Watch one PR's review thread and dispatch the work to address incoming feedback. |
+| `/muggle:muggle-feedback` | `/mfeedback` | Flag a generated action script, or one step in it, as wrong so Muggle can analyze and regenerate affected scripts. |
+| `/muggle:muggle-preferences` | `/mprefs` | View, set, or reset the preferences that gate Muggle Test behavior. |
+| `/muggle:muggle-status` | `/mstatus` | Health check for Electron browser test runner, MCP server, and authentication. |
+| `/muggle:muggle-repair` | `/mrepair` | Diagnose and fix broken installation automatically. |
+| `/muggle:muggle-upgrade` | `/mupgrade` | Update Electron browser test runner and MCP server to latest version. |
 
-Each skill above also ships a short alias to save typing — `m` (router), `mtest`, `mdo`, `mpr`, `mprefs`, `mstatus`, `mrepair`, `mupgrade`, `mfeedback`, `mimport`, `mtestlocal`, `mtestprep`, `mregen`. Type `/m` (Claude Code) or `m` (Cursor) to open the menu, or jump straight to one (e.g. `/mtest`).
+Every skill ships the short alias in the table above. Type `/m` (Claude Code) or `m` (Cursor) to open the menu, or jump straight to one (e.g. `/mtest`). Claude Code namespaces plugin commands, so the aliases resolve as `/muggle:mtest`; mirror them into `~/.claude/commands/` to type `/mtest` bare.
 
 ## MCP Tools
 


### PR DESCRIPTION
The plugin ships 15 skills, each with a short alias. The docs never said so.

`plugin/README.md` listed 9 skills in its Skills table and 13 aliases in the trailing sentence — `/mbt` and `/mprfollowup` appeared nowhere, and `muggle-browser-task`, `muggle-preferences`, `muggle-feedback`, `muggle-pr-followup`, `muggle-pr-visual-walkthrough`, and `muggle-test-prepare` were invisible. The root `README.md` install list named 8 of 15 and never mentioned shorthands at all.

Adds a `Shorthand` column so each command sits next to its alias instead of the aliases being a prose list you have to cross-reference, completes both lists to all 15, and notes that Claude Code namespaces plugin commands (`/muggle:mtest`) — with the `~/.claude/commands/` mirror as the way to type `/mtest` bare.

Docs only; no skill, command, or manifest files touched. Verified every alias in `plugin/skills/_aliases.json` appears in the rendered table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QdY97GwqpjFajz8rabtqtN
