### PR TITLE
perf(ops): run memwatch hidden and bound its log growth

### DIFF
--- a/ops/memwatch/README.md
+++ b/ops/memwatch/README.md
@@ -6,7 +6,7 @@ Captures the context a memory-leak post-mortem needs: who held the memory, their
 
 | Piece | Needs admin | What it captures |
 | :---- | :---------- | :--------------- |
-| `memwatch.ps1` (scheduled task, 1/min) | no | JSON line per minute: commit %, free RAM, top-15 processes by private bytes with pid/ppid/parent-alive/command line. Tripwire at 85% commit: full process snapshot + toast, re-arms below 75%. |
+| `memwatch.ps1` (scheduled task, 1/min, no window) | no | JSON line per minute: commit %, free RAM, top-15 processes by private bytes plus every `claude.exe` whatever its rank, each with pid/ppid/parent-alive/session id/command line. Tripwire at 85% commit: full process snapshot + toast, re-arms below 75%. |
 | perfmon flight recorder (`logman`, via `install-elevated.ps1`) | yes | 30s circular counter log (512 MB cap): system commit + per-process Private Bytes / Working Set. Open the `.blg` in perfmon after a crash. |
 | process-creation audit (via `install-elevated.ps1`) | yes | Security event 4688 per process birth, including command line — names who spawned what after processes die. CLI-passed secrets land in the local Security log; accepted trade-off. |
 
@@ -17,7 +17,9 @@ Captures the context a memory-leak post-mortem needs: who held the memory, their
 Start-Process powershell -Verb RunAs -ArgumentList '-NoProfile','-ExecutionPolicy','Bypass','-File',"$PWD\install-elevated.ps1"
 ```
 
-`install-memwatch.ps1` copies the sampler to `~\.muggle-ai\memwatch\bin\` so the task survives checkout deletion. The elevated installer writes `~\.muggle-ai\memwatch\install-elevated-result.json` for verification from an unelevated shell.
+`install-memwatch.ps1` copies the sampler and `memwatch-hidden.vbs` to `~\.muggle-ai\memwatch\bin\` so the task survives checkout deletion. The elevated installer writes `~\.muggle-ai\memwatch\install-elevated-result.json` for verification from an unelevated shell.
+
+The task's action is `wscript.exe memwatch-hidden.vbs`, not `powershell.exe`. Windows allocates a console at process creation for a console-subsystem binary, so `-WindowStyle Hidden` only hides a window that has already been painted — 1440 visible flashes a day. `wscript.exe` is GUI-subsystem and spawns the sampler hidden from the start. An S4U task principal would hide it too, but registering one needs elevation and its non-interactive station drops the tripwire toast.
 
 ## Pause / resume
 
@@ -33,12 +35,16 @@ Turn the sampler off or on without unregistering it — samples and `trip-state.
 
 ## Data locations
 
