### PR TITLE
[UNIT-ONLY] Gate the watcher hand-off behind an E2E repair loop

### DIFF
--- a/plugin/skills/_shared/telemetry-events/muggle-do-escalation.md
+++ b/plugin/skills/_shared/telemetry-events/muggle-do-escalation.md
@@ -1,6 +1,6 @@
 # `muggle-do:escalation`
 
-Zero or one per address-reviews invocation. Fires when `/muggle-do` emits a terminal escalation message to the user.
+Zero or one per address-reviews invocation, plus zero or one per forward cycle that waives a failing E2E run. Fires when `/muggle-do` emits a terminal escalation message to the user.
 
 ```json
 {
@@ -9,7 +9,7 @@ Zero or one per address-reviews invocation. Fires when `/muggle-do` emits a term
   "session_slug": "<slug>",
   "repo": "<owner>/<repo>",
   "pr_number": <int>,
-  "kind": "ambiguous-review" | "design-adjustment" | "rebase-conflict",
+  "kind": "ambiguous-review" | "design-adjustment" | "rebase-conflict" | "e2e-unrepairable",
   "review_ids": [<int>, ...]
 }
 ```
@@ -18,3 +18,4 @@ Zero or one per address-reviews invocation. Fires when `/muggle-do` emits a term
 - `"ambiguous-review"` — one or more reviews classified ambiguous in this batch.
 - `"design-adjustment"` — mid-cycle, the work surfaced a design-level conflict.
 - `"rebase-conflict"` — an opt-in auto-rebase hit conflicts that couldn't be resolved and verified; the branch was restored to its pre-rebase SHA. `review_ids` may be empty.
+- `"e2e-unrepairable"` — the E2E repair loop shipped with failures it could not fix: the user waived, an unattended run had nobody to ask, or the iteration cap ran out. `review_ids` is empty.

--- a/plugin/skills/do/build.md
+++ b/plugin/skills/do/build.md
@@ -56,3 +56,12 @@ The address-reviews orchestrator ([`address-reviews.md`](address-reviews.md)) in
 - Continue on the existing branch — do not re-create the worktree.
 - After this stage, the orchestrator runs unit-tests → ONE E2E pass → create-or-update PR (push to the existing branch; refresh title/desc if state changed) → per-comment inline replies → resolve-reminder → respawn the watcher.
 - If the requested work cannot be implemented without rethinking design (e.g. a load-bearing invariant must change), return `failed: design-adjustment` and let the orchestrator escalate via the design-adjustment terminal message. Do not partially implement.
+
+## Re-entry from the E2E repair loop
+
+[`e2e-repair.md`](e2e-repair.md) invokes this stage when a failing acceptance run root-causes to a product defect the change introduced. When re-entered:
+
+- The loop passes the named defects — failing step, expected-versus-actual, and the implicated code path — as the requirements amendment for this iteration. Treat them as additions to the goal/AC.
+- Continue on the existing branch; the worktree and the PR already exist.
+- After this stage, the loop runs unit-tests → a re-run scoped to the affected test cases → `open-prs/update.md`. Impact analysis does not re-run.
+- If the defect can't be fixed without rethinking design, return `failed: design-adjustment`. The loop routes it to its user decision instead of burning an iteration on it.

--- a/plugin/skills/do/e2e-acceptance.md
+++ b/plugin/skills/do/e2e-acceptance.md
@@ -147,6 +147,8 @@ For each test case:
 
 **Overall:** PASS | FAIL | PARTIAL | INCONCLUSIVE | BLOCKED | SKIPPED — see [`../_shared/failure-mode-handling.md`](../_shared/failure-mode-handling.md) section F for the canonical taxonomy.
 
+A non-passing verdict does not end the cycle. [`e2e-repair.md`](e2e-repair.md) consumes this report at Stage 7.5 and root-causes every Failed and Inconclusive entry before a watcher is armed, so write those blocks in full — the bucket, failing step, and `artifactsDir` recorded here are that stage's entire input.
+
 Failed runs use the same evidence + diagnosis assembly as the interactive debug path ([`../_shared/debug-failed-run.md`](../_shared/debug-failed-run.md) Steps 1–2) — write that evidence into the **Failed** block above. This stage is autonomous, so it skips Step 3's interactive offer.
 
 ## Hard constraints

