### PR TITLE
fix(guardrails): a reopen retracts the terminal verdict it un-does

### DIFF
--- a/plugin/scripts/guardrails.mjs
+++ b/plugin/scripts/guardrails.mjs
@@ -43,6 +43,7 @@ ${input2.tool_response?.output ?? ""}`;
 // src/guardrails/constants.ts
 var GH_PR_MERGED_LINE = /\b(?:Merged|Squashed and merged|Rebased and merged) pull request [\w./-]*#(\d+)/;
 var GH_PR_CLOSED_LINE = /\bClosed pull request [\w./-]*#(\d+)/;
+var GH_PR_REOPENED_LINE = /\bReopened pull request [\w./-]*#(\d+)/;
 var PR_MONITOR_TERMINAL_LINE = /\bTERMINAL pr=(\d+): (MERGED|CLOSED)\b/;
 var MAX_PR_TERMINAL_BLOCKS = 3;
 var MAX_WATCH_BLOCKS = 3;
@@ -70,6 +71,23 @@ function detectPrTerminal(input2) {
     };
   }
   return null;
+}
+function detectPrReopened(input2) {
+  if (input2.tool_name !== "Bash") return null;
+  const response = input2.tool_response;
+  const haystack = [response?.stdout, response?.stderr, response?.output, response?.content].filter((part) => typeof part === "string").join("\n");
+  const reopenedMatch = haystack.match(GH_PR_REOPENED_LINE);
+  return reopenedMatch ? Number(reopenedMatch[1]) : null;
+}
+function applyPrReopened(state, prNumber) {
+  const pending = state.terminalPending ?? [];
+  const handled = state.terminalHandled ?? [];
+  if (!pending.includes(prNumber) && !handled.includes(prNumber)) return state;
+  return {
+    ...state,
+    terminalPending: pending.filter((number) => number !== prNumber),
+    terminalHandled: handled.filter((number) => number !== prNumber)
+  };
 }
 function applyPrTerminalDetected(state, prNumber) {
   const pending = state.terminalPending ?? [];
@@ -299,6 +317,13 @@ Per the autoWatchPR preference, a muggle-pr-followup watcher should handle its i
   return envelope("PostToolUse", ctx, host);
 }
 function prTerminal() {
+  const reopenedPrNumber = detectPrReopened(input);
+  if (reopenedPrNumber !== null) {
+    const state2 = readState(sessionId);
+    const next2 = applyPrReopened(state2, reopenedPrNumber);
+    if (next2 !== state2) writeState(next2);
+    return "{}";
+  }
   const terminalEvent = detectPrTerminal(input);
   if (!terminalEvent) return "{}";
   const state = readState(sessionId);

--- a/src/guardrails/cli.ts
+++ b/src/guardrails/cli.ts
@@ -3,7 +3,9 @@ import { readState, writeState, markPrHandled } from "./sessionState.js";
 import { detectPrOpened } from "./prOpened.js";
 import {
   detectPrTerminal,
+  detectPrReopened,
   applyPrTerminalDetected,
+  applyPrReopened,
   applyNextOptionsOffered,
   prTerminalGateDecision,
 } from "./prTerminal.js";
@@ -48,6 +50,15 @@ function prOpened(): string {
 }
 
 function prTerminal(): string {
+  // Reopen first: it retracts a close, so a close+reopen within one tool output
+  // must settle as open rather than arming a handoff for a live change.
+  const reopenedPrNumber = detectPrReopened(input);
+  if (reopenedPrNumber !== null) {
+    const state = readState(sessionId);
+    const next = applyPrReopened(state, reopenedPrNumber);
+    if (next !== state) writeState(next);
+    return "{}";
+  }
   const terminalEvent = detectPrTerminal(input);
   if (!terminalEvent) return "{}";
   const state = readState(sessionId);

--- a/src/guardrails/constants.ts
+++ b/src/guardrails/constants.ts
@@ -1,7 +1,7 @@
-// gh success lines: `✓ Merged pull request #12 (title)` — also the
+// gh success lines: `✓ Merged pull request #<n> (title)` — also the
 // "Squashed and merged" / "Rebased and merged" strategy variants — and
