### PR TITLE
chore(release): @muggleai/works 5.11.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "5.10.0"
+      "version": "5.11.0"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "5.10.0"
+      "version": "5.11.0"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@muggleai/works",
   "mcpName": "io.github.multiplex-ai/muggle",
-  "version": "5.10.0",
+  "version": "5.11.0",
   "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
   "type": "module",
   "main": "dist/index.js",
@@ -49,14 +49,14 @@
     "eval:studio-gen": "tsx internal/studio-gen-eval/src/run.ts"
   },
   "muggleConfig": {
-    "electronAppVersion": "1.8.0",
+    "electronAppVersion": "1.9.0",
     "downloadBaseUrl": "https://github.com/multiplex-ai/muggle-ai-works/releases/download",
     "runtimeTargetDefault": "dev",
     "checksums": {
-      "darwin-arm64": "38a2a9c392c7c4e55bf510dbcdcf31713db341b35218759961d2672fa8eb6d20",
-      "darwin-x64": "687dd81c3fe808109e11e8db0cea8bb9c1dc05717f9f35699cf64081b591b7bd",
-      "linux-x64": "a7fad7a5370066c338916a5cf54851212bd49e36371ed62dd1f0b70349229d67",
-      "win32-x64": "803aa0690b1047e16bbe5239911d7de3751b6bf2ae8730db75e16da08b778148"
+      "darwin-arm64": "1baa38bde71b74984705bcac3e5a42a7a158a7b0574dab496f3e240846c0ac65",
+      "darwin-x64": "098cc2db6f32c7857bd933512320524d213804b378dc8bf0ade791396f058041",
+      "linux-x64": "d434a88a087c7410785a443cfe03102322fa7a295b77600f5ed92e2113e271c2",
+      "win32-x64": "0aecbc01010ab0a268137ed31bcaaa05fe9215daa9f4c0e4871b07554d28c0c8"
     }
   },
   "dependencies": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "5.10.0",
+  "version": "5.11.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "5.10.0",
+  "version": "5.11.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "5.10.0",
+  "version": "5.11.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "5.10.0",
+      "version": "5.11.0",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
## Version

| | |
|---|---|
| Last on npm | 5.10.0 |
| Baseline | 5.10.0 (npm and master agreed) |
| **This release** | **5.11.0** |
| Electron pin | 1.8.0 → **1.9.0** |

**Why minor:** five `feat` commits in the batch and nothing marked `feat!` or `BREAKING CHANGE`, so conventional-commit rules put this at minor.

## Shipping

**PR-followup watcher** — ship the watch loop as a file and scope recovery to its owning session (#383); stop the loop collapsing empty state fields (#394); 7-day watch lifetime, configurable (#375).

**Posted-body signatures** (#389) — every posted PR/MR body now signs through `plugin/scripts/sign-body.sh` instead of prose retyped per call site. Ten call sites converted, including four GitLab recipes that had no signing step at all, enforced by a new `post-signatures` CI job. Also pins `*.sh` and `*.mjs` to LF, which Windows checkouts had been converting to CRLF.

**Guardrails** — mandatory-stage enforcement (#381); reachable skip markers and reopen/comment-edit paths (#379); turn-end block when an acceptance run has no walkthrough (#374).

**Studio / MCP** — forward LLM env overrides to the Studio spawn (#378) and `MUGGLE_LLM_TOP_P` with them (#391); studio-gen-eval no longer abandons a run mid-restart (#390).

**Evals / tooling** — browser-bench WebVoyager suite (#387); routing eval scores the whole session (#385), lets a real route outrank a coarse tool signal (#392), gates scoped runs on regression (#386), names the query per progress line (#382), gets a cwd with a referent (#380), retries its preflight (#373); prepare learns the recipe once then replays (#384).

**Docs / CI / ops** — muggle-test description back under budget (#396) and beyond-Playwright framing (#364); cancel superseded PR runs (#395); spare subscription token fallback (#388); memwatch hidden with bounded logs (#376); post-merge cleanup verifies per step (#368).

## Electron

`muggleConfig.electronAppVersion` 1.8.0 → 1.9.0, with all four `muggleConfig.checksums` rewritten from the `electron-app-v1.9.0` release's `checksums.txt`. Hashes were derived programmatically from that file rather than transcribed, and `verify:electron-release-checksums` re-fetches and confirms them.

## Manifests

Touched by `sync:versions`, not by hand: `.claude-plugin/marketplace.json`, `.cursor-plugin/marketplace.json`, `plugin/.claude-plugin/plugin.json`, `plugin/.cursor-plugin/plugin.json`, `server.json`.

## Test plan

- [x] `lint:check` — no errors
- [x] `typecheck`
- [x] `test` — full suite green (1290 tests, 87 files)
- [x] `build`
- [x] `verify:plugin`
- [x] `verify:contracts`
- [x] `verify:electron-release-checksums` — confirmed against `electron-app-v1.9.0`

Publish runs in CI via `publish-works-to-npm.yml` (OIDC trusted publishing); no local `npm publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HUYRMQkhHvRze25mKdMmv
