### PR TITLE
fix(routing-eval): name the query on every live progress line

### DIFF
--- a/internal/skill-routing-eval/analyze.py
+++ b/internal/skill-routing-eval/analyze.py
@@ -16,18 +16,7 @@ import json
 from collections import Counter, defaultdict
 from pathlib import Path
 
-NONE = "none"
-
-
-def is_muggle(route: str) -> bool:
-    return route.startswith("muggle")
-
-
-def scored_pass(expected: str, majority: str) -> bool:
-    """Negative class passes iff no muggle skill fired; positives need an exact match."""
-    if expected == NONE:
-        return not is_muggle(majority)
-    return majority == expected
+from scoring import NONE, is_muggle, scored_pass
 
 
 def load(path):

--- a/internal/skill-routing-eval/router_eval.py
+++ b/internal/skill-routing-eval/router_eval.py
@@ -23,11 +23,29 @@ from pathlib import Path
 from threading import Lock
 
 import throttle
-
-NONE = "none"
+from scoring import NONE, scored_pass
 
 # Shared across the worker pool: one rate-limited run pauses new starts for all.
 THROTTLE_GATE = throttle.ThrottleGate()
+
+PROGRESS_QUERY_CHARS = 140
+
+
+def format_run_progress(done: int, total: int, query: str, route: str, expected: str) -> str:
+    """One live progress line, naming the query that produced `route`.
+
+    Runs complete out of order across the worker pool, so each line has to carry
+    its own query — a bare route belongs to whichever of N parallel sessions
+    happened to finish. The marker scores this single run against the query's
+    label; reported accuracy still scores the majority route across its runs.
+
+    Output shape: `  12/78 MISS route=none :: test my changes before I open the PR`
+    """
+    marker = "ok  " if scored_pass(expected, route) else "MISS"
+    shown = " ".join(query.split())
+    if len(shown) > PROGRESS_QUERY_CHARS:
+        shown = shown[: PROGRESS_QUERY_CHARS - 3] + "..."
+    return f"  {done}/{total} {marker} route={route} :: {shown}"
 
 
 def normalize_skill(raw: str) -> str:
@@ -248,9 +266,14 @@ def main():
         for fut in as_completed(futs):
             i, route = fut.result()
             results[i] = route
+            qi, query = jobs[i]
+            expected = eval_set[qi].get("expected_skill", NONE)
             with lock:
                 done += 1
-                print(f"  {done}/{len(jobs)} runs done (last route={route})", file=sys.stderr, flush=True)
+                print(
+                    format_run_progress(done, len(jobs), query, route, expected),
+                    file=sys.stderr, flush=True,
+                )
 
     fired: dict[int, list[str]] = {}
     for i, route in enumerate(results):
@@ -264,13 +287,7 @@ def main():
         counts = Counter(runs)
         majority = counts.most_common(1)[0][0] if counts else NONE
         expected = item.get("expected_skill", NONE)
