### PR TITLE
feat(install): verify the studio download's sigstore signature before extracting

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "plugin",
     "bin/muggle.js",
     "scripts/postinstall.mjs",
+    "scripts/release-integrity",
     "config/runtime-targets.json"
   ],
   "scripts": {
@@ -66,7 +67,9 @@
         "linux-x64": "929396f628a05f001782d48524cd9f76fdbb59216658982a5a3909dfe413cbea",
         "win32-x64": "a8b5b46b97ed788030be84982a3e8d463abbfa7f3e8bc795692ccbffc82bfa92"
       }
-    }
+    },
+    "electronAppSignedFromVersion": "1.10.0",
+    "signerIdentityUri": "https://github.com/multiplex-ai/muggle-ai-teaching-service/.github/workflows/release-electron-app-reusable.yml@refs/heads/master"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.3",
@@ -74,6 +77,7 @@
     "axios": "^1.7.9",
     "commander": "^14.0.3",
     "open": "^11.0.0",
+    "sigstore": "^5.0.0",
     "ulid": "^3.0.2",
     "uuid": "^14.0.0",
     "winston": "^3.17.0",

--- a/packages/mcps/src/shared/config.ts
+++ b/packages/mcps/src/shared/config.ts
@@ -607,6 +607,25 @@ export function getElectronAppChecksums(): IMuggleConfigChecksums | undefined {
 }
 
 /**
+ * Get the first electron-app version published with a Sigstore signature.
+ *
+ * Releases below this version predate signing and are verified by checksum
+ * alone, so the pin is what stops an attacker downgrading to an unsigned one.
+ * @returns The pinned version, or empty string when signing is not configured.
+ */
+export function getElectronAppSignedFromVersion(): string {
+  return getMuggleConfig().electronAppSignedFromVersion ?? "";
+}
+
+/**
+ * Get the certificate subject a release signature must carry to be trusted.
+ * @returns The signer identity URI, or empty string when none is configured.
+ */
+export function getReleaseSignerIdentityUri(): string {
+  return getMuggleConfig().signerIdentityUri ?? "";
+}
+
+/**
  * Check if the electron-app binary is installed for the expected version.
  * @returns True if the binary is installed and accessible.
  */

