### PR TITLE
fix(eval): score alias skill routes as their canonical skill

### DIFF
--- a/internal/skill-routing-eval/router_eval.py
+++ b/internal/skill-routing-eval/router_eval.py
@@ -35,6 +35,54 @@ PROGRESS_QUERY_CHARS = 140
 # before the route ever reaches the stream.
 SESSION_MAX_TURNS = 2
 
+# The plugin tree sits beside `internal/` in the checkout, so the map is anchored
+# to this file: `--repo-root` points at a throwaway clean cwd in CI, not here.
+PLUGIN_SKILLS_DIR = Path(__file__).resolve().parents[2] / "plugin" / "skills"
+
+ALIAS_TARGET_PATTERN = re.compile(
+    r"^description:.*\balias for the `([^`]+)` skill", re.MULTILINE
+)
+
+
+def build_alias_to_canonical(skills_dir: Path) -> dict[str, str]:
+    """Alias skill name to the canonical skill it delegates to, read from SKILL.md frontmatter.
+
+    Derived from the tree rather than listed here, so an alias added later is
+    resolved without touching the eval. A missing or unreadable skills tree
+    yields an empty map, leaving routes unresolved rather than ending the run.
+
+    Output shape: `{"mfeedback": "muggle-feedback", "mtestlocal": "muggle-test-feature-local"}`
+    """
+    alias_to_canonical: dict[str, str] = {}
+    try:
+        skill_files = sorted(skills_dir.glob("*/SKILL.md"))
+    except OSError:
+        return alias_to_canonical
+    for skill_file in skill_files:
+        try:
+            declaration = skill_file.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        target = ALIAS_TARGET_PATTERN.search(declaration)
+        if target:
+            alias_to_canonical[skill_file.parent.name] = target.group(1)
+    return alias_to_canonical
+
+
+ALIAS_TO_CANONICAL = build_alias_to_canonical(PLUGIN_SKILLS_DIR)
+
+
+def resolve_alias_route(route: str) -> str:
+    """Canonical skill behind an alias route; every other route passes through unchanged.
+
+    Routing through an alias reaches exactly the canonical skill, so scoring the
+    bare alias name counts a correct route as a miss — and hides it from the
+    negative class, which only rejects routes starting with "muggle".
+
+    Output shape: `"mfeedback"` -> `"muggle-feedback"`
+    """
+    return ALIAS_TO_CANONICAL.get(route, route)
+
 
 def format_run_progress(done: int, total: int, query: str, route: str, expected: str) -> str:
     """One live progress line, naming the query that produced `route`.
@@ -113,7 +161,8 @@ def parse_route_from_session(out: str) -> str:
     plugin is loaded but not which skill won, so it only stands in when the whole
     session invoked no skill. Both of its spellings start with "muggle", so they
     miss a positive query expecting a named skill and correctly fail the negative
-    class, which passes only when nothing muggle fires.
+    class, which passes only when nothing muggle fires. A route that names an
+    alias skill is reported as the canonical skill it delegates to.
 
     Output shape: `"muggle-test"`
     """
@@ -121,7 +170,7 @@ def parse_route_from_session(out: str) -> str:
     for tool_name, tool_input in _iter_tool_calls(out):
         route = _route_from_tool_call(tool_name, tool_input)
         if route:
-            return route
+            return resolve_alias_route(route)
         if not muggle_tool_signal:
             muggle_tool_signal = _muggle_tool_signal(tool_name, tool_input)
     return muggle_tool_signal or NONE

--- a/internal/skill-routing-eval/test_router_eval.py
+++ b/internal/skill-routing-eval/test_router_eval.py
@@ -1,10 +1,20 @@
 import json
 import subprocess
+import tempfile
 import unittest
+from pathlib import Path
 from unittest import mock
 
 import router_eval
 from scoring import scored_pass
+
+SKILL_FIXTURE_TEMPLATE = '''---
+name: {name}
+description: {description}
+---
+
+# {name}
+'''
 
 
 def assistant_event(tool_name: str, tool_input: dict) -> str:
@@ -284,6 +294,106 @@ class TestFormatRunProgress(unittest.TestCase):
     def test_line_is_ascii_so_windows_consoles_can_encode_it(self):
         line = router_eval.format_run_progress(1, 3, "q", "none", "none")
         line.encode("ascii")