-All under `~\.muggle-ai\memwatch\`: `memwatch-YYYYMMDD.jsonl` (14-day retention), `memsnapshot-*.json` (tripwire dumps, 90-day retention), `flight\memflight*.blg` (circular), `trip-state.json`.
+All under `~\.muggle-ai\memwatch\`: `memwatch-YYYYMMDD.jsonl` (samples, 14-day retention), `memwatch-YYYYMMDD.seen` (that day's command-line ledger, evicted with its samples), `memsnapshot-*.json` (tripwire dumps, 90-day retention), `flight\memflight*.blg` (circular), `trip-state.json`.
+
+Age is not a size bound on its own — one runaway day can outgrow a fortnight of quiet ones — so the sampler also evicts whole sample days, oldest first, until the directory fits `-LogDirBudgetMb` (default 100). The current day's file and every snapshot are exempt: snapshots are the incident evidence and are orders of magnitude smaller than the samples.
 
 ## Reading a post-mortem
 
 1. `memwatch-*.jsonl` around the incident: growth curve + top consumers per minute (`parentAlive: false` on a heavy process = orphaned work).
-2. `memsnapshot-*.json`: full process table at the 85% crossing.
+2. `memsnapshot-*.json`: full process table at the 85% crossing, every command line spelled out.
+
+A command line never changes for the life of a process, so `cmd` is written on an incarnation's first sighting only — re-emitting it each minute was 57% of every file. Resolve a bare entry from the newest earlier entry with the same `pid` that carries one; a reused pid re-emits, so that lookup can never cross incarnations. `sessionId` stays on every entry, so grepping a session id still hits every sample it appears in.
 3. `relog flight\memflight*.blg -f csv -o out.csv` (or perfmon) for per-process counter history.
 4. Security log 4688 events: spawn tree with command lines.
 

--- a/ops/memwatch/install-memwatch.ps1
+++ b/ops/memwatch/install-memwatch.ps1
@@ -1,6 +1,6 @@
 # Installs the per-minute MuggleMemwatch scheduled task for the current user
-# (no elevation needed). Copies memwatch.ps1 to a stable path first so the task
-# survives deletion of the source checkout/worktree.
+# (no elevation needed). Copies the sampler and its launcher to a stable path
+# first so the task survives deletion of the source checkout/worktree.
 [CmdletBinding()]
 param(
     [string]$TaskName = "MuggleMemwatch"
@@ -10,20 +10,27 @@ $ErrorActionPreference = "Stop"
 
 $installDir = Join-Path $env:USERPROFILE ".muggle-ai\memwatch\bin"
 New-Item -ItemType Directory -Force -Path $installDir | Out-Null
-$installedScript = Join-Path $installDir "memwatch.ps1"
-Copy-Item (Join-Path $PSScriptRoot "memwatch.ps1") $installedScript -Force
+Copy-Item (Join-Path $PSScriptRoot "memwatch.ps1") (Join-Path $installDir "memwatch.ps1") -Force
+$installedLauncher = Join-Path $installDir "memwatch-hidden.vbs"
+Copy-Item (Join-Path $PSScriptRoot "memwatch-hidden.vbs") $installedLauncher -Force
 
-$existingTask = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
-if ($existingTask) { Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false }
-
-$taskAction = New-ScheduledTaskAction -Execute "powershell.exe" `
-    -Argument "-NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File `"$installedScript`""
+# Launching wscript.exe rather than powershell.exe is what keeps the sampler off
+# the desktop every minute — see the header of memwatch-hidden.vbs.
+$taskAction = New-ScheduledTaskAction -Execute (Join-Path $env:SystemRoot "System32\wscript.exe") `
+    -Argument "`"$installedLauncher`""
+# Omitting RepetitionDuration is what makes the repetition indefinite. Passing
+# [TimeSpan]::MaxValue instead serializes to P99999999DT23H59M59S, which Windows
+# PowerShell 5.1 rejects outright — and 5.1 is what the task itself runs under.
 $taskTrigger = New-ScheduledTaskTrigger -Once -At (Get-Date).AddMinutes(1) `
-    -RepetitionInterval (New-TimeSpan -Minutes 1) -RepetitionDuration ([TimeSpan]::MaxValue)
+    -RepetitionInterval (New-TimeSpan -Minutes 1)
 $taskSettings = New-ScheduledTaskSettingsSet -MultipleInstances IgnoreNew -StartWhenAvailable `
     -ExecutionTimeLimit (New-TimeSpan -Minutes 5)
+# -Force overwrites in place: unregistering first would leave the machine
+# unmonitored for the length of this call, and unmonitored for good if the
+# registration below then failed.
 Register-ScheduledTask -TaskName $TaskName -Action $taskAction -Trigger $taskTrigger `
