### PR TITLE
fix(routing-eval): let an actual route outrank a coarse muggle tool signal

### DIFF
--- a/internal/skill-routing-eval/router_eval.py
+++ b/internal/skill-routing-eval/router_eval.py
@@ -67,15 +67,8 @@ def _route_from_path(path: str) -> str:
     return normalize_skill(m.group(1)) if m else ""
 
 
-def parse_route_from_session(out: str) -> str:
-    """First route reached anywhere in the session, or NONE if it never routed.
-
-    A realistic query makes the model orient (`git status`, `ls`) before it
-    routes, so a scan that stops at the first tool_use scores a healthy session
-    as a miss.
-
-    Output shape: `"muggle-test"`
-    """
+def _iter_tool_calls(out: str):
+    """Yields `(tool_name, tool_input)` for every tool_use block, in stream order."""
     for line in out.splitlines():
         line = line.strip()
         if not line:
@@ -89,27 +82,49 @@ def parse_route_from_session(out: str) -> str:
         for content_block in event.get("message", {}).get("content", []):
             if content_block.get("type") != "tool_use":
                 continue
-            tool_name = content_block.get("name", "")
-            tool_input = content_block.get("input") or {}
-            if tool_name == "Skill":
-                skill = normalize_skill(tool_input.get("skill", ""))
-                if skill:
-                    return skill
-            if tool_name == "Read":
-                skill = _route_from_path(tool_input.get("file_path", ""))
-                if skill:
-                    return skill
-            # Muggle ships its MCP tools deferred, so a healthy session often
-            # loads them via ToolSearch before invoking anything else. Reaching
-            # for a muggle tool proves the plugin is loaded and routable just as
-            # a Skill call does. Both spellings start with "muggle", so they miss
-            # a positive query expecting a named skill and correctly fail the
-            # negative class, which passes only when nothing muggle fires.
-            if tool_name.startswith("mcp__") and "muggle" in tool_name:
-                return "muggle-mcp-tool"
-            if tool_name == "ToolSearch" and "muggle" in str(tool_input).lower():
-                return "muggle-tools"
-    return NONE
+            yield content_block.get("name", ""), content_block.get("input") or {}
+
+
+def _route_from_tool_call(tool_name: str, tool_input: dict) -> str:
+    """Skill named by an invocation or by a SKILL.md read, or "" when the call is not a route."""
+    if tool_name == "Skill":
+        return normalize_skill(tool_input.get("skill", ""))
+    if tool_name == "Read":
+        return _route_from_path(tool_input.get("file_path", ""))
+    return ""
+
+
+def _muggle_tool_signal(tool_name: str, tool_input: dict) -> str:
+    """`"muggle-mcp-tool"` or `"muggle-tools"` when the call reaches for muggle tooling, else ""."""
+    if tool_name.startswith("mcp__") and "muggle" in tool_name:
+        return "muggle-mcp-tool"
+    if tool_name == "ToolSearch" and "muggle" in str(tool_input).lower():
+        return "muggle-tools"
+    return ""
+
+
+def parse_route_from_session(out: str) -> str:
+    """First route reached anywhere in the session, or NONE if it never routed.
+
+    A realistic query makes the model orient (`git status`, `ls`) before it
+    routes, so a scan that stops at the first tool_use scores a healthy session
+    as a miss. Muggle ships its MCP tools deferred, so a healthy session often
+    loads them via ToolSearch before invoking anything else; that proves the
+    plugin is loaded but not which skill won, so it only stands in when the whole
+    session invoked no skill. Both of its spellings start with "muggle", so they
+    miss a positive query expecting a named skill and correctly fail the negative
+    class, which passes only when nothing muggle fires.
+
+    Output shape: `"muggle-test"`
+    """
+    muggle_tool_signal = ""
+    for tool_name, tool_input in _iter_tool_calls(out):
+        route = _route_from_tool_call(tool_name, tool_input)
+        if route:
+            return route
+        if not muggle_tool_signal:
+            muggle_tool_signal = _muggle_tool_signal(tool_name, tool_input)
+    return muggle_tool_signal or NONE
 
 
 def stream_error_text(out: str) -> str:

