### PR TITLE
perf(evals): pool the routing sweep and raise eval concurrency

### DIFF
--- a/.github/workflows/skill-eval.yml
+++ b/.github/workflows/skill-eval.yml
@@ -24,7 +24,7 @@ on:
         default: "10"
       gate_concurrency:
         description: "skill-gate-eval: parallel reps per gate"
-        default: "4"
+        default: "8"
       routing_runs:
         description: "skill-routing-eval: runs per query (full sweep)"
         default: "3"
@@ -32,14 +32,14 @@ on:
         description: "skill-routing-eval: runs per query (scoped PR run)"
         default: "5"
       routing_workers:
-        description: "skill-routing-eval: parallel sessions per chunk"
-        default: "6"
+        description: "skill-routing-eval: parallel sessions across the pooled sweep"
+        default: "12"
       agent_runs:
         description: "agent-gate-eval: runs per scenario"
         default: "5"
       agent_concurrency:
         description: "agent-gate-eval: parallel reps per agent"
-        default: "4"
+        default: "8"
 
 concurrency:
   group: skill-eval-${{ github.ref }}
@@ -60,7 +60,7 @@ jobs:
     timeout-minutes: 180
     env:
       GATE_RUNS: ${{ inputs.gate_runs || '10' }}
-      GATE_CONCURRENCY: ${{ inputs.gate_concurrency || '4' }}
+      GATE_CONCURRENCY: ${{ inputs.gate_concurrency || '8' }}
       MUGGLE_BRAIN_DIR: ${{ github.workspace }}/muggle-ai-brain
       # Fresh, writable config dir for the headless Claude Code CLI (same as
       # skill-routing-eval) — avoids first-run state in an unwritable HOME.
@@ -269,7 +269,7 @@ jobs:
     timeout-minutes: 90
     env:
       AGENT_RUNS: ${{ inputs.agent_runs || '5' }}
-      AGENT_CONCURRENCY: ${{ inputs.agent_concurrency || '4' }}
+      AGENT_CONCURRENCY: ${{ inputs.agent_concurrency || '8' }}
       CLAUDE_CONFIG_DIR: ${{ github.workspace }}/.cc-config
     steps:
       - name: Require secrets
@@ -413,7 +413,7 @@ jobs:
       ROUTING_RUNS_SCOPED: ${{ inputs.routing_runs_scoped || '5' }}
       # Safe above the old default of 3 now that router_eval retries throttled
       # runs with a pool-wide backoff instead of scoring them as `none`.
-      ROUTING_WORKERS: ${{ inputs.routing_workers || '6' }}
+      ROUTING_WORKERS: ${{ inputs.routing_workers || '12' }}
       CLAUDE_CONFIG_DIR: ${{ github.workspace }}/.cc-config
       CLEAN_CWD: ${{ github.workspace }}/.clean-cwd
       BASELINE_CANDIDATE: ${{ github.workspace }}/internal/skill-routing-eval/reports/run/recall-baseline.candidate.json

--- a/internal/agent-gate-eval/src/run.ts
+++ b/internal/agent-gate-eval/src/run.ts
@@ -9,7 +9,7 @@
  *     [--runs 5] \
  *     [--agents-dir plugin/agents] \
  *     [--scenarios-dir internal/agent-gate-eval/scenarios] \
- *     [--concurrency 4]           # parallel reps; AGENT_GATE_EVAL_CONCURRENCY env also works
+ *     [--concurrency 8]           # parallel reps; AGENT_GATE_EVAL_CONCURRENCY env also works
  *     [--scenario <substring>]    # only run scenarios whose name contains this
  *     [--verbose]                 # dump per-run trace to stderr
  *