+
+
+class TestAliasRoutesResolveToCanonical(unittest.TestCase):
+    def test_alias_skill_invocation_scores_the_canonical_skill(self):
+        out = assistant_event("Skill", {"skill": "muggle:mfeedback"})
+        self.assertEqual(router_eval.parse_route_from_session(out), "muggle-feedback")
+
+    def test_bare_alias_name_scores_the_canonical_skill(self):
+        out = assistant_event("Skill", {"skill": "mupgrade"})
+        self.assertEqual(router_eval.parse_route_from_session(out), "muggle-upgrade")
+
+    def test_canonical_skill_invocation_passes_through(self):
+        out = assistant_event("Skill", {"skill": "muggle:muggle-test"})
+        self.assertEqual(router_eval.parse_route_from_session(out), "muggle-test")
+
+    def test_non_muggle_skill_passes_through(self):
+        out = assistant_event("Skill", {"skill": "superpowers:brainstorming"})
+        self.assertEqual(router_eval.parse_route_from_session(out), "brainstorming")
+
+    def test_a_name_that_is_no_alias_passes_through(self):
+        self.assertEqual(router_eval.resolve_alias_route("mnevershipped"), "mnevershipped")
+        self.assertEqual(router_eval.resolve_alias_route(""), "")
+
+    def test_read_of_an_alias_skill_md_scores_the_canonical_skill(self):
+        out = assistant_event("Read", {"file_path": "/repo/plugin/skills/mtestlocal/SKILL.md"})
+        self.assertEqual(router_eval.parse_route_from_session(out), "muggle-test-feature-local")
+
+    def test_alias_after_orienting_still_scores_the_canonical_skill(self):
+        out = session(
+            assistant_event("Bash", {"command": "git status"}),
+            assistant_event("Skill", {"skill": "muggle:mregen"}),
+        )
+        self.assertEqual(
+            router_eval.parse_route_from_session(out), "muggle-test-regenerate-missing"
+        )
+
+    def test_every_shipped_alias_targets_a_canonical_muggle_skill(self):
+        self.assertTrue(router_eval.ALIAS_TO_CANONICAL)
+        for alias, canonical in router_eval.ALIAS_TO_CANONICAL.items():
+            self.assertTrue(canonical.startswith("muggle"), alias)
+            self.assertNotIn(canonical, router_eval.ALIAS_TO_CANONICAL)
+
+
+class TestAliasRoutesAgainstScoring(unittest.TestCase):
+    def test_alias_route_passes_its_canonical_positive_query(self):
+        out = assistant_event("Skill", {"skill": "muggle:mfeedback"})
+        self.assertTrue(scored_pass("muggle-feedback", router_eval.parse_route_from_session(out)))
+
+    def test_alias_route_fails_the_negative_class(self):
+        out = assistant_event("Skill", {"skill": "muggle:mfeedback"})
+        route = router_eval.parse_route_from_session(out)
+        self.assertFalse(scored_pass(router_eval.NONE, route))
+
+    def test_alias_route_is_marked_a_miss_on_a_negative_query(self):
+        out = assistant_event("Skill", {"skill": "muggle:mtest"})
+        route = router_eval.parse_route_from_session(out)
+        self.assertIn("MISS", router_eval.format_run_progress(1, 3, "q", route, router_eval.NONE))
+
+
+class TestBuildAliasToCanonical(unittest.TestCase):
+    def _write_skill(self, skills_dir, name, description):
+        skill_dir = skills_dir / name
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            SKILL_FIXTURE_TEMPLATE.format(name=name, description=description),
+            encoding="utf-8",
+        )
+
+    def test_map_is_derived_from_frontmatter_declarations(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            skills_dir = Path(tmp)
+            self._write_skill(
+                skills_dir,
+                "xshort",
+                "Explicit short alias for the `example-canonical` skill. ONLY invoke when"
+                " the user explicitly types `xshort`.",
+            )
+            self._write_skill(
+                skills_dir, "example-canonical", "Does the real work and delegates to nothing."
+            )
+            self.assertEqual(
+                router_eval.build_alias_to_canonical(skills_dir),
+                {"xshort": "example-canonical"},
+            )
+
+    def test_declaration_outside_the_description_is_not_an_alias(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            skills_dir = Path(tmp)
+            self._write_skill(skills_dir, "example-canonical", "Does the real work.")
+            body = skills_dir / "example-canonical" / "SKILL.md"
+            body.write_text(
+                body.read_text(encoding="utf-8")
+                + "Users may reach this via an alias for the `example-canonical` skill.",
+                encoding="utf-8",
+            )
+            self.assertEqual(router_eval.build_alias_to_canonical(skills_dir), {})
+
+    def test_missing_skills_dir_yields_an_empty_map(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(router_eval.build_alias_to_canonical(Path(tmp) / "absent"), {})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The plugin ships 15 alias skills (`m`, `mbt`, `mdo`, `mfeedback`, `mimport`, `mpr`, `mprefs`, `mprfollowup`, `mregen`, `mrepair`, `mstatus`, `mtest`, `mtestlocal`, `mtestprep`, `mupgrade`). Each is a thin delegator whose entire body is "invoke the `<canonical>` skill via the Skill tool", so a session that routes through an alias reaches exactly the canonical skill — a correct route.

`normalize_skill` yielded the bare alias name (`muggle:mfeedback` -> `mfeedback`), which never equals the expected `muggle-feedback`, so every alias route scored as a miss.

On the 2026-08-13 nightly full sweep:

| skill | scored | alias runs | correct score |
| --- | --- | --- | --- |
| `muggle-feedback` | 7/24 | 46 of 72 runs routed to `mfeedback` | 22/24 |
| `muggle-upgrade` | 21/26 | 14 runs routed to `mupgrade` | 24/26 |

The regression gate flagged both as regressions. They are measurement artifacts, not routing regressions.

## The more serious half: the negative class

The 48 queries labelled `expected_skill: "none"` pass iff no muggle skill fires, and the rule is `route.startswith("muggle")`. `mfeedback` does not start with `muggle`, so **a negative query that wrongly fired an alias silently passed**. The negative class was blind to every one of the 15 aliases. Resolving to canonical closes that hole: `scoring.scored_pass("none", "muggle-feedback")` is now `False`.

## Change

`parse_route_from_session` is the single funnel where a route is finalised (both the `Skill` invocation and the `SKILL.md` read paths flow through it), so resolution happens there once. `_route_from_tool_call` stays a pure parser.

The map is **derived from the repo, not hardcoded**: `build_alias_to_canonical` scans `plugin/skills/*/SKILL.md` and matches the machine-readable declaration already present in each alias's frontmatter description —

```
description: Explicit short alias for the `muggle-feedback` skill. ONLY invoke when ...
```

via `^description:.*\balias for the `([^`]+)` skill`. A hardcoded list would rot the moment an alias is added; anchoring to the declaration means a new alias needs no eval change.

Details:

- **Path anchored to the harness file**, `Path(__file__).resolve().parents[2] / "plugin" / "skills"` — not `--repo-root`, which points at a throwaway clean cwd in CI, not the checkout.
- **Built once at import**, not per run; the eval scores hundreds of runs.
- **Degrades safely** — a missing or unreadable skills tree yields an empty map and routes pass through unchanged rather than crashing the eval.
- **Anchored to the description line**, so a canonical skill whose body prose mentions an alias is not mistaken for one.
- An unknown route passes through untouched.

Scope: `router_eval.py` and its test file only. `run.py`, `regression_gate.py`, `analyze.py`, `gate_*.py`, the workflows and `plugin/**` are untouched — `analyze.py` and the gate read the report `router_eval.py` writes, so they see canonical names for free.

## Real-tree sanity check

```
$ python -c "import router_eval; ..."
count: 15
  m           -> muggle
  mbt         -> muggle-browser-task
  mdo         -> muggle-do
  mfeedback   -> muggle-feedback
  mimport     -> muggle-test-import
  mpr         -> muggle-pr-visual-walkthrough
  mprefs      -> muggle-preferences
  mprfollowup -> muggle-pr-followup
  mregen      -> muggle-test-regenerate-missing
  mrepair     -> muggle-repair
  mstatus     -> muggle-status
  mtest       -> muggle-test
  mtestlocal  -> muggle-test-feature-local
  mtestprep   -> muggle-test-prepare
  mupgrade    -> muggle-upgrade
resolve mfeedback:   muggle-feedback
resolve muggle-test: muggle-test   (canonical, unchanged)
resolve brainstorming: brainstorming (not an alias, unchanged)
```

All 15 aliases, correct targets, and no canonical skill was misread as an alias.

## Verification

`python -m unittest discover -s internal/skill-routing-eval -p "test_*.py" -v` — **94/94 tests OK** (80 pre-existing, all still green, plus 14 new). No LLM eval was run.

New coverage:

- `Skill` invocation of `muggle:mfeedback` scores `muggle-feedback`; bare `mupgrade` scores `muggle-upgrade`.
- A canonical skill and a non-muggle skill pass through unchanged.
- An unknown/absent alias name passes through unchanged.
- A `Read` of an alias `SKILL.md` scores the canonical skill.
- A negative-class query that fires an alias is now caught (`scored_pass("none", resolved)` is `False`, and the live progress line marks it `MISS`).
- The map builds from a temp directory of fixture `SKILL.md` files, so the builder test does not depend on the live plugin tree; a missing directory yields an empty map without raising.
- Every shipped alias targets a canonical muggle skill that is not itself an alias.

## Follow-up (deliberately not in this PR)

`recall-baseline.json` is **not** updated here. This change raises measured recall for `muggle-feedback` and `muggle-upgrade`, so the baseline should be re-recorded from a nightly once this lands. It is stale for other reasons too; refreshing it is a separate decision.

Line endings preserved — `router_eval.py` is all-CRLF and `git diff --stat` matches `git diff -w --stat` exactly.
