### PR TITLE
fix(guardrails): make the documented skip markers and reopen/comment-edit paths reachable

### DIFF
--- a/plugin/hooks/README.md
+++ b/plugin/hooks/README.md
@@ -26,6 +26,8 @@ Enforcement is reserved for the handoffs that were being skipped: the E2E accept
 
 Each guardrail is a thin bash wrapper in `../scripts/` registered in `hooks.json`. The wrapper pipes the event payload (stdin JSON) to the bundled `../scripts/guardrails.mjs <subcommand>`, which holds the decision logic (built from `src/guardrails/`, vitest-covered). Per-session state in `~/.muggle-ai/guardrails/<session_id>.json` tracks what fired. Any *failure* degrades to `{}` (allow) — a gate blocks only by an explicit, tested decision, never by accident.
 
+Each wrapper short-circuits in shell first, so the common case never pays Node cold-start. That pre-filter is a second, looser copy of what `guardrails.mjs` matches, and it is the one place a guardrail can fail *silently*: a payload it drops — a skip marker, a reopen line, a comment edit — reaches no recorder, and the gate keeps demanding an action the user already took. Over-matching is free; under-matching is a dead escape hatch. `src/test/guardrails/hook-prefilter.test.ts` pins every payload each subcommand acts on against the wrapper guarding it, and derives the skip-marker tokens from source so a new marker is covered the moment it exists.
+
 ## Guardrails
 
 | Hook event | Wrapper | Strength | Condition | Preference | Effect |

--- a/plugin/scripts/guardrail-pr-terminal.sh
+++ b/plugin/scripts/guardrail-pr-terminal.sh
@@ -9,10 +9,14 @@ set -uo pipefail
 # AskUserQuestion offer runs. Decision logic lives in the bundled guardrails.mjs.
 #
 # Fires after every Bash call, so a keyword pre-filter for the terminal output
-# shapes keeps Node off the hot path. Degrades to {} so it never blocks.
+# shapes keeps Node off the hot path. The reopen line belongs here too: it is
+# the one signal that retracts a terminal verdict, and while the pre-filter
+# dropped it a close+reopen — routine, to re-fire a lost workflow trigger — left
+# the handoff armed on a change that is open again. Degrades to {} so it never
+# blocks.
 payload="$(cat)"
 
-if ! grep -Eiq 'merged pull request|closed pull request|TERMINAL pr=' <<<"$payload"; then
+if ! grep -Eiq '(merged|closed|reopened) pull request|TERMINAL pr=' <<<"$payload"; then
   printf '{}'
   exit 0
 fi

--- a/plugin/scripts/guardrail-record-tests.sh
+++ b/plugin/scripts/guardrail-record-tests.sh
@@ -10,12 +10,19 @@ set -uo pipefail
 # pre-filter for test runners and the muggle E2E tool names keeps Node off the
 # hot path. Only a `test` command (npm/pnpm/yarn/jest/vitest/pytest/go/cargo),
 # a muggle execute/replay/test-generation event, a muggle-test skill telemetry
-# emit (registers a clean-SKIP verdict as an E2E run), or an E2E skip marker
-# reaches guardrails.mjs, which then inspects the output for pass/fail and
-# updates state. Degrades to {}.
+# emit (registers a clean-SKIP verdict as an E2E run), a skip marker, or a PR
+# publish carrying a rendered walkthrough reaches guardrails.mjs, which then
+# inspects the output for pass/fail and updates state. Degrades to {}.
+#
+# The marker arm matches the MUGGLE_<GATE>_SKIP shape, never one token: every
+# Stop gate documents its own marker as the escape hatch, and a per-token list
+# left the watcher and walkthrough markers unreachable — the gates instructed
+# the user to run an echo that could never reach the recorder, then blocked the
+# turn anyway. Anchoring the marker to a leading `echo` stays in guardrails.mjs;
+# over-matching here only costs a needless spawn.
 payload="$(cat)"
 
-if ! grep -Eiq '(pnpm|npm|yarn)[[:space:]]+(run[[:space:]]+)?test|jest|vitest|pytest|go[[:space:]]+test|cargo[[:space:]]+test|muggle.*(execute|test-generation|replay)|muggle-local-telemetry-skill-emit|MUGGLE_E2E_SKIP' <<<"$payload"; then
+if ! grep -Eiq '(pnpm|npm|yarn)[[:space:]]+(run[[:space:]]+)?test|jest|vitest|pytest|go[[:space:]]+test|cargo[[:space:]]+test|muggle.*(execute|test-generation|replay)|muggle-local-telemetry-skill-emit|MUGGLE_[A-Z0-9_]+_SKIP|gh[[:space:]]+pr[[:space:]]+(comment|create|edit)|issues/comments/[0-9]' <<<"$payload"; then
   printf '{}'
   exit 0
 fi

