### PR TITLE
fix(browser-bench): match studio's one-flag spawn contract

### DIFF
--- a/internal/browser-bench/README.md
+++ b/internal/browser-bench/README.md
@@ -43,7 +43,7 @@ skipped and its results are folded back into the report in task-file order.
 The harness spawns one process per task:
 
 ```
-<studio-binary> --benchmark-task <path/to/task.json> --out <path/to/result.json>
+<studio-binary> --benchmark-task <path/to/task.json>
 ```
 
 The harness writes `task.json`:
@@ -54,9 +54,14 @@ The harness writes `task.json`:
   "instruction": "Provide a recipe for vegetarian lasagna…",
   "startUrl": "https://www.allrecipes.com/",
   "maxSteps": 15,
-  "trajectoryDir": "<out>/trajectories/Allrecipes--0"
+  "trajectoryDir": "<out>/trajectories/Allrecipes--0",
+  "outputFilePath": "<out>/trajectories/Allrecipes--0/result.json"
 }
 ```
+
+Where the result goes travels in the task rather than as a second flag: it is
+part of the task, and neither could ever be passed without the other. Studio
+rejects a task file missing any of these fields.
 
 Studio writes `result.json`:
 
@@ -83,13 +88,14 @@ infrastructure error instead, which is excluded from the pass-rate denominator.
 | Variable | Default | Meaning |
 | :--- | :------ | :------ |
 | `MUGGLE_STUDIO_BIN` | `muggle-studio` on `PATH` | The studio binary to spawn |
-| `MUGGLE_STUDIO_BROWSER_PROFILE_DIR` | set per task by the harness | The empty browser profile studio must use |
 
 Set `MUGGLE_STUDIO_BIN` to a local build; the default resolves on `PATH` because
-a machine-specific path must never be committed. The profile directory travels
-by environment because the spawn contract's two flags are fixed and neither
-names one — studio must honour it, or state leaks between tasks and the scores
-stop meaning anything.
+a machine-specific path must never be committed.
+
+Per-task browser isolation needs nothing from the harness: studio's benchmark
+mode sets `freshSession` itself, clearing cookies and local storage when the
+webview attaches. Isolation is a property of benchmark mode rather than
+something a caller can forget to pass.
 
 ## Task data
 

--- a/internal/browser-bench/src/studio/constants.ts
+++ b/internal/browser-bench/src/studio/constants.ts
@@ -4,18 +4,8 @@ export const STUDIO_BIN_ENV_VAR = "MUGGLE_STUDIO_BIN";
 /** Resolved on `PATH` when `MUGGLE_STUDIO_BIN` is unset — set the env var to a build output instead. */
 export const DEFAULT_STUDIO_BIN = "muggle-studio";
 
-/**
- * Carries the per-task browser profile to studio. The spawn contract's two
- * flags are fixed and neither names a profile, so the environment is the only
- * seam left for it.
- */
-export const BROWSER_PROFILE_DIR_ENV_VAR = "MUGGLE_STUDIO_BROWSER_PROFILE_DIR";
-
 /** Names the studio flag that points at the task file. */
 export const BENCHMARK_TASK_FLAG = "--benchmark-task";
-
-/** Names the studio flag that points at the result file studio must write. */
-export const BENCHMARK_OUT_FLAG = "--out";
 
 /** The harness writes the task file here, inside the task's own trajectory directory. */
 export const STUDIO_TASK_FILENAME = "task.json";

--- a/internal/browser-bench/src/studio/node-studio-spawn.ts
+++ b/internal/browser-bench/src/studio/node-studio-spawn.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 
-import { BROWSER_PROFILE_DIR_ENV_VAR, STDERR_TAIL_LIMIT } from "./constants";
+import { STDERR_TAIL_LIMIT } from "./constants";
 import { buildStudioArgv } from "./studio-invocation";
 import { type StudioExitReport, type StudioInvocation, type StudioProcess } from "./types";
 
@@ -29,7 +29,7 @@ const killProcessTree = (pid: number | undefined): void => {
  */
 export const spawnStudioProcess = (invocation: StudioInvocation): StudioProcess => {
   const child = spawn(invocation.studioBinPath, buildStudioArgv(invocation), {
-    env: { ...process.env, [BROWSER_PROFILE_DIR_ENV_VAR]: invocation.browserProfileDir },
+
     stdio: ["ignore", "ignore", "pipe"],
     windowsHide: true,
   });

--- a/internal/browser-bench/src/studio/studio-invocation.test.ts
+++ b/internal/browser-bench/src/studio/studio-invocation.test.ts
@@ -11,12 +11,13 @@ const task: BenchmarkTask = {
 };
 
 describe("buildStudioTaskFile", () => {
-  it("carries exactly the fields studio reads", () => {
+  it("carries exactly the fields studio reads, including where to write the result", () => {
     expect(
       buildStudioTaskFile({
         task: task,
         maxSteps: MAX_STEPS_PER_TASK,
         trajectoryDir: "/out/trajectories/Allrecipes--0",
+        resultFilePath: "/out/trajectories/Allrecipes--0/result.json",
       }),
     ).toEqual({
       taskId: "Allrecipes--0",
@@ -24,12 +25,26 @@ describe("buildStudioTaskFile", () => {
       startUrl: "https://www.allrecipes.com/",
       maxSteps: MAX_STEPS_PER_TASK,
       trajectoryDir: "/out/trajectories/Allrecipes--0",
+      outputFilePath: "/out/trajectories/Allrecipes--0/result.json",
     });
+  });
+
+  it("names the result path outputFilePath, the key studio requires", () => {
+    // Studio's readBenchmarkTaskAsync rejects a task file missing this field, so
+    // the spelling is the contract rather than an implementation detail.
+    const taskFile = buildStudioTaskFile({
+      task: task,
+      maxSteps: MAX_STEPS_PER_TASK,
+      trajectoryDir: "/out/trajectories/Allrecipes--0",
+      resultFilePath: "/out/result.json",
+    });
+
+    expect(Object.keys(taskFile)).toContain("outputFilePath");
   });
 });
 
 describe("buildStudioArgv", () => {
-  it("pins the two-flag spawn contract", () => {
+  it("pins the single-flag spawn contract", () => {
     expect(
       buildStudioArgv({
         studioBinPath: "/bin/muggle-studio",
@@ -37,11 +52,17 @@ describe("buildStudioArgv", () => {
         resultFilePath: "/out/trajectories/Allrecipes--0/result.json",
         browserProfileDir: "/out/profiles/Allrecipes--0",
       }),
-    ).toEqual([
-      "--benchmark-task",
-      "/out/trajectories/Allrecipes--0/task.json",
-      "--out",
-      "/out/trajectories/Allrecipes--0/result.json",
-    ]);
+    ).toEqual(["--benchmark-task", "/out/trajectories/Allrecipes--0/task.json"]);
+  });
+
+  it("does not pass --out; studio reads the result path from the task file", () => {
+    const argv = buildStudioArgv({
+      studioBinPath: "/bin/muggle-studio",
+      taskFilePath: "/out/task.json",
+      resultFilePath: "/out/result.json",
+      browserProfileDir: "/out/profiles/x",
+    });
+
+    expect(argv).not.toContain("--out");
   });
 });

--- a/internal/browser-bench/src/studio/studio-invocation.ts
+++ b/internal/browser-bench/src/studio/studio-invocation.ts
@@ -1,5 +1,5 @@
 import { type BenchmarkTask } from "../domain/types";
-import { BENCHMARK_OUT_FLAG, BENCHMARK_TASK_FLAG } from "./constants";
+import { BENCHMARK_TASK_FLAG } from "./constants";
 import { type StudioInvocation, type StudioTaskFile } from "./types";
 
 /**
@@ -7,34 +7,36 @@ import { type StudioInvocation, type StudioTaskFile } from "./types";
  *
  * Output shape: `{ taskId: "Allrecipes--0", instruction: "Provide a recipe…",
  * startUrl: "https://www.allrecipes.com/", maxSteps: 15,
- * trajectoryDir: "…/trajectories/Allrecipes--0" }`
+ * trajectoryDir: "…/trajectories/Allrecipes--0",
+ * outputFilePath: "…/trajectories/Allrecipes--0/result.json" }`
  */
 export const buildStudioTaskFile = ({
   task,
   maxSteps,
   trajectoryDir,
+  resultFilePath,
 }: {
   task: BenchmarkTask;
   maxSteps: number;
   trajectoryDir: string;
+  resultFilePath: string;
 }): StudioTaskFile => ({
   taskId: task.taskId,
   instruction: task.instruction,
   startUrl: task.startUrl,
   maxSteps: maxSteps,
   trajectoryDir: trajectoryDir,
+  outputFilePath: resultFilePath,
 });
 
 /**
  * Builds studio's argument list. The contract is fixed on both sides — studio
- * reads exactly these two flags — so it is pinned here rather than assembled
+ * reads exactly this one flag — so it is pinned here rather than assembled
  * inline at the spawn site.
  *
- * Output shape: `["--benchmark-task", "…/task.json", "--out", "…/result.json"]`
+ * Output shape: `["--benchmark-task", "…/task.json"]`
  */
 export const buildStudioArgv = (invocation: StudioInvocation): string[] => [
   BENCHMARK_TASK_FLAG,
   invocation.taskFilePath,
-  BENCHMARK_OUT_FLAG,
-  invocation.resultFilePath,
 ];