--- a/packages/mcps/src/shared/types.ts
+++ b/packages/mcps/src/shared/types.ts
@@ -30,6 +30,10 @@ export interface IMuggleConfig {
   checksumsByStream?: Partial<Record<ElectronAppReleaseStream, IMuggleConfigChecksums>>;
   /** Default runtime target baked into the package at build/publish time. */
   runtimeTargetDefault?: RuntimeTarget;
+  /** First electron-app version published with a Sigstore signature. */
+  electronAppSignedFromVersion?: string;
+  /** Certificate subject a release signature must carry to be trusted. */
+  signerIdentityUri?: string;
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       open:
         specifier: ^11.0.0
         version: 11.0.0
+      sigstore:
+        specifier: ^5.0.0
+        version: 5.0.0
       ulid:
         specifier: ^3.0.2
         version: 3.0.2
@@ -478,6 +481,10 @@ packages:
     resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  '@gar/promise-retry@1.0.3':
+    resolution: {integrity: sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   '@grpc/grpc-js@1.14.4':
     resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
     engines: {node: '>=12.10.0'}
@@ -551,6 +558,18 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@npmcli/agent@5.0.2':
+    resolution: {integrity: sha512-EkzGmEsgbQ1rqWkRJe2P0oQHx/ylZozDUNPMXCklLuSFL3GY+QyEfBUjhjCsgGXzh4OGpnHvkboSQgczjP/jJg==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  '@npmcli/fs@6.0.0':
+    resolution: {integrity: sha512-AheOs4swKka/XLtht6xxJDPezlQ7K2IYQ9Y8lST4JLDjnralnWuMM9AE2CdVcgQJ5omrXhsRzM7F7aYmeZBvKQ==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  '@npmcli/redact@5.0.0':
+    resolution: {integrity: sha512-3zcN5Q3yEmeyxXBzqB6fXPQFzYa2ROsGFSr69W0ArXIAGJqxl/aFECOVPD2kbkYPm0U/EHxFKgclK3UA9WQg5A==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   '@opentelemetry/api-logs@0.211.0':
     resolution: {integrity: sha512-swFdZq8MCdmdR22jTVGQDhwqDzcI4M10nhjXkLr1EsIzXgZBqm4ZlmmcWsg3TSNf+3mzgOiqveXmBLZuDi2Lgg==}
@@ -1048,11 +1067,43 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sigstore/bundle@5.0.0':
+    resolution: {integrity: sha512-wefjygudENbzbQMks1t5u34EP0fFoD0XvaEP7DOUP/sXKvogzEJYFw5E6pegGyp3onGWzVEYKVa3bNZWyTYX+A==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  '@sigstore/core@4.0.1':
+    resolution: {integrity: sha512-9v5hRjujn5NXq8o7XFEUgLyAtdr5Iisb4pzM05u3K61IS5q3hP3luWAndk0RkPPLTUFoTbg7Vb84UQ1ZQeajWQ==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  '@sigstore/protobuf-specs@0.5.2':
+    resolution: {integrity: sha512-SQqvFMt4V78fdjcDdYX6HbiVSOR4QK3ZgwCa2KOsopAgPIHy1rU5UDUmzLl02r5oyyaYcYHR1hpwDRk/yUe+Mw==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  '@sigstore/sign@5.0.0':
+    resolution: {integrity: sha512-DSFivqz9/i5AkwZ5fq0YdjaJlc4o1WeS2Zffon0kqtChx0vy4W9NOjkEet9bF2vkzOufX72eVH8kZBIGtcBp1w==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  '@sigstore/tuf@5.0.0':
+    resolution: {integrity: sha512-Zyqg9tcHps3uRAlKHLNmsW4ohsUZAjb9G+31r7lg0ICh/JOcadzmJsIRdjKljlRHpaR0K4aJ2kXXIdywdcdMlA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  '@sigstore/verify@4.1.2':
+    resolution: {integrity: sha512-BfD9eLrz3A/DG58aSgfgZYmIR6V9Yw96QVN/frtu2bEH7ctSTk2TDvHU12un3JsDPBTqTNkqkIkucjxljpOFqQ==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
   '@so-ric/colorspace@1.1.6':
     resolution: {integrity: sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tufjs/canonical-json@2.0.0':
+    resolution: {integrity: sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==}
+    engines: {node: ^16.14.0 || >=18.0.0}
+
+  '@tufjs/models@5.0.0':
+    resolution: {integrity: sha512-U4mVcdFGOi6pt8n38LdWZp67Svn7ppnU1Pj8SGOVaBi1X4gm+G4ztQlLfkoJbKSHfjA6WeaiJp2A4V83AJF6nQ==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   '@turbo/darwin-64@2.9.12':
     resolution: {integrity: sha512-eu3eFRmE9NjgZ0wPdRJ44l+LGSeIky+tz5ZQd8zQkw/Yqi+BM7wq+8nbabeoiVUcICi/IZweMOKl/MCmkrd1+g==}
@@ -1255,6 +1306,10 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
+  agent-base@9.0.0:
+    resolution: {integrity: sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==}
+    engines: {node: '>= 20'}
+
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
@@ -1332,6 +1387,10 @@ packages:
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  cacache@21.0.1:
+    resolution: {integrity: sha512-pTwz/uj3Jyp6WXdJ6fWhR+7LVxVs6RyroQSn7KJwHsSxXuyGSp0pcMVcwSwTpCFq1X2YG8QBe0W+vN+cr0SwzA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -1677,6 +1736,10 @@ packages:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
 
+  fs-minipass@3.0.3:
+    resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1735,6 +1798,9 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  http-cache-semantics@4.2.0:
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -1743,6 +1809,10 @@ packages:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
 
+  http-proxy-agent@9.1.0:
+    resolution: {integrity: sha512-2NxoveTT58mjYT4n3RPTEfCZGLMbidoO8XEieXfpSYxu+PQJ1qpx4ypwH6N+uF9twBPIvRRgvkvW5HUTYWENig==}
+    engines: {node: '>= 20'}
+
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
@@ -1750,6 +1820,10 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  https-proxy-agent@9.1.0:
+    resolution: {integrity: sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==}
+    engines: {node: '>= 20'}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -1783,6 +1857,10 @@ packages:
 
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
+  ip-address@10.5.0:
+    resolution: {integrity: sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -2023,6 +2101,10 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  make-fetch-happen@16.0.1:
+    resolution: {integrity: sha512-uUv1yxHzaKVVEPfcFeGSNov/Cehjv08ovlY8ImTljgL7Q+SiA0dAYLQ6SYVa2kkKqNj4Y3aZEI7xv2teadie0A==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -2055,9 +2137,37 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
+  minipass-collect@2.0.1:
+    resolution: {integrity: sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass-fetch@6.0.0:
+    resolution: {integrity: sha512-AWI8bKapGmgx/J0E6IGYSKj8TiHebZkmKWSs8raPSw8KXwgEAJ+Bw3+LSdXHR6T/RHKAWCOYk2MiLrYluaUU6w==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  minipass-flush@1.0.7:
+    resolution: {integrity: sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==}
+    engines: {node: '>= 8'}
+
+  minipass-pipeline@1.2.4:
+    resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
+    engines: {node: '>=8'}
+
+  minipass-sized@2.0.0:
+    resolution: {integrity: sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==}
+    engines: {node: '>=8'}
+
+  minipass@3.3.6:
+    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
+    engines: {node: '>=8'}
+
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
@@ -2123,6 +2233,10 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  p-map@7.0.6:
+    resolution: {integrity: sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==}
+    engines: {node: '>=18'}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -2224,6 +2338,10 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  proc-log@7.0.0:
+    resolution: {integrity: sha512-FYgfaA69XZ93zaXLoMNQ+ViDXGGBgR8aLh03txzcFhV+9xOXx7+8DLCULrKKpR9+GsH9ZfHm82aSUPpozX0Ztg==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
   protobufjs@7.6.0:
     resolution: {integrity: sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==}
     engines: {node: '>=12.0.0'}
@@ -2235,6 +2353,15 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  proxy-agent-negotiate@1.1.0:
+    resolution: {integrity: sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      kerberos: ^2.0.0
+    peerDependenciesMeta:
+      kerberos:
+        optional: true
 
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
@@ -2364,6 +2491,22 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  sigstore@5.0.0:
+    resolution: {integrity: sha512-hJqJfoG/e4qFQaauQL00c6J6FrHLBGKtkFvW3JbTSIEFOhLrSjdSM/gWd/yUOfYo/gsERehTXGC1VZWX+9X4Dg==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks-proxy-agent@10.1.0:
+    resolution: {integrity: sha512-WlMj/67cEJ6MDI1OcsnjuYKDNDoyPCCYZ249kuuXPiMDw9F8PXkVaQ7YWu3siTydfQ/4BEZcvGzu+aYvz7dDCQ==}
+    engines: {node: '>= 20'}
+
+  socks@2.8.9:
+    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2371,6 +2514,10 @@ packages:
   source-map@0.7.6:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
+
+  ssri@14.0.0:
+    resolution: {integrity: sha512-jQxKI0yx0ZnTKrqjKkLDV2DXkBQn3k49JVmVqDGcDwKDtGDbImD/GXsq04KD0VVzCQQ9wZJYal3RwR1GzWTSow==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   stack-trace@0.0.10:
     resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
@@ -2487,6 +2634,10 @@ packages:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  tuf-js@6.0.0:
+    resolution: {integrity: sha512-zlJVOIO68hmgo1//X4ENEcTGfuOTAtDPi8PsTsG+FyxD85E/ww1ZnwBbWo/yCEExGpI+Kilg7Z3qCdHX2BoJTQ==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   turbo@2.9.12:
     resolution: {integrity: sha512-lCPgus1NuTiBdaITWqzSH/Ff6HVL8HHGBtOXHg1dHRfcshN79XkygSdh0M6g8b0td91ILLG5MTkLOkp5UvyPJw==}
@@ -2666,6 +2817,9 @@ packages:
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
@@ -3065,6 +3219,8 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
+  '@gar/promise-retry@1.0.3': {}
+
   '@grpc/grpc-js@1.14.4':
     dependencies:
       '@grpc/proto-loader': 0.8.1
@@ -3149,6 +3305,23 @@ snapshots:
       '@emnapi/runtime': 1.9.1
       '@tybys/wasm-util': 0.10.2
     optional: true
+
+  '@npmcli/agent@5.0.2':
+    dependencies:
+      agent-base: 9.0.0
+      http-proxy-agent: 9.1.0
+      https-proxy-agent: 9.1.0
+      lru-cache: 11.2.7
+      socks-proxy-agent: 10.1.0
+    transitivePeerDependencies:
+      - kerberos
+      - supports-color
+
+  '@npmcli/fs@6.0.0':
+    dependencies:
+      semver: 7.8.1
+
+  '@npmcli/redact@5.0.0': {}
 
   '@opentelemetry/api-logs@0.211.0':
     dependencies:
@@ -3642,12 +3815,52 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
+  '@sigstore/bundle@5.0.0':
+    dependencies:
+      '@sigstore/protobuf-specs': 0.5.2
+
+  '@sigstore/core@4.0.1': {}
+
+  '@sigstore/protobuf-specs@0.5.2': {}
+
+  '@sigstore/sign@5.0.0':
+    dependencies:
+      '@gar/promise-retry': 1.0.3
+      '@sigstore/bundle': 5.0.0
+      '@sigstore/core': 4.0.1
+      '@sigstore/protobuf-specs': 0.5.2
+      make-fetch-happen: 16.0.1
+      proc-log: 7.0.0
+    transitivePeerDependencies:
+      - kerberos
+      - supports-color
+
+  '@sigstore/tuf@5.0.0':
+    dependencies:
+      '@sigstore/protobuf-specs': 0.5.2
+      tuf-js: 6.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sigstore/verify@4.1.2':
+    dependencies:
+      '@sigstore/bundle': 5.0.0
+      '@sigstore/core': 4.0.1
+      '@sigstore/protobuf-specs': 0.5.2
+
   '@so-ric/colorspace@1.1.6':
     dependencies:
       color: 5.0.3
       text-hex: 1.0.0
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@tufjs/canonical-json@2.0.0': {}
+
+  '@tufjs/models@5.0.0':
+    dependencies:
+      '@tufjs/canonical-json': 2.0.0
+      minimatch: 10.2.5
 
   '@turbo/darwin-64@2.9.12':
     optional: true
@@ -3892,6 +4105,8 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  agent-base@9.0.0: {}
+
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
@@ -4002,6 +4217,19 @@ snapshots:
   bytes@3.1.2: {}
 
   cac@6.7.14: {}
+
+  cacache@21.0.1:
+    dependencies:
+      '@npmcli/fs': 6.0.0
+      fs-minipass: 3.0.3
+      glob: 13.0.6
+      lru-cache: 11.2.7
+      minipass: 7.1.3
+      minipass-collect: 2.0.1
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      p-map: 7.0.6
+      ssri: 14.0.0
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -4367,6 +4595,10 @@ snapshots:
 
   fresh@2.0.0: {}
 
+  fs-minipass@3.0.3:
+    dependencies:
+      minipass: 7.1.3
+
   fsevents@2.3.3:
     optional: true
 
@@ -4424,6 +4656,8 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  http-cache-semantics@4.2.0: {}
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -4439,6 +4673,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  http-proxy-agent@9.1.0:
+    dependencies:
+      agent-base: 9.0.0
+      debug: 4.4.3
+      proxy-agent-negotiate: 1.1.0
+    transitivePeerDependencies:
+      - kerberos
+      - supports-color
+
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
@@ -4451,6 +4694,15 @@ snapshots:
       agent-base: 7.1.4
       debug: 4.4.3
     transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@9.1.0:
+    dependencies:
+      agent-base: 9.0.0
+      debug: 4.4.3
+      proxy-agent-negotiate: 1.1.0
+    transitivePeerDependencies:
+      - kerberos
       - supports-color
 
   iconv-lite@0.6.3:
@@ -4484,6 +4736,8 @@ snapshots:
   inherits@2.0.4: {}
 
   ip-address@10.1.0: {}
+
+  ip-address@10.5.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -4686,6 +4940,24 @@ snapshots:
     dependencies:
       semver: 7.8.1
 
+  make-fetch-happen@16.0.1:
+    dependencies:
+      '@gar/promise-retry': 1.0.3
+      '@npmcli/agent': 5.0.2
+      '@npmcli/redact': 5.0.0
+      cacache: 21.0.1
+      http-cache-semantics: 4.2.0
+      minipass: 7.1.3
+      minipass-fetch: 6.0.0
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      negotiator: 1.0.0
+      proc-log: 7.0.0
+      ssri: 14.0.0
+    transitivePeerDependencies:
+      - kerberos
+      - supports-color
+
   math-intrinsics@1.1.0: {}
 
   media-typer@1.1.0: {}
@@ -4708,7 +4980,39 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.6
 
+  minipass-collect@2.0.1:
+    dependencies:
+      minipass: 7.1.3
+
+  minipass-fetch@6.0.0:
+    dependencies:
+      minipass: 7.1.3
+      minipass-sized: 2.0.0
+      minizlib: 3.1.0
+    optionalDependencies:
+      iconv-lite: 0.7.2
+
+  minipass-flush@1.0.7:
+    dependencies:
+      minipass: 3.3.6
+
+  minipass-pipeline@1.2.4:
+    dependencies:
+      minipass: 3.3.6
+
+  minipass-sized@2.0.0:
+    dependencies:
+      minipass: 7.1.3
+
+  minipass@3.3.6:
+    dependencies:
+      yallist: 4.0.0
+
   minipass@7.1.3: {}
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
 
   mlly@1.8.2:
     dependencies:
@@ -4784,6 +5088,8 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  p-map@7.0.6: {}
+
   package-json-from-dist@1.0.1: {}
 
   parseurl@1.3.3: {}
@@ -4855,6 +5161,8 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  proc-log@7.0.0: {}
+
   protobufjs@7.6.0:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
@@ -4889,6 +5197,8 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  proxy-agent-negotiate@1.1.0: {}
 
   proxy-from-env@2.1.0: {}
 
@@ -5075,9 +5385,40 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  sigstore@5.0.0:
+    dependencies:
+      '@sigstore/bundle': 5.0.0
+      '@sigstore/core': 4.0.1
+      '@sigstore/protobuf-specs': 0.5.2
+      '@sigstore/sign': 5.0.0
+      '@sigstore/tuf': 5.0.0
+      '@sigstore/verify': 4.1.2
+    transitivePeerDependencies:
+      - kerberos
+      - supports-color
+
+  smart-buffer@4.2.0: {}
+
+  socks-proxy-agent@10.1.0:
+    dependencies:
+      agent-base: 9.0.0
+      debug: 4.4.3
+      socks: 2.8.9
+    transitivePeerDependencies:
+      - supports-color
+
+  socks@2.8.9:
+    dependencies:
+      ip-address: 10.5.0
+      smart-buffer: 4.2.0
+
   source-map-js@1.2.1: {}
 
   source-map@0.7.6: {}
+
+  ssri@14.0.0:
+    dependencies:
+      minipass: 7.1.3
 
   stack-trace@0.0.10: {}
 
@@ -5193,6 +5534,14 @@ snapshots:
       get-tsconfig: 4.13.6
     optionalDependencies:
       fsevents: 2.3.3
+
+  tuf-js@6.0.0:
+    dependencies:
+      '@gar/promise-retry': 1.0.3
+      '@tufjs/models': 5.0.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   turbo@2.9.12:
     optionalDependencies:
@@ -5332,6 +5681,8 @@ snapshots:
   xtend@4.0.2: {}
 
   y18n@5.0.8: {}
+
+  yallist@4.0.0: {}
 
   yaml@2.9.0: {}
 

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -25,6 +25,11 @@ import { dirname, join } from "path";
 import { pipeline } from "stream/promises";
 import { createRequire } from "module";
 import { fileURLToPath } from "url";
+import {
+    SIGNATURE_BUNDLE_SUFFIX,
+    resolveIntegrityPolicy,
+    verifyReleaseSignature,
+} from "./release-integrity/index.mjs";
 
 const require = createRequire(import.meta.url);
 const VERSION_DIRECTORY_NAME_PATTERN = /^\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.-]+)?$/;
@@ -728,7 +733,35 @@ async function downloadElectronApp() {
             clearTimeout(streamTimer);
         }
 
-        log("Download complete, verifying checksum...");
+        log("Download complete, verifying integrity...");
+
+        const integrityPolicy = resolveIntegrityPolicy({
+            version: version,
+            signedFromVersion: config.electronAppSignedFromVersion || "",
+            expectedChecksum: expectedChecksum,
+        });
+
+        if (integrityPolicy.unverifiableReason) {
+            rmSync(versionDir, { recursive: true, force: true });
+            throw new Error("Refusing to install an unverifiable download: " + integrityPolicy.unverifiableReason);
+        }
+
+        if (integrityPolicy.requiresSignature) {
+            const signatureResult = await verifyReleaseSignature({
+                artifactPath: tempFile,
+                bundleUrl: downloadUrl + SIGNATURE_BUNDLE_SUFFIX,
+                signerIdentityUri: config.signerIdentityUri || "",
+            });
+
+            if (!signatureResult.valid) {
+                rmSync(versionDir, { recursive: true, force: true });
+                throw new Error(
+                    "Signature verification failed, refusing to install: " + signatureResult.reason,
+                );
+            }
+
+            log("Signature verified successfully.");
+        }
 
         // Verify checksum
         const checksumResult = await verifyFileChecksum(tempFile, expectedChecksum);
@@ -743,9 +776,7 @@ async function downloadElectronApp() {
             );
         }
 
-        if (checksumResult.skipped) {
-            log("Warning: No checksum configured, skipping verification.");
-        } else {
+        if (!checksumResult.skipped) {
             log("Checksum verified successfully.");
         }
 

--- a/scripts/release-integrity/compareVersions.mjs
+++ b/scripts/release-integrity/compareVersions.mjs
@@ -1,0 +1,24 @@
+/**
+ * Compare two semver versions.
+ * @param {string} a - First version.
+ * @param {string} b - Second version.
+ * @returns {number} 1 if a > b, -1 if a < b, 0 if equal.
+ */
+export function compareVersions(a, b) {
+    const partsA = a.split(".").map(Number);
+    const partsB = b.split(".").map(Number);
+
+    for (let index = 0; index < 3; index++) {
+        const partA = partsA[index] || 0;
+        const partB = partsB[index] || 0;
+
+        if (partA > partB) {
+            return 1;
+        }
+        if (partA < partB) {
+            return -1;
+        }
+    }
+
+    return 0;
+}

--- a/scripts/release-integrity/constants.mjs
+++ b/scripts/release-integrity/constants.mjs
@@ -1,0 +1,8 @@
+/** Suffix appended to a release asset's name to locate its Sigstore bundle. */
+export const SIGNATURE_BUNDLE_SUFFIX = ".sigstore.json";
+
+/** OIDC issuer that must have issued the signing certificate. */
+export const SIGNER_CERTIFICATE_ISSUER = "https://token.actions.githubusercontent.com";
+
+/** Abort budget for fetching a signature bundle. */
+export const SIGNATURE_FETCH_TIMEOUT_MS = 30_000;

--- a/scripts/release-integrity/index.d.mts
+++ b/scripts/release-integrity/index.d.mts
@@ -1,0 +1,21 @@
+export declare const SIGNATURE_BUNDLE_SUFFIX: string;
+export declare const SIGNATURE_FETCH_TIMEOUT_MS: number;
+export declare const SIGNER_CERTIFICATE_ISSUER: string;
+
+export declare function compareVersions(a: string, b: string): number;
+
+export declare function resolveIntegrityPolicy(params: {
+    version: string;
+    signedFromVersion: string;
+    expectedChecksum: string;
+}): {
+    requiresSignature: boolean;
+    requiresChecksum: boolean;
+    unverifiableReason: string;
+};
+
+export declare function verifyReleaseSignature(params: {
+    artifactPath: string;
+    bundleUrl: string;
+    signerIdentityUri: string;
+}): Promise<{ valid: boolean; reason: string }>;

--- a/scripts/release-integrity/index.mjs
+++ b/scripts/release-integrity/index.mjs
@@ -1,0 +1,4 @@
+export { SIGNATURE_BUNDLE_SUFFIX, SIGNATURE_FETCH_TIMEOUT_MS, SIGNER_CERTIFICATE_ISSUER } from "./constants.mjs";
+export { compareVersions } from "./compareVersions.mjs";
+export { resolveIntegrityPolicy } from "./resolveIntegrityPolicy.mjs";
+export { verifyReleaseSignature } from "./verifyReleaseSignature.mjs";

--- a/scripts/release-integrity/resolveIntegrityPolicy.mjs
+++ b/scripts/release-integrity/resolveIntegrityPolicy.mjs
@@ -1,0 +1,37 @@
+import { compareVersions } from "./compareVersions.mjs";
+
+/**
+ * Decide which integrity evidence a download must produce before it is trusted.
+ *
+ * Releases cut before signing existed carry only a checksum, so the signature
+ * requirement is pinned to the first version that ships one. Below that pin the
+ * checksum is mandatory rather than advisory: a download with neither signature
+ * nor checksum is refused instead of being installed behind a warning.
+ *
+ * @param {object} params - Policy inputs.
+ * @param {string} params.version - Electron app version being installed.
+ * @param {string} params.signedFromVersion - First version published with a signature.
+ * @param {string} params.expectedChecksum - Configured SHA256, empty when none.
+ * @returns {{requiresSignature: boolean, requiresChecksum: boolean, unverifiableReason: string}} Which checks apply, and why none can.
+ */
+export function resolveIntegrityPolicy({ version, signedFromVersion, expectedChecksum }) {
+    const requiresSignature = Boolean(signedFromVersion) && compareVersions(version, signedFromVersion) >= 0;
+    const hasChecksum = Boolean(expectedChecksum && expectedChecksum.trim());
+
+    if (!requiresSignature && !hasChecksum) {
+        return {
+            requiresSignature: false,
+            requiresChecksum: false,
+            unverifiableReason:
+                `no integrity evidence is available for v${version}: it predates release signing ` +
+                `(first signed version: ${signedFromVersion || "none configured"}) ` +
+                `and no checksum is configured for this release stream`,
+        };
+    }
+
+    return {
+        requiresSignature: requiresSignature,
+        requiresChecksum: !requiresSignature,
+        unverifiableReason: "",
+    };
+}

--- a/scripts/release-integrity/verifyReleaseSignature.mjs
+++ b/scripts/release-integrity/verifyReleaseSignature.mjs
@@ -1,0 +1,51 @@
+/* global AbortController */
+import { readFile } from "node:fs/promises";
+import { verify } from "sigstore";
+import { SIGNATURE_FETCH_TIMEOUT_MS, SIGNER_CERTIFICATE_ISSUER } from "./constants.mjs";
+
+/**
+ * Verify a downloaded release asset against the Sigstore bundle published beside it.
+ *
+ * The bundle proves the asset was produced by a specific workflow in the studio
+ * source repository, so the signer identity is pinned exactly: a bundle that is
+ * otherwise valid but was issued to any other workflow is rejected.
+ *
+ * @param {object} params - Verification parameters.
+ * @param {string} params.artifactPath - Path to the downloaded asset.
+ * @param {string} params.bundleUrl - URL of the asset's Sigstore bundle.
+ * @param {string} params.signerIdentityUri - Certificate subject the signer must carry.
+ * @returns {Promise<{valid: boolean, reason: string}>} Verification outcome, with the rejection cause when invalid.
+ */
+export async function verifyReleaseSignature({ artifactPath, bundleUrl, signerIdentityUri }) {
+    if (!signerIdentityUri) {
+        return { valid: false, reason: "no signer identity is configured to verify against" };
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), SIGNATURE_FETCH_TIMEOUT_MS);
+    let bundle;
+    try {
+        const response = await fetch(bundleUrl, { signal: controller.signal });
+        if (!response.ok) {
+            return {
+                valid: false,
+                reason: `signature bundle unavailable (HTTP ${response.status}) at ${bundleUrl}`,
+            };
+        }
+        bundle = await response.json();
+    } catch (error) {
+        return { valid: false, reason: `could not fetch signature bundle: ${error.message}` };
+    } finally {
+        clearTimeout(timer);
+    }
+
+    try {
+        await verify(bundle, await readFile(artifactPath), {
+            certificateIssuer: SIGNER_CERTIFICATE_ISSUER,
+            certificateIdentityURI: signerIdentityUri,
+        });
+        return { valid: true, reason: "" };
+    } catch (error) {
+        return { valid: false, reason: error.message };
+    }
+}

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -17,8 +17,10 @@ import {
   getDataDir,
   getElectronAppChecksums,
   getElectronAppDir,
+  getElectronAppSignedFromVersion,
   getElectronAppVersion,
   getLogger,
+  getReleaseSignerIdentityUri,
   getPlatformKey,
   isElectronAppInstalled,
   isFirstRun,
@@ -28,6 +30,11 @@ import {
   verifyFileChecksum,
   writePreferences,
 } from "../../packages/mcps/src/index.js";
+import {
+  SIGNATURE_BUNDLE_SUFFIX,
+  resolveIntegrityPolicy,
+  verifyReleaseSignature,
+} from "../../scripts/release-integrity/index.mjs";
 
 const logger = getLogger();
 
@@ -349,11 +356,37 @@ export async function setupCommand(options: ISetupOptions): Promise<void> {
 
     // Download with retry
     await downloadWithRetry(downloadUrl, tempFile);
-    console.log("Download complete, verifying checksum...");
+    console.log("Download complete, verifying integrity...");
 
     // Verify checksum
     const checksums = getElectronAppChecksums();
     const expectedChecksum = getChecksumForPlatform(checksums);
+    const integrityPolicy = resolveIntegrityPolicy({
+      version: version,
+      signedFromVersion: getElectronAppSignedFromVersion(),
+      expectedChecksum: expectedChecksum ?? "",
+    });
+
+    if (integrityPolicy.unverifiableReason) {
+      cleanupFailedInstall(versionDir);
+      throw new Error("Refusing to install an unverifiable download: " + integrityPolicy.unverifiableReason);
+    }
+
+    if (integrityPolicy.requiresSignature) {
+      const signatureResult = await verifyReleaseSignature({
+        artifactPath: tempFile,
+        bundleUrl: downloadUrl + SIGNATURE_BUNDLE_SUFFIX,
+        signerIdentityUri: getReleaseSignerIdentityUri(),
+      });
+
+      if (!signatureResult.valid) {
+        cleanupFailedInstall(versionDir);
+        throw new Error("Signature verification failed, refusing to install: " + signatureResult.reason);
+      }
+
+      console.log("Signature verified successfully.");
+    }
+
     const checksumResult = await verifyFileChecksum(tempFile, expectedChecksum);
 
     if (!checksumResult.valid && expectedChecksum) {
@@ -368,8 +401,6 @@ export async function setupCommand(options: ISetupOptions): Promise<void> {
 
     if (expectedChecksum) {
       console.log("Checksum verified successfully.");
-    } else {
-      console.log("Warning: No checksum configured, skipping verification.");
     }
 
     console.log("Extracting...");

--- a/src/cli/upgrade.ts
+++ b/src/cli/upgrade.ts
@@ -15,11 +15,19 @@ import {
   calculateFileChecksum,
   getDataDir,
   getElectronAppDir,
+  getElectronAppSignedFromVersion,
   getElectronAppVersion,
   getLogger,
   getPlatformKey,
+  getReleaseSignerIdentityUri,
   verifyFileChecksum,
 } from "../../packages/mcps/src/index.js";
+import {
+  SIGNATURE_BUNDLE_SUFFIX,
+  compareVersions,
+  resolveIntegrityPolicy,
+  verifyReleaseSignature,
+} from "../../scripts/release-integrity/index.mjs";
 import { cleanupOldVersions, formatBytes } from "./cleanup.js";
 
 const logger = getLogger();
@@ -218,31 +226,6 @@ async function checkForUpdates (): Promise<IUpdateCheckResult> {
 }
 
 /**
- * Compare two semver versions.
- * @param a - First version.
- * @param b - Second version.
- * @returns 1 if a > b, -1 if a < b, 0 if equal.
- */
-function compareVersions(a: string, b: string): number {
-  const partsA = a.split(".").map(Number);
-  const partsB = b.split(".").map(Number);
-
-  for (let i = 0; i < 3; i++) {
-    const partA = partsA[i] || 0;
-    const partB = partsB[i] || 0;
-
-    if (partA > partB) {
-      return 1;
-    }
-    if (partA < partB) {
-      return -1;
-    }
-  }
-
-  return 0;
-}
-
-/**
  * Get the expected executable path after extraction.
  * @param versionDir - Version directory path.
  * @returns Path to the expected executable.
@@ -434,12 +417,38 @@ async function downloadAndInstall(
 
   await pipeline(response.body as unknown as NodeJS.ReadableStream, fileStream);
 
-  console.log("Download complete, verifying checksum...");
+  console.log("Download complete, verifying integrity...");
 
   // Get checksum (from parameter or fetch from release)
   let expectedChecksum = checksum;
   if (!expectedChecksum) {
     expectedChecksum = await fetchChecksumFromRelease(version);
+  }
+
+  const integrityPolicy = resolveIntegrityPolicy({
+    version: version,
+    signedFromVersion: getElectronAppSignedFromVersion(),
+    expectedChecksum: expectedChecksum ?? "",
+  });
+
+  if (integrityPolicy.unverifiableReason) {
+    rmSync(versionDir, { recursive: true, force: true });
+    throw new Error("Refusing to install an unverifiable download: " + integrityPolicy.unverifiableReason);
+  }
+
+  if (integrityPolicy.requiresSignature) {
+    const signatureResult = await verifyReleaseSignature({
+      artifactPath: tempFile,
+      bundleUrl: downloadUrl + SIGNATURE_BUNDLE_SUFFIX,
+      signerIdentityUri: getReleaseSignerIdentityUri(),
+    });
+
+    if (!signatureResult.valid) {
+      rmSync(versionDir, { recursive: true, force: true });
+      throw new Error("Signature verification failed, refusing to install: " + signatureResult.reason);
+    }
+
+    console.log("Signature verified successfully.");
   }
 
   // Verify checksum
@@ -457,8 +466,6 @@ async function downloadAndInstall(
 
   if (expectedChecksum) {
     console.log("Checksum verified successfully.");
-  } else {
-    console.log("Warning: No checksum available, skipping verification.");
   }
 
   console.log("Extracting...");

--- a/src/test/cli/setup.test.ts
+++ b/src/test/cli/setup.test.ts
@@ -14,6 +14,10 @@ const mcpsMocks = vi.hoisted(() => ({
   getElectronAppChecksums: vi.fn(() => ({})),
   getElectronAppDir: vi.fn((v: string) => `/data/electron-app/${v}`),
   getElectronAppVersion: vi.fn(() => "1.0.5"),
+  getElectronAppSignedFromVersion: vi.fn(() => "1.10.0"),
+  getReleaseSignerIdentityUri: vi.fn(
+    () => "https://github.com/multiplex-ai/muggle-ai-teaching-service/.github/workflows/release-electron-app-reusable.yml@refs/heads/master",
+  ),
   getPlatformKey: vi.fn(() => "win32-x64"),
   isElectronAppInstalled: vi.fn(() => false),
   isFirstRun: vi.fn(() => false),
@@ -108,6 +112,7 @@ describe("setupCommand", () => {
     });
     mcpsMocks.verifyFileChecksum.mockResolvedValue({ valid: true, expected: "e", actual: "e" });
     mcpsMocks.getChecksumForPlatform.mockReturnValue("expected-archive-sum");
+    mcpsMocks.getElectronAppVersion.mockReturnValue("1.0.5");
     childProcessMock.execFile.mockImplementation((_c, _a, cb) => cb(null));
     logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
     errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
@@ -166,11 +171,18 @@ describe("setupCommand", () => {
     expect(logSpy.mock.calls.map((c) => String(c[0])).join("\n")).toContain("Checksum verified");
   });
 
-  it("warns and skips verification when no checksum is configured", async () => {
+  it("refuses to install when neither a signature nor a checksum can verify the download", async () => {
     mcpsMocks.getChecksumForPlatform.mockReturnValue("");
-    fsState.existing.add(EXE_PATH);
     await setupCommand({ force: true });
-    expect(logSpy.mock.calls.map((c) => String(c[0])).join("\n")).toContain("No checksum configured");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(childProcessMock.execFile).not.toHaveBeenCalled();
+  });
+
+  it("refuses a release at the signed-from version whose signature does not verify", async () => {
+    mcpsMocks.getElectronAppVersion.mockReturnValue("1.10.0");
+    await setupCommand({ force: true });
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(childProcessMock.execFile).not.toHaveBeenCalled();
   });
 
   it("exits 1 when checksum verification fails", async () => {

--- a/src/test/cli/upgrade.test.ts
+++ b/src/test/cli/upgrade.test.ts
@@ -18,6 +18,10 @@ const mcpsMocks = vi.hoisted(() => ({
   getDataDir: vi.fn(() => "/data"),
   getElectronAppDir: vi.fn((v: string) => `/data/electron-app/${v}`),
   getElectronAppVersion: vi.fn(() => "1.0.5"),
+  getElectronAppSignedFromVersion: vi.fn(() => "1.10.0"),
+  getReleaseSignerIdentityUri: vi.fn(
+    () => "https://github.com/multiplex-ai/muggle-ai-teaching-service/.github/workflows/release-electron-app-reusable.yml@refs/heads/master",
+  ),
   getPlatformKey: vi.fn(() => "win32-x64"),
   getLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
   verifyFileChecksum: vi.fn(async () => ({ valid: true, expected: "e", actual: "e" })),
@@ -84,6 +88,20 @@ function releasesResponse(tags: string[]): Record<string, unknown> {
 function downloadResponse(): Record<string, unknown> {
   return { ok: true, status: 200, statusText: "OK", body: { kind: "body" } };
 }
+
+/** checksums.txt covering every published asset name, so any mocked platform resolves. */
+const checksumsResponse = () => ({
+  ok: true,
+  status: 200,
+  statusText: "OK",
+  text: async () =>
+    [
+      "MuggleAI-win32-x64.zip",
+      "MuggleAI-darwin-x64.zip",
+      "MuggleAI-darwin-arm64.zip",
+      "MuggleAI-linux-x64.zip",
+    ].map((name) => "a".repeat(64) + "  " + name).join("\n"),
+});
 
 describe("getEffectiveElectronAppVersion", () => {
   // getEffectiveElectronAppVersion reads the override via require("fs"), which
@@ -184,7 +202,7 @@ describe("upgradeCommand", () => {
     stubFetchSequence([
       releasesResponse(["v1.0.6"]),
       downloadResponse(),
-      { ok: true, status: 200, statusText: "OK", text: async () => "" },
+      checksumsResponse(),
     ]);
 
     await upgradeCommand({});
@@ -198,17 +216,29 @@ describe("upgradeCommand", () => {
   });
 
   it("installs a specific --version using the parameterized download URL", async () => {
+    fsState.existing.add(join("/data/electron-app/1.0.9", "MuggleAI.exe"));
+    stubFetchSequence([
+      downloadResponse(),
+      checksumsResponse(),
+    ]);
+    await upgradeCommand({ version: "1.0.9" });
+    expect(mcpsMocks.buildElectronAppReleaseAssetUrl).toHaveBeenCalledWith({
+      version: "1.0.9",
+      assetFileName: "MuggleAI-win32-x64.zip",
+    });
+    expect(fsState.written.has(join("/data/electron-app/1.0.9", ".install-metadata.json"))).toBe(true);
+  });
+
+  it("refuses a --version at or above the signed-from version when its signature does not verify", async () => {
     fsState.existing.add(join("/data/electron-app/3.1.4", "MuggleAI.exe"));
     stubFetchSequence([
       downloadResponse(),
-      { ok: true, status: 200, statusText: "OK", text: async () => "" },
+      checksumsResponse(),
+      { ok: false, status: 404, statusText: "Not Found" },
     ]);
     await upgradeCommand({ version: "3.1.4" });
-    expect(mcpsMocks.buildElectronAppReleaseAssetUrl).toHaveBeenCalledWith({
-      version: "3.1.4",
-      assetFileName: "MuggleAI-win32-x64.zip",
-    });
-    expect(fsState.written.has(join("/data/electron-app/3.1.4", ".install-metadata.json"))).toBe(true);
+    expect(childProcessMock.execFile).not.toHaveBeenCalled();
+    expect(fsState.written.has(join("/data/electron-app/3.1.4", ".install-metadata.json"))).toBe(false);
   });
 
   it("verifies a checksum parsed from checksums.txt", async () => {
@@ -249,7 +279,7 @@ describe("upgradeCommand", () => {
     stubFetchSequence([
       releasesResponse(["v1.0.6"]),
       downloadResponse(),
-      { ok: true, status: 200, statusText: "OK", text: async () => "" },
+      checksumsResponse(),
     ]);
     await upgradeCommand({});
     expect(exitSpy).toHaveBeenCalledWith(1);
@@ -260,7 +290,7 @@ describe("upgradeCommand", () => {
     stubFetchSequence([
       releasesResponse(["v1.0.5"]),
       downloadResponse(),
-      { ok: true, status: 200, statusText: "OK", text: async () => "" },
+      checksumsResponse(),
     ]);
     await upgradeCommand({ force: true });
     expect(streamMock.pipeline).toHaveBeenCalledOnce();
@@ -291,7 +321,7 @@ describe("upgradeCommand", () => {
             ],
           };
         }
-        return { ok: true, status: 200, statusText: "OK", text: async () => "" };
+        return checksumsResponse();
       }),
     );
     await upgradeCommand({ check: true });
@@ -299,15 +329,14 @@ describe("upgradeCommand", () => {
     expect(out).toContain("Latest version:  1.0.7");
   });
 
-  it("warns and skips verification when the checksums file is absent", async () => {
-    fsState.existing.add(EXE_106);
+  it("refuses to install when the checksums file is absent and the release predates signing", async () => {
     stubFetchSequence([
       releasesResponse(["v1.0.6"]),
       downloadResponse(),
       { ok: false, status: 404, statusText: "Not Found" },
     ]);
     await upgradeCommand({});
-    expect(logSpy.mock.calls.map((c) => String(c[0])).join("\n")).toContain("No checksum available");
+    expect(childProcessMock.execFile).not.toHaveBeenCalled();
   });
 
   it("exits 1 when the download response is not ok", async () => {
@@ -328,7 +357,7 @@ describe("upgradeCommand", () => {
     stubFetchSequence([
       releasesResponse(["v1.0.6"]),
       downloadResponse(),
-      { ok: true, status: 200, statusText: "OK", text: async () => "" },
+      checksumsResponse(),
     ]);
     await upgradeCommand({});
     expect(childProcessMock.execFile.mock.calls[0][0]).toBe("unzip");

--- a/test/scripts/release-integrity.test.mjs
+++ b/test/scripts/release-integrity.test.mjs
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("sigstore", () => ({ verify: vi.fn() }));
+
+const { verify } = await import("sigstore");
+const { compareVersions } = await import("../../scripts/release-integrity/compareVersions.mjs");
+const { resolveIntegrityPolicy } = await import("../../scripts/release-integrity/resolveIntegrityPolicy.mjs");
+const { verifyReleaseSignature } = await import("../../scripts/release-integrity/verifyReleaseSignature.mjs");
+
+const SIGNER = "https://github.com/multiplex-ai/muggle-ai-teaching-service/.github/workflows/release-electron-app-reusable.yml@refs/heads/master";
+
+describe("compareVersions", () => {
+    it("orders by major, minor, then patch", () => {
+        expect(compareVersions("1.10.0", "1.9.0")).toBe(1);
+        expect(compareVersions("1.9.0", "1.10.0")).toBe(-1);
+        expect(compareVersions("1.10.0", "1.10.0")).toBe(0);
+    });
+
+    it("treats missing segments as zero", () => {
+        expect(compareVersions("2", "2.0.0")).toBe(0);
+    });
+});
+
+describe("resolveIntegrityPolicy", () => {
+    it("requires a signature at the pinned version", () => {
+        const policy = resolveIntegrityPolicy({
+            version: "1.10.0",
+            signedFromVersion: "1.10.0",
+            expectedChecksum: "",
+        });
+
+        expect(policy.requiresSignature).toBe(true);
+        expect(policy.requiresChecksum).toBe(false);
+        expect(policy.unverifiableReason).toBe("");
+    });
+
+    it("requires a signature above the pinned version even when a checksum exists", () => {
+        const policy = resolveIntegrityPolicy({
+            version: "2.0.0",
+            signedFromVersion: "1.10.0",
+            expectedChecksum: "a".repeat(64),
+        });
+
+        expect(policy.requiresSignature).toBe(true);
+    });
+
+    it("falls back to a mandatory checksum below the pinned version", () => {
+        const policy = resolveIntegrityPolicy({
+            version: "1.9.0",
+            signedFromVersion: "1.10.0",
+            expectedChecksum: "a".repeat(64),
+        });
+
+        expect(policy.requiresSignature).toBe(false);
+        expect(policy.requiresChecksum).toBe(true);
+        expect(policy.unverifiableReason).toBe("");
+    });
+
+    it("refuses a pre-pin version that has no checksum instead of skipping verification", () => {
+        const policy = resolveIntegrityPolicy({
+            version: "1.9.0",
+            signedFromVersion: "1.10.0",
+            expectedChecksum: "",
+        });
+
+        expect(policy.requiresSignature).toBe(false);
+        expect(policy.requiresChecksum).toBe(false);
+        expect(policy.unverifiableReason).toContain("no integrity evidence");
+    });
+
+    it("refuses a whitespace-only checksum", () => {
+        const policy = resolveIntegrityPolicy({
+            version: "1.9.0",
+            signedFromVersion: "1.10.0",
+            expectedChecksum: "   ",
+        });
+
+        expect(policy.unverifiableReason).toContain("no integrity evidence");
+    });
+
+    it("refuses everything when no signed-from version is configured and no checksum exists", () => {
+        const policy = resolveIntegrityPolicy({
+            version: "9.9.9",
+            signedFromVersion: "",
+            expectedChecksum: "",
+        });
+
+        expect(policy.requiresSignature).toBe(false);
+        expect(policy.unverifiableReason).toContain("none configured");
+    });
+});
+
+describe("verifyReleaseSignature", () => {
+    beforeEach(() => {
+        vi.mocked(verify).mockReset();
+    });
+
+    it("accepts a bundle that verifies against the pinned signer identity", async () => {
+        const bundle = { mediaType: "application/vnd.dev.sigstore.bundle.v0.3+json" };
+        vi.stubGlobal("fetch", vi.fn(async () => ({ ok: true, status: 200, json: async () => bundle })));
+        vi.mocked(verify).mockResolvedValue(undefined);
+
+        const result = await verifyReleaseSignature({
+            artifactPath: "package.json",
+            bundleUrl: "https://example.invalid/asset.zip.sigstore.json",
+            signerIdentityUri: SIGNER,
+        });
+
+        expect(result.valid).toBe(true);
+        expect(vi.mocked(verify).mock.calls[0][2]).toEqual({
+            certificateIssuer: "https://token.actions.githubusercontent.com",
+            certificateIdentityURI: SIGNER,
+        });
+    });
+
+    it("rejects when the signature does not verify", async () => {
+        vi.stubGlobal("fetch", vi.fn(async () => ({ ok: true, status: 200, json: async () => ({}) })));
+        vi.mocked(verify).mockRejectedValue(new Error("signature verification failed"));
+
+        const result = await verifyReleaseSignature({
+            artifactPath: "package.json",
+            bundleUrl: "https://example.invalid/asset.zip.sigstore.json",
+            signerIdentityUri: SIGNER,
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.reason).toContain("signature verification failed");
+    });
+
+    it("rejects when the bundle is missing from the release", async () => {
+        vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, status: 404, json: async () => ({}) })));
+
+        const result = await verifyReleaseSignature({
+            artifactPath: "package.json",
+            bundleUrl: "https://example.invalid/asset.zip.sigstore.json",
+            signerIdentityUri: SIGNER,
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.reason).toContain("404");
+        expect(vi.mocked(verify)).not.toHaveBeenCalled();
+    });
+
+    it("rejects when the bundle cannot be fetched at all", async () => {
+        vi.stubGlobal("fetch", vi.fn(async () => {
+            throw new Error("network down");
+        }));
+
+        const result = await verifyReleaseSignature({
+            artifactPath: "package.json",
+            bundleUrl: "https://example.invalid/asset.zip.sigstore.json",
+            signerIdentityUri: SIGNER,
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.reason).toContain("network down");
+    });
+
+    it("rejects when no signer identity is configured rather than trusting any signature", async () => {
+        const fetchSpy = vi.fn();
+        vi.stubGlobal("fetch", fetchSpy);
+
+        const result = await verifyReleaseSignature({
+            artifactPath: "package.json",
+            bundleUrl: "https://example.invalid/asset.zip.sigstore.json",
+            signerIdentityUri: "",
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.reason).toContain("no signer identity");
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Verifies the Sigstore signature of the studio download before extracting it, and closes the hole where a download with no integrity evidence installed anyway.

Companion to multiplex-ai/muggle-ai-teaching-service#363, which produces the signatures.

## The hole

`verifyFileChecksum` returned `{ valid: true, skipped: true }` for an empty expected checksum, and all three download paths treated that as success behind a log line:

- `scripts/postinstall.mjs` — "Warning: No checksum configured, skipping verification."
- `src/cli/setup.ts` — same
- `src/cli/upgrade.ts` — same, and `fetchChecksumFromRelease` returns `""` on 404, parse-miss, or network error, so an unreachable `checksums.txt` silently downgraded to no verification at all

Nothing at runtime distinguished "verified" from "not checked".

## The policy

Signature is now primary, pinned by version:

- At or above `muggleConfig.electronAppSignedFromVersion` a valid Sigstore bundle is **required**, and its absence is fatal.
- Below it, the existing checksum applies and is now **mandatory** rather than advisory.
- Neither available means the install is refused, never a warning-and-continue.

Version-pinning is what makes this safe to land: releases predating signing keep installing exactly as before, so no existing install breaks. It is also what stops an attacker downgrading a user to an unsigned release.

Verification runs in pure JS via `sigstore`, against the bundle published beside the artifact — no `gh` CLI, no token, no credentials on the user's machine. The signer identity is pinned to the exact release workflow in the studio source repo, so a bundle that is cryptographically valid but issued to some other workflow is rejected.

## Blast radius

None today. Every runtime target resolves to a stream with all four platform checksums recorded on master:

```
target production  stream production  linux-x64 -> require checksum
target staging     stream staging     linux-x64 -> require checksum
target dev         stream production  linux-x64 -> require checksum
```

The hole being closed is latent: a stream added without checksums, or `upgrade.ts`'s `checksums.txt` fetch failing, both of which previously installed an unverified archive.

## Evidence

The library call and identity pinning were proven against a genuine public-good Sigstore bundle (npm provenance for `sigstore@5.0.0`, one Rekor transparency-log entry): the correct signer identity is accepted, and a wrong one is rejected with `certificate identity error`.

Worth recording why GitHub attestations were abandoned: their bundles are signed by GitHub's internal root and fail public-good verification with `timestamp could not be verified`. Details in the companion PR.

Full suite is green (1528 tests, plus 27 skipped), typecheck, lint and build all clean. Two guardrail hook-execution tests time out under parallel load and pass in isolation — pre-existing flakiness in a file this PR does not touch.

Six `upgrade.test.ts` fixtures supplied an **empty** `checksums.txt` and so encoded the very behaviour being removed; they now carry real checksums. Two tests that asserted the warning now assert refusal.

## Notes

- `src/cli/upgrade.ts`'s local `compareVersions` is deleted in favour of the shared one. `src/cli/cleanup.ts` keeps its own copy — out of scope here.
- `scripts/verify-electron-release-checksums.mjs` still validates checksums only; extending that maintainer preflight to assert bundles exist is a reasonable follow-up.
- `electronAppSignedFromVersion` is set to `1.10.0`, the next release after signing ships. It must not be lowered to a version that was published unsigned.