--- a/plugin/skills/do/e2e-repair.md
+++ b/plugin/skills/do/e2e-repair.md
@@ -1,0 +1,98 @@
+# E2E Repair Loop (Stage 7.5)
+
+Runs between Stage 7's posted walkthrough and Stage 8's watcher dispatch. A failing acceptance run means the change is not ready for a reviewer, so this stage root-causes every failure and either repairs it in-pipeline or puts one decision in front of the user. The watcher is armed only once this stage clears.
+
+## Turn preamble
+
+```
+**Stage 7.5 — E2E repair** — root-causing the failing acceptance runs before handing off to the watcher.
+```
+
+## Inputs
+
+- The Stage 6 acceptance report from [`e2e-acceptance.md`](e2e-acceptance.md) — its Failed and Inconclusive blocks and the run-level verdict.
+- `state.md` — validation strategy, per-repo worktree path, project id.
+- The PR opened by [`open-prs/forward.md`](open-prs/forward.md) — repo and number, for the escalation event and the refresh path.
+- `repairIteration` — how many times this stage has already run in this session, read from `iterations/<NNN>.md`.
+
+## Step 0: Clearance check
+
+Read the Stage 6 run-level verdict, defined in [`../_shared/failure-mode-handling.md`](../_shared/failure-mode-handling.md) section F.
+
+- `PASS` or `SKIPPED` → nothing to repair. Append `e2e-repair: clear (<verdict>)` to the iteration log and hand to Stage 8.
+- A verdict the user waived earlier in this session → clear on the recorded waiver; never re-ask.
+- `FAIL`, `PARTIAL`, `INCONCLUSIVE`, or `BLOCKED` → the loop runs over every entry in the Failed and Inconclusive blocks.
+
+## Step 1: Root-cause each failure
+
+Per failing test case, assemble evidence and a diagnosis with [`../_shared/debug-failed-run.md`](../_shared/debug-failed-run.md) Steps 1–2 — attempted steps, halt reason, the failing step's screenshot, then the bucket. That doc's Step 3 is the interactive debug card; this stage is autonomous and does not run it.
+
+Stage 6 already wrote this evidence into its Failed block. Re-derive a bucket only for entries that arrived without one.
+
+The bucket is the root cause. Anything that does not land in a bucket is `unclassified` — never force-fit one to reach an auto-repair disposition.
+
+## Step 2: Disposition
+
+Map each bucket to exactly one disposition. Buckets are defined in [`../_shared/failure-mode-handling.md`](../_shared/failure-mode-handling.md) sections B and C.
+
+| Bucket | Disposition | Why |
+| :----- | :---------- | :-- |
+| `product-defect` (replay) | `repair` | The change broke a flow that used to work. That is this pipeline's own bug to fix. |
+| `product-uxux` (regen) | `repair` | The product blocks the agent because the feature does not work. |
+| `stale-script` (replay) | `regenerate` | Selectors moved; the product is fine. Regenerating is self-healing, not a code change. |
+| `transient` (regen) | `retry` | Once, then re-bucket the second result. A twice-transient failure is `infra`. |
+| `infra` (either) | `ask` | A Muggle Test bug. Nothing in this repo fixes it. |
+| `agent-course` (regen) | `ask` | The agent needs steering, which is the user's `muggle-feedback` call to make. |
+| `unclassified` | `ask` | No bucket, no automatic action. |
+
+A `repair` disposition requires a named defect: the failing step, expected-versus-actual, and the code path it implicates. Without one it is `ask`, whatever the bucket said.
+
+## Step 3: Act
+
+Process dispositions in order — `retry`, then `regenerate`, then `repair` — so cheap self-healing runs before any code change.
+
+- **`retry`** — re-execute the case unchanged through the Stage 6 loop. Re-bucket the result and fold it back into Step 2.
+- **`regenerate`** — regenerate the script for that test case, then re-replay. One regeneration per test case per iteration, matching Stage 6's own cap.
+- **`repair`** — re-enter [`build.md`](build.md) with the named defects as this iteration's requirements amendment, then run [`unit-tests.md`](unit-tests.md) and refresh the PR through [`open-prs/update.md`](open-prs/update.md). Impact analysis does not re-run; the change is scoped to a known defect.
+- **`ask`** — collect every `ask` failure and present **one** `AskUserQuestion` (Step 4). Never one picker per failure.
+
+## Step 4: The user decision
+
+One question, listing each unrepairable failure with its bucket, failing step, and dashboard link. Options:
+
+1. **Repair anyway** — the user names what the fix should be; the loop treats it as a `repair` disposition and re-enters Step 3.
+2. **Give feedback and rerun** — invoke `muggle-feedback` for the run, then re-execute in regen mode. The right answer for `agent-course`.
+3. **Waive and ship** — record the waiver in `state.md`, retitle the PR `[E2E FAILING]`, and clear to Stage 8.
+4. **Stop here** — leave the PR open and unwatched; the user takes it from there.
+
+**Unattended runs.** When the cycle was started autonomously there is nobody to ask. Do not skip the loop — run Steps 1–3 in full, then treat a surviving `ask` as an automatic waive: emit the escalation event, retitle `[E2E FAILING]`, and clear to Stage 8. Silently arming the watcher on a red run is the failure this stage exists to prevent.
+
+## Step 5: Close the loop
+
+After a `repair`, `regenerate`, or `retry` pass, re-run [`e2e-acceptance.md`](e2e-acceptance.md) over the affected test cases only, increment `repairIteration`, and return to Step 0.
+
+The loop is bounded at **3** repair iterations, the same bound the cycle guardrail already applies to E2E failures. On the third exhausted iteration, waive automatically: retitle `[E2E FAILING]`, record the surviving failures in `result.md`, and clear to Stage 8. A PR a reviewer can see is worth more than a loop that never terminates.
+
+## Telemetry
+
+Steps 1–3 emit the `*-classified` / `*-resolved` pair per [`../_shared/failure-mode-handling.md`](../_shared/failure-mode-handling.md) section D, with `userAction` set to the disposition this stage took (`repair`, `regenerate`, `retry`) rather than a human pick. A failure that reaches Step 4 records the user's actual choice.
+
+Every waive — user-picked, unattended, or iteration-capped — also emits `muggle-do:escalation` with `kind: "e2e-unrepairable"` per [`../_shared/telemetry-events/muggle-do-escalation.md`](../_shared/telemetry-events/muggle-do-escalation.md).
+
+## Output
+
+**Verdict in:** `<Stage 6 verdict>`
+**Repair iterations:** `<n>` of 3
+**Repaired:** test case → root cause → commit subject
+**Regenerated:** test case → new script id
+**Waived:** test case → bucket → reason
+**Verdict out:** `<verdict after the final re-run>`
+**Clearance:** `green` | `waived — <reason>` | `iteration-cap`
+
+## Invariants
+
+- Stage 8 is unreachable while clearance is unresolved — the only exits are green, waived, or iteration-capped.
+- No bucket auto-repairs without a named defect.
+- One `AskUserQuestion` per stage run, never one per failure.
+- An unattended run still executes Steps 1–3; only Step 4 collapses.
+- Re-runs are scoped to the affected test cases, never the whole suite.