--- a/plugin/scripts/guardrail-report-format.sh
+++ b/plugin/scripts/guardrail-report-format.sh
@@ -7,14 +7,18 @@ set -uo pipefail
 # deterministic renderer.
 #
 # This must stay synchronous (only a sync PreToolUse hook can deny), and it fires
-# before every Bash call. A keyword pre-filter for the three PR-posting commands
+# before every Bash call. A keyword pre-filter for the PR-publishing commands
 # keeps Node off the hot path: a plain `ls`/`git status`/build command returns {}
-# in-shell and never pays cold-start. Only a `gh pr comment|create|edit` reaches
-# guardrails.mjs, which reads the body (incl. --body-file) and decides. Degrades
-# to {} so it never blocks an unrelated command.
+# in-shell and never pays cold-start. Only a `gh pr comment|create|edit` or a
+# `gh api` comment edit reaches guardrails.mjs, which reads the body (incl.
+# --body-file) and decides. The comment-edit arm matters as much as the post
+# arm: guardrails.mjs gates that path precisely so a sanctioned walkthrough
+# can't be overwritten with hand-written markdown afterwards, and a pre-filter
+# on `gh pr` alone left that bypass wide open. Degrades to {} so it never blocks
+# an unrelated command.
 payload="$(cat)"
 
-if ! grep -Eiq 'gh[[:space:]]+pr[[:space:]]+(comment|create|edit)' <<<"$payload"; then
+if ! grep -Eiq 'gh[[:space:]]+pr[[:space:]]+(comment|create|edit)|issues/comments/[0-9]' <<<"$payload"; then
   printf '{}'
   exit 0
 fi

--- a/src/test/guardrails/hook-execution.test.ts
+++ b/src/test/guardrails/hook-execution.test.ts
@@ -528,11 +528,39 @@ describe.skipIf(process.platform === "win32")("guardrail wrapper pre-filter (no 
     ).toContain(NODE_RAN);
   });
 
-  it("record-tests: spawns Node on an E2E skip marker", () => {
+  // Every Stop gate documents its own marker as the way out, so all three must
+  // survive the pre-filter — a per-token list left two of them unreachable and
+  // the gates blocked users who followed the instruction. hook-prefilter.test.ts
+  // derives the token set from source; these confirm real grep agrees.
+  it.each(["MUGGLE_E2E_SKIP", "MUGGLE_WATCH_SKIP", "MUGGLE_WALKTHROUGH_SKIP"])(
+    "record-tests: spawns Node on the %s marker",
+    (token) => {
+      expect(
+        runWrapper(
+          "guardrail-record-tests.sh",
+          event({ tool_name: "Bash", tool_input: { command: `echo "${token}: reason"` } }),
+        ),
+      ).toContain(NODE_RAN);
+    },
+  );
+
+  it("record-tests: spawns Node on a walkthrough post so it registers without a provider lookup", () => {
     expect(
       runWrapper(
         "guardrail-record-tests.sh",
-        event({ tool_name: "Bash", tool_input: { command: 'echo "MUGGLE_E2E_SKIP: no app"' } }),
+        event({ tool_name: "Bash", tool_input: { command: "gh pr comment 7 --body-file walkthrough.md" } }),
+      ),
+    ).toContain(NODE_RAN);
+  });
+
+  it("report-format: spawns Node on a gh api comment edit", () => {
+    expect(
+      runWrapper(
+        "guardrail-report-format.sh",
+        event({
+          tool_name: "Bash",
+          tool_input: { command: "gh api --method PATCH repos/o/r/issues/comments/1 -f body=@report.md" },
+        }),
       ),
     ).toContain(NODE_RAN);
   });
@@ -563,6 +591,18 @@ describe.skipIf(process.platform === "win32")("guardrail wrapper pre-filter (no 
       runWrapper(
         "guardrail-pr-terminal.sh",
         event({ tool_name: "Bash", tool_response: { stdout: "TERMINAL pr=331: MERGED" } }),
+      ),
+    ).toContain(NODE_RAN);
+  });
+
+  // The reopen retracts a close, so it must reach the detector — while the
+  // pre-filter dropped it, a routine close+reopen left the post-merge handoff
+  // armed on a PR that is open again.
+  it("pr-terminal: spawns Node on a reopen success line", () => {
+    expect(
+      runWrapper(
+        "guardrail-pr-terminal.sh",
+        event({ tool_name: "Bash", tool_response: { stderr: "✓ Reopened pull request o/r#369 (gate fix)" } }),
       ),
     ).toContain(NODE_RAN);
   });

