### PR TITLE
feat(config): record the staging Auth0 device code client

### DIFF
--- a/config/runtime-targets.json
+++ b/config/runtime-targets.json
@@ -18,7 +18,7 @@
     "staging": {
       "promptServiceBaseUrl": "https://staging.promptservice.muggle-ai.com",
       "auth0Domain": "login.staging.muggle-ai.com",
-      "auth0ClientId": "",
+      "auth0ClientId": "C6rmJN3FeX3EuGZdY8qbHpbJVRadxsly",
       "auth0Audience": "https://staging-muggleai.us.auth0.com/api/v2/",
       "electronAppReleaseStream": "staging"
     },

--- a/packages/mcps/src/test/runtime-target-resolution.test.ts
+++ b/packages/mcps/src/test/runtime-target-resolution.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { RUNTIME_TARGET_ENV_VAR } from "../shared/runtime-target-constants.js";
 import {
@@ -50,14 +50,45 @@ describe("resolveActiveProfile", () => {
 });
 
 describe("assertDeviceCodeClientProvisioned", () => {
-  it("passes for a target with a provisioned client", () => {
-    expect(() => assertDeviceCodeClientProvisioned(RuntimeTarget.Production)).not.toThrow();
+  it("passes for every shipped target", () => {
+    for (const target of Object.values(RuntimeTarget)) {
+      expect(() => assertDeviceCodeClientProvisioned(target)).not.toThrow();
+    }
   });
 
-  it("rejects a target whose Auth0 client is not provisioned, naming the target", () => {
-    expect(() => assertDeviceCodeClientProvisioned(RuntimeTarget.Staging)).toThrow(/staging/);
-    expect(() => assertDeviceCodeClientProvisioned(RuntimeTarget.Staging)).toThrow(
-      /no Auth0 device code client/,
+  // Asserted against a stubbed profile rather than a real target: every shipped
+  // target now has a client, and pinning this to whichever one happened to lack
+  // it made provisioning that tenant fail the suite.
+  it("rejects a target whose Auth0 client is not provisioned, naming the target", async () => {
+    // resetModules first: runtime-target.js is already cached from this file's
+    // top-level import, so without it the dynamic import below returns the
+    // unmocked copy and the guard never sees the stubbed profile.
+    vi.resetModules();
+    vi.doMock("../shared/runtime-target-constants.js", async (importOriginal) => {
+      const actual = await importOriginal<
+        typeof import("../shared/runtime-target-constants.js")
+      >();
+      const realProfiles = actual.getRuntimeTargetProfiles();
+      return {
+        ...actual,
+        getRuntimeTargetProfiles: () => ({
+          ...realProfiles,
+          [RuntimeTarget.Staging]: {
+            ...realProfiles[RuntimeTarget.Staging],
+            auth0ClientId: "",
+          },
+        }),
+      };
+    });
+
+    const { assertDeviceCodeClientProvisioned: assertWithStub } = await import(
+      "../shared/runtime-target.js"
     );
+
+    expect(() => assertWithStub(RuntimeTarget.Staging)).toThrow(/staging/);
+    expect(() => assertWithStub(RuntimeTarget.Staging)).toThrow(/no Auth0 device code client/);
+
+    vi.doUnmock("../shared/runtime-target-constants.js");
+    vi.resetModules();
   });
 });

--- a/src/test/cli/runtime-target-visibility.test.ts
+++ b/src/test/cli/runtime-target-visibility.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { resetConfig } from "../../../packages/mcps/src/shared/config.js";
 import { RUNTIME_TARGET_ENV_VAR } from "../../../packages/mcps/src/shared/runtime-target-constants.js";
-import { loginCommand, statusCommand } from "../../cli/login.js";
+import { statusCommand } from "../../cli/login.js";
 
 afterEach(() => {
   delete process.env[RUNTIME_TARGET_ENV_VAR];
@@ -50,10 +50,29 @@ describe("statusCommand", () => {
 });
 
 describe("loginCommand", () => {
+  // The guard is driven by a stub rather than by a real unprovisioned target.
+  // Every shipped target now has a client, so pinning this to one of them would
+  // both fail and — worse — let the command reach a live device-code request.
   it("refuses a target with no provisioned device code client", async () => {
-    process.env[RUNTIME_TARGET_ENV_VAR] = "staging";
+    vi.resetModules();
+    vi.doMock("../../../packages/mcps/src/index.js", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("../../../packages/mcps/src/index.js")>();
+      return {
+        ...actual,
+        assertDeviceCodeClientProvisioned: () => {
+          throw new Error(
+            "Runtime target 'staging' has no Auth0 device code client provisioned.",
+          );
+        },
+      };
+    });
+
+    const { loginCommand: gatedLoginCommand } = await import("../../cli/login.js");
     vi.spyOn(console, "log").mockImplementation(() => undefined);
 
-    await expect(loginCommand({})).rejects.toThrow(/no Auth0 device code client/);
+    await expect(gatedLoginCommand({})).rejects.toThrow(/no Auth0 device code client/);
+
+    vi.doUnmock("../../../packages/mcps/src/index.js");
+    vi.resetModules();
   });
 });


### PR DESCRIPTION
Unblocks the staging channel. The staging runtime target shipped with an empty Auth0 client ID and a login path that refused with provisioning instructions, because the staging tenant had no application supporting the device code grant. One now exists.

## Verified before recording

Auth0 offers the Device Code grant only on **Native** applications, and the staging tenant had none — its six applications are SPA, Regular Web App, and Machine-to-Machine. I probed all six against the tenant's device authorization endpoint and every one refused:

| Application | Type | Result |
| --- | --- | --- |
| API Explorer Application | M2M | rejected |
| Muggle AI | SPA | grant not allowed |
| Muggle AI Auth0 Management API | M2M | rejected |
| Muggle AI Service | Regular Web App | grant not allowed |
| …Teaching Studio Web Service M2M | M2M | rejected |
| Muggle AI Teaching Studio | M2M | rejected |

The new client returns a device code and an activation URL on the same probe, so the value recorded here is confirmed working rather than assumed.

Exercised end-to-end against the built artifact: `muggle login` on the staging target now starts the device code flow and opens `login.staging.muggle-ai.com/activate`, where it previously refused before contacting Auth0.

## Test changes, and why they were necessary

Two tests asserted the unprovisioned-client guard by pointing it at staging — the target that happened to lack a client. Provisioning one made both fail.

The CLI one was worse than a failing assertion: with the guard no longer throwing, `loginCommand` would have proceeded into a **live device-code request** during the test run.

Both now drive the guard from a stubbed profile, so each asserts the guard's behavior rather than which tenant is behind on setup. The resolution test additionally asserts the invariant that every shipped target has a client — which is the thing actually worth pinning now.

## Validation

`npm test` exit 0 — 95 files, 1345 passed, 27 skipped. `tsc --noEmit` exit 0. Lint introduces no new errors.
