### PR TITLE
test: size the vitest timeout for the suites that spawn a compiler

### DIFF
--- a/src/test/vitest-config.test.ts
+++ b/src/test/vitest-config.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+
+// The timeout is the only thing standing between this suite and the flake it
+// was raised for, and nothing else would notice if it were dropped: a shorter
+// ceiling fails intermittently, on a different file each time, and only under
+// parallel load. That reads as "flaky tests" rather than "someone changed the
+// config", so pin it here where the reason is written down.
+const CONFIG = fileURLToPath(new URL("../../vitest.config.ts", import.meta.url));
+
+const VITEST_DEFAULT_TIMEOUT_MS = 5_000;
+
+describe("vitest config", () => {
+  const configBody = readFileSync(CONFIG, "utf-8");
+
+  it("declares a test timeout above vitest's default", () => {
+    const declared = configBody.match(/const SPAWN_HEAVY_TIMEOUT_MS = ([\d_]+);/)?.[1];
+    expect(declared, "SPAWN_HEAVY_TIMEOUT_MS is no longer declared").toBeDefined();
+    expect(Number(declared!.replaceAll("_", ""))).toBeGreaterThan(VITEST_DEFAULT_TIMEOUT_MS);
+  });
+
+  it("applies it to both tests and hooks", () => {
+    expect(configBody).toContain("testTimeout: SPAWN_HEAVY_TIMEOUT_MS");
+    expect(configBody).toContain("hookTimeout: SPAWN_HEAVY_TIMEOUT_MS");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,22 @@
 import { defineConfig } from "vitest/config";
 
+/** Ceiling for a single test or hook. Sized for the suites that spawn a TypeScript-compiling subprocess per assertion, not for the median test. */
+const SPAWN_HEAVY_TIMEOUT_MS = 30_000;
+
 export default defineConfig({
   test: {
     // Watch never exits and orphans on Windows kill; opt-in only.
     watch: process.env.MUGGLE_VITEST_WATCH === "1",
     passWithNoTests: true,
+    // Vitest defaults to 5s. Several suites here spawn `node --import tsx` per
+    // assertion — hook-execution.test.ts alone does it 78 times, recompiling
+    // TypeScript each call — and local-execution-lock.test.ts takes a real
+    // 500ms lock. Under parallel load on Windows that tips over: three
+    // different files have failed at 5058ms, 5262ms and 5718ms while passing
+    // in isolation, including on unmodified master. Generous enough to absorb
+    // spawn contention, short enough to still catch a genuine hang.
+    testTimeout: SPAWN_HEAVY_TIMEOUT_MS,
+    hookTimeout: SPAWN_HEAVY_TIMEOUT_MS,
     // First entry is Vitest's default glob (kept so packages/** and internal/**
     // stay discovered); second makes the top-level test/ tree — tests mirror
     // their src/ path there — explicit.


### PR DESCRIPTION
Vitest's 5s default is too tight for the suites in this repo that spawn a TypeScript-compiling subprocess per assertion.

## Evidence

Three *different* files failed across full-suite runs while this session's other work was being verified, each passing in isolation immediately afterwards — including on unmodified master:

| File | Duration | Default |
| :-- | --: | --: |
| `stage-gate-hooks.test.ts` | 5058 ms | 5000 ms |
| `local-execution-lock.test.ts` | 5262 ms | 5000 ms |
| `hook-execution.test.ts` | 5718 ms | 5000 ms |

All three sit just past the line, which is the signature of a budget problem rather than a logic bug. `hook-execution.test.ts` spawns `node --import tsx` **78 times**, recompiling TypeScript on each call; `local-execution-lock.test.ts` takes a real 500 ms lock. Under parallel load on Windows they tip over.

Because it lands on a different file each time and only under load, it reads as "flaky tests" rather than "the timeout is too low" — which is why it survived.

## Change

`testTimeout` and `hookTimeout` raised to 30s at the config, with the reasoning written where the number lives. Config-level rather than per-file: three files across three different trees hit it, so it is a repo-wide default problem, not a per-file quirk. Still short enough to catch a genuine hang.

A small test pins it. Nothing else would notice its removal — the symptom is intermittent and misattributed.

## Verification

Two consecutive full-suite runs green: 109 files, 1532 tests.

## Note on the baseline

Those numbers are higher than the counts quoted in this session's earlier PRs (107 files / 1498 tests). This repo is pnpm-only — `pnpm-lock.yaml`, no `package-lock.json` — and I had been installing worktrees with `npm ci`, which produced a tree missing `sigstore`, so `src/test/cli/setup.test.ts` and `upgrade.test.ts` could not load at all and were silently counted as absent rather than failing. Reinstalling with `pnpm install --frozen-lockfile` recovers 2 files and 34 tests. CI has always used pnpm, so every merged PR was validated correctly; only my local counts were understated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5x29dpkFsVvENqJDFeqxg