-// `✓ Closed pull request owner/repo#12 (title)`. Newer gh prefixes the number
-// with owner/repo, older prints a bare `#12`; the optional [\w./-]* run accepts
+// `✓ Closed pull request owner/repo#<n> (title)`. Newer gh prefixes the number
+// with owner/repo, older prints a bare `#<n>`; the optional [\w./-]* run accepts
 // both. Anchoring on the full verb phrase (never a bare MERGED/CLOSED token) is
 // what keeps `"state":"MERGED"` out: every `gh pr view --json`/API fetch
 // carries that token, and matching it would arm the gate on a routine status
@@ -9,6 +9,14 @@
 // request #N"), which differs by verb tense.
 export const GH_PR_MERGED_LINE = /\b(?:Merged|Squashed and merged|Rebased and merged) pull request [\w./-]*#(\d+)/;
 export const GH_PR_CLOSED_LINE = /\bClosed pull request [\w./-]*#(\d+)/;
+
+// `gh pr reopen` success line: `✓ Reopened pull request owner/repo#12 (title)`.
+// A reopen retracts a close, and is the only signal that un-does a terminal
+// verdict. Closing and reopening is a routine maneuver — it re-fires a lost
+// workflow trigger to start checks, and re-syncs a head left pointing at the
+// base branch after a force-push through it — so without this the transient
+// close leaves a post-merge handoff owed on a change that is open again.
+export const GH_PR_REOPENED_LINE = /\bReopened pull request [\w./-]*#(\d+)/;
 
 // The pr-followup watch monitor's exit line (e.g. `TERMINAL pr=331: MERGED`),
 // which also surfaces when a monitor event notification is replayed through a

--- a/src/guardrails/prTerminal.ts
+++ b/src/guardrails/prTerminal.ts
@@ -3,6 +3,7 @@ import type { GuardrailState, HookInput, PrTerminalEvent, PrTerminalGateDecision
 import {
   GH_PR_MERGED_LINE,
   GH_PR_CLOSED_LINE,
+  GH_PR_REOPENED_LINE,
   PR_MONITOR_TERMINAL_LINE,
   MAX_PR_TERMINAL_BLOCKS,
 } from "./constants.js";
@@ -32,6 +33,37 @@ export function detectPrTerminal(input: HookInput): PrTerminalEvent | null {
     };
   }
   return null;
+}
+
+/** The pull-request number a `gh pr reopen` success line names, or null when the tool output carries no reopen. */
+export function detectPrReopened(input: HookInput): number | null {
+  if (input.tool_name !== "Bash") return null;
+  const response = input.tool_response;
+  const haystack = [response?.stdout, response?.stderr, response?.output, response?.content]
+    .filter((part): part is string => typeof part === "string")
+    .join("\n");
+  const reopenedMatch = haystack.match(GH_PR_REOPENED_LINE);
+  return reopenedMatch ? Number(reopenedMatch[1]) : null;
+}
+
+// Retract a terminal verdict the reopen un-did. Drops the number from BOTH sets:
+// out of `terminalPending` because no post-merge handoff is owed on a change
+// that is open again, and out of `terminalHandled` so a later, genuine close
+// re-arms the gate instead of being swallowed as already-handled.
+//
+// This deliberately does NOT rewind `terminalBlockCount` — only the offer does
+// (applyNextOptionsOffered). Clearing the pending set can only ever reduce
+// nagging, but rewinding the counter here would let a close/reopen cycle hand
+// the gate a fresh budget each time and turn the cap into an unbounded loop.
+export function applyPrReopened(state: GuardrailState, prNumber: number): GuardrailState {
+  const pending = state.terminalPending ?? [];
+  const handled = state.terminalHandled ?? [];
+  if (!pending.includes(prNumber) && !handled.includes(prNumber)) return state;
+  return {
+    ...state,
+    terminalPending: pending.filter((number) => number !== prNumber),
+    terminalHandled: handled.filter((number) => number !== prNumber),
+  };
 }
 
 // Arm the handoff for a newly terminal PR. Returns the same reference when the

