### PR TITLE
fix(setup): install each studio release stream in its own directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,12 @@
         "linux-x64": "d434a88a087c7410785a443cfe03102322fa7a295b77600f5ed92e2113e271c2",
         "win32-x64": "0aecbc01010ab0a268137ed31bcaaa05fe9215daa9f4c0e4871b07554d28c0c8"
       },
-      "staging": {}
+      "staging": {
+        "darwin-x64": "754bbdaa9ccb0f10bfd92c0f5efd7877c4635708b8a7dde8bbf76bc6c74598b1",
+        "darwin-arm64": "8f8854788769971af4ad5c83531d595951f3c0306d3ddcc9b6b8cb5a5ccd375d",
+        "linux-x64": "929396f628a05f001782d48524cd9f76fdbb59216658982a5a3909dfe413cbea",
+        "win32-x64": "a8b5b46b97ed788030be84982a3e8d463abbfa7f3e8bc795692ccbffc82bfa92"
+      }
     }
   },
   "dependencies": {

--- a/packages/mcps/src/shared/config.ts
+++ b/packages/mcps/src/shared/config.ts
@@ -166,6 +166,33 @@ export function getDataDir(): string {
 }
 
 /**
+ * Build the install directory name for an electron-app version.
+ *
+ * Both release streams publish the same version deliberately, so a version
+ * alone does not identify a binary. Without the stream in the path, installing
+ * a staging harness on a machine that already has the production studio finds
+ * the directory present, skips the download, and runs the production studio
+ * against the staging backend — and no checksum catches it, because
+ * verification only happens on download.
+ *
+ * The production stream keeps the bare version so existing installs are not
+ * orphaned and nobody re-downloads on upgrade.
+ * @param params - Directory parameters.
+ * @param params.version - Electron app version.
+ * @param params.releaseStream - Release stream the binary came from.
+ * @returns Directory name, for example "1.9.0" or "1.9.0-staging".
+ */
+function buildElectronAppDirName(params: {
+  version: string;
+  releaseStream: ElectronAppReleaseStream;
+}): string {
+  if (params.releaseStream === ElectronAppReleaseStream.Production) {
+    return params.version;
+  }
+  return `${params.version}-${params.releaseStream}`;
+}
+
+/**
  * Get the path to the downloaded electron-app binary for the current platform.
  * Uses the effective version (env -> override -> bundled) to match where
  * setup/upgrade actually installs the binary.
@@ -175,7 +202,14 @@ function getDownloadedElectronAppPath(): string | null {
   const platformName = os.platform();
   const version = getElectronAppVersion();
 
-  const baseDir = path.join(getDataDir(), ELECTRON_APP_DIR, version);
+  const baseDir = path.join(
+    getDataDir(),
+    ELECTRON_APP_DIR,
+    buildElectronAppDirName({
+      version: version,
+      releaseStream: getActiveElectronAppReleaseStream(),
+    }),
+  );
 
   let binaryPath: string;
 
@@ -560,5 +594,12 @@ export function isElectronAppInstalled(): boolean {
  */
 export function getElectronAppDir(version?: string): string {
   const resolvedVersion = version ?? getElectronAppVersion();
-  return path.join(getDataDir(), ELECTRON_APP_DIR, resolvedVersion);
+  return path.join(
+    getDataDir(),
+    ELECTRON_APP_DIR,
+    buildElectronAppDirName({
+      version: resolvedVersion,
+      releaseStream: getActiveElectronAppReleaseStream(),
+    }),
+  );
 }

--- a/packages/mcps/src/test/electron-app-dir-per-stream.test.ts
+++ b/packages/mcps/src/test/electron-app-dir-per-stream.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { getElectronAppDir, resetConfig } from "../shared/config.js";
+import { RUNTIME_TARGET_ENV_VAR } from "../shared/runtime-target-constants.js";
+
+afterEach(() => {
+  delete process.env[RUNTIME_TARGET_ENV_VAR];
+  resetConfig();
+});
+
+/**
+ * Resolve the install directory under a given runtime target.
+ * @param runtimeTarget - Target to resolve under.
+ * @returns The resolved install directory path.
+ */
+function resolveDirForTarget(runtimeTarget: string): string {
+  process.env[RUNTIME_TARGET_ENV_VAR] = runtimeTarget;
+  resetConfig();
+  return getElectronAppDir("1.9.0");
+}
+
+describe("electron-app install directory", () => {
+  it("keeps the bare version on the production stream", () => {
+    expect(resolveDirForTarget("production").endsWith("1.9.0")).toBe(true);
+  });
+
+  it("keeps the bare version for dev, which shares the production studio", () => {
+    expect(resolveDirForTarget("dev").endsWith("1.9.0")).toBe(true);
+  });
+
+  it("suffixes the staging stream so it cannot occupy the production directory", () => {
+    expect(resolveDirForTarget("staging").endsWith("1.9.0-staging")).toBe(true);
+  });
+
+  // The two streams publish the same version on purpose, so the version alone
+  // does not identify a binary. Sharing a directory made an existing production
+  // install look like a satisfied staging install: setup skipped the download
+  // and ran the production studio against the staging backend, with no checksum
+  // check because verification only happens while downloading.
+  it("gives production and staging different directories at the same version", () => {
+    const productionDir = resolveDirForTarget("production");
+    const stagingDir = resolveDirForTarget("staging");
+
+    expect(productionDir).not.toBe(stagingDir);
+  });
+});

--- a/plugin/skills/muggle-status/SKILL.md
+++ b/plugin/skills/muggle-status/SKILL.md
@@ -16,17 +16,25 @@ Gates run per `preference-gates/README.md`.
 
 | Preference | Step | Decision it gates |
 |------------|------|-------------------|
-| `checkForUpdates` | Check 4 | Check for newer Muggle Test version |
+| `checkForUpdates` | Check 5 | Check for newer Muggle Test version |
 
 ## Checks
 
-1. **Electron app** — read `~/.muggle-ai/electron-app/` to find the installed version directory. Read `.install-metadata.json` to get version and checksum. Verify the binary exists at the expected path. On macOS, check code signing with `spctl --assess --verbose`.
+1. **Release ring** — run `muggle status` and read its `Runtime target:` and `Backend:` lines. Report the ring and the backend it resolves to.
 
-2. **MCP server** — call `muggle-local-check-status` to verify the server is responsive. Report auth state (authenticated, email, token expiry).
+   This is the first check because it reframes every other one: an install on a non-production ring talks to a different backend, authenticates against a different tenant, and runs a different studio binary, so "is it healthy" cannot be answered without it.
 
-3. **Authentication** — call `muggle-remote-auth-status`. Report whether credentials are valid and when they expire.
+   - `production` → render as `[pass]`.
+   - Any other ring → render as `[note]`, not a failure. A staging or dev install is a deliberate state, not a fault, but it must be visible: it is the explanation for auth and backend behaviour that would otherwise look broken.
+   - If `MUGGLE_MCP_PROMPT_SERVICE_TARGET` is set in the environment, say so and name its value. It overrides the ring baked in at publish time, it is easy to leave set from an earlier shell, and it explains a ring that disagrees with the installed package.
 
-4. **CLI version** — gate `checkForUpdates` (per `preference-gates/README.md`):
+2. **Electron app** — read `~/.muggle-ai/electron-app/` to find the installed version directory. Non-production rings install to a ring-suffixed directory (`<version>-staging`), so match the directory for the ring reported in Check 1 rather than assuming the bare version — the streams publish the same version deliberately, and the bare directory belongs to production. Read `.install-metadata.json` to get version and checksum. Verify the binary exists at the expected path. On macOS, check code signing with `spctl --assess --verbose`.
+
+3. **MCP server** — call `muggle-local-check-status` to verify the server is responsive. Report auth state (authenticated, email, token expiry).
+
+4. **Authentication** — call `muggle-remote-auth-status`. Report whether credentials are valid and when they expire.
+
+5. **CLI version** — gate `checkForUpdates` (per `preference-gates/README.md`):
    - `always` → run the check below.
    - `never` → render the row as `[skip]  check disabled by preference`.
    - `ask` → run Picker 1 from `preference-gates/checkForUpdates.md` via `AskUserQuestion`; map the answer back to one of the actions above.
@@ -38,6 +46,7 @@ Gates run per `preference-gates/README.md`.
 ```
 Muggle AI — Status
 
+Release ring   [pass/note]  ring, backend URL
 Electron app   [pass/fail]  version, binary status
 MCP server     [pass/fail]  responsive, auth state
 Authentication [pass/fail]  user, expiry
@@ -46,4 +55,4 @@ CLI version    [pass/warn]  installed → latest
 [All systems operational / Issues found — run /muggle:muggle-repair to fix.]
 ```
 
-Use pass/fail indicators for each check. If any check fails, tell the user to run `/muggle:muggle-repair`. If the CLI version check warns (installed < latest), tell the user to run `/muggle:muggle-upgrade`.
+Use pass/fail indicators for each check; the release ring uses `[pass]` on production and `[note]` elsewhere, never `[fail]`. When the ring is not production, state it in the closing line too, so it is not lost in a table the reader skims. If any check fails, tell the user to run `/muggle:muggle-repair`. If the CLI version check warns (installed < latest), tell the user to run `/muggle:muggle-upgrade`.


### PR DESCRIPTION
Two things the staging channel needed before anyone can actually install it, plus the `/mstatus` surface for telling which ring you are on.

## The bug

Studio installs were keyed by version alone — `~/.muggle-ai/electron-app/1.9.0/`. Both release streams publish the *same* version deliberately; that shared version is what makes a staging rehearsal say anything about production.

So on a machine that already has the production studio installed:

1. `npm i -g @muggleai/works@staging`
2. `muggle setup`
3. `setup.ts` sees the version directory present, prints **"already installed"**, skips the download
4. The **production studio** now runs against the **staging backend**

Checksums do not catch it. Verification only runs while downloading, and nothing downloaded.

This is the exact silent cross-wiring the design named as the failure mode to prevent, and it reproduces on any machine with both — including the one this was developed on, where it would have made the end-to-end rehearsal a false pass.

**Fix:** non-production streams install to a ring-suffixed directory (`1.9.0-staging`). Production keeps the bare version, so no existing install is orphaned and nobody re-downloads on upgrade.

## `/mstatus` shows the ring

`muggle-status` gains a **Release ring** check, reported first — a non-production ring means a different backend, a different identity tenant, and a different studio binary, so the other checks cannot be read without it.

- `production` renders `[pass]`; any other ring renders `[note]`, never `[fail]`. A staging install is deliberate, not a fault — but it has to be visible, because it explains auth and backend behaviour that otherwise looks broken.
- It names `MUGGLE_MCP_PROMPT_SERVICE_TARGET` when set. An override left over in a shell is exactly what makes the live ring disagree with the installed package.
- The electron-app check now looks in the ring's directory instead of assuming the bare version.

## Staging checksums recorded

`electron-app-staging-v1.9.0` is published, so the staging stream has fingerprints and stops being skipped.

Parsed from the release's own `checksums.txt` rather than transcribed, and cross-checked two ways: all four platforms present, and no staging hash equal to its production counterpart. An equal pair would mean the staging build never baked a different backend — the one way that release could be wrong while still looking correct.

Verified after recording:

```
checksums.txt verified for electron-app-v1.9.0.
checksums.txt verified for electron-app-staging-v1.9.0.
```

## Validation

`npm test` — 96 files, 1351 passed, 27 skipped. `tsc --noEmit` exit 0. Skill tests 390 passed; `check-skill-deps` exit 0.

New test pins the behaviour that broke: production and staging resolve to different directories at the same version, and dev stays on the production directory because it shares that studio.

Not yet exercised: the install itself. That is the next rehearsal step — `npm i -g @muggleai/works@staging` then `muggle setup`, which should download into `1.9.0-staging` and verify against the hashes recorded here.