--- a/internal/skill-routing-eval/test_router_eval.py
+++ b/internal/skill-routing-eval/test_router_eval.py
@@ -97,6 +97,82 @@ class TestParseRouteFromSession(unittest.TestCase):
         self.assertEqual(router_eval.parse_route_from_session(out), router_eval.NONE)
 
 
+class TestRealRouteOutranksToolSignal(unittest.TestCase):
+    def test_muggle_toolsearch_before_the_skill_scores_the_skill(self):
+        out = session(
+            assistant_event("ToolSearch", {"query": "select:muggle-remote-project-list"}),
+            assistant_event("Skill", {"skill": "muggle:muggle-test"}),
+        )
+        self.assertEqual(router_eval.parse_route_from_session(out), "muggle-test")
+
+    def test_muggle_mcp_tool_before_the_skill_scores_the_skill(self):
+        out = session(
+            assistant_event("mcp__plugin_muggle_muggle__muggle-remote-project-list", {}),
+            assistant_event("Skill", {"skill": "muggle-do"}),
+        )
+        self.assertEqual(router_eval.parse_route_from_session(out), "muggle-do")
+
+    def test_muggle_toolsearch_before_a_skill_md_read_scores_the_skill(self):
+        out = session(
+            assistant_event("ToolSearch", {"query": "select:muggle-remote-project-list"}),
+            assistant_event("Read", {"file_path": "C:\repo\plugin\skills\muggle-status\SKILL.md"}),
+        )
+        self.assertEqual(router_eval.parse_route_from_session(out), "muggle-status")
+
+    def test_tool_signal_and_skill_in_one_turn_score_the_skill(self):
+        out = json.dumps({
+            "type": "assistant",
+            "message": {"content": [
+                {"type": "tool_use", "name": "ToolSearch", "input": {"query": "muggle"}},
+                {"type": "tool_use", "name": "Skill", "input": {"skill": "muggle-test"}},
+            ]},
+        })
+        self.assertEqual(router_eval.parse_route_from_session(out), "muggle-test")
+
+    def test_muggle_toolsearch_with_no_skill_anywhere_still_falls_back(self):
+        out = session(
+            assistant_event("ToolSearch", {"query": "select:muggle-remote-project-list"}),
+            assistant_event("Bash", {"command": "ls"}),
+            json.dumps({"type": "result", "result": "answered directly"}),
+        )
+        self.assertEqual(router_eval.parse_route_from_session(out), "muggle-tools")
+
+    def test_muggle_mcp_tool_with_no_skill_anywhere_still_falls_back(self):
+        out = session(
+            assistant_event("mcp__plugin_muggle_muggle__muggle-remote-project-list", {}),
+            assistant_event("Bash", {"command": "ls"}),
+        )
+        self.assertEqual(router_eval.parse_route_from_session(out), "muggle-mcp-tool")
+
+    def test_first_of_two_skill_invocations_wins(self):
+        out = session(
+            assistant_event("Skill", {"skill": "muggle-test"}),
+            assistant_event("Skill", {"skill": "muggle-do"}),
+        )
+        self.assertEqual(router_eval.parse_route_from_session(out), "muggle-test")
+
+    def test_a_skill_md_read_beats_a_later_skill_invocation(self):
+        out = session(
+            assistant_event("Read", {"file_path": "C:\repo\plugin\skills\muggle-status\SKILL.md"}),
+            assistant_event("Skill", {"skill": "muggle-test"}),
+        )
+        self.assertEqual(router_eval.parse_route_from_session(out), "muggle-status")
+
+    def test_first_tool_signal_wins_when_the_session_never_routes(self):
+        out = session(
+            assistant_event("ToolSearch", {"query": "select:muggle-remote-project-list"}),
+            assistant_event("mcp__plugin_muggle_muggle__muggle-remote-project-list", {}),
+        )
+        self.assertEqual(router_eval.parse_route_from_session(out), "muggle-tools")
+
+    def test_session_touching_nothing_muggle_is_none(self):
+        out = session(
+            assistant_event("ToolSearch", {"query": "notebook jupyter"}),
+            assistant_event("Bash", {"command": "ls"}),
+        )
+        self.assertEqual(router_eval.parse_route_from_session(out), router_eval.NONE)
+
+
 class TestToolRoutesAgainstScoring(unittest.TestCase):
     def test_tool_routes_fail_the_negative_class(self):
         self.assertFalse(scored_pass(router_eval.NONE, "muggle-mcp-tool"))