--- a/src/test/guardrails/hook-prefilter.test.ts
+++ b/src/test/guardrails/hook-prefilter.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "fs";
+import { fileURLToPath } from "url";
+import { join } from "path";
+
+// Each bash wrapper re-encodes, in shell, the payloads its guardrails.mjs
+// subcommand acts on. Nothing ties the two together, so a marker a gate's own
+// instruction tells the user to run can be short-circuited before Node ever
+// sees it — the failure that made MUGGLE_WATCH_SKIP and MUGGLE_WALKTHROUGH_SKIP
+// dead tokens while the gates kept demanding them. These assertions run on every
+// platform; the end-to-end wrapper runs in hook-execution.test.ts are bash-only.
+const SCRIPTS = fileURLToPath(new URL("../../../plugin/scripts", import.meta.url));
+const GUARDRAIL_SOURCE = fileURLToPath(new URL("../../guardrails", import.meta.url));
+
+function payloadPrefilter(wrapperScriptName: string): RegExp {
+  const wrapperBody = readFileSync(join(SCRIPTS, wrapperScriptName), "utf-8");
+  const prefilter = wrapperBody.match(/grep -Eiq '([^']+)'/);
+  if (!prefilter) throw new Error(`${wrapperScriptName} has no payload pre-filter`);
+  return new RegExp(prefilter[1].replaceAll("[[:space:]]", "\\s"), "i");
+}
+
+const commandPayload = (command: string): string =>
+  JSON.stringify({ tool_name: "Bash", tool_input: { command: command } });
+
+const outputPayload = (stderr: string): string =>
+  JSON.stringify({ tool_name: "Bash", tool_response: { stderr: stderr } });
+
+describe("record-tests pre-filter reaches every payload the recorder acts on", () => {
+  const prefilter = payloadPrefilter("guardrail-record-tests.sh");
+  const reaching: Array<[string, string]> = [
+    ["a unit-test run", commandPayload("pnpm test")],
+    ["a muggle replay tool call", JSON.stringify({ tool_name: "mcp__muggle__muggle-local-execute-replay" })],
+    [
+      "a muggle-test skill telemetry emit",
+      JSON.stringify({
+        tool_name: "mcp__plugin_muggle_muggle__muggle-local-telemetry-skill-emit",
+        tool_input: { skillName: "muggle-test" },
+      }),
+    ],
+    ["a walkthrough posted as a PR comment", commandPayload("gh pr comment 7 --body-file walkthrough.md")],
+    [
+      "a walkthrough edited into an existing comment",
+      commandPayload("gh api --method PATCH repos/o/r/issues/comments/12345 --input walkthrough.json"),
+    ],
+  ];
+
+  it.each(reaching)("spawns Node for %s", (_label, payload) => {
+    expect(prefilter.test(payload)).toBe(true);
+  });
+
+  // Derived from the source rather than listed here, so a marker added to a
+  // future gate is covered the moment it exists — listing them by hand is how
+  // the pre-filter came to know only MUGGLE_E2E_SKIP.
+  it("spawns Node for every skip marker the guardrails define", () => {
+    const markerTokens = new Set(
+      readdirSync(GUARDRAIL_SOURCE).flatMap(
+        (name) =>
+          readFileSync(join(GUARDRAIL_SOURCE, name), "utf-8").match(/MUGGLE_[A-Z0-9_]+_SKIP/g) ?? [],
+      ),
+    );
+    expect(markerTokens.size).toBeGreaterThanOrEqual(3);
+    for (const token of markerTokens) {
+      expect(prefilter.test(commandPayload(`echo "${token}: reason"`)), token).toBe(true);
+    }
+  });
+
+  it("short-circuits an unrelated command", () => {
+    expect(prefilter.test(commandPayload("git log --oneline -5"))).toBe(false);
+  });
+});
+
+describe("pr-terminal pre-filter reaches every payload the detector acts on", () => {
+  const prefilter = payloadPrefilter("guardrail-pr-terminal.sh");
+  const reaching: Array<[string, string]> = [
+    ["a merge success line", outputPayload("✓ Merged pull request o/r#341 (feat: thing)")],
+    ["a squash-merge success line", outputPayload("✓ Squashed and merged pull request o/r#341 (feat: thing)")],
+    ["a close success line", outputPayload("✓ Closed pull request o/r#369 (stale)")],
+    ["a reopen success line", outputPayload("✓ Reopened pull request o/r#369 (gate fix)")],
+    ["the watch monitor's terminal exit line", JSON.stringify({ tool_name: "Monitor", tool_response: { stdout: "TERMINAL pr=331: MERGED" } })],
+  ];
+
+  it.each(reaching)("spawns Node for %s", (_label, payload) => {
+    expect(prefilter.test(payload)).toBe(true);
+  });
+
+  it("short-circuits an unrelated command", () => {
+    expect(prefilter.test(commandPayload("git status"))).toBe(false);
+  });
+});
+
+describe("report-format pre-filter reaches every command the gate can deny", () => {
+  const prefilter = payloadPrefilter("guardrail-report-format.sh");
+  const reaching: Array<[string, string]> = [
+    ["a new PR comment", commandPayload("gh pr comment 1 --body 'results'")],
+    ["a PR description at creation", commandPayload("gh pr create --title x --body y")],
+    ["a PR description edit", commandPayload("gh pr edit 1 --body y")],
+    [
+      "an edit to an existing comment",
+      commandPayload("gh api --method PATCH repos/o/r/issues/comments/12345 -f body=@report.md"),
+    ],
+  ];
+
+  it.each(reaching)("spawns Node for %s", (_label, payload) => {
+    expect(prefilter.test(payload)).toBe(true);
+  });
+
+  it("short-circuits an unrelated command", () => {
+    expect(prefilter.test(commandPayload("git status"))).toBe(false);
+  });
+});
+
+describe("pr-opened pre-filter reaches every command the detector acts on", () => {
+  const prefilter = payloadPrefilter("guardrail-pr-opened.sh");
+  const reaching: Array<[string, string]> = [
+    ["gh pr create", commandPayload("gh pr create --fill")],
+    ["gh pr ready", commandPayload("gh pr ready 12")],
+    ["glab mr create", commandPayload("glab mr create --fill")],
+    ["glab mr update --ready", commandPayload("glab mr update 5 --ready")],
+  ];
+
+  it.each(reaching)("spawns Node for %s", (_label, payload) => {
+    expect(prefilter.test(payload)).toBe(true);
+  });
+
+  it("short-circuits an unrelated command", () => {
+    expect(prefilter.test(commandPayload("ls -la"))).toBe(false);
+  });
+});
+
+describe("build-router pre-filter reaches every prompt detectBuildIntent accepts", () => {
+  const prefilter = payloadPrefilter("guardrail-build-router.sh");
+  const reaching: Array<[string, string]> = [
+    ["a build verb", JSON.stringify({ prompt: "implement a dark-mode toggle" })],
+    ["a wire-up ask", JSON.stringify({ prompt: "wire up the export button" })],
+    ["a conflict-resolution ask", JSON.stringify({ prompt: "resolve the merge conflicts on my branch" })],
+    ["a drive-the-PR-green ask", JSON.stringify({ prompt: "get PR 12 to green" })],
+  ];
+
+  it.each(reaching)("spawns Node for %s", (_label, payload) => {
+    expect(prefilter.test(payload)).toBe(true);
+  });
+
+  it("short-circuits a question", () => {
+    expect(prefilter.test(JSON.stringify({ prompt: "what time is it?" }))).toBe(false);
+  });
+});
+
+// The Stop gates pre-filter on the per-session state file instead of a payload,
+// which couples them to sessionState's exact serialization — key names, the
+// two-space indent, and the empty-array form. A renamed field or a changed
+// indent would silently retire the gate rather than break it.
+describe("state-file pre-filters match the state guardrails.mjs writes", () => {
+  const armedState = JSON.stringify(
+    {
+      sessionId: "s",
+      prsHandled: ["https://github.com/o/r/pull/1"],
+      unitTestsGreen: true,
+      e2eRun: true,
+      terminalPending: [7],
+      watchSkipped: true,
+      walkthroughPosted: true,
+      walkthroughSkipped: true,
+    },
+    null,
+    2,
+  );
+  const idleState = JSON.stringify({ sessionId: "s", prsHandled: [], terminalPending: [] }, null, 2);
+  const serializedStates = `${armedState}\n${idleState}`;
+
+  const wrapperScriptNames = readdirSync(SCRIPTS).filter(
+    (name) => name.startsWith("guardrail-") && name.endsWith(".sh"),
+  );
+
+  it.each(wrapperScriptNames)("%s greps only for shapes the state file can hold", (wrapperScriptName) => {
+    const wrapperBody = readFileSync(join(SCRIPTS, wrapperScriptName), "utf-8");
+    for (const [, statePattern] of wrapperBody.matchAll(/grep -q '([^']+)'/g)) {
+      const literal = statePattern.replaceAll("\\[", "[").replaceAll("\\]", "]");
+      expect(serializedStates, `${wrapperScriptName} greps for ${literal}`).toContain(literal);
+    }
+  });
+});


