### PR TITLE
ci(evals): fall back to a spare subscription token when the primary fails

### DIFF
--- a/.github/actions/resolve-claude-token/action.yml
+++ b/.github/actions/resolve-claude-token/action.yml
@@ -1,0 +1,85 @@
+name: Resolve Claude subscription token
+description: >-
+  Probe the primary subscription token and fall back to the secondary when it is
+  rejected, exporting the one that authenticated as CLAUDE_CODE_OAUTH_TOKEN for
+  every later step in the job.
+
+inputs:
+  primary-token:
+    description: Preferred subscription token, from the CLAUDE_CODE_OAUTH_TOKEN secret.
+    required: true
+  fallback-token:
+    description: >-
+      Token used when the primary is rejected, from the CLAUDE_CODE_OAUTH_TOKEN_2
+      secret. Leave unset to run single-token — resolution then behaves exactly
+      like the primary-only preflight it replaces.
+    required: false
+    default: ""
+
+outputs:
+  slot:
+    description: "Which token authenticated: `primary` or `fallback`."
+    value: ${{ steps.probe.outputs.slot }}
+
+runs:
+  using: composite
+  steps:
+    - id: probe
+      shell: bash
+      env:
+        PRIMARY_TOKEN: ${{ inputs.primary-token }}
+        FALLBACK_TOKEN: ${{ inputs.fallback-token }}
+      run: |
+        set -uo pipefail
+        : "${CLAUDE_CONFIG_DIR:?the calling job must set CLAUDE_CONFIG_DIR to a writable path}"
+        mkdir -p "$CLAUDE_CONFIG_DIR"
+        # A pay-per-use key outranks the subscription token, so leaving one set
+        # would bill the API and make the probe pass on the wrong credential.
+        unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN
+
+        # Any non-zero exit counts as unusable, not just a rejected token:
+        # a throttled primary should hand off to the fallback the same way an
+        # expired one does, and both are indistinguishable from this side.
+        probe_token() {
+          CLAUDE_CODE_OAUTH_TOKEN="$1" claude -p 'Respond with exactly: OK' --max-turns 1 2>&1
+        }
+
+        select_token() {
+          echo "slot=$1" >> "$GITHUB_OUTPUT"
+          echo "CLAUDE_CODE_OAUTH_TOKEN=$2" >> "$GITHUB_ENV"
+        }
+
+        if [ -z "$PRIMARY_TOKEN" ]; then
+          echo "::error::No CLAUDE_CODE_OAUTH_TOKEN repo secret is set. Generate one with \`claude setup-token\` and add it before running skill evals." >&2
+          exit 1
+        fi
+
+        if primary_output="$(probe_token "$PRIMARY_TOKEN")"; then
+          echo "auth ok on the primary token"
+          select_token primary "$PRIMARY_TOKEN"
+          exit 0
+        fi
+
+        if [ -z "$FALLBACK_TOKEN" ]; then
+          echo "::error::Subscription auth failed — CLAUDE_CODE_OAUTH_TOKEN is rejected and no CLAUDE_CODE_OAUTH_TOKEN_2 is configured. Regenerate with \`claude setup-token\` and re-set the secret (no trailing newline)." >&2
+          echo "claude output:" >&2
+          echo "$primary_output" >&2
+          exit 1
+        fi
+
+        if fallback_output="$(probe_token "$FALLBACK_TOKEN")"; then
+          # Surfaced loudly rather than silently absorbed: the run is healthy,
+          # but the primary needs regenerating before the fallback expires too.
+          echo "::warning title=Primary Claude token rejected::Fell back to CLAUDE_CODE_OAUTH_TOKEN_2. This run is unaffected, but regenerate CLAUDE_CODE_OAUTH_TOKEN with \`claude setup-token\` — the next expiry leaves no spare."
+          echo "primary token output:"
+          echo "$primary_output"
+          select_token fallback "$FALLBACK_TOKEN"
+          exit 0
+        fi
+
+        echo "::error::Subscription auth failed on both tokens. Regenerate each with \`claude setup-token\` and re-set the secrets (no trailing newline)." >&2
+        echo "primary token output:" >&2
+        echo "$primary_output" >&2
+        echo "fallback token output:" >&2
+        echo "$fallback_output" >&2
+        exit 1

