### PR TITLE
fix(pr-followup): stop the watch loop collapsing empty state fields

### DIFF
--- a/plugin/scripts/pr-watch-events.sh
+++ b/plugin/scripts/pr-watch-events.sh
@@ -16,6 +16,21 @@
 # Each caller owns its own floor and advances it only on a real wake, so one
 # occurrence fires exactly once.
 
+# Splits the tab-separated state line into its fields, one per line, preserving
+# empty ones. Not a wake, but every wake below reads its arguments out of this.
+#
+# `IFS=$'\t' read` cannot do it: tab is an IFS *whitespace* character, so bash
+# collapses runs of tabs into a single delimiter, and the two adjacent tabs an
+# empty field produces silently shift every later field left. With no unresolved
+# thread — the common case, and also what a push leaves behind once its thread
+# goes outdated — the thread field is empty, so the pending-check count lands in
+# unresolved_threads and fires a thread wake for a PR with no threads, while the
+# check digest lands in failed_checks and leaves red-CI detection reading a
+# string where it expects a count. awk with an explicit FS does not collapse.
+watch_split_state() {
+    printf '%s\n' "$1" | awk -F'\t' '{for (i = 1; i <= NF; i++) print $i}'
+}
+
 # A submitted review newer than the floor. Monotonic ids, so `>` is the whole
 # test. PENDING (unsubmitted) reviews are excluded by the caller's query — they
 # are the reviewer's own drafts and are not feedback until submitted.

--- a/plugin/scripts/pr-watch-loop.sh
+++ b/plugin/scripts/pr-watch-loop.sh
@@ -181,8 +181,17 @@ while :; do
         continue
     fi
 
-    IFS=$'\t' read -r pr_state head_sha base_sha mergeable latest_review latest_comment \
-        unresolved_threads pending_checks failed_checks ci_digest <<< "$state_line"
+    mapfile -t state_fields < <(watch_split_state "$state_line")
+    pr_state="${state_fields[0]-}"
+    head_sha="${state_fields[1]-}"
+    base_sha="${state_fields[2]-}"
+    mergeable="${state_fields[3]-}"
+    latest_review="${state_fields[4]-}"
+    latest_comment="${state_fields[5]-}"
+    unresolved_threads="${state_fields[6]-}"
+    pending_checks="${state_fields[7]-}"
+    failed_checks="${state_fields[8]-}"
+    ci_digest="${state_fields[9]-}"
 
     if [ "$pr_state" = "MERGED" ] || [ "$pr_state" = "CLOSED" ]; then
         echo "TERMINAL pr=$pr_number state=$pr_state"

--- a/src/test/scripts/pr-watch-events.test.ts
+++ b/src/test/scripts/pr-watch-events.test.ts
@@ -40,6 +40,55 @@ function wake(call: string): string {
   }
 }
 
+/**
+ * Splits a state line and returns the fields. Deliberately not trimmed — a
+ * trailing empty field is exactly what a trimming helper would hide.
+ */
+function splitState(line: string): string[] {
+  const stdout = execFileSync("bash", ["-c", `source "$SCRIPT"; watch_split_state "$LINE"`], {
+    env: { ...process.env, SCRIPT: scriptPath, LINE: line },
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  return stdout.split("\n").slice(0, -1);
+}
+
+describe.skipIf(!hasBash)("watch_split_state", () => {
+  it("preserves an empty field instead of collapsing it", () => {
+    // `IFS=$'\t' read` returns ["a","b"] here: tab is IFS whitespace, so the two
+    // adjacent tabs collapse into one delimiter and "b" shifts into slot 1.
+    expect(splitState("a\t\tb")).toEqual(["a", "", "b"]);
+  });
+
+  it("keeps every later field in place when the thread list is empty", () => {
+    // The production shape, with no unresolved thread. Field 6 is the thread
+    // list; the shift used to put pending_checks (2) there and fire a thread
+    // wake for a PR with no threads, while the digest landed in failed_checks.
+    const fields = splitState(
+      ["OPEN", "headsha", "basesha", "MERGEABLE", "0", "0", "", "2", "1", "build:PENDING"].join(
+        "\t",
+      ),
+    );
+    expect(fields).toHaveLength(10);
+    expect(fields[6]).toBe("");
+    expect(fields[7]).toBe("2");
+    expect(fields[8]).toBe("1");
+    expect(fields[9]).toBe("build:PENDING");
+  });
+
+  it("preserves runs of empty fields and a trailing empty field", () => {
+    expect(splitState("a\t\t\tb\t")).toEqual(["a", "", "", "b", ""]);
+  });
+
+  it("keeps a populated thread list intact", () => {
+    const fields = splitState(
+      ["OPEN", "h", "b", "MERGEABLE", "5", "6", "PRRT_a;PRRT_b", "0", "0", "d"].join("\t"),
+    );
+    expect(fields[6]).toBe("PRRT_a;PRRT_b");
+    expect(fields[9]).toBe("d");
+  });
+});
+
 describe.skipIf(!hasBash)("watch_wake_rebase", () => {
   // The regression this whole file exists for.
   it("wakes on a branch that is merely behind, which reports MERGEABLE", () => {


### PR DESCRIPTION
## Problem

The watch loop parses its 10-field TSV state line with:

```sh
IFS=$'\t' read -r pr_state head_sha ... unresolved_threads pending_checks failed_checks ci_digest
```

Tab is an **IFS whitespace** character, so bash collapses runs of tabs into a single delimiter. The two adjacent tabs an empty field produces shift every later field left. On the same line, `awk -F'\t'` counts 10 fields where `read` binds 9.

The thread list is empty in the common case — no unresolved thread, or the only one went `isOutdated` behind a push — so this was routine, not an edge case:

| Variable | Receives | Should receive |
|---|---|---|
| `unresolved_threads` | pending-check **count** | thread ids |
| `pending_checks` | failed count | pending count |
| `failed_checks` | the whole check **digest** | failed count |
| `ci_digest` | empty | the digest |

Two consequences, one noisy and one dangerous:

- **Phantom wakes.** `EVENT pr=389 thread newly unresolved id=2` against a PR with zero threads, the id tracking the pending count. Each one wakes the owning session for nothing.
- **Blind CI detection.** `watch_wake_ci_red` and `watch_wake_blocked_resume` compare a string against a count. A genuinely red head went unreported on #389 while the watcher looked healthy — alive, heartbeating, no fetch errors. It was found by reading the digest by hand.

That second one is the same failure shape this file's own header warns about: *"A dropped wake has no failure mode that anyone notices."*

## Fix

Split with `awk -F'\t'`, which does not collapse under an explicit FS, and index positionally.

The split lives in `pr-watch-events.sh` beside the wakes it feeds rather than inline in the loop, because that file's functions are pure and directly testable — the property the header calls out as the one prose never had. The loop cannot be sourced (it runs), so a parse embedded there is untestable by construction.

## Verification

- Four tests pin the split. **Three fail against the `read`-based version** with exactly the observed shift — `['a','b']` instead of `['a','','b']`, and length 9 instead of 10. The fourth (populated thread list) passes under both, correctly: that is the case the bug never touched.
- End-to-end through the loop's real path on a no-thread line: fields land in the right slots, `failed_checks` is a count again, and `watch_wake_thread` stays quiet instead of firing a phantom.
- Full suite green (1290 tests, 87 files), `tsc --noEmit`, `check-skill-deps`, `check-post-signatures`, `bash -n` on both scripts, LF endings confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HUYRMQkhHvRze25mKdMmv