--- a/plugin/skills/do/open-prs/forward.md
+++ b/plugin/skills/do/open-prs/forward.md
@@ -41,9 +41,13 @@ Forward pipeline's Stage 7. Invoked by `/muggle-do` after stages 1–6 of a fres
 
 6. **Overflow comment:** if the walkthrough skill returned a non-null `comment`, post it once using the provider resolved in Step 5 — `github` per [`../../_shared/vcs/github/top-level-comment.md`](../../_shared/vcs/github/top-level-comment.md), `gitlab` per [`../../_shared/vcs/gitlab/mr-note.md`](../../_shared/vcs/gitlab/mr-note.md). End the posted body with the signature line (command `/muggle-do`) per [`../../_shared/vcs/post-signature.md`](../../_shared/vcs/post-signature.md). Never post when `comment` is `null`.
 
+## Stage 7.5 gate
+
+The E2E repair loop ([`../e2e-repair.md`](../e2e-repair.md)) runs once this stage has created the PR and posted the walkthrough, and before the handoff below. Proceed only on its `green`, `waived`, or `iteration-cap` clearance — handing a red run to a watcher puts it in front of reviewers with nobody looking at the failures. When Stage 6 recorded `PASS` or `SKIPPED` the loop clears in its own Step 0 at no cost, so there is never a reason to skip it.
+
 ## Stage 8 handoff
 