--- a/internal/skill-gate-eval/src/constants.ts
+++ b/internal/skill-gate-eval/src/constants.ts
@@ -16,10 +16,11 @@ export const DEFAULT_MODEL = "claude-sonnet-4-6";
 
 /**
  * Reps are isolated agent sessions sharing one subscription token, so the
- * ceiling is the token's rate budget, not CPU. 4 keeps a healthy sweep fast
- * while leaving headroom before the throttle gate starts firing.
+ * ceiling is the token's rate budget, not CPU. 8 halves a healthy sweep's wall
+ * clock; the throttle gate absorbs the overshoot when the budget does bind,
+ * pausing new starts pool-wide rather than failing the run.
  */
-export const DEFAULT_GATE_EVAL_CONCURRENCY = 4;
+export const DEFAULT_GATE_EVAL_CONCURRENCY = 8;
 
 export const THROTTLE_MAX_RETRIES = 3;
 export const THROTTLE_BACKOFF_BASE_MS = 15_000;

--- a/internal/skill-gate-eval/src/run.ts
+++ b/internal/skill-gate-eval/src/run.ts
@@ -10,7 +10,7 @@
  *     --runs 10 \
  *     [--brain-dir ../muggle-ai-brain] \
  *     [--model claude-sonnet-4-6] \
- *     [--concurrency 4]           # parallel reps; SKILL_GATE_EVAL_CONCURRENCY env also works
+ *     [--concurrency 8]           # parallel reps; SKILL_GATE_EVAL_CONCURRENCY env also works
  *     [--scenario <substring>]   # only run scenarios whose name contains this
  *     [--verbose]                 # dump per-run trace to stderr
  */

--- a/internal/skill-routing-eval/README.md
+++ b/internal/skill-routing-eval/README.md
@@ -24,7 +24,7 @@ This is faithful in a way isolated single-skill triggering tests are not: it cat
 
 ## Run it
 
-One command — chunks per skill, guards against MCP disconnects, aggregates, and writes the report:
+One command — one pooled sweep, guards against MCP disconnects, aggregates, and writes the report:
 
 ```bash
 python internal/skill-routing-eval/run.py --all          # full set
@@ -32,11 +32,11 @@ python internal/skill-routing-eval/run.py --skill muggle-status   # one skill
 python internal/skill-routing-eval/run.py --all --sync-cache      # see below
 ```
 
-Output lands in `reports/run/` (`combined.json` + `combined.md`, plus per-skill `chunk_*.json`). `run.py` runs each skill's queries as a separate `claude -p` batch so an MCP disconnect can only spoil one chunk, not the whole sweep; a positive chunk that comes back all-`none` (the disconnect signature) is re-run once and flagged if it stays empty. Within a chunk, a run that fails with a rate-limit signature retries up to 3× with exponential backoff shared across the worker pool (`throttle.py`), and exhausted retries score as `THROTTLED` rather than a silent `none` — which is what makes `--workers` above the old default of 3 safe (CI uses 6).
+Output lands in `reports/run/` (`combined.json` + `combined.md`, plus `chunk_pooled.json` and a per-skill `chunk_*.json` for any skill the guard re-ran). `run.py` plans every selected skill's queries into **one** `claude -p` batch `--workers` wide, so no worker idles while a skill's tail drains — the sequential per-skill batches this replaced left the pool draining once per skill. Skill identity is carried on each result row, so grouping and the guard are a partition of the pooled run. A positive skill that comes back all-`none` (the disconnect signature) is re-run alone in a fresh subprocess up to 3× and flagged inconclusive if it stays empty; isolating the retry is what makes a pooled sweep as recoverable as per-skill batches were. A run that fails with a rate-limit signature retries up to 3× with exponential backoff shared across the worker pool (`throttle.py`), and exhausted retries score as `THROTTLED` rather than a silent `none` — which is what makes the default of 12 workers safe. Pooling also makes that backoff genuinely global: a separate subprocess per skill previously gave each chunk its own gate.
 
 **`--sync-cache`:** the harness routes via the *installed* muggle plugin, not the working tree. When you've edited a `SKILL.md` description but not reinstalled, `claude -p` sees both the cached copy and the bare-name working-tree skill and results are unreliable. `--sync-cache` copies `plugin/skills/*/SKILL.md` over the installed cache first (auto-detected from `~/.claude/plugins/installed_plugins.json`) so the eval tests your edits. Always pass it when validating a description change.
 