--- a/.github/workflows/skill-eval.yml
+++ b/.github/workflows/skill-eval.yml
@@ -59,9 +59,6 @@ jobs:
     # Budget kept generous — throttling can serialize a run back down.
     timeout-minutes: 180
     env:
-      # Subscription auth, not a pay-per-use API key. Generate with
-      # `claude setup-token` and store as the CLAUDE_CODE_OAUTH_TOKEN secret.
-      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       GATE_RUNS: ${{ inputs.gate_runs || '10' }}
       GATE_CONCURRENCY: ${{ inputs.gate_concurrency || '4' }}
       MUGGLE_BRAIN_DIR: ${{ github.workspace }}/muggle-ai-brain
@@ -73,6 +70,7 @@ jobs:
       # cryptic git-auth error deep in the scenario-repo checkout.
       - name: Require secrets
         env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           BRAIN_REPO_TOKEN: ${{ secrets.BRAIN_REPO_TOKEN }}
         run: |
           : "${CLAUDE_CODE_OAUTH_TOKEN:?set the CLAUDE_CODE_OAUTH_TOKEN repo secret (run \`claude setup-token\`) to run skill evals}"
@@ -178,25 +176,17 @@ jobs:
         if: steps.scope.outputs.should_run == 'true'
         run: npm install -g @anthropic-ai/claude-code
 
-      # Prove the subscription token authenticates before the agent-SDK harness
+      # Prove a subscription token authenticates before the agent-SDK harness
       # runs, via the same `claude -p` path skill-routing-eval relies on. A
-      # rejected CLAUDE_CODE_OAUTH_TOKEN and an SDK/harness fault otherwise both
-      # surface only as the SDK's opaque "process exited with code 1"; this
-      # separates them and fails fast with an actionable message.
-      - name: Preflight — confirm subscription auth
+      # rejected token and an SDK/harness fault otherwise both surface only as
+      # the SDK's opaque "process exited with code 1"; resolving here separates
+      # them, and hands off to the spare token when the primary is unusable.
+      - name: Resolve subscription auth
         if: steps.scope.outputs.should_run == 'true'
-        run: |
-          set -euo pipefail
-          unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN
-          mkdir -p "$CLAUDE_CONFIG_DIR"
-          if out="$(claude -p 'Respond with exactly: OK' --max-turns 1 2>&1)"; then
-            echo "auth preflight ok"
-          else
-            echo "::error::Subscription auth preflight failed — CLAUDE_CODE_OAUTH_TOKEN is rejected. Regenerate with \`claude setup-token\` and re-set the secret (no trailing newline)." >&2
-            echo "claude output:" >&2
-            echo "$out" >&2
-            exit 1
-          fi
+        uses: ./.github/actions/resolve-claude-token
+        with:
+          primary-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          fallback-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_2 }}
 
       - name: Run skill-gate evals (every gate in the scenario repo)
         if: steps.scope.outputs.should_run == 'true'
@@ -278,12 +268,13 @@ jobs:
     # checkout) and small: 2 agents × 3 scenarios × AGENT_RUNS reps.
     timeout-minutes: 90
     env:
-      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       AGENT_RUNS: ${{ inputs.agent_runs || '5' }}
       AGENT_CONCURRENCY: ${{ inputs.agent_concurrency || '4' }}
       CLAUDE_CONFIG_DIR: ${{ github.workspace }}/.cc-config
     steps:
       - name: Require secrets
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: |
           : "${CLAUDE_CODE_OAUTH_TOKEN:?set the CLAUDE_CODE_OAUTH_TOKEN repo secret (run \`claude setup-token\`) to run skill evals}"
 
@@ -337,20 +328,12 @@ jobs:
         if: steps.scope.outputs.should_run == 'true'
         run: npm install -g @anthropic-ai/claude-code
 