--- a/internal/browser-bench/src/studio/studio-runner.test.ts
+++ b/internal/browser-bench/src/studio/studio-runner.test.ts
@@ -120,6 +120,7 @@ describe("runStudioTaskAsync", () => {
       startUrl: "https://www.allrecipes.com/",
       maxSteps: MAX_STEPS_PER_TASK,
       trajectoryDir: trajectoryDir,
+      outputFilePath: path.join(trajectoryDir, "result.json"),
     });
   });
 

--- a/internal/browser-bench/src/studio/studio-runner.ts
+++ b/internal/browser-bench/src/studio/studio-runner.ts
@@ -82,6 +82,7 @@ export const runStudioTaskAsync = async ({
     task: task,
     maxSteps: maxSteps,
     trajectoryDir: trajectoryDir,
+    resultFilePath: resultFilePath,
   });
   await fileSystem.writeTextAsync(taskFilePath, `${JSON.stringify(studioTaskFile, null, 2)}\n`);
 

--- a/internal/browser-bench/src/studio/types.ts
+++ b/internal/browser-bench/src/studio/types.ts
@@ -5,6 +5,12 @@ export interface StudioTaskFile {
   startUrl: string;
   maxSteps: number;
   trajectoryDir: string;
+  /**
+   * Where studio writes its result. Carried in the task rather than as a second
+   * command-line flag: where a task's result goes is part of the task, and
+   * neither could be passed without the other.
+   */
+  outputFilePath: string;
 }
 
 /** The `result.json` studio writes when an attempt completes. */


