### PR TITLE
feat(mcp): forward LLM env overrides from preferences to the Studio spawn

### DIFF
--- a/packages/mcps/src/mcp/local/services/execution-service.ts
+++ b/packages/mcps/src/mcp/local/services/execution-service.ts
@@ -20,6 +20,7 @@ import {
   getElectronAppVersion,
   resolveElectronAppPathOrNull,
 } from "../../../shared/config.js";
+import { applyLlmEnvOverrides } from "../../../shared/llm-env-service.js";
 import { getLogger } from "../../../shared/logger.js";
 import type { TestCaseDetails, TestScriptDetails } from "../contracts/project-schemas.js";
 import { getAuthService, getRunResultStorageService, getStorageService } from "./index.js";
@@ -520,15 +521,20 @@ async function executeElectronAppAsync(params: {
     spawnArgs.push("--fresh-session");
   }
 
+  // Resolved per spawn, not at server start, so an edited preference applies to the next run
+  // instead of waiting for the MCP host to restart.
+  const { env: electronEnv, appliedNames: llmEnvOverrideNames } = applyLlmEnvOverrides({
+    ...process.env,
+  });
+  delete electronEnv.ELECTRON_RUN_AS_NODE;
+
   logger.info("Spawning electron-app for local execution", {
     runId: params.runId,
     mode: mode,
     electronAppPath: electronAppPath,
     spawnArgs: spawnArgs,
+    llmEnvOverrideNames: llmEnvOverrideNames,
   });
-
-  const electronEnv = { ...process.env };
-  delete electronEnv.ELECTRON_RUN_AS_NODE;
 
   const electronCwd = path.dirname(electronAppPath);
   const child = spawn(electronAppPath, spawnArgs, {

--- a/packages/mcps/src/shared/llm-env-constants.ts
+++ b/packages/mcps/src/shared/llm-env-constants.ts
@@ -1,0 +1,30 @@
+/**
+ * LLM environment overrides — the `llmEnv` block users set in
+ * `~/.muggle-ai/preferences.json` to point Studio at a different LLM provider.
+ *
+ * The block is a sibling of `preferences`, not a member of it: preference values are a
+ * closed enum (`always`/`ask`/`never`/...), these are free-text, and keeping them out of
+ * `preferences` also keeps them out of the SessionStart one-liner that echoes preferences
+ * into session context.
+ */
+
+/** Top-level key in the preferences file holding the env overrides. */
+export const LLM_ENV_PREFERENCE_KEY = "llmEnv";
+
+/**
+ * Environment variables Studio reads to select its LLM provider. Only these names are
+ * forwarded from the preferences file, so the file cannot inject arbitrary environment
+ * (`PATH`, `NODE_OPTIONS`, ...) into the spawned Studio process.
+ */
+export const FORWARDABLE_LLM_ENV_NAMES: readonly string[] = [
+  "MUGGLE_LLM_PROVIDER",
+  "MUGGLE_LLM_BASE_URL",
+  "MUGGLE_LLM_API_KEY",
+  "MUGGLE_LLM_MODEL",
+  "MUGGLE_LLM_MODEL_PREDICTION",
+  "MUGGLE_LLM_MODEL_SUMMARIZER",
+  "MUGGLE_LLM_MODEL_EVAL",
+  "MUGGLE_LLM_MAX_TOKENS",
+  "MUGGLE_LLM_TEMPERATURE",
+  "MUGGLE_LLM_TIMEOUT_MS",
+];

--- a/packages/mcps/src/shared/llm-env-service.ts
+++ b/packages/mcps/src/shared/llm-env-service.ts
@@ -1,0 +1,77 @@
+/**
+ * Resolve the user's LLM environment overrides and apply them to a spawned process env.
+ *
+ * Users set an `llmEnv` block in `~/.muggle-ai/preferences.json`; muggle-works forwards it to
+ * Studio at spawn time so a provider change takes effect on the next run, without restarting
+ * the MCP host. Studio itself only reads environment variables.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { getDataDir } from "./data-dir.js";
+import { FORWARDABLE_LLM_ENV_NAMES, LLM_ENV_PREFERENCE_KEY } from "./llm-env-constants.js";
+import { PREFERENCES_FILE_NAME } from "./preferences-constants.js";
+
+/**
+ * Read the `llmEnv` block from the preferences file, keeping only forwardable names.
+ * Values are stringified so numeric entries (maxTokens, temperature) survive JSON typing.
+ * @param dataDirOverride - Override data dir for testing.
+ * @returns Env overrides, e.g. `{ MUGGLE_LLM_PROVIDER: "local", MUGGLE_LLM_MODEL: "llava" }`.
+ */
+export function resolveLlmEnvOverrides(dataDirOverride?: string): Record<string, string> {
+  const filePath = path.join(dataDirOverride ?? getDataDir(), PREFERENCES_FILE_NAME);
+  let block: unknown;
+  try {
+    if (!fs.existsSync(filePath)) {
+      return {};
+    }
+    const raw = JSON.parse(fs.readFileSync(filePath, "utf-8")) as Record<string, unknown>;
+    block = raw[LLM_ENV_PREFERENCE_KEY];
+  } catch {
+    return {};
+  }
+
+  if (!block || typeof block !== "object" || Array.isArray(block)) {
+    return {};
+  }
+
+  const overrides: Record<string, string> = {};
+  for (const [name, value] of Object.entries(block as Record<string, unknown>)) {
+    if (!FORWARDABLE_LLM_ENV_NAMES.includes(name)) {
+      continue;
+    }
+    if (value === null || value === undefined || value === "") {
+      continue;
+    }
+    overrides[name] = String(value);
+  }
+  return overrides;
+}
+
+/**
+ * Apply the user's LLM env overrides to a process environment, without displacing values the
+ * caller already exported — an explicit shell variable outranks the stored preference.
+ * @param baseEnv - Environment to extend (typically a copy of `process.env`).
+ * @param dataDirOverride - Override data dir for testing.
+ * @returns The extended environment plus the names taken from preferences, for the caller to log.
+ *
+ * Output shape: `{ env: { MUGGLE_LLM_MODEL: "llava", ... }, appliedNames: ["MUGGLE_LLM_MODEL"] }`
+ */
+export function applyLlmEnvOverrides(
+  baseEnv: NodeJS.ProcessEnv,
+  dataDirOverride?: string,
+): { env: NodeJS.ProcessEnv; appliedNames: string[] } {
+  const overrides = resolveLlmEnvOverrides(dataDirOverride);
+  const appliedNames: string[] = [];
+
+  for (const [name, value] of Object.entries(overrides)) {
+    if (baseEnv[name] !== undefined && baseEnv[name] !== "") {
+      continue;
+    }
+    baseEnv[name] = value;
+    appliedNames.push(name);
+  }
+
+  return { env: baseEnv, appliedNames: appliedNames };
+}

--- a/packages/mcps/src/shared/preferences-service.ts
+++ b/packages/mcps/src/shared/preferences-service.ts
@@ -63,11 +63,25 @@ function readPreferencesFile(filePath: string): IPartialPreferences {
 }
 
 function writePreferencesFile(filePath: string, prefs: IPartialPreferences): void {
+  // Preserve sibling top-level blocks (e.g. `llmEnv`); rewriting only `version` + `preferences`
+  // would silently drop them on every preference write.
   const file: IPreferencesFile = {
+    ...readRawPreferencesFile(filePath),
     version: PREFERENCES_VERSION,
     preferences: prefs,
   };
   fs.writeFileSync(filePath, `${JSON.stringify(file, null, 2)}\n`, "utf-8");
+}
+
+function readRawPreferencesFile(filePath: string): Partial<IPreferencesFile> {
+  try {
+    if (!fs.existsSync(filePath)) {
+      return {};
+    }
+    return JSON.parse(fs.readFileSync(filePath, "utf-8")) as Partial<IPreferencesFile>;
+  } catch {
+    return {};
+  }
 }
 
 /**

--- a/packages/mcps/src/shared/preferences-types.ts
+++ b/packages/mcps/src/shared/preferences-types.ts
@@ -97,6 +97,11 @@ export interface IPreferencesFile {
   version: number;
   /** The preference key-value pairs. */
   preferences: IPartialPreferences;
+  /**
+   * Environment variables forwarded to the Studio process at spawn (`MUGGLE_LLM_*`). A sibling
+   * of `preferences` because these are free-text, unlike the closed enum of preference values.
+   */
+  llmEnv?: Record<string, string>;
 }
 
 /**

--- a/packages/mcps/src/test/llm-env-service.test.ts
+++ b/packages/mcps/src/test/llm-env-service.test.ts
@@ -1,0 +1,97 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { applyLlmEnvOverrides, resolveLlmEnvOverrides } from "../shared/llm-env-service.js";
+import { writePreferences } from "../shared/preferences-service.js";
+
+describe("llm env overrides", () => {
+  let dataDir: string;
+
+  function writePreferencesFileContent(content: unknown): void {
+    fs.writeFileSync(path.join(dataDir, "preferences.json"), JSON.stringify(content, null, 2), "utf-8");
+  }
+
+  beforeEach(() => {
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "muggle-llm-env-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("returns an empty map when the preferences file is missing", () => {
+    expect(resolveLlmEnvOverrides(path.join(dataDir, "absent"))).toEqual({});
+  });
+
+  it("returns an empty map when no llmEnv block is present", () => {
+    writePreferencesFileContent({ version: 1, preferences: { autoLogin: "always" } });
+    expect(resolveLlmEnvOverrides(dataDir)).toEqual({});
+  });
+
+  it("reads forwardable names and stringifies numeric values", () => {
+    writePreferencesFileContent({
+      version: 1,
+      preferences: {},
+      llmEnv: {
+        MUGGLE_LLM_PROVIDER: "local",
+        MUGGLE_LLM_BASE_URL: "http://localhost:11434/v1",
+        MUGGLE_LLM_MODEL: "llava",
+        MUGGLE_LLM_MAX_TOKENS: 4096,
+      },
+    });
+
+    expect(resolveLlmEnvOverrides(dataDir)).toEqual({
+      MUGGLE_LLM_PROVIDER: "local",
+      MUGGLE_LLM_BASE_URL: "http://localhost:11434/v1",
+      MUGGLE_LLM_MODEL: "llava",
+      MUGGLE_LLM_MAX_TOKENS: "4096",
+    });
+  });
+
+  it("drops names outside the forwardable allowlist", () => {
+    writePreferencesFileContent({
+      version: 1,
+      preferences: {},
+      llmEnv: { PATH: "/evil", NODE_OPTIONS: "--inspect", MUGGLE_LLM_MODEL: "llava" },
+    });
+
+    expect(resolveLlmEnvOverrides(dataDir)).toEqual({ MUGGLE_LLM_MODEL: "llava" });
+  });
+
+  it("skips empty values and tolerates a malformed block", () => {
+    writePreferencesFileContent({ version: 1, preferences: {}, llmEnv: { MUGGLE_LLM_MODEL: "" } });
+    expect(resolveLlmEnvOverrides(dataDir)).toEqual({});
+
+    writePreferencesFileContent({ version: 1, preferences: {}, llmEnv: "not-an-object" });
+    expect(resolveLlmEnvOverrides(dataDir)).toEqual({});
+  });
+
+  it("fills missing variables but never displaces an exported one", () => {
+    writePreferencesFileContent({
+      version: 1,
+      preferences: {},
+      llmEnv: { MUGGLE_LLM_MODEL: "llava", MUGGLE_LLM_BASE_URL: "http://localhost:11434/v1" },
+    });
+
+    const applied = applyLlmEnvOverrides({ MUGGLE_LLM_MODEL: "qwen2-vl" }, dataDir);
+
+    expect(applied.env.MUGGLE_LLM_MODEL).toBe("qwen2-vl");
+    expect(applied.env.MUGGLE_LLM_BASE_URL).toBe("http://localhost:11434/v1");
+    expect(applied.appliedNames).toEqual(["MUGGLE_LLM_BASE_URL"]);
+  });
+
+  it("survives a preference write", () => {
+    writePreferencesFileContent({
+      version: 1,
+      preferences: { autoLogin: "always" },
+      llmEnv: { MUGGLE_LLM_MODEL: "llava" },
+    });
+
+    writePreferences({ autoWatchPR: "always" } as never, dataDir);
+
+    expect(resolveLlmEnvOverrides(dataDir)).toEqual({ MUGGLE_LLM_MODEL: "llava" });
+  });
+});


### PR DESCRIPTION
Lets a muggle-works user point Studio at a different LLM provider (local Ollama/LM Studio/vLLM, or a private endpoint) by declaring an `llmEnv` block in `~/.muggle-ai/preferences.json`. works forwards it into the Studio process environment at spawn.

Studio already consumes `MUGGLE_LLM_*` (teaching-service #348), so **no Studio change is needed**.

## Usage
```jsonc
// ~/.muggle-ai/preferences.json
{
  "version": 1,
  "preferences": { "autoLogin": "always" },
  "llmEnv": {
    "MUGGLE_LLM_PROVIDER": "local",
    "MUGGLE_LLM_BASE_URL": "http://localhost:11434/v1",
    "MUGGLE_LLM_MODEL": "qwen3.6"
  }
}
```

## Design notes
- **Resolved per spawn**, not at server start — an edit applies to the next run without restarting the MCP host.
- **Allowlisted** to `MUGGLE_LLM_*`, so the file cannot inject arbitrary environment (`PATH`, `NODE_OPTIONS`) into the spawned child.
- **Exported shell variables win** over the stored value.
- The block is a **sibling of `preferences`**, not a member: preference values are a closed enum (`always`/`ask`/`never`/…) while these are free-text, and this keeps them out of `formatPreferencesOneLiner()`, which echoes preferences into session context at SessionStart (an API key there would land in the model's context every session).
- **Bug fix:** `writePreferencesFile` now preserves sibling top-level blocks. It previously rewrote `{version, preferences}` wholesale, silently dropping them on every preference write.

## Verification
- 7 new unit tests (allowlist, stringification, empty/malformed block, shell-env precedence, survives a preference write).
- Full suite **1042 passed / 16 skipped**; `tsc --noEmit` exit 0; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)