-### Lower-level (single set, no chunking)
+### Lower-level (single set, no guard)
 
 ```bash
 python internal/skill-routing-eval/router_eval.py --eval-set <set.json> --repo-root "$(pwd)" --runs 3 --workers 5 --timeout 180 --out <report.json>

--- a/internal/skill-routing-eval/pool_constants.py
+++ b/internal/skill-routing-eval/pool_constants.py
@@ -1,0 +1,11 @@
+"""Tuning constants for the routing eval's pooled sweep."""
+
+# Every selected skill's queries run in one pool, so no worker idles through a
+# chunk's tail. Safe to raise because the throttle gate is the backstop: one 429
+# pauses new starts for the whole pool, which a pooled sweep makes true across
+# skills for the first time (per-chunk subprocesses each had their own gate).
+DEFAULT_ROUTING_WORKERS = 12
+
+# A positive-skill chunk that comes back entirely `none` is re-run in a fresh
+# subprocess this many times before it is called inconclusive.
+MAX_DISCONNECT_ATTEMPTS = 3

--- a/internal/skill-routing-eval/pooling.py
+++ b/internal/skill-routing-eval/pooling.py
@@ -1,0 +1,69 @@
+"""Planning and result regrouping for the routing eval's single-pass sweep.
+
+Chunk identity survives the pool: every result row carries `expected_skill`, so
+the per-skill view the report and the disconnect guard need is a partition of
+one pooled run rather than a subprocess per skill.
+"""
+
+from pool_constants import MAX_DISCONNECT_ATTEMPTS
+from regression_gate import skill_tally
+from scoring import NONE
+
+
+def plan_pooled_items(skills: list[str], by_skill: dict) -> list[dict]:
+    """Every selected skill's queries flattened into one pool, in `skills` order."""
+    return [item for skill in skills for item in by_skill.get(skill, [])]
+
+
+def partition_results_by_skill(results: list[dict], skills: list[str]) -> dict[str, list[dict]]:
+    """Pooled result rows regrouped under the skill each one was expected to route to.
+
+    Output shape: `{"muggle-test": [row, ...], "none": [row, ...]}`, one key per
+    entry in `skills` even when that skill contributed no rows.
+    """
+    grouped: dict[str, list[dict]] = {skill: [] for skill in skills}
+    for result in results:
+        expected = result.get("expected_skill", NONE)
+        if expected in grouped:
+            grouped[expected].append(result)
+    return grouped
+
+
+def recall_from_results(results: list[dict], skill: str) -> float:
+    """Share of one skill's queries that routed correctly. No queries reads as 1.0."""
+    passed, total = skill_tally(results, skill)
+    return passed / total if total else 1.0
+
+
+def resolve_disconnect_retries(
+    grouped: dict[str, list[dict]],
+    rerun_skill,
+    max_attempts: int = MAX_DISCONNECT_ATTEMPTS,
+    on_retry=None,
+) -> tuple[dict[str, list[dict]], list[str]]:
+    """Re-run every positive skill the pool returned at 0% recall, one skill at a time.
+
+    A flat 0% is almost always a mid-sweep MCP disconnect rather than a real
+    routing collapse, and a genuine description regression surfaces as partial
+    recall instead. `rerun_skill(skill)` re-runs that one skill's queries in
+    isolation and returns its replacement rows; `on_retry(skill, attempt, limit)`
+    reports each attempt.
+
+    Output shape: `(grouped, ["muggle-status"])` — the second element names the
+    skills still at 0% after `max_attempts`, which are inconclusive, not failures.
+    """
+    flagged = []
+    for skill in list(grouped):
+        if skill == NONE:
+            continue
+        results = grouped[skill]
+        attempts = 1
+        while recall_from_results(results, skill) == 0.0 and attempts < max_attempts:
+            attempts += 1
+            if on_retry:
+                on_retry(skill, attempts, max_attempts)
+            results = rerun_skill(skill)
+            grouped[skill] = results
+        if recall_from_results(results, skill) == 0.0:
+            flagged.append(skill)
+    return grouped, flagged

--- a/internal/skill-routing-eval/router_eval.py
+++ b/internal/skill-routing-eval/router_eval.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from threading import Lock
 
 import throttle
+from pool_constants import DEFAULT_ROUTING_WORKERS
 from route_constants import (
     COMMAND_VERB_EDGE_CHARS,
     DISCARDED_REDIRECT,
@@ -349,7 +350,7 @@ def main():
     ap.add_argument("--repo-root", default=".")
     ap.add_argument("--model", default=None)
     ap.add_argument("--runs", type=int, default=3)
-    ap.add_argument("--workers", type=int, default=6)
+    ap.add_argument("--workers", type=int, default=DEFAULT_ROUTING_WORKERS)
     ap.add_argument("--timeout", type=int, default=120)
     ap.add_argument("--out")
     ap.add_argument("--limit", type=int, default=0)

--- a/internal/skill-routing-eval/run.py
+++ b/internal/skill-routing-eval/run.py
@@ -2,10 +2,11 @@
 """One-command runner for the skill-routing eval.
 
 Wraps router_eval.py + analyze.py with the operational lessons learned running
-this by hand: per-skill chunking (so an MCP disconnect can't silently crater a
-whole sweep), a disconnect guard (re-run a positive chunk that comes back
-all-`none`), aggregation, and report generation — plus an optional cache sync so
-`claude -p` tests the working-tree descriptions rather than the installed copy.
+this by hand: one pooled sweep across every selected skill (so no worker idles
+through a chunk's tail), a disconnect guard (re-run a positive skill that comes
+back all-`none` in a fresh subprocess), aggregation, and report generation —
+plus an optional cache sync so `claude -p` tests the working-tree descriptions
+rather than the installed copy.
 
 Usage:
     python internal/skill-routing-eval/run.py --all
@@ -28,7 +29,9 @@ import sys
 from pathlib import Path
 
 from gate_constants import BASELINE_FILENAME, BASELINE_SOURCE_FULL_SWEEP
-from regression_gate import build_baseline, format_gate_report, gate_failures, judge_run, load_baseline, skill_tally
+from pool_constants import DEFAULT_ROUTING_WORKERS, MAX_DISCONNECT_ATTEMPTS
+from pooling import partition_results_by_skill, plan_pooled_items, resolve_disconnect_retries
+from regression_gate import build_baseline, format_gate_report, gate_failures, judge_run, load_baseline
 from scoring import NONE, scored_pass
 
 HERE = Path(__file__).resolve().parent
@@ -77,12 +80,6 @@ def run_chunk(items: list[dict], out_file: Path, repo_root: Path, runs: int, wor
     return json.loads(out_file.read_text(encoding="utf-8"))
 
 
-def recall(report: dict, skill: str) -> float:
-    """Share of one skill's queries that routed correctly in a chunk report."""
-    passed, total = skill_tally(report["results"], skill)
-    return passed / total if total else 1.0
-
-
 def has_no_coverage(skills: list[str], by_skill: dict) -> bool:
     return not any(by_skill.get(s) for s in skills)
 
@@ -94,7 +91,7 @@ def main():
     g.add_argument("--skill", help="run only this expected_skill chunk")
     g.add_argument("--skills", help="comma-separated subset of expected_skills to run (e.g. the skills changed in a PR)")
     ap.add_argument("--runs", type=int, default=3)
-    ap.add_argument("--workers", type=int, default=3, help="parallel claude sessions per chunk; router_eval's per-run throttle retry + shared backoff make higher values safe (CI uses 6)")
+    ap.add_argument("--workers", type=int, default=DEFAULT_ROUTING_WORKERS, help="parallel claude sessions across the pooled sweep; router_eval's per-run throttle retry + shared backoff make higher values safe")
     ap.add_argument("--timeout", type=int, default=200)
     ap.add_argument("--out-dir", default=str(HERE / "reports" / "run"))
     ap.add_argument("--repo-root", default=str(REPO_ROOT))
@@ -151,29 +148,35 @@ def main():
         print(f"Report: {out_dir / 'combined.md'}", file=sys.stderr)
         return
 
-    all_results = []
-    flagged = []
+    for uncovered in [s for s in skills if not by_skill.get(s)]:
+        print(f"!! no queries for '{uncovered}'", file=sys.stderr)
 
-    for skill in skills:
-        items = by_skill.get(skill, [])
-        if not items:
-            print(f"!! no queries for '{skill}'", file=sys.stderr)
-            continue
-        print(f"== {skill} ({len(items)} queries) ==", file=sys.stderr)
-        rep = run_chunk(items, out_dir / f"chunk_{skill}.json", repo_root, args.runs, args.workers, args.timeout)
-        # disconnect guard: a positive-skill chunk that comes back entirely `none`
-        # is almost certainly a mid-chunk MCP disconnect, not a real 0% — the
-        # preflight already proved routing works. Retry in fresh subprocesses
-        # (which usually reconnect); only flag as unverified if it never recovers.
-        attempts = 1
-        while skill != NONE and recall(rep, skill) == 0.0 and attempts < 3:
-            attempts += 1
-            print(f"   {skill} came back 0% — retry {attempts}/3 (suspected MCP disconnect)", file=sys.stderr)
-            rep = run_chunk(items, out_dir / f"chunk_{skill}.json", repo_root, args.runs, args.workers, args.timeout)
-        if skill != NONE and recall(rep, skill) == 0.0:
-            flagged.append(skill)
-            print(f"   {skill} still 0% after {attempts} tries — flagged suspected-disconnect (inconclusive)", file=sys.stderr)
-        all_results.extend(rep["results"])
+    planned = plan_pooled_items(skills, by_skill)
+    print(
+        f"== pooled sweep: {len(planned)} queries x {args.runs} runs, {args.workers} workers ==",
+        file=sys.stderr,
+    )
+    pooled = run_chunk(planned, out_dir / "chunk_pooled.json", repo_root, args.runs, args.workers, args.timeout)
+
+    def rerun_skill(skill: str) -> list[dict]:
+        """One skill's queries alone, in a fresh subprocess that usually reconnects."""
+        rep = run_chunk(by_skill[skill], out_dir / f"chunk_{skill}.json", repo_root, args.runs, args.workers, args.timeout)
+        return rep["results"]
+
+    def announce_retry(skill: str, attempt: int, limit: int) -> None:
+        print(f"   {skill} came back 0% — retry {attempt}/{limit} (suspected MCP disconnect)", file=sys.stderr)
+
+    grouped, flagged = resolve_disconnect_retries(
+        partition_results_by_skill(pooled["results"], skills),
+        rerun_skill,
+        on_retry=announce_retry,
+    )
+    for skill in flagged:
+        print(
+            f"   {skill} still 0% after {MAX_DISCONNECT_ATTEMPTS} tries — flagged suspected-disconnect (inconclusive)",
+            file=sys.stderr,
+        )
+    all_results = [row for skill in skills for row in grouped.get(skill, [])]
 
     combined = {"model": "claude (run.py)", "runs_per_query": args.runs, "results": all_results}
     combined_path = out_dir / "combined.json"

--- a/internal/skill-routing-eval/test_pooling.py
+++ b/internal/skill-routing-eval/test_pooling.py
@@ -1,0 +1,151 @@
+import unittest
+
+import pooling
+from pool_constants import MAX_DISCONNECT_ATTEMPTS
+
+MUGGLE_TEST = "muggle-test"
+MUGGLE_STATUS = "muggle-status"
+STEALER = "muggle-do"
+NONE = "none"
+
+
+def rows(skill, passed, total, missed_route=STEALER):
+    """Result rows in which `passed` of `total` queries for `skill` routed correctly."""
+    out = [{"expected_skill": skill, "majority": skill} for _ in range(passed)]
+    out += [{"expected_skill": skill, "majority": missed_route} for _ in range(total - passed)]
+    return out
+
+
+def queries(skill, count):
+    return [{"query": f"{skill} q{i}", "expected_skill": skill} for i in range(count)]
+
+
+class TestPlanPooledItems(unittest.TestCase):
+    def test_flattens_every_selected_skill_in_order(self):
+        by_skill = {MUGGLE_TEST: queries(MUGGLE_TEST, 2), MUGGLE_STATUS: queries(MUGGLE_STATUS, 3)}
+        planned = pooling.plan_pooled_items([MUGGLE_TEST, MUGGLE_STATUS], by_skill)
+        self.assertEqual(len(planned), 5)
+        self.assertEqual([p["expected_skill"] for p in planned[:2]], [MUGGLE_TEST] * 2)
+
+    def test_skips_a_skill_with_no_queries(self):
+        by_skill = {MUGGLE_TEST: queries(MUGGLE_TEST, 2)}
+        planned = pooling.plan_pooled_items([MUGGLE_TEST, "muggle-nonexistent"], by_skill)
+        self.assertEqual(len(planned), 2)
+
+    def test_scoped_run_pools_only_the_requested_skills(self):
+        by_skill = {MUGGLE_TEST: queries(MUGGLE_TEST, 2), MUGGLE_STATUS: queries(MUGGLE_STATUS, 3)}
+        planned = pooling.plan_pooled_items([MUGGLE_STATUS], by_skill)
+        self.assertEqual({p["expected_skill"] for p in planned}, {MUGGLE_STATUS})
+
+
+class TestPartitionResultsBySkill(unittest.TestCase):
+    def test_regroups_a_pooled_run_by_expected_skill(self):
+        pooled = rows(MUGGLE_TEST, 2, 3) + rows(MUGGLE_STATUS, 1, 2)
+        grouped = pooling.partition_results_by_skill(pooled, [MUGGLE_TEST, MUGGLE_STATUS])
+        self.assertEqual(len(grouped[MUGGLE_TEST]), 3)
+        self.assertEqual(len(grouped[MUGGLE_STATUS]), 2)
+
+    def test_keeps_a_key_for_a_skill_that_contributed_no_rows(self):
+        grouped = pooling.partition_results_by_skill(rows(MUGGLE_TEST, 1, 1), [MUGGLE_TEST, MUGGLE_STATUS])
+        self.assertEqual(grouped[MUGGLE_STATUS], [])
+
+    def test_drops_rows_for_skills_outside_the_selection(self):
+        pooled = rows(MUGGLE_TEST, 1, 1) + rows(MUGGLE_STATUS, 1, 1)
+        grouped = pooling.partition_results_by_skill(pooled, [MUGGLE_TEST])
+        self.assertEqual(list(grouped), [MUGGLE_TEST])
+        self.assertEqual(len(grouped[MUGGLE_TEST]), 1)
+
+
+class TestRecallFromResults(unittest.TestCase):
+    def test_counts_exact_routes_for_a_positive_skill(self):
+        self.assertAlmostEqual(pooling.recall_from_results(rows(MUGGLE_TEST, 19, 26), MUGGLE_TEST), 19 / 26)
+
+    def test_a_skill_with_no_queries_is_not_a_zero(self):
+        self.assertEqual(pooling.recall_from_results([], MUGGLE_TEST), 1.0)
+
+    def test_every_query_stolen_reads_as_zero(self):
+        self.assertEqual(pooling.recall_from_results(rows(MUGGLE_TEST, 0, 4), MUGGLE_TEST), 0.0)
+
+
+class TestResolveDisconnectRetries(unittest.TestCase):
+    def test_a_healthy_pool_reruns_nothing(self):
+        grouped = {MUGGLE_TEST: rows(MUGGLE_TEST, 3, 4), MUGGLE_STATUS: rows(MUGGLE_STATUS, 2, 4)}
+        rerun = []
+        _, flagged = pooling.resolve_disconnect_retries(grouped, lambda s: rerun.append(s) or [])
+        self.assertEqual(rerun, [])
+        self.assertEqual(flagged, [])
+
+    def test_a_zero_skill_is_rerun_alone_and_its_rows_replaced(self):
+        grouped = {MUGGLE_TEST: rows(MUGGLE_TEST, 0, 4), MUGGLE_STATUS: rows(MUGGLE_STATUS, 3, 4)}
+        rerun = []
+
+        def rerun_skill(skill):
+            rerun.append(skill)
+            return rows(skill, 3, 4)
+
+        resolved, flagged = pooling.resolve_disconnect_retries(grouped, rerun_skill)
+        self.assertEqual(rerun, [MUGGLE_TEST])
+        self.assertEqual(flagged, [])
+        self.assertAlmostEqual(pooling.recall_from_results(resolved[MUGGLE_TEST], MUGGLE_TEST), 0.75)
+
+    def test_retrying_one_skill_leaves_the_other_pooled_rows_untouched(self):
+        healthy = rows(MUGGLE_STATUS, 3, 4)
+        grouped = {MUGGLE_TEST: rows(MUGGLE_TEST, 0, 4), MUGGLE_STATUS: healthy}
+        resolved, _ = pooling.resolve_disconnect_retries(grouped, lambda s: rows(s, 2, 4))
+        self.assertEqual(resolved[MUGGLE_STATUS], healthy)
+
+    def test_a_skill_that_never_recovers_is_flagged_not_failed(self):
+        grouped = {MUGGLE_TEST: rows(MUGGLE_TEST, 0, 4)}
+        rerun = []
+
+        def rerun_skill(skill):
+            rerun.append(skill)
+            return rows(skill, 0, 4)
+
+        _, flagged = pooling.resolve_disconnect_retries(grouped, rerun_skill)
+        self.assertEqual(flagged, [MUGGLE_TEST])
+        self.assertEqual(len(rerun), MAX_DISCONNECT_ATTEMPTS - 1)
+
+    def test_recovery_on_the_final_attempt_still_clears_the_flag(self):
+        grouped = {MUGGLE_TEST: rows(MUGGLE_TEST, 0, 4)}
+        attempts = []
+
+        def rerun_skill(skill):
+            attempts.append(skill)
+            return rows(skill, 0, 4) if len(attempts) < MAX_DISCONNECT_ATTEMPTS - 1 else rows(skill, 1, 4)
+
+        _, flagged = pooling.resolve_disconnect_retries(grouped, rerun_skill)
+        self.assertEqual(flagged, [])
+
+    def test_the_negative_class_is_never_retried_even_at_zero(self):
+        grouped = {NONE: rows(NONE, 0, 4, missed_route=STEALER)}
+        rerun = []
+        _, flagged = pooling.resolve_disconnect_retries(grouped, lambda s: rerun.append(s) or [])
+        self.assertEqual(rerun, [])
+        self.assertEqual(flagged, [])
+
+    def test_every_collapsed_skill_is_retried_independently(self):
+        grouped = {MUGGLE_TEST: rows(MUGGLE_TEST, 0, 4), MUGGLE_STATUS: rows(MUGGLE_STATUS, 0, 4)}
+        rerun = []
+
+        def rerun_skill(skill):
+            rerun.append(skill)
+            return rows(skill, 2, 4)
+
+        _, flagged = pooling.resolve_disconnect_retries(grouped, rerun_skill)
+        self.assertEqual(sorted(rerun), [MUGGLE_STATUS, MUGGLE_TEST])
+        self.assertEqual(flagged, [])
+
+    def test_each_retry_is_announced_with_its_attempt_number(self):
+        grouped = {MUGGLE_TEST: rows(MUGGLE_TEST, 0, 4)}
+        announced = []
+        pooling.resolve_disconnect_retries(
+            grouped,
+            lambda s: rows(s, 0, 4),
+            on_retry=lambda skill, attempt, limit: announced.append((skill, attempt, limit)),
+        )
+        self.assertEqual(announced, [(MUGGLE_TEST, 2, MAX_DISCONNECT_ATTEMPTS), (MUGGLE_TEST, 3, MAX_DISCONNECT_ATTEMPTS)])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

The routing eval ran one `claude -p` subprocess **per skill, sequentially** (`run.py`'s `for skill in skills:` loop). Each chunk drained its worker pool to empty before the next started, so a full sweep stalled 15 times — once per skill — with workers idling through every tail.

Raising `--workers` alone does not fix that; it just makes each tail steeper. The chunk boundary itself was the bottleneck.

## What changed

**One pooled sweep.** Every selected skill's queries are planned up front and run in a single subprocess `--workers` wide.

Chunking existed for failure recovery, so that property is preserved rather than dropped:

- Each result row already carries `expected_skill`, so per-skill report grouping and the disconnect guard become a **partition** of the pooled run.
- A positive skill returning a flat 0% is still re-run **alone in a fresh subprocess** (up to 3 attempts), and still flagged inconclusive — not failed — if it never recovers. Isolating that retry is what keeps a pooled sweep as recoverable as per-skill batches were.

**The throttle gate becomes genuinely global.** `THROTTLE_GATE` is a module-level object, so a subprocess per skill gave every chunk *its own* gate — a 429 only paused the chunk that hit it. One pool means one gate pausing all workers. This is a correctness improvement that arrives with the change, and it is why the higher worker count is safe.

**Concurrency defaults raised:**

| Knob | Before | After |
| :--- | :----- | :---- |
| `routing_workers` (workflow + code) | 6 / 3 | **12** |
| `gate_concurrency` | 4 | **8** |
| `agent_concurrency` | 4 | **8** |

`run.py` and `router_eval.py` had *divergent* defaults for the same concept (3 and 6); both now read one shared `DEFAULT_ROUTING_WORKERS`.

Untouched on purpose: gates stay sequential inside `skill-gate-eval` so `::group::` logs remain attributable, and `studio-gen-eval` keeps its concurrency of 2.

## New files

`pooling.py` (planning, partition, guard), `pool_constants.py` (tuning values), `test_pooling.py` (17 cases).

## Verification

- Python suite (`python -m unittest discover -s internal/skill-routing-eval`) — **146 green**, including 17 new cases covering pooling, partitioning, and the disconnect guard.
- Full `vitest run` — **1487 green**, 27 skipped, 104 files.
- `tsc --noEmit` clean; ESLint reports no errors on the touched files (its 17 warnings are pre-existing `unused eslint-disable` directives on untouched lines).
- **End-to-end wiring smoke test** with `run_chunk` stubbed, so no LLM budget was spent. Three scenarios asserted:
  - healthy pool → exactly **one** subprocess invocation (was two for two skills)
  - one skill collapses → pooled run + 2 isolated retries, each carrying only that skill's 24 queries
  - collapse then recovery → pooled run + 1 retry, then stop

No real routing sweep was executed — it costs subscription budget and hours. The orchestration is unit-tested instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SMKVA1rFhGNDwsLWUYCio
