### PR TITLE
fix(browser-bench): pass studio's positional run mode when spawning

### DIFF
--- a/internal/browser-bench/src/studio/constants.ts
+++ b/internal/browser-bench/src/studio/constants.ts
@@ -18,3 +18,12 @@ export const STUDIO_STATUS_SUCCESS = "success";
 
 /** How much studio stderr to keep for an error message — enough for a stack, short of a log dump. */
 export const STDERR_TAIL_LIMIT = 4_000;
+
+/**
+ * Studio's run mode, passed positionally as the first argument. Studio reads
+ * `argv[1]` as the mode before scanning for flags, so omitting it makes the
+ * benchmark flag itself land in the mode slot and the process exits with
+ * "Unsupported run mode --benchmark-task". Benchmark mode is explore plus the
+ * task-file marker, never a mode of its own.
+ */
+export const STUDIO_RUN_MODE = "explore";

--- a/internal/browser-bench/src/studio/studio-invocation.test.ts
+++ b/internal/browser-bench/src/studio/studio-invocation.test.ts
@@ -44,7 +44,7 @@ describe("buildStudioTaskFile", () => {
 });
 
 describe("buildStudioArgv", () => {
-  it("pins the single-flag spawn contract", () => {
+  it("pins the run mode plus single-flag spawn contract", () => {
     expect(
       buildStudioArgv({
         studioBinPath: "/bin/muggle-studio",
@@ -52,7 +52,21 @@ describe("buildStudioArgv", () => {
         resultFilePath: "/out/trajectories/Allrecipes--0/result.json",
         browserProfileDir: "/out/profiles/Allrecipes--0",
       }),
-    ).toEqual(["--benchmark-task", "/out/trajectories/Allrecipes--0/task.json"]);
+    ).toEqual(["explore", "--benchmark-task", "/out/trajectories/Allrecipes--0/task.json"]);
+  });
+
+  it("leads with the positional run mode, which studio reads as argv[1]", () => {
+    // Studio resolves the run mode positionally before scanning flags. Omit it
+    // and "--benchmark-task" lands in the mode slot: the process exits with
+    // "Unsupported run mode --benchmark-task" before the agent loop is reached.
+    const argv = buildStudioArgv({
+      studioBinPath: "/bin/muggle-studio",
+      taskFilePath: "/out/task.json",
+      resultFilePath: "/out/result.json",
+      browserProfileDir: "/out/profiles/x",
+    });
+
+    expect(argv[0]).toBe("explore");
   });
 
   it("does not pass --out; studio reads the result path from the task file", () => {

--- a/internal/browser-bench/src/studio/studio-invocation.ts
+++ b/internal/browser-bench/src/studio/studio-invocation.ts
@@ -1,5 +1,5 @@
 import { type BenchmarkTask } from "../domain/types";
-import { BENCHMARK_TASK_FLAG } from "./constants";
+import { BENCHMARK_TASK_FLAG, STUDIO_RUN_MODE } from "./constants";
 import { type StudioInvocation, type StudioTaskFile } from "./types";
 
 /**
@@ -31,12 +31,13 @@ export const buildStudioTaskFile = ({
 
 /**
  * Builds studio's argument list. The contract is fixed on both sides — studio
- * reads exactly this one flag — so it is pinned here rather than assembled
- * inline at the spawn site.
+ * reads a positional run mode and then this one flag — so it is pinned here
+ * rather than assembled inline at the spawn site.
  *
- * Output shape: `["--benchmark-task", "…/task.json"]`
+ * Output shape: `["explore", "--benchmark-task", "…/task.json"]`
  */
 export const buildStudioArgv = (invocation: StudioInvocation): string[] => [
+  STUDIO_RUN_MODE,
   BENCHMARK_TASK_FLAG,
   invocation.taskFilePath,
 ];


### PR DESCRIPTION
**Found by the first live run**, not by tests.

Studio resolves its run mode positionally from `argv[1]` *before* it scans for flags. The harness spawned `MuggleAI.exe --benchmark-task <path>` with no positional mode, so the flag itself landed in the mode slot and the process died on boot:

```
Error: Unsupported run mode --benchmark-task
exit 4294967295 · 3.4s · zero steps
```

`buildStudioArgv` now leads with `explore`. Benchmark mode is *explore plus the task-file marker*, never a mode of its own — that was the design, and the studio PR documented the invocation as `studio explore --benchmark-task <task.json>`. The harness simply never emitted the positional part.

## Why no test caught it

Both halves' unit tests passed throughout, because **each tested its own side of the contract**. The studio tested that it parses the flag; the harness tested that it emits the flag. Nothing asserted the *composed* argv against what studio actually parses on boot.

A test now pins `argv[0] === "explore"` with the failure mode written into the comment, so the next person to touch this sees why the positional matters.

## Verification

- 54 tests, typecheck and lint clean
- **Verified against a real studio build** (electron-app v1.10.0, which contains the benchmark code): the run-mode error is gone and boot proceeds past argument parsing

## Known next blocker — not addressed here

The run now fails further along, on authentication:

```
Unable to refresh tokens: 403  →  exit 23 (UNABLE_TO_AUTHENTICATE)
```

`showWindowAsync` refreshes tokens from `authFilePath`, and the benchmark contract has no slot for one — the works MCP writes a temp `auth.json` and passes it positionally, but the harness doesn't. That is a design gap about how credentials reach a benchmark run, and it needs a decision rather than a quiet workaround, so it is deliberately out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)