-    -Settings $taskSettings -Description "Per-minute memory sampler + commit tripwire (muggle-ai-works ops/memwatch)" | Out-Null
+    -Settings $taskSettings -Force `
+    -Description "Per-minute memory sampler + commit tripwire (muggle-ai-works ops/memwatch)" | Out-Null
 
 Start-ScheduledTask -TaskName $TaskName
 Start-Sleep -Seconds 5

--- a/ops/memwatch/memwatch-hidden.vbs
+++ b/ops/memwatch/memwatch-hidden.vbs
@@ -1,0 +1,24 @@
+' Console-free launcher for memwatch.ps1, used as the MuggleMemwatch task action.
+'
+' powershell.exe is a console-subsystem binary: Windows allocates its console at
+' process creation, so -WindowStyle Hidden only hides a window that has already
+' been painted — a visible flash on every one of the 1440 daily runs. wscript.exe
+' is GUI-subsystem, so the child it spawns with intWindowStyle 0 is never shown.
+' An S4U task principal would also avoid the console, but registering one needs
+' elevation and its non-interactive station silently drops the tripwire toast.
+'
+' The Run call waits: the task's IgnoreNew overlap guard and LastTaskResult both
+' read the action's own lifetime, which a fire-and-forget launcher would end
+' immediately while the sampler was still running.
+Option Explicit
+
+Dim windowsShell, samplerPath, samplerExitCode
+Set windowsShell = CreateObject("WScript.Shell")
+samplerPath = CreateObject("Scripting.FileSystemObject") _
+    .GetParentFolderName(WScript.ScriptFullName) & "\memwatch.ps1"
+
+samplerExitCode = windowsShell.Run( _
+    "powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File """ & samplerPath & """", _
+    0, True)
+
+WScript.Quit samplerExitCode

--- a/ops/memwatch/memwatch.ps1
+++ b/ops/memwatch/memwatch.ps1
@@ -1,12 +1,17 @@
 # Per-minute memory sampler + commit tripwire. Runs from the MuggleMemwatch
-# scheduled task (see install-memwatch.ps1); PowerShell 5.1-compatible.
+# scheduled task via memwatch-hidden.vbs (see install-memwatch.ps1);
+# PowerShell 5.1-compatible.
 [CmdletBinding()]
 param(
     [string]$LogDir = (Join-Path $env:USERPROFILE ".muggle-ai\memwatch"),
     [int]$TopN = 15,
+    [string[]]$AlwaysTrackedProcessNames = @("claude.exe"),
+    [int]$MaxProcessEntriesPerSample = 60,
     [double]$TripCommitPct = 85,
     [double]$RearmCommitPct = 75,
-    [int]$RetentionDays = 14,
+    [int]$SampleRetentionDays = 14,
+    [int]$SnapshotRetentionDays = 90,
+    [int]$LogDirBudgetMb = 100,
     [switch]$ForceTrip
 )
 
@@ -14,44 +19,113 @@ $ErrorActionPreference = "Stop"
 New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
 $now = Get-Date
 
-$counterSamples = (Get-Counter '\Memory\% Committed Bytes In Use', '\Memory\Committed Bytes').CounterSamples
-$commitPct = [math]::Round(($counterSamples | Where-Object { $_.Path -like '*% committed*' })[0].CookedValue, 1)
-$commitGb = [math]::Round(($counterSamples | Where-Object { $_.Path -like '*committed bytes' })[0].CookedValue / 1GB, 2)
+# TotalVirtualMemorySize/FreeVirtualMemory are the commit limit and commit
+# available, so one CIM call replaces a '\Memory\*' Get-Counter pair that cost
+# ~1s of the sampler's ~1.7s runtime and agreed to within 0.02.
 $osInfo = Get-CimInstance Win32_OperatingSystem
+$commitLimitKb = [double]$osInfo.TotalVirtualMemorySize
+$commitUsedKb = $commitLimitKb - [double]$osInfo.FreeVirtualMemory
+$commitPct = [math]::Round(($commitUsedKb / $commitLimitKb) * 100, 1)
+$commitGb = [math]::Round($commitUsedKb / 1MB, 2)
 $freeRamGb = [math]::Round($osInfo.FreePhysicalMemory / 1MB, 2)
 
-$allProcesses = Get-CimInstance Win32_Process |
-    Select-Object ProcessId, ParentProcessId, Name, PrivatePageCount, WorkingSetSize, CommandLine
+$allProcesses = Get-CimInstance Win32_Process -Property ProcessId, ParentProcessId, Name,
+PrivatePageCount, WorkingSetSize, CommandLine, CreationDate
 $livePids = @{}
 foreach ($processRow in $allProcesses) { $livePids[[int]$processRow.ProcessId] = $true }
 
+$sessionIdPattern = "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+
+function Resolve-ClaudeSessionId {
+    param([string]$CommandLine)
+    if (-not $CommandLine) { return "" }
+    $sessionIdMatch = [regex]::Match($CommandLine, "--session-id\s+($sessionIdPattern)")
+    if ($sessionIdMatch.Success) { return $sessionIdMatch.Groups[1].Value }
+    $resumeMatch = [regex]::Match($CommandLine, "($sessionIdPattern)\.jsonl")
+    if ($resumeMatch.Success) { return $resumeMatch.Groups[1].Value }
+    return ""
+}
+
+# A pid alone is ambiguous across reuse, so incarnation is pid + process start.
+function Resolve-ProcessIncarnationKey {
+    param($ProcessRow)
+    $startedTicks = 0
+    if ($ProcessRow.CreationDate) { $startedTicks = ([datetime]$ProcessRow.CreationDate).Ticks }
+    return "{0}:{1}" -f [int]$ProcessRow.ProcessId, $startedTicks
+}
+
 function ConvertTo-ProcessEntry {
-    param($ProcessRow, [int]$CommandMaxChars)
-    $command = ""
-    if ($ProcessRow.CommandLine) {
-        $command = $ProcessRow.CommandLine.Substring(0, [Math]::Min($CommandMaxChars, $ProcessRow.CommandLine.Length))
-    }
-    return [ordered]@{
+    param($ProcessRow, [int]$CommandMaxChars, [bool]$IncludeCommand = $true)
+    $entry = [ordered]@{
         pid         = [int]$ProcessRow.ProcessId
         ppid        = [int]$ProcessRow.ParentProcessId
         parentAlive = [bool]$livePids[[int]$ProcessRow.ParentProcessId]
         name        = $ProcessRow.Name
         privMb      = [math]::Round($ProcessRow.PrivatePageCount / 1MB, 1)
         wsMb        = [math]::Round($ProcessRow.WorkingSetSize / 1MB, 1)
-        cmd         = $command
     }
+    $sessionId = Resolve-ClaudeSessionId $ProcessRow.CommandLine
+    if ($sessionId) { $entry.sessionId = $sessionId }
+    if ($IncludeCommand -and $ProcessRow.CommandLine) {
+        $entry.cmd = $ProcessRow.CommandLine.Substring(
+            0, [Math]::Min($CommandMaxChars, $ProcessRow.CommandLine.Length))
+    }
+    return $entry
 }
 
-$topProcesses = $allProcesses | Sort-Object PrivatePageCount -Descending | Select-Object -First $TopN
+$rankedProcesses = $allProcesses | Sort-Object PrivatePageCount -Descending
+$trackedPids = @{}
+$sampledProcesses = New-Object System.Collections.ArrayList
+foreach ($processRow in ($rankedProcesses | Select-Object -First $TopN)) {
+    if (-not $trackedPids[[int]$processRow.ProcessId]) {
+        $trackedPids[[int]$processRow.ProcessId] = $true
+        $sampledProcesses.Add($processRow) | Out-Null
+    }
+}
+foreach ($processRow in $rankedProcesses) {
+    if ($AlwaysTrackedProcessNames -contains $processRow.Name -and -not $trackedPids[[int]$processRow.ProcessId]) {
+        $trackedPids[[int]$processRow.ProcessId] = $true
+        $sampledProcesses.Add($processRow) | Out-Null
+    }
+}
+# Heaviest-first ordering above means a runaway process count sheds the least
+# interesting entries rather than blowing the per-sample size budget.
+if ($sampledProcesses.Count -gt $MaxProcessEntriesPerSample) {
+    $sampledProcesses = $sampledProcesses | Select-Object -First $MaxProcessEntriesPerSample
+}
+
+# A command line never changes for the life of a process, so re-emitting it every
+# minute was 57% of every log file. It is written on an incarnation's first
+# sighting only; readers resolve a bare entry from the newest earlier entry with
+# the same pid that carried one. Losing the ledger only re-emits, never corrupts.
+$commandLedgerFile = Join-Path $LogDir ("memwatch-{0:yyyyMMdd}.seen" -f $now)
+$loggedIncarnations = New-Object 'System.Collections.Generic.HashSet[string]'
+if (Test-Path $commandLedgerFile) {
+    try {
+        foreach ($ledgerLine in [System.IO.File]::ReadAllLines($commandLedgerFile)) {
+            if ($ledgerLine) { $loggedIncarnations.Add($ledgerLine) | Out-Null }
+        }
+    } catch { $loggedIncarnations.Clear() }
+}
+
+$newIncarnations = New-Object System.Collections.ArrayList
+$sampleEntries = @(foreach ($processRow in $sampledProcesses) {
+        $incarnationKey = Resolve-ProcessIncarnationKey $processRow
+        $isFirstSighting = -not $loggedIncarnations.Contains($incarnationKey)
+        if ($isFirstSighting) { $newIncarnations.Add($incarnationKey) | Out-Null }
+        ConvertTo-ProcessEntry $processRow 180 $isFirstSighting
+    })
+
 $sampleLine = [ordered]@{
     at        = $now.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
     commitPct = $commitPct
     commitGb  = $commitGb
     freeRamGb = $freeRamGb
-    top       = @(foreach ($processRow in $topProcesses) { ConvertTo-ProcessEntry $processRow 180 })
+    top       = $sampleEntries
 }
 $sampleFile = Join-Path $LogDir ("memwatch-{0:yyyyMMdd}.jsonl" -f $now)
 Add-Content -Path $sampleFile -Value ($sampleLine | ConvertTo-Json -Compress -Depth 4)
+if ($newIncarnations.Count -gt 0) { Add-Content -Path $commandLedgerFile -Value $newIncarnations }
 
 $tripStateFile = Join-Path $LogDir "trip-state.json"
 $armed = $true
@@ -60,16 +134,14 @@ if (Test-Path $tripStateFile) {
 }
 
 if (($commitPct -ge $TripCommitPct -or $ForceTrip) -and $armed) {
+    # The snapshot is the post-mortem's ground truth, so it carries every process
+    # and every command line regardless of what the sample line deduplicated.
     $snapshot = [ordered]@{
         at        = $sampleLine.at
         commitPct = $commitPct
         commitGb  = $commitGb
         freeRamGb = $freeRamGb
-        processes = @(
-            foreach ($processRow in ($allProcesses | Sort-Object PrivatePageCount -Descending)) {
-                ConvertTo-ProcessEntry $processRow 400
-            }
-        )
+        processes = @(foreach ($processRow in $rankedProcesses) { ConvertTo-ProcessEntry $processRow 400 $true })
     }
     $snapshotFile = Join-Path $LogDir ("memsnapshot-{0:yyyyMMdd-HHmmss}.json" -f $now)
     Set-Content -Path $snapshotFile -Value ($snapshot | ConvertTo-Json -Depth 4)
@@ -96,9 +168,33 @@ Set-Content -Path $tripStateFile -Value ([ordered]@{
         updated_at = $sampleLine.at
     } | ConvertTo-Json)
 
-$sampleCutoff = $now.AddDays(-$RetentionDays)
-Get-ChildItem $LogDir -Filter "memwatch-*.jsonl" | Where-Object { $_.LastWriteTime -lt $sampleCutoff } |
-    Remove-Item -Force -Confirm:$false
-$snapshotCutoff = $now.AddDays(-90)
+function Remove-SampleDay {
+    param([string]$SampleFilePath)
+    Remove-Item $SampleFilePath -Force -Confirm:$false -ErrorAction SilentlyContinue
+    $ledgerPath = [System.IO.Path]::ChangeExtension($SampleFilePath, ".seen")
+    Remove-Item $ledgerPath -Force -Confirm:$false -ErrorAction SilentlyContinue
+}
+
+$sampleCutoff = $now.AddDays(-$SampleRetentionDays)
+foreach ($expiredSample in (Get-ChildItem $LogDir -Filter "memwatch-*.jsonl" |
+            Where-Object { $_.LastWriteTime -lt $sampleCutoff })) {
+    Remove-SampleDay $expiredSample.FullName
+}
+$snapshotCutoff = $now.AddDays(-$SnapshotRetentionDays)
 Get-ChildItem $LogDir -Filter "memsnapshot-*.json" | Where-Object { $_.LastWriteTime -lt $snapshotCutoff } |
     Remove-Item -Force -Confirm:$false
+
+# Age-based retention alone cannot bound the directory: one runaway day can
+# outgrow a fortnight of normal ones. Oldest sample days are evicted until the
+# directory fits, sparing today's file and the tripwire snapshots — those are the
+# incident evidence, and they are orders of magnitude smaller than the samples.
+$logDirBudgetBytes = $LogDirBudgetMb * 1MB
+$evictableSamples = New-Object System.Collections.Queue
+Get-ChildItem $LogDir -Filter "memwatch-*.jsonl" |
+    Where-Object { $_.FullName -ne $sampleFile } |
+    Sort-Object LastWriteTime |
+    ForEach-Object { $evictableSamples.Enqueue($_.FullName) }
+while ($evictableSamples.Count -gt 0 -and
+    ((Get-ChildItem $LogDir -Recurse -File | Measure-Object Length -Sum).Sum -gt $logDirBudgetBytes)) {
+    Remove-SampleDay $evictableSamples.Dequeue()
+}


### PR DESCRIPTION
## Console window

The task action ran `powershell.exe` directly. Windows allocates the console at process creation for a console-subsystem binary, so `-WindowStyle Hidden` only hid a window that had already been painted — a flash on each of the 1440 daily runs. The action is now `wscript.exe` running `memwatch-hidden.vbs` (GUI-subsystem), which spawns the sampler hidden from the start and waits on it, so the task's `IgnoreNew` overlap guard and `LastTaskResult` still describe the sampler rather than the launcher.

An S4U principal would also avoid the console, but registering one returns `Access is denied` unelevated on this machine, and its non-interactive station drops the tripwire toast.

## Run cost

`Get-Counter` over the two `\Memory\*` counters was ~1.0s of a ~1.7s run. `Win32_OperatingSystem` — already queried for free RAM — carries the same figures via `TotalVirtualMemorySize`/`FreeVirtualMemory`, agreeing within 0.02 on both commit % and commit GB. Steady-state run is now ~0.35s.

## Log volume

Sample files grew ~10.6 MB/day against no size bound. Measured on a real day's file: `cmd` was 56.6% of the bytes, and 56.5% of the file was redundant — 18,145 logged entries across only 43 distinct pids, each command line rewritten ~422 times for a process whose command line cannot change.

`cmd` is now written on a pid incarnation's first sighting only, tracked in a per-day ledger keyed on pid + process start so a reused pid re-emits rather than inheriting its predecessor's. Readers resolve a bare entry from the newest earlier entry with the same pid that carries one; the rule is documented in the README. `sessionId` stays on every entry so grepping a session id still hits every sample it appears in, and tripwire snapshots still spell out every command line.

Retention gained a directory budget (`-LogDirBudgetMb`, default 100) that evicts whole sample days oldest-first, sparing the current day and every snapshot. Age alone is not a size bound — one runaway day can outgrow a fortnight of quiet ones.

## Incidental fixes

- The repo copy had drifted behind the deployed sampler; this restores per-process `sessionId` and tracking of every `claude.exe` regardless of rank.
- `-RepetitionDuration ([TimeSpan]::MaxValue)` serializes to `P99999999DT23H59M59S`, which Windows PowerShell 5.1 rejects — the installer only ever worked under pwsh 7, while the task itself runs 5.1. Omitting the duration is what makes a repetition indefinite.
- The installer unregistered before registering, so a rejected registration left the machine with no task at all. Now one `Register-ScheduledTask -Force`.

## Verification

Under Windows PowerShell 5.1, which is what the task runs:

| Check | Result |
| :-- | :-- |
| Sample line size | 8147 → 3536 bytes (−57%) |
| Run duration | 1.71s → 0.35s |
| `sessionId` on deduped samples | retained, 20 of 26 entries |
| TTL sweep | 20-day-old sample day and its paired ledger removed |
| Budget sweep | 6.02 MB → 2.02 MB at `-LogDirBudgetMb 3`, current day spared |
| Tripwire snapshot | 436 processes, command lines intact |
| Visible-window poll (Win32 `EnumWindows`, 10 ms) | old invocation surfaced a `powershell` window; new launcher surfaced none |

Installed live on the workstation: task `Ready`, `LastTaskResult=0`, trigger `PT1M` with no duration (indefinite), action `wscript.exe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Z3hWcGNDxrqAjfTS6V1b5