-      - name: Preflight — confirm subscription auth
+      - name: Resolve subscription auth
         if: steps.scope.outputs.should_run == 'true'
-        run: |
-          set -euo pipefail
-          unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN
-          mkdir -p "$CLAUDE_CONFIG_DIR"
-          if out="$(claude -p 'Respond with exactly: OK' --max-turns 1 2>&1)"; then
-            echo "auth preflight ok"
-          else
-            echo "::error::Subscription auth preflight failed — CLAUDE_CODE_OAUTH_TOKEN is rejected. Regenerate with \`claude setup-token\` and re-set the secret (no trailing newline)." >&2
-            echo "claude output:" >&2
-            echo "$out" >&2
-            exit 1
-          fi
+        uses: ./.github/actions/resolve-claude-token
+        with:
+          primary-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          fallback-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_2 }}
 
       - name: Run agent-gate evals (every scenario file)
         if: steps.scope.outputs.should_run == 'true'
@@ -423,8 +406,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 180
     env:
-      # Subscription auth, not a pay-per-use API key (see skill-gate-eval above).
-      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       ROUTING_RUNS: ${{ inputs.routing_runs || '3' }}
       # A scoped run measures one chunk, so it can afford a wider majority
       # vote than the 391-query sweep: this is what damps the per-query flips
@@ -510,6 +491,15 @@ jobs:
       - name: Install Claude Code CLI
         if: steps.scope.outputs.should_run == 'true'
         run: npm install -g @anthropic-ai/claude-code
+
+      # Resolved ahead of the plugin install so every `claude` call in this job,
+      # marketplace and probe alike, runs on the token that actually works.
+      - name: Resolve subscription auth
+        if: steps.scope.outputs.should_run == 'true'
+        uses: ./.github/actions/resolve-claude-token
+        with:
+          primary-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          fallback-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_2 }}
 
       # Install the plugin from THIS checkout (not GitHub master) so the eval
       # tests the PR's skill descriptions. Fresh CLAUDE_CONFIG_DIR + a clean cwd

--- a/internal/skill-gate-eval/README.md
+++ b/internal/skill-gate-eval/README.md
@@ -80,8 +80,9 @@ It checks out `muggle-ai-brain` for the scenarios, so
 CI needs two repo secrets: `CLAUDE_CODE_OAUTH_TOKEN` (subscription auth, from
 `claude setup-token`) and `BRAIN_REPO_TOKEN` (read access to the scenario repo).
 
-`CLAUDE_CODE_OAUTH_TOKEN_2` is an optional third secret holding a spare
-subscription token. Every eval job probes the primary before it starts work and
+`CLAUDE_CODE_OAUTH_TOKEN_2` is an optional secret holding a **second
+subscription token**, spare to the one above — `BRAIN_REPO_TOKEN` is repo-read
+auth and unrelated. Every eval job probes the primary before it starts work and
 switches to the spare for that run when the primary is rejected or throttled,
 so one expired token no longer red-lines the suite. The fallback raises a
 workflow warning rather than passing silently — the primary still needs

--- a/internal/skill-gate-eval/README.md
+++ b/internal/skill-gate-eval/README.md
@@ -79,3 +79,11 @@ for de-risking a refactor that changes how skills run, not their definitions.
 It checks out `muggle-ai-brain` for the scenarios, so
 CI needs two repo secrets: `CLAUDE_CODE_OAUTH_TOKEN` (subscription auth, from
 `claude setup-token`) and `BRAIN_REPO_TOKEN` (read access to the scenario repo).
+
+`CLAUDE_CODE_OAUTH_TOKEN_2` is an optional third secret holding a spare
+subscription token. Every eval job probes the primary before it starts work and
+switches to the spare for that run when the primary is rejected or throttled,
+so one expired token no longer red-lines the suite. The fallback raises a
+workflow warning rather than passing silently — the primary still needs
+regenerating, and nothing rotates back on its own. Leave the secret unset to
+run single-token.

