### PR TITLE
chore(release): @muggleai/works 5.10.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "5.9.0"
+      "version": "5.10.0"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "5.9.0"
+      "version": "5.10.0"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@muggleai/works",
   "mcpName": "io.github.multiplex-ai/muggle",
-  "version": "5.9.0",
+  "version": "5.10.0",
   "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
   "type": "module",
   "main": "dist/index.js",
@@ -48,14 +48,14 @@
     "eval:studio-gen": "tsx internal/studio-gen-eval/src/run.ts"
   },
   "muggleConfig": {
-    "electronAppVersion": "1.6.12",
+    "electronAppVersion": "1.8.0",
     "downloadBaseUrl": "https://github.com/multiplex-ai/muggle-ai-works/releases/download",
     "runtimeTargetDefault": "dev",
     "checksums": {
-      "darwin-arm64": "d313b881b6f448b968c838a3b9bea4d8f226c60b703c377514d37f33d0dacd66",
-      "darwin-x64": "31f316bdcc97dbc764a9656fc3003a2640c613d6ce1f8ba1a73564987235f2f1",
-      "linux-x64": "1d06dfbf66ea97f55abfb6e3cd8a3edbea2c7c6bf75acbbd607039e7c6dae69b",
-      "win32-x64": "ff1150431afad2717e30d419d4ba15df79d20e10ae48a6293f71a723c7b3159a"
+      "darwin-arm64": "38a2a9c392c7c4e55bf510dbcdcf31713db341b35218759961d2672fa8eb6d20",
+      "darwin-x64": "687dd81c3fe808109e11e8db0cea8bb9c1dc05717f9f35699cf64081b591b7bd",
+      "linux-x64": "a7fad7a5370066c338916a5cf54851212bd49e36371ed62dd1f0b70349229d67",
+      "win32-x64": "803aa0690b1047e16bbe5239911d7de3751b6bf2ae8730db75e16da08b778148"
     }
   },
   "dependencies": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "5.9.0",
+  "version": "5.10.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "5.9.0",
+  "version": "5.10.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "5.9.0",
+  "version": "5.10.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "5.9.0",
+      "version": "5.10.0",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
Cuts `@muggleai/works` **5.9.0 → 5.10.0**.

Rebased onto `ca50d51` after #371 landed mid-release, so this branch ships it too.

## Bump rationale

**Minor**, not patch. #367 (`feat(preferences)`) and #366 both changed *where* preferences and the last-host/last-project caches resolve from — now the home directory rather than a cwd-keyed location. That is observable behaviour for existing users, so it clears the patch bar.

## Shipping

| PR | Change |
| :-- | :--- |
| #371 | `fix(guardrails)`: a reopen retracts the terminal verdict it un-does |
| #369 | `fix(guardrails)`: accept a seeded slot as the watcher hand-off |
| #370 | `docs(readme)`: complete the command table with every skill and its shorthand |
| #367 | `feat(preferences)`: resolve preferences from the home directory only |
| #366 | store last-host and last-project caches in the home directory |
| #365 | capture E2E run instructions for reuse (unit-only) |

## Electron

Bumped `muggleConfig.electronAppVersion` **1.6.12 → 1.8.0** (two minors behind; 1.7.0 was skipped) and all four `muggleConfig.checksums`. Hashes were taken from the `electron-app-v1.8.0` `checksums.txt` asset and independently re-verified by `verify:electron-release-checksums`, which refetches the asset and compares.

## Manifests

Written by `pnpm run sync:versions`, not by hand:

- `.claude-plugin/marketplace.json`
- `.cursor-plugin/marketplace.json`
- `plugin/.claude-plugin/plugin.json`
- `plugin/.cursor-plugin/plugin.json`
- `server.json`

## Local verify

Full release gate run on this branch before pushing:

| Command | Result |
| :-- | :--- |
| `pnpm run lint:check` | 0 errors, 17 pre-existing warnings |
| `pnpm run typecheck` | clean |
| `pnpm test` | 72 files, 992 tests — 981 green, 11 skipped, zero failures |
| `pnpm run build` | plugin artifact built at `dist/plugin/` |
| `pnpm run verify:plugin` | passed |
| `pnpm run verify:contracts` | passed |
| `pnpm run verify:electron-release-checksums` | `checksums.txt` verified for `electron-app-v1.8.0` |

Publish is CI-only via `publish-works-to-npm.yml` once this merges; no local `npm publish`.