-After every repo is processed, build the watcher manifest and dispatch one watcher loop per opened PR. The dispatches are the LAST action this stage takes.
+After every repo is processed and Stage 7.5 has cleared, build the watcher manifest and dispatch one watcher loop per opened PR. The dispatches are the LAST action this stage takes.
 
 Write `~/.muggle-ai/muggle-do/sessions/<slug>/prs.json` per [`../../muggle-pr-followup/state-schemas.md`](../../muggle-pr-followup/state-schemas.md#prsjson):
 
@@ -64,7 +68,7 @@ If `prs.json` is empty, **do not dispatch** — record the reason in `result.md`
 
 ## Invariants
 
-- Branch synced with its base before the push, never after; PR creation per non-skipped repo; walkthrough block via Mode B; `prs.json`+`last_seen.json` seeded (no `cycle.json`, no `requirements.md`); `/loop` dispatch is the last action.
+- Branch synced with its base before the push, never after; PR creation per non-skipped repo; walkthrough block via Mode B; `prs.json`+`last_seen.json` seeded (no `cycle.json`, no `requirements.md`); Stage 7.5 cleared before the dispatch; `/loop` dispatch is the last action.
 
 ## Output
 
@@ -72,6 +76,7 @@ If `prs.json` is empty, **do not dispatch** — record the reason in `result.md`
 **PRs Created:** repo → URL
 **Skipped:** repo → reason (when `autoCreatePR` short-circuited)
 **Overflow comments posted:** repo → PR #
+**Stage 7.5:** `green` | `waived — <reason>` | `iteration-cap`
 **Stage 8:** `Watching <N> PR(s) — one /loop 1m /muggle:muggle-pr-followup <slug> <pr#> per PR` | `No PRs to watch — stage 8 not dispatched`
 **Errors:** repo → message
 

--- a/plugin/skills/muggle-do/SKILL.md
+++ b/plugin/skills/muggle-do/SKILL.md
@@ -20,9 +20,10 @@ Runs an autonomous dev cycle from requirements to PR. **Fire and review:** user 
 | 5 | Unit tests | [`../do/unit-tests.md`](../do/unit-tests.md) |
 | 6 | E2E acceptance | [`../do/e2e-acceptance.md`](../do/e2e-acceptance.md) |
 | 7 | Create or update PR | [`../do/open-prs.md`](../do/open-prs.md) |
+| 7.5 | E2E repair loop | [`../do/e2e-repair.md`](../do/e2e-repair.md) |
 | 8 | Hand off to watcher | [`../muggle-pr-followup/SKILL.md`](../muggle-pr-followup/SKILL.md) |
 
-Stage 7 dispatches one watcher per opened PR as its last action.
+Stage 7 dispatches one watcher per opened PR as its last action, gated on Stage 7.5's clearance — a cycle with unrepaired E2E failures never reaches a watcher.
 
 ## Execution protocol (non-negotiable)
 
@@ -31,12 +32,12 @@ The pipeline table lists **pointers, not summaries**. Open each stage's file and
 **Bootstrap before any code, in order:**
 1. Emit telemetry — [`../_shared/telemetry-emit.md`](../_shared/telemetry-emit.md), `skillName: "muggle-do"`.
 2. Create `~/.muggle-ai/muggle-do/sessions/<slug>/` with `state.md` + `iterations/001.md` (pre-flight owns this; do it even when running unattended).
-3. `TodoWrite` one item per stage 1–8 — these stages are the checklist; never swap in your own decomposition.
+3. `TodoWrite` one item per stage 1–8, Stage 7.5 included — these stages are the checklist; never swap in your own decomposition.
 
 **Per stage:** read the file → execute it → append a marker to `iterations/<NNN>.md` citing the evidence that file requires (jest exit code, E2E verdict + `runId`, screenshot path). A stage is done only when its evidence is written, never on recollection.
 
 ### "Autonomous" / "without my intervention" collapses exactly one thing
-Best-effort the Stage-1 questionnaire and don't ask. It does **not** license skipping telemetry, session artifacts, requirements, unit tests, E2E (`autoE2ETest` defaults to `always`), browser verification, the gate below, or the watcher hand-off. Run the whole pipeline silently — never a shortcut.
+Best-effort the Stage-1 questionnaire and don't ask. It does **not** license skipping telemetry, session artifacts, requirements, unit tests, E2E (`autoE2ETest` defaults to `always`), browser verification, the gate below, the Stage-7.5 repair loop, or the watcher hand-off. Stage 7.5 investigates and repairs unattended too; only its user decision collapses, into an automatic waive. Run the whole pipeline silently — never a shortcut.
 
 ### Definition of Done — gate before Stage 7
 Do not create or update a PR until each line holds, or is waived by a one-line reason written into `state.md` (silence is not a waiver):
@@ -81,7 +82,7 @@ When invoked with the directive (PR URL + slug + review ids), routes to [`../do/
 
 ## Guardrails
 
-- Stage 1 is the only user-facing forward stage. Stages 2–7 don't ask mid-cycle; blocker → pre-flight bug.
+- Stage 1 and Stage 7.5's user decision are the only user-facing forward stages. Stages 2–7 don't ask mid-cycle; blocker → pre-flight bug.
 - Same stage failing 3× → escalate.
-- 3 cycle iterations reach E2E with failures → ship with `[E2E FAILING]`.
+- 3 repair iterations reach E2E with failures → waive, ship with `[E2E FAILING]`, and hand to the watcher.
 - Address-reviews escalation (ambiguous or design-adjustment) does not block the watcher; user resolves on GitHub.


### PR DESCRIPTION
## Goal

In the muggle-do forward pipeline, a failing E2E run is investigated, root-caused and triaged into a repair iteration or a user decision before the PR watcher is ever armed.

## Acceptance Criteria

- Stage 7.5 runs after Stage 7 posts the PR and walkthrough, and before Stage 8 dispatches the watcher.
- A verdict with no failures clears the loop immediately, at no cost.
- Failures are root-caused through the existing `_shared/debug-failed-run.md` evidence path and `_shared/failure-mode-handling.md` buckets, not a restated copy of them.
- Each failure resolves to exactly one disposition: repair, regenerate, retry, or ask.
- `product-defect` / `product-uxux` re-enter Stage 3 (Build) with the named defect; no nested `/muggle-do`.
- `stale-script` regenerates, `transient` retries once, and `infra` / `agent-course` / unclassified stop for a single user decision.
- Repairs refresh the PR through `do/open-prs/update.md`, then E2E re-runs scoped to the affected test cases.
- Bounded at three repair iterations; on exhaustion it waives, ships `[E2E FAILING]`, and hands off anyway.
- Stage 8 is reachable only on a `green`, `waived`, or `iteration-cap` clearance.

## Changes

- **New** `plugin/skills/do/e2e-repair.md` — the Stage 7.5 procedure: clearance check, root-cause, the bucket-to-disposition table, act, the single user decision, loop closure and bound.
- `plugin/skills/muggle-do/SKILL.md` — Stage 7.5 joins the pipeline table; the hand-off note names the clearance gate; the autonomous-collapse clause states the loop still investigates and repairs unattended, with only its question collapsing; guardrails name Stage 7.5 as the second user-facing forward stage and restate the three-iteration bound as a waive.
- `plugin/skills/do/open-prs/forward.md` — a Stage 7.5 gate ahead of the Stage 8 hand-off, carried into the invariants and the output block.
- `plugin/skills/do/build.md` — a re-entry section for the repair loop, mirroring the existing address-reviews one.
- `plugin/skills/do/e2e-acceptance.md` — records that a non-passing verdict feeds Stage 7.5, so its Failed and Inconclusive blocks are that stage's entire input.
- `plugin/skills/_shared/telemetry-events/muggle-do-escalation.md` — extends `kind` with `e2e-unrepairable` rather than minting a new event.

### Design notes

The loop sits **after** Stage 7 rather than before it, so a repair pushes through `open-prs/update.md` — the path that already refreshes title, description and walkthrough — instead of needing a new hold-the-PR-back path.

Repairs re-enter this pipeline rather than dispatching `/muggle-do`: muggle-do *is* `/mdo`, so a nested dispatch would spawn a second cycle carrying its own pre-flight and PR stages.

No `mandatoryStages` entry was added. Per `plugin/skills/CLAUDE.md`, a file only one branch consults does not qualify — Stage 7.5 reads the failure-mode taxonomy only when there are failures, and a gate cannot tell that the branch was never taken.

## Validation

`unit-only` — a markdown-only change under `plugin/skills/` with `pathClassification: none`, so the E2E stage exited SKIPPED with that reason recorded.

Gates run locally against this branch:

- `node scripts/check-skill-deps.mjs` → OK, 365 cross-skill links, no reverse dependencies
- `node scripts/verify-plugin-marketplace.mjs` → verification passed
- `node scripts/verify-compatibility-contracts.mjs` → verification passed
- relative-link check across all six touched files → every link resolves

<!-- muggle-works:signature -->
🤖 _Posted by `/muggle-do` · [Muggle Works](https://github.com/multiplex-ai/muggle-ai-works)_