--- a/internal/skill-routing-eval/README.md
+++ b/internal/skill-routing-eval/README.md
@@ -53,7 +53,7 @@ refactor that touches no `SKILL.md`).
 - `--record-baseline PATH` — write this run's per-skill tallies for a human to promote. Full sweeps only; a scoped run would drop every skill it did not measure.
 - `router_eval.py --probe "<query>"` — route one query and print the result; CI uses it to fail fast when the plugin didn't load.
 
-CI installs the plugin from the PR checkout (`claude plugin marketplace add "$GITHUB_WORKSPACE"`), so it tests the PR's descriptions rather than master — no `--sync-cache` needed. Requires the `CLAUDE_CODE_OAUTH_TOKEN` repo secret (subscription auth from `claude setup-token`, not a pay-per-use API key).
+CI installs the plugin from the PR checkout (`claude plugin marketplace add "$GITHUB_WORKSPACE"`), so it tests the PR's descriptions rather than master — no `--sync-cache` needed. Requires the `CLAUDE_CODE_OAUTH_TOKEN` repo secret (subscription auth from `claude setup-token`, not a pay-per-use API key). Set the optional `CLAUDE_CODE_OAUTH_TOKEN_2` secret to a spare token and the job falls back to it for that run when the primary is rejected or throttled, with a workflow warning.
 
 ## Regression gate
 


### PR DESCRIPTION
## Problem

All three `skill-eval` jobs authenticated from a single `CLAUDE_CODE_OAUTH_TOKEN`. When that token expired or got throttled, every job's auth preflight failed and the whole suite went red until someone regenerated the secret by hand — with `skill-gate-eval` and `skill-routing-eval` each burning up to their 180-minute budget's worth of setup first.

## Change

Resolve the token instead of asserting it. A shared composite action, `.github/actions/resolve-claude-token`, probes the primary with `claude -p`; on any non-zero exit it retries with the optional `CLAUDE_CODE_OAUTH_TOKEN_2` secret and exports whichever one authenticated as `CLAUDE_CODE_OAUTH_TOKEN` for the rest of the job.

Defined once and called from all three jobs, replacing the two duplicated preflight blocks.

### Design notes

- **Any probe failure triggers the handoff, not just rejection.** A throttled primary and an expired one are indistinguishable from the caller's side, and both are reasons to use the spare.
- **Falling back warns, it does not pass quietly.** A `::warning::` annotation names the dead primary — the run survives, but the token still needs regenerating before the spare expires too.
- **Resolution is per-run and stateless.** Nothing is written back to the repo secrets, so a repaired primary is picked up again on the next run with no manual flip. Persistently repointing "token 2 is now active" would need a PAT with `Variables: write` (the existing `BRAIN_REPO_TOKEN` is scoped to the brain repo) and would strand the suite on the spare after the primary was fixed.
- **The routing job resolves before the plugin install**, so its `claude plugin marketplace add` / `install` calls run on the same credential as the eval itself.

## Setup required

Add a `CLAUDE_CODE_OAUTH_TOKEN_2` repo secret holding a second token from `claude setup-token` (no trailing newline). Until it is set, the action behaves exactly like the primary-only preflight it replaces, so this is safe to merge before the secret exists.

A spare from a *different* Claude account also raises the ceiling on concurrent eval capacity; a spare from the same account shares one quota and only buys resilience against expiry and revocation.

## Verification

The action's shipped `run:` body was extracted from the YAML and exercised against a stubbed `claude` across six cases — healthy primary, dead primary with a working spare, dead primary with no spare configured, both dead, unset primary, and single-token operation. All six behave as intended: the right slot wins, the token is exported, the warning fires only on handoff, and both no-usable-token cases exit non-zero.

That testing caught one real defect, now fixed: the unset-primary path exited `127` through a `${VAR:?}` guard and emitted a bare shell message with no GitHub annotation, unlike every other failure path in the action.

Both YAML files parse. Line endings are preserved — `core.autocrlf` is `false` and `skill-eval.yml` is CRLF in the repo, so the commit was written from raw bytes rather than normalized text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017kGwCqxeyTggaUNbLJeDXn