--- a/src/test/guardrails/hook-execution.test.ts
+++ b/src/test/guardrails/hook-execution.test.ts
@@ -170,6 +170,48 @@ describe("guardrail hook execution (cli entry)", () => {
     expect(runHook("watch-gate", event({ session_id: "no-pr" })).out).toBe("{}");
   });
 
+  // Close+reopen is routine: it re-fires a lost workflow trigger to start checks
+  // and re-syncs a head left at the base branch after a force-push through it.
+  // The change is open again, so the terminal gate must let the turn end.
+  it("pr-terminal -> reopen -> terminal-gate: a transient close does not hold the Stop", () => {
+    const session = "reopen-chain";
+    runHook(
+      "pr-terminal",
+      event({
+        session_id: session,
+        tool_name: "Bash",
+        tool_input: { command: "gh pr close 369" },
+        tool_response: { stderr: "✓ Closed pull request multiplex-ai/muggle-ai-works#369 (gate fix)\n" },
+      }),
+    );
+    expect(JSON.parse(runHook("terminal-gate", event({ session_id: session })).out).decision).toBe("block");
+
+    runHook(
+      "pr-terminal",
+      event({
+        session_id: session,
+        tool_input: { command: "gh pr reopen 369" },
+        tool_name: "Bash",
+        tool_response: { stderr: "✓ Reopened pull request multiplex-ai/muggle-ai-works#369 (gate fix)\n" },
+      }),
+    );
+    expect(runHook("terminal-gate", event({ session_id: session })).out).toBe("{}");
+  });
+
+  it("reopen then a genuine merge re-arms the handoff", () => {
+    const session = "reopen-then-merge";
+    const bashEvent = (stderr: string): string =>
+      event({ session_id: session, tool_name: "Bash", tool_response: { stderr: stderr } });
+    runHook("pr-terminal", bashEvent("✓ Closed pull request o/r#77 (transient)\n"));
+    runHook("pr-terminal", bashEvent("✓ Reopened pull request o/r#77 (transient)\n"));
+    expect(runHook("terminal-gate", event({ session_id: session })).out).toBe("{}");
+
+    runHook("pr-terminal", bashEvent("✓ Squashed and merged pull request o/r#77 (shipped)\n"));
+    const blocked = JSON.parse(runHook("terminal-gate", event({ session_id: session })).out);
+    expect(blocked.decision).toBe("block");
+    expect(blocked.reason).toContain("#77");
+  });
+
   it("pr-terminal -> terminal-gate: a merged PR holds the Stop until the AskUserQuestion offer runs", () => {
     const session = "terminal-chain";
     const detect = runHook(

--- a/src/test/guardrails/prTerminal.test.ts
+++ b/src/test/guardrails/prTerminal.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "vitest";
 import {
   detectPrTerminal,
+  detectPrReopened,
   applyPrTerminalDetected,
+  applyPrReopened,
   applyNextOptionsOffered,
   prTerminalGateDecision,
 } from "../../guardrails/prTerminal";
@@ -186,5 +188,68 @@ describe("prTerminalGateDecision", () => {
     expect(afterUnitPass.terminalBlockCount).toBe(2);
     expect(afterUnitPass.terminalPending).toEqual([341]);
     expect(prTerminalGateDecision(afterUnitPass)).toEqual({ action: PrTerminalGateAction.Block, blockCount: 3 });
+  });
+});
+
+describe("detectPrReopened", () => {
+  const bash = (stderr: string): Parameters<typeof detectPrReopened>[0] => ({
+    tool_name: "Bash",
+    tool_response: { stderr: stderr },
+  });
+
+  it("reads the pull-request number off a gh pr reopen success line", () => {
+    expect(detectPrReopened(bash("✓ Reopened pull request multiplex-ai/muggle-ai-works#369 (fix: x)\n"))).toBe(369);
+    expect(detectPrReopened(bash("✓ Reopened pull request #12 (title)\n"))).toBe(12);
+  });
+
+  it("ignores a close, a merge, and a routine status fetch", () => {
+    expect(detectPrReopened(bash("✓ Closed pull request o/r#12 (stale)\n"))).toBeNull();
+    expect(detectPrReopened(bash("✓ Merged pull request #12 (feat)\n"))).toBeNull();
+    expect(detectPrReopened({ tool_name: "Bash", tool_response: { stdout: '{"state":"OPEN"}' } })).toBeNull();
+  });
+
+  it("ignores non-Bash tools", () => {
+    expect(detectPrReopened({ tool_name: "Monitor", tool_response: { stdout: "✓ Reopened pull request #12 (t)" } })).toBeNull();
+  });
+});
+
+describe("applyPrReopened", () => {
+  const base = (over: Partial<GuardrailState> = {}): GuardrailState => ({
+    sessionId: "s",
+    prsHandled: [],
+    ...over,
+  });
+
+  // The transient close: closing and reopening re-fires a lost workflow trigger
+  // and re-syncs a head left at the base branch. The change is open again, so no
+  // post-merge handoff is owed and the Stop gate must not hold the turn.
+  it("drops a reopened number from terminalPending so the gate stops blocking", () => {
+    const pending = base({ terminalPending: [369] });
+    const next = applyPrReopened(pending, 369);
+    expect(next.terminalPending).toEqual([]);
+    expect(prTerminalGateDecision(next).action).toBe(PrTerminalGateAction.None);
+  });
+
+  it("drops it from terminalHandled too, so a later genuine close re-arms", () => {
+    const handled = base({ terminalHandled: [369] });
+    const reopened = applyPrReopened(handled, 369);
+    expect(reopened.terminalHandled).toEqual([]);
+    const closedAgain = applyPrTerminalDetected(reopened, 369);
+    expect(closedAgain.terminalPending).toEqual([369]);
+  });
+
+  it("never rewinds the block counter — only the offer does", () => {
+    const blocked = base({ terminalPending: [369], terminalBlockCount: 2 });
+    expect(applyPrReopened(blocked, 369).terminalBlockCount).toBe(2);
+  });
+
+  it("leaves other PRs' pending state untouched", () => {
+    const twoPending = base({ terminalPending: [341, 369] });
+    expect(applyPrReopened(twoPending, 369).terminalPending).toEqual([341]);
+  });
+
+  it("returns the same reference when the number was never terminal", () => {
+    const state = base({ terminalPending: [341] });
+    expect(applyPrReopened(state, 369)).toBe(state);
   });
 });


### PR DESCRIPTION
## The bug

Closing and reopening a change is **routine**: it re-fires a workflow trigger GitHub dropped (so checks actually start), and it re-syncs a head left pointing at the base branch after a force-push through it. Both were needed on #369 in the session that found this.

The terminal gate saw only the close. It armed a post-merge handoff and then **held turn-end demanding an `AskUserQuestion` offer for a change that was open again seconds later** — with no way to retract the verdict. The gate had to be waited out for three blocks.

## The fix

A reopen is the one signal that un-does a terminal verdict, so it now clears the number from **both** sets:

| Set | Why |
|---|---|
| `terminalPending` | no handoff is owed on a change that is open again |
| `terminalHandled` | so a later **genuine** close re-arms, instead of being swallowed as already-handled |

It deliberately does **not** rewind `terminalBlockCount` — only the offer does. Clearing the pending set can only ever *reduce* nagging, but rewinding the counter would let a close/reopen cycle hand the gate a fresh budget each time and turn the three-block cap into an unbounded loop. That is precisely the failure the counter's single-writer rule exists to prevent, so it is preserved.

Detection mirrors the existing terminal lines: anchored on the full verb phrase (`Reopened pull request …#<n>`), Bash-only, scanning the same four response fields. Reopen is checked **before** the terminal match, so a close and reopen in one tool output settles as open.

## Tests

- the retraction clears pending and the gate goes quiet
- a genuine merge **after** a reopen still arms the handoff
- the block counter never rewinds
- other numbers' pending state is untouched; a never-terminal number is a no-op
- the full `close → reopen → merge` sequence through the real hook entry

## Verification

- Full suite **991 passed**, 11 skipped, 72 files; `typecheck` clean, `lint:check` 0 errors, `check-skill-deps` OK.
- Rebuilt `guardrails.mjs` exercised end-to-end: **blocks** after close → **`{}`** after reopen → **blocks again** after a real merge.

Found while landing #369; this is the sibling Stop-gate defect to the one that PR fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