-        if expected == NONE:
-            # Negative class: pass iff NO muggle skill fired. An appropriate
-            # non-muggle skill (systematic-debugging, review, brainstorming...)
-            # winning is correct — it means no muggle skill over-triggered.
-            ok = not majority.startswith("muggle")
-        else:
-            ok = (majority == expected)
+        ok = scored_pass(expected, majority)
         passed += int(ok)
         out.append({
             "query": item["query"],

--- a/internal/skill-routing-eval/run.py
+++ b/internal/skill-routing-eval/run.py
@@ -27,12 +27,13 @@ import subprocess
 import sys
 from pathlib import Path
 
+from scoring import NONE, scored_pass
+
 HERE = Path(__file__).resolve().parent
 REPO_ROOT = HERE.parents[1]  # internal/skill-routing-eval -> repo root
 EVAL_SET = HERE / "eval-set.json"
 ROUTER = HERE / "router_eval.py"
 ANALYZE = HERE / "analyze.py"
-NONE = "none"
 
 
 def find_plugin_cache() -> Path | None:
@@ -174,9 +175,6 @@ def main():
     md_path = out_dir / "combined.md"
     subprocess.run([sys.executable, str(ANALYZE), "report", "--in", str(combined_path), "--out", str(md_path)], check=True)
 
-    def ok(r):
-        # mirror analyze.py's rule: negatives pass when no muggle skill fires
-        return (not r["majority"].startswith("muggle")) if r["expected_skill"] == NONE else (r["majority"] == r["expected_skill"])
     # Suspected-disconnect chunks are inconclusive, not failures. A persistent
     # all-`none` chunk is an MCP-disconnect artifact (the preflight already proved
     # routing works, and genuine description regressions surface as partial recall,
@@ -185,7 +183,7 @@ def main():
     flagged_set = set(flagged)
     verified = [r for r in all_results if r["expected_skill"] not in flagged_set]
     total = len(verified)
-    passed = sum(1 for r in verified if ok(r))
+    passed = sum(1 for r in verified if scored_pass(r["expected_skill"], r["majority"]))
     accuracy = passed / total if total else 0.0
     print(f"\nDone. verified {passed}/{total} = {accuracy:.1%}", file=sys.stderr)
     if flagged:

--- a/internal/skill-routing-eval/scoring.py
+++ b/internal/skill-routing-eval/scoring.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Pass/fail rule shared by the router harness, the chunked runner, and the analyzer.
+
+One definition, so the live progress log, the CI gate, and the posted report can
+never disagree about what counts as a pass.
+"""
+
+NONE = "none"
+
+
+def is_muggle(route: str) -> bool:
+    """True when `route` names a muggle skill — what the negative class must avoid."""
+    return route.startswith("muggle")
+
+
+def scored_pass(expected: str, fired: str) -> bool:
+    """Negative class passes iff no muggle skill fired; positives need an exact match.
+
+    `fired` is a query's majority route when scoring the eval, or a single run's
+    route when labelling live progress.
+    """
+    if expected == NONE:
+        return not is_muggle(fired)
+    return fired == expected

--- a/internal/skill-routing-eval/test_router_eval.py
+++ b/internal/skill-routing-eval/test_router_eval.py
@@ -43,5 +43,43 @@ class TestStreamErrorText(unittest.TestCase):
         self.assertEqual(router_eval.stream_error_text(out), "")
 
 
+class TestFormatRunProgress(unittest.TestCase):
+    def test_line_carries_the_query(self):
+        line = router_eval.format_run_progress(12, 78, "test before I merge", "muggle-test", "muggle-test")
+        self.assertIn("test before I merge", line)
+        self.assertIn("12/78", line)
+
+    def test_matching_route_is_marked_ok(self):
+        line = router_eval.format_run_progress(1, 3, "q", "muggle-test", "muggle-test")
+        self.assertIn("ok", line)
+        self.assertNotIn("MISS", line)
+
+    def test_wrong_route_is_marked_miss(self):
+        line = router_eval.format_run_progress(1, 3, "q", "none", "muggle-test")
+        self.assertIn("MISS", line)
+
+    def test_negative_query_passes_on_a_non_muggle_route(self):
+        line = router_eval.format_run_progress(1, 3, "q", "systematic-debugging", router_eval.NONE)
+        self.assertIn("ok", line)
+
+    def test_negative_query_misses_when_a_muggle_skill_fires(self):
+        line = router_eval.format_run_progress(1, 3, "q", "muggle-test", router_eval.NONE)
+        self.assertIn("MISS", line)
+
+    def test_long_query_is_truncated_to_one_line(self):
+        line = router_eval.format_run_progress(1, 3, "x" * 400, "none", "none")
+        self.assertLessEqual(len(line), 200)
+        self.assertTrue(line.endswith("..."))
+
+    def test_whitespace_is_collapsed_so_one_run_is_one_line(self):
+        line = router_eval.format_run_progress(1, 3, "a\n  b\tc", "none", "none")
+        self.assertIn("a b c", line)
+        self.assertNotIn("\n", line)
+
+    def test_line_is_ascii_so_windows_consoles_can_encode_it(self):
+        line = router_eval.format_run_progress(1, 3, "q", "none", "none")
+        line.encode("ascii")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/internal/skill-routing-eval/test_scoring.py
+++ b/internal/skill-routing-eval/test_scoring.py
@@ -1,0 +1,35 @@
+import unittest
+
+import scoring
+
+
+class TestScoredPass(unittest.TestCase):
+    def test_positive_query_needs_an_exact_match(self):
+        self.assertTrue(scoring.scored_pass("muggle-test", "muggle-test"))
+        self.assertFalse(scoring.scored_pass("muggle-test", "muggle-test-feature-local"))
+
+    def test_positive_query_fails_when_nothing_routed(self):
+        self.assertFalse(scoring.scored_pass("muggle-test", scoring.NONE))
+
+    def test_negative_query_passes_when_no_muggle_skill_fires(self):
+        self.assertTrue(scoring.scored_pass(scoring.NONE, scoring.NONE))
+        self.assertTrue(scoring.scored_pass(scoring.NONE, "brainstorming"))
+
+    def test_negative_query_fails_when_a_muggle_skill_fires(self):
+        self.assertFalse(scoring.scored_pass(scoring.NONE, "muggle-do"))
+
+    def test_infra_statuses_never_pass_a_positive_query(self):
+        for status in ("TIMEOUT", "ERROR", "THROTTLED"):
+            self.assertFalse(scoring.scored_pass("muggle-test", status))
+
+
+class TestIsMuggle(unittest.TestCase):
+    def test_muggle_routes_are_detected(self):
+        self.assertTrue(scoring.is_muggle("muggle-status"))
+
+    def test_other_skills_are_not_muggle(self):
+        self.assertFalse(scoring.is_muggle("systematic-debugging"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The routing eval's live log was unreadable:

```
== muggle-test (26 queries) ==
  1/78 runs done (last route=muggle-test)
  2/78 runs done (last route=muggle-test)
```

Each query runs `--runs` times across a `--workers`-wide pool, and `as_completed` yields futures in **completion order**. `last route=` therefore reported whichever of six parallel sessions happened to finish — attributable to no particular query. Watching a run told you nothing about which query was misrouting.

## Change

Every line now carries the query that produced the route, plus an `ok`/`MISS` marker for that run:

```
  1/78 MISS route=muggle-test-feature-local :: test my changes before I open the PR
  2/78 ok   route=muggle-test :: run e2e before merging
  5/78 ok   route=systematic-debugging :: why is this test flaky
```

- `MISS` is greppable, so a failing chunk can be read straight off the log.
- Negative-class queries score by the real rule — a non-muggle route is `ok` (line 5 above).
- The marker is per-run; reported accuracy still scores the **majority** route across a query's runs, so a 2-of-3 query can show one `MISS` and still pass.
- ASCII only and whitespace-collapsed: one run stays one line, and the Windows console can encode it.
- Queries truncate at 140 chars (eval-set median is 86, p90 156).

## Deduplication

The pass rule (`expected == none` passes iff no muggle skill fired) was written out separately in `router_eval.main`, `run.ok`, and `analyze.scored_pass`. The progress marker needed it too, so rather than add a fourth copy it moves to `scoring.py` — the same shape as the existing `throttle.py` — and the three call sites now share it. No behavior change: accuracy on a fixture is identical before and after.

## Verification

- `python -m unittest discover -s internal/skill-routing-eval -p "test_*.py"` — 34/34 OK (was 20; +14 covering the formatter and the shared rule).
- End-to-end wiring exercised with stubbed routing, confirming each line pairs the correct route with the correct query and that overall accuracy is unchanged.
- All three CI invocation paths re-checked for the new import: `router_eval.py --probe` from repo root, `run.py` from repo root, and `analyze.py` as `run.py` subprocesses it.
- `router_eval.py` is committed with mixed line endings (lines 73-118 are LF, the rest CRLF); the untouched lines keep their original endings, holding the diff to 37 lines instead of 129.

No skill frontmatter changed, so the routing eval itself is correctly out of scope for this PR.