### PR DESCRIPTION
## The failure

Every guardrail hook short-circuits in shell before spawning Node, and that pre-filter is a second, looser copy of what `guardrails.mjs` matches. Where the copy fell short the payload never reached its recorder — so a gate kept demanding an action the caller had already taken, with no way to satisfy it.

Concretely: the watcher gate blocks the turn and prints

> tell the user why and run `echo "MUGGLE_WATCH_SKIP: <reason>"` — that records the skip and keeps this gate quiet for the rest of the session

`guardrail-record-tests.sh` is the only route to that recorder, and its pre-filter listed `MUGGLE_E2E_SKIP` and no other marker. The echo was dropped in shell, `watchSkipped` was never written, and the gate blocked twice more before hard-releasing. Following the instruction the gate itself printed could not work. Same for `MUGGLE_WALKTHROUGH_SKIP`.

## Everything the sweep found

Each `plugin/scripts/guardrail-*.sh` pre-filter was checked against the payloads its `guardrails.mjs` subcommand actually acts on. Four gaps, all the same class:

| Wrapper | Dropped payload | Consequence |
| :------ | :-------------- | :---------- |
| `guardrail-record-tests.sh` | `echo "MUGGLE_WATCH_SKIP: …"`, `echo "MUGGLE_WALKTHROUGH_SKIP: …"` | documented escape hatch is a no-op; gate blocks the caller who followed it |
| `guardrail-record-tests.sh` | `gh pr comment\|create\|edit` and `gh api … issues/comments/<id>` PATCH | `detectWalkthroughPost` is dead; a posted walkthrough registers only via the gate's own `gh` lookups at the next turn end, never from state |
| `guardrail-pr-terminal.sh` | `Reopened pull request …` | `detectPrReopened` is dead; a close+reopen (routine — re-fires a lost workflow trigger) leaves the post-merge handoff armed on a PR that is open again |
| `guardrail-report-format.sh` | `gh api … issues/comments/<id>` PATCH | the comment-edit arm exists precisely so a sanctioned walkthrough can't be overwritten with hand-written markdown afterwards; that bypass was open |