### PR DESCRIPTION
**master currently disagrees with itself.** The studio half (teaching-service#357) merged with a one-flag contract; this half merged earlier with the two-flag one.

| | master today |
|---|---|
| **Studio** reads | `--benchmark-task <path>` only; result path comes from *inside* `task.json` |
| **Harness** sends | `--benchmark-task <path> --out <path>`; task file has 5 fields, **no `outputFilePath`** |

A run right now would throw `missing required field: outputFilePath` on every task, exit non-zero, and record all 20 smoke tasks as infrastructure errors — **0 scored reps**. Not a wrong number; no number at all.

## The fix

- `task.json` gains `outputFilePath`; spawn drops `--out`
- **Removes `MUGGLE_STUDIO_BROWSER_PROFILE_DIR`.** It was a workaround for the contract having no profile slot, but studio's benchmark mode sets `freshSession` itself — clearing cookies and local storage on webview attach. Isolation is a property of benchmark mode rather than something a caller passes, so the env var was dead weight that would have quietly drifted out of sync.
- README updated to document the real contract rather than the old one

## Tests pin the contract, rather than describing it

Two new assertions that would have **failed** against the pre-merge shape:

- `buildStudioArgv` must not contain `--out`
- the task file must carry the `outputFilePath` key studio requires

That matters because this exact class of bug — two halves agreeing on paper and disagreeing in code — has now bitten this integration twice. The first time, studio emitted `"active"` where the harness scored `"success"`, which would have reported every passing task as a failure.

## Verification

- 53 tests pass (9 files)
- `tsc --noEmit` clean, `eslint internal/browser-bench` clean

Verified with dependencies actually installed — an earlier `npx tsc` in a fresh worktree reported "0 errors" with an empty `node_modules`, which is not a check, just silence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)