### PR TITLE
ci: publish a staging pre-release on every green master build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,3 +202,38 @@ jobs:
 
       - name: Smoke-test the built CLI
         run: pnpm run smoke:cli
+
+  # Every green master build publishes a staging pre-release, so the staging
+  # channel always reflects what is on master rather than whatever someone last
+  # dispatched by hand.
+  #
+  # Dispatches the publish workflow rather than triggering it on `workflow_run`:
+  # that workflow resolves its channel from `inputs.channel || 'production'` in
+  # three places, so a trigger carrying no inputs would silently resolve to
+  # production and move the `latest` dist-tag. Dispatching states the channel
+  # outright and leaves that logic untouched.
+  staging-release:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs:
+      - lint-and-test
+      - harness-unit-tests
+      - skill-deps
+      - post-signatures
+      - typecheck
+      - node-compat
+      - platform-compat
+      - verify-compatibility
+    permissions:
+      actions: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Publish a staging pre-release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run publish-works-to-npm.yml \
+            --ref master \
+            -f channel=staging

--- a/.github/workflows/publish-works-to-npm.yml
+++ b/.github/workflows/publish-works-to-npm.yml
@@ -186,13 +186,50 @@ jobs:
             npm version "$INPUT_BUMP" --no-git-tag-version
           fi
 
+      # The base comes from what is published, never from package.json. That
+      # file drifts behind the registry — it sat at 5.11.0 while `latest` was
+      # 5.11.1 and `staging` was 5.12.0 — so a base computed from it lands below
+      # the current staging tag and publishing moves that tag *backwards*,
+      # downgrading everyone tracking it. One minor above `latest` cannot do
+      # that, and advances on its own after each production release.
       - name: Apply staging pre-release version
         if: ${{ inputs.channel == 'staging' }}
         env:
           RUN_NUMBER: ${{ github.run_number }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          BASE=$(node -p "require('./package.json').version")
-          npm version "${BASE%%-*}-staging.${RUN_NUMBER}" --no-git-tag-version
+          set -euo pipefail
+          if [ -n "$INPUT_VERSION" ]; then
+            BASE="${INPUT_VERSION%%-*}"
+          else
+            LATEST=$(timeout 60 npm view "$(node -p "require('./package.json').name")" version 2>/dev/null || true)
+            if [ -z "$LATEST" ]; then
+              echo "Could not read the published latest version; refusing to guess a staging base." >&2
+              exit 1
+            fi
+            BASE=$(node -e 'const [major, minor] = process.argv[1].split("-")[0].split(".").map(Number); console.log(major + "." + (minor + 1) + ".0");' "$LATEST")
+          fi
+          CANDIDATE="${BASE}-staging.${RUN_NUMBER}"
+
+          # The invariant this whole step exists for, asserted rather than assumed.
+          CURRENT=$(timeout 60 npm view "$(node -p "require('./package.json').name")" version --tag staging 2>/dev/null || true)
+          if [ -n "$CURRENT" ]; then
+            node -e '
+              const parse = (version) => {
+                const [core, prerelease] = version.split("-staging.");
+                return [...core.split(".").map(Number), Number(prerelease ?? 0)];
+              };
+              const candidate = parse(process.argv[1]);
+              const current = parse(process.argv[2]);
+              const firstDifference = candidate.findIndex((part, index) => part !== current[index]);
+              if (firstDifference === -1 || candidate[firstDifference] < current[firstDifference]) {
+                console.error("Refusing to publish " + process.argv[1] + ": not greater than the current staging tag " + process.argv[2] + ".");
+                process.exit(1);
+              }
+            ' "$CANDIDATE" "$CURRENT"
+          fi
+
+          npm version "$CANDIDATE" --no-git-tag-version
 
       - name: Set runtime target to match the channel
         env:


### PR DESCRIPTION
The staging channel only moved when someone remembered to dispatch the publish workflow by hand, so it drifted behind master. Every green master build now publishes a staging pre-release.

## Trigger

A `staging-release` job in `ci.yml`, gated on `push` to `master` and needing all eight existing jobs, dispatches the publish workflow with `channel=staging`.

**Dispatch rather than `workflow_run`,** which was the obvious wiring and is wrong here: the publish workflow resolves its channel from `inputs.channel || 'production'` in **three** places. A trigger carrying no inputs resolves every one of them to `production` and moves the `latest` dist-tag. Dispatching states the channel outright and leaves that logic untouched.

## Version

The staging base now comes from the registry, not `package.json`.

That file drifts behind published reality — right now it reads `5.11.0` while `latest` is `5.11.1` and `staging` is `5.12.0-staging.76`. The old rule (bump `package.json`) would have computed `5.11.1-staging.N` on the **first automatic run**, which is *below* the current staging tag: publishing it moves the tag backwards and downgrades everyone tracking it. I hit that trap twice by hand today before spotting it.

The new rule is **one minor above the published `latest`**:

| `latest` | staging base |
| :-- | :-- |
| 5.11.1 | 5.12.0 |
| 5.12.0 | 5.13.0 |
| 5.9.14 | 5.10.0 |

It matches the existing train exactly, cannot land below `latest`, and advances on its own after each production release with no file to remember to bump. An explicit `version` input still overrides it.

## Guard

Ordering is asserted before publishing rather than assumed — the candidate must be strictly greater than the current `staging` tag. Verified against the real cases:

| candidate | current | |
| :-- | :-- | :-- |
| `5.12.0-staging.77` | `5.12.0-staging.76` | allow |
| `5.13.0-staging.5` | `5.12.0-staging.76` | allow |
| `5.11.1-staging.77` | `5.12.0-staging.76` | **refuse** — the regression above |
| `5.12.0-staging.76` | `5.12.0-staging.76` | **refuse** |
| `5.12.0-staging.75` | `5.12.0-staging.76` | **refuse** |

Both registry reads are bounded to 60s. `|| true` catches a failed read but not a stalled one, and a hung `npm view` would otherwise burn the job's budget — which is not hypothetical: the call hung while I was testing this locally.

## Verification

Both workflows parse as valid YAML; the base derivation and the ordering guard were each exercised against the table above. Full suite green — 109 files, 1537 tests.

Not exercised end-to-end: the trigger only fires on a real master push, so merging this is the first live run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5x29dpkFsVvENqJDFeqxg