The state-file pre-filters (`e2e-gate`, `watch-gate`, `walkthrough-gate`, `terminal-gate`, `offer-ran`) and `pr-opened` / `build-router` were checked too and are correct; they are now covered by assertions so a renamed state field or changed indent can't silently retire a gate.

## The fix

The marker arm matches the `MUGGLE_<GATE>_SKIP` shape rather than one token, so a marker added to a future gate cannot silently become unreachable. The other three arms add the specific shapes their recorders need. Over-matching in the pre-filter costs at most a needless Node spawn — the real anchoring (`^\s*echo …`, tool-name matching) stays in `guardrails.mjs` — so the cheap-in-shell property is intact and the negative cases assert it.

No change to `guardrails.mjs`: the recorder already handled all three markers. The entire defect was the shell pre-filter in front of it. Rebuilding from `src/` produces a byte-identical artifact.

## Tests

TDD — red first, in this order:

- `src/test/guardrails/hook-prefilter.test.ts` (new, all platforms) — reachability, per wrapper. Started red on five: *spawns Node for every skip marker the guardrails define*, *…for a walkthrough posted as a PR comment*, *…for a walkthrough edited into an existing comment*, *pr-terminal … for a reopen success line*, *report-format … for an edit to an existing comment*. The marker set is derived by scanning `src/guardrails/` for the `MUGGLE_*_SKIP` shape rather than hand-listed, so a new marker is covered the moment it exists — hand-listing is how this bug happened.
- `src/test/guardrails/hook-execution.test.ts` — the bash-only wrapper block gains the three markers, the walkthrough post, the reopen line and the `gh api` comment edit, run through real `bash` + real `grep` with `node` stubbed. These confirm the regex translation the cross-platform file relies on; they are skipped on win32 and were verified locally against Git Bash by hand.

Full suite green — 1094 total, zero failures, no new skips. `tsc --noEmit` clean, `eslint` clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjcrkrFW1J7XeM9gFco4sp
