### PR TITLE
[UNIT-ONLY] Cancel superseded CI runs on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  # Superseded PR pushes are dead work. Master runs are per-commit history, so
+  # they always run to completion.
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Goal

Cancel superseded in-progress CI runs on pull requests, so rapid re-pushes stop burning GitHub Actions minutes on results nobody reads.

## Acceptance Criteria

- `.github/workflows/ci.yml` declares a top-level `concurrency` block.
- The group key is `ci-${{ github.ref }}`, scoping cancellation per-branch so a push to one PR can never cancel another PR's run.
- `cancel-in-progress` evaluates true for `pull_request` events and false for `push` events, so every commit landing on `master` still records its own CI verdict.
- No other workflow file is modified.
- The workflow stays valid YAML and GitHub still schedules it.
- `ci.yml` keeps LF line endings.

## Changes

`.github/workflows/ci.yml` (+6):

```yaml
concurrency:
  group: ci-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

`ci.yml` triggers on both `push: [master]` and `pull_request: [master]`. Until now a rapid sequence of pushes to a PR left every superseded lint/test run executing to completion.

Two alternatives were considered and rejected:

- `group: ci-${{ github.head_ref || github.run_id }}` with `cancel-in-progress: true` — identical behaviour, but the `|| run_id` fallback reads as a bug to anyone who has not already seen the idiom.
- Blanket `cancel-in-progress: true` — a fast follow-up merge would kill the previous master commit's run, leaving that commit with no CI verdict at all.

Deliberately out of scope:

- `publish-works-to-npm.yml` — cancelling a mid-flight npm publish is worse than a wasted run. If serialization is ever wanted there, the correct shape is a concurrency group with `cancel-in-progress: false`.
- `verify-end-user-upgrade.yml` — weekly cron plus dispatch, so overlap is near-impossible.
- `skill-eval.yml` — already carries `cancel-in-progress: true`.

## Validation

`unit-only` — this diff touches no app or UI surface, so E2E acceptance was skipped.

- `pnpm run lint:check` → exit 0 (17 pre-existing warnings in `agent-gate-eval`/`skill-gate-eval`, none introduced here)
- `vitest run` → exit 0; 87 test files, 1286 tests green, 27 skipped

This PR's own CI run is the live proof that the block parses and that GitHub still schedules the workflow.

<!-- muggle-works:signature -->
🤖 _Posted by `/muggle-do` · [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works)_
