### PR TITLE
fix(skill-eval): give the routing eval a cwd where change-driven queries have a referent

### DIFF
--- a/.github/workflows/skill-eval.yml
+++ b/.github/workflows/skill-eval.yml
@@ -517,6 +517,53 @@ jobs:
           claude plugin list | grep -Fq "muggleai@muggle-works" \
             || { echo "muggle plugin failed to install/enable" >&2; exit 1; }
 
+      # The eval cwd used to be an empty dir, which made every change-driven
+      # query ("test my changes", "validate what I've been working on") a
+      # trick question: the model inspects, finds no repo and no diff, and
+      # correctly answers that there is nothing to test — scoring `none` no
+      # matter how the skill is described. Seed a small web app with real
+      # uncommitted changes so those queries have a referent. It stays isolated
+      # from this repo, so the plugin is still the only skill source.
+      - name: Seed the eval cwd with a changed web app
+        if: steps.scope.outputs.should_run == 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p "$CLEAN_CWD/src"
+          cd "$CLEAN_CWD"
+          git init -q
+          git config user.email eval@example.com
+          git config user.name "routing eval"
+          cat > package.json <<'JSON'
+          { "name": "shop", "version": "1.0.0", "scripts": { "dev": "vite" } }
+          JSON
+          cat > index.html <<'HTML'
+          <!doctype html><title>Shop</title><div id="app"></div>
+          <form id="login"><input name="email"><input name="password" type="password"><button>Sign in</button></form>
+          HTML
+          cat > src/checkout.js <<'JS'
+          export function total(items) { return items.reduce((n, i) => n + i.price, 0); }
+          JS
+          cat > src/login.js <<'JS'
+          export function submit(form) { return fetch("/api/login", { method: "POST", body: new FormData(form) }); }
+          JS
+          git add -A
+          git commit -qm "shop: checkout and login"
+          # Uncommitted work — this is what "my changes" refers to.
+          cat > src/checkout.js <<'JS'
+          export function total(items, coupon) {
+            const sum = items.reduce((n, i) => n + i.price, 0);
+            return coupon ? sum * (1 - coupon.rate) : sum;
+          }
+          JS
+          cat > src/login.js <<'JS'
+          export function submit(form) {
+            const body = new FormData(form);
+            return fetch("/api/login", { method: "POST", body, credentials: "include" });
+          }
+          JS
+          git status --short
+
+
       - name: Preflight — confirm the plugin actually routes
         id: preflight
         if: steps.scope.outputs.should_run == 'true'


### PR DESCRIPTION
Follow-up to #377 item 2.

## Problem

The routing eval runs in an empty `CLEAN_CWD`. Roughly half the `muggle-test` positives are change-driven — *"validate my changes before I open the PR"*, *"test the changes I made on that preview URL"*, *"validate everything I've been working on this sprint"*. In an empty directory those are trick questions: the model inspects, finds no repo and no diff, and correctly answers that there is nothing to test.

Traced under CI-identical conditions (isolated `CLAUDE_CONFIG_DIR` + credentials, empty cwd):

```
T1 [text] "I'll start by looking at what's actually in the working directory and what changes exist to test."
T2 [TOOL] Bash {"command":"pwd && ls -la"}
T3 [TOOL] Bash {"command":"git status …"}
T5 [text] "The working directory isn't a git repo and has no code…"
```

First `tool_use` is `Bash`, so the query scores `none` — regardless of how the skill is described.

## Evidence this is the dominant factor

Same description, same harness, only the cwd changed:

| cwd | accuracy |
| :-- | :-- |
| empty (today) | 6/26 = 23.1% |
| seeded with a changed web app | **15/26 = 57.7%** |

For contrast, wording changes moved almost nothing on the same 6 hard queries: three variants scored at or below baseline, including one using near-verbatim copies of the failing queries.

## Change

Seed `CLEAN_CWD` with a minimal web app (checkout + login) plus two uncommitted edits, so "my changes" refers to something. It's still a throwaway dir isolated from this repo, so the plugin remains the only skill source and the original reason for `CLEAN_CWD` is preserved.

## Note on the threshold

`--fail-under 100%` has not been met since 2026-08-02 — the broken preflight masked every run. On today's harness `master`'s own description scores 3/26. Once this lands, `--fail-under` should be re-baselined against `master` so the bar reflects the harness as it now behaves; that's tracked in #377.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EzkKPGtBY821LqJ62BtVz