@@ -113,6 +189,13 @@ class TestToolRoutesAgainstScoring(unittest.TestCase):
         )
         route = router_eval.parse_route_from_session(out)
         self.assertFalse(scored_pass(router_eval.NONE, route))
+
+    def test_a_skill_after_a_tool_signal_passes_its_positive_query(self):
+        out = session(
+            assistant_event("ToolSearch", {"query": "select:muggle-remote-project-list"}),
+            assistant_event("Skill", {"skill": "muggle-test"}),
+        )
+        self.assertTrue(scored_pass("muggle-test", router_eval.parse_route_from_session(out)))
 
     def test_a_non_muggle_skill_still_passes_the_negative_class(self):
         out = session(


### PR DESCRIPTION
## Defect

`parse_route_from_session` returned the first route-ish signal it reached, and the two muggle tool fallbacks short-circuited the scan:

```python
if tool_name.startswith("mcp__") and "muggle" in tool_name:
    return "muggle-mcp-tool"
if tool_name == "ToolSearch" and "muggle" in str(tool_input).lower():
    return "muggle-tools"
```

Muggle ships its MCP tools deferred, so a healthy session routinely loads them via `ToolSearch` and only *then* invokes the correct `Skill`. That session scored `muggle-tools` — a miss — despite routing correctly. Those fallbacks were written for the CI preflight, where any muggle signal means "the plugin is loaded". Shared with the 391-query eval, where the question is *which* skill routes, a coarse signal must never outrank an actual skill invocation.

## Fix

The scan now runs to the end of the session looking for a real route — a `Skill` invocation, or a `Read` of a `SKILL.md` — and only falls back to `muggle-mcp-tool` / `muggle-tools` when the session produced none. The tool-signal value is remembered on the way through rather than returned on sight.

Extracted three helpers so precedence reads as one rule: `_iter_tool_calls` (tool_use blocks in stream order), `_route_from_tool_call` (real route or `""`), `_muggle_tool_signal` (coarse signal or `""`).

## Preserved

- One function, one behavior — no second parsing mode, no flag. `--probe` and the eval share it.
- Preflight signal intact: a session whose only muggle evidence is an MCP call or a muggle `ToolSearch` still reports `muggle-mcp-tool` / `muggle-tools`.
- Both values still start with `muggle`, so the negative class still fails on them.
- Ordering among real routes unchanged — the first route in the session wins.
- A session that never routes and touches nothing muggle still returns `NONE`.

## Verification

`python -m unittest discover -s internal/skill-routing-eval -p "test_*.py"` — 80/80 tests OK (69 before, 11 added).

Against the pre-fix parser, 5 of the new tests fail, so they pin the defect rather than the implementation.

New coverage: muggle `ToolSearch` then `Skill`, muggle MCP call then `Skill`, tool signal then `SKILL.md` read, signal and skill in one turn, each fallback with no skill anywhere, first-of-two real routes, first tool signal when nothing routes, and nothing-muggle-at-all.

No LLM eval was run — unit tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss4tXrSMFGMnNKatJyVNdh
