### PR TITLE
feat(mcps): expose delete-by-id tools for use case, test case, test script, action script

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Use Cases (muggle-remote-use-case-*)
 | `muggle-remote-use-case-prompt-preview`        | Preview before creating                                  |
 | `muggle-remote-use-case-update-from-prompt`    | Regenerate from new prompt                               |
 | `muggle-remote-use-case-bulk-preview-submit`   | Async batch-preview via OpenAI Batch API (~50% cheaper)  |
+| `muggle-remote-use-case-delete`                | Delete use case (cascades to its test cases + scripts)   |
 
 
 Test Cases (muggle-remote-test-case-*)
@@ -278,6 +279,7 @@ Test Cases (muggle-remote-test-case-*)
 | `muggle-remote-test-case-create`               | Create test case                                         |
 | `muggle-remote-test-case-generate-from-prompt` | Generate from prompt                                     |
 | `muggle-remote-test-case-bulk-preview-submit`  | Async batch-preview via OpenAI Batch API (~50% cheaper)  |
+| `muggle-remote-test-case-delete`               | Delete test case                                         |
 
 
 Bulk Preview Jobs (muggle-remote-bulk-preview-job-*)
@@ -300,6 +302,8 @@ Test Scripts and Workflows (muggle-remote-workflow-*)
 | ------------------------------------------------------ | ----------------------- |
 | `muggle-remote-test-script-list`                       | List test scripts       |
 | `muggle-remote-test-script-get`                        | Get script details      |
+| `muggle-remote-test-script-delete`                     | Delete test script      |
+| `muggle-remote-action-script-delete`                   | Delete action script (permanent) |
 | `muggle-remote-workflow-start-website-scan`            | Scan site for use cases |
 | `muggle-remote-workflow-start-test-case-detection`     | Generate test cases     |
 | `muggle-remote-workflow-start-test-script-generation`  | Generate scripts        |

--- a/packages/mcps/src/mcp/e2e/contracts/index.ts
+++ b/packages/mcps/src/mcp/e2e/contracts/index.ts
@@ -193,6 +193,10 @@ export const UseCaseGetInputSchema = z.object({
   useCaseId: IdSchema.describe("Use case ID (UUID) to retrieve"),
 });
 
+export const UseCaseDeleteInputSchema = z.object({
+  useCaseId: IdSchema.describe("Use case ID (UUID) to delete"),
+});
+
 export const UseCasePromptPreviewInputSchema = z.object({
   projectId: IdSchema.describe("Project ID (UUID) to generate use case for"),
   instruction: z.string().min(1).describe("Natural language instruction describing the use case (e.g., 'As a logged-in user, I can add items to cart')"),
@@ -312,6 +316,10 @@ export const TestCaseGetInputSchema = z.object({
   testCaseId: IdSchema.describe("Test case ID (UUID) to retrieve"),
 });
 
+export const TestCaseDeleteInputSchema = z.object({
+  testCaseId: IdSchema.describe("Test case ID (UUID) to delete"),
+});
+
 export const TestCaseAncestorsGetInputSchema = z.object({
   testCaseId: IdSchema.describe("Test case ID (UUID) to resolve the test-plan-graph ancestor chain for"),
 });
@@ -374,8 +382,16 @@ export const TestScriptGetInputSchema = z.object({
   testScriptId: IdSchema.describe("Test script ID (UUID) to retrieve"),
 });
 
+export const TestScriptDeleteInputSchema = z.object({
+  testScriptId: IdSchema.describe("Test script ID (UUID) to delete"),
+});
+
 export const ActionScriptGetInputSchema = z.object({
   actionScriptId: IdSchema.describe("Action script ID (UUID) to retrieve"),
+});
+
+export const ActionScriptDeleteInputSchema = z.object({
+  actionScriptId: IdSchema.describe("Action script ID (UUID) to delete"),
 });
 
 export const WorkflowStartWebsiteScanInputSchema = z.object({

--- a/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
+++ b/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
@@ -263,6 +263,18 @@ const useCaseTools: IQaToolDefinition[] = [
       };
     },
   },
+  {
+    name: "muggle-remote-use-case-delete",
+    description: "Delete a use case by ID. Soft delete, and it cascades: the use case's test cases and their test scripts are deleted with it.",
+    inputSchema: schemas.UseCaseDeleteInputSchema,
+    mapToUpstream: (input) => {
+      const useCaseDeleteInput = input as z.infer<typeof schemas.UseCaseDeleteInputSchema>;
+      return {
+        method: "DELETE",
+        path: `${MUGGLE_TEST_PREFIX}/use-cases/${useCaseDeleteInput.useCaseId}`,
+      };
+    },
+  },
 ];
 
 const testCaseTools: IQaToolDefinition[] = [
@@ -401,6 +413,18 @@ const testCaseTools: IQaToolDefinition[] = [
       };
     },
   },
+  {
+    name: "muggle-remote-test-case-delete",
+    description: "Delete a test case by ID. This is a soft delete.",
+    inputSchema: schemas.TestCaseDeleteInputSchema,
+    mapToUpstream: (input) => {
+      const testCaseDeleteInput = input as z.infer<typeof schemas.TestCaseDeleteInputSchema>;
+      return {
+        method: "DELETE",
+        path: `${MUGGLE_TEST_PREFIX}/test-cases/${testCaseDeleteInput.testCaseId}`,
+      };
+    },
+  },
 ];
 
 const bulkPreviewTools: IQaToolDefinition[] = [
@@ -483,6 +507,18 @@ const testScriptTools: IQaToolDefinition[] = [
       };
     },
   },
+  {
+    name: "muggle-remote-test-script-delete",
+    description: "Delete a test script by ID. This is a soft delete; the test case it belongs to is not affected.",
+    inputSchema: schemas.TestScriptDeleteInputSchema,
+    mapToUpstream: (input) => {
+      const testScriptDeleteInput = input as z.infer<typeof schemas.TestScriptDeleteInputSchema>;
+      return {
+        method: "DELETE",
+        path: `${MUGGLE_TEST_PREFIX}/test-scripts/${testScriptDeleteInput.testScriptId}`,
+      };
+    },
+  },
 ];
 
 const actionScriptTools: IQaToolDefinition[] = [
@@ -495,6 +531,18 @@ const actionScriptTools: IQaToolDefinition[] = [
       return {
         method: "GET",
         path: `/v1/protected/actionScript/${data.actionScriptId}`,
+      };
+    },
+  },
+  {
+    name: "muggle-remote-action-script-delete",
+    description: "Permanently delete an action script by ID. Unlike the other delete tools this is a hard delete and cannot be undone, and any test script referencing it keeps an orphaned actionScriptId. Only the owner or a super user may call it.",
+    inputSchema: schemas.ActionScriptDeleteInputSchema,
+    mapToUpstream: (input) => {
+      const actionScriptDeleteInput = input as z.infer<typeof schemas.ActionScriptDeleteInputSchema>;
+      return {
+        method: "DELETE",
+        path: `/v1/protected/actionScript/${actionScriptDeleteInput.actionScriptId}`,
       };
     },
   },

--- a/packages/mcps/src/test/__snapshots__/mcp-tool-surface.test.ts.snap
+++ b/packages/mcps/src/test/__snapshots__/mcp-tool-surface.test.ts.snap
@@ -75,6 +75,10 @@ exports[`MCP tool surface (Lazy-core parity oracle) > advertises the exact name 
     "name": "muggle-local-test-script-list",
   },
   {
+    "description": "Permanently delete an action script by ID. Unlike the other delete tools this is a hard delete and cannot be undone, and any test script referencing it keeps an orphaned actionScriptId. Only the owner or a super user may call it.",
+    "name": "muggle-remote-action-script-delete",
+  },
+  {
     "description": "Get the full action script content by ID. Use actionScriptId from a test script to fetch the complete script with all steps and element labels needed for replay.",
     "name": "muggle-remote-action-script-get",
   },
@@ -227,6 +231,10 @@ exports[`MCP tool surface (Lazy-core parity oracle) > advertises the exact name 
     "name": "muggle-remote-test-case-create",
   },
   {
+    "description": "Delete a test case by ID. This is a soft delete.",
+    "name": "muggle-remote-test-case-delete",
+  },
+  {
     "description": "Generate E2E acceptance test cases from a plain-English description of what to test — e.g., 'test the signup flow with invalid email' or 'verify the checkout handles empty cart'. Returns preview test cases that can be used to generate executable browser test scripts.",
     "name": "muggle-remote-test-case-generate-from-prompt",
   },
@@ -245,6 +253,10 @@ exports[`MCP tool surface (Lazy-core parity oracle) > advertises the exact name 
   {
     "description": "Directly update an existing test case's fields. Pass only the fields you want to change — others are left untouched. Use this for cheap, deterministic edits (rename, change status/priority, fix expected result, add tags). Does not touch the associated test script — script regeneration is a separate workflow (muggle-remote-workflow-start-test-script-generation).",
     "name": "muggle-remote-test-case-update",
+  },
+  {
+    "description": "Delete a test script by ID. This is a soft delete; the test case it belongs to is not affected.",
+    "name": "muggle-remote-test-script-delete",
   },
   {
     "description": "Get details of a specific test script.",
@@ -269,6 +281,10 @@ exports[`MCP tool surface (Lazy-core parity oracle) > advertises the exact name 
   {
     "description": "Create one or more use cases from natural language instructions.",
     "name": "muggle-remote-use-case-create-from-prompts",
+  },
+  {
+    "description": "Delete a use case by ID. Soft delete, and it cascades: the use case's test cases and their test scripts are deleted with it.",
+    "name": "muggle-remote-use-case-delete",
   },
   {
     "description": "Get the use case discovery memory for a project, including all discovered use case candidates.",
@@ -429,6 +445,7 @@ exports[`MCP tool surface (Lazy-core parity oracle) > advertises the exact set o
   "muggle-local-telemetry-skill-emit",
   "muggle-local-test-script-get",
   "muggle-local-test-script-list",
+  "muggle-remote-action-script-delete",
   "muggle-remote-action-script-get",
   "muggle-remote-auth-api-key-create",
   "muggle-remote-auth-api-key-get",
@@ -467,17 +484,20 @@ exports[`MCP tool surface (Lazy-core parity oracle) > advertises the exact set o
   "muggle-remote-test-case-ancestors-get",
   "muggle-remote-test-case-bulk-preview-submit",
   "muggle-remote-test-case-create",
+  "muggle-remote-test-case-delete",
   "muggle-remote-test-case-generate-from-prompt",
   "muggle-remote-test-case-get",
   "muggle-remote-test-case-list",
   "muggle-remote-test-case-list-by-use-case",
   "muggle-remote-test-case-update",
+  "muggle-remote-test-script-delete",
   "muggle-remote-test-script-get",
   "muggle-remote-test-script-list",
   "muggle-remote-use-case-bulk-preview-submit",
   "muggle-remote-use-case-candidates-approve",
   "muggle-remote-use-case-create",
   "muggle-remote-use-case-create-from-prompts",
+  "muggle-remote-use-case-delete",
   "muggle-remote-use-case-discovery-memory-get",
   "muggle-remote-use-case-get",
   "muggle-remote-use-case-list",

--- a/packages/mcps/src/test/tool-registry-delete.test.ts
+++ b/packages/mcps/src/test/tool-registry-delete.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for the delete-by-id tools on the cloud E2E registry.
+ *
+ * Covers:
+ *   - every delete-by-id tool is advertised and maps to the right verb + path
+ *   - each input schema requires exactly one well-formed UUID
+ *   - the action-script tool keeps warning that its delete is permanent
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../shared/config.js", () => ({
+  getConfig: () => ({
+    logLevel: "silent",
+    serverName: "test",
+    serverVersion: "0.0.0",
+    e2e: {
+      promptServiceBaseUrl: "http://test.invalid",
+      requestTimeoutMs: 1000,
+      workflowTimeoutMs: 1000,
+    },
+  }),
+}));
+
+vi.mock("../shared/logger.js", () => {
+  const noop = () => undefined;
+  const fakeLogger = {
+    info: noop,
+    warn: noop,
+    error: noop,
+    debug: noop,
+    verbose: noop,
+    silly: noop,
+    child: () => fakeLogger,
+  };
+  return { getLogger: () => fakeLogger, createChildLogger: () => fakeLogger, resetLogger: noop };
+});
+
+vi.mock("../mcp/e2e/upstream-client.js", () => ({
+  getPromptServiceClient: () => ({ execute: vi.fn() }),
+}));
+
+vi.mock("../shared/auth.js", () => ({
+  getCallerCredentialsAsync: vi.fn(async () => ({ bearerToken: "test-token" })),
+}));
+
+import { getQaToolByName } from "../mcp/tools/e2e/tool-registry.js";
+
+const VALID_UUID = "11111111-1111-4111-8111-111111111111";
+
+/**
+ * One row per delete-by-id tool: the id field its schema requires and the
+ * upstream path that id must land in. Paths are asserted in full because a
+ * wrong prefix still type-checks and would only surface as a 404 at runtime.
+ */
+const DELETE_TOOL_CONTRACTS = [
+  {
+    name: "muggle-remote-project-delete",
+    idField: "projectId",
+    expectedPath: `/v1/protected/muggle-test/projects/${VALID_UUID}`,
+  },
+  {
+    name: "muggle-remote-use-case-delete",
+    idField: "useCaseId",
+    expectedPath: `/v1/protected/muggle-test/use-cases/${VALID_UUID}`,
+  },
+  {
+    name: "muggle-remote-test-case-delete",
+    idField: "testCaseId",
+    expectedPath: `/v1/protected/muggle-test/test-cases/${VALID_UUID}`,
+  },
+  {
+    name: "muggle-remote-test-script-delete",
+    idField: "testScriptId",
+    expectedPath: `/v1/protected/muggle-test/test-scripts/${VALID_UUID}`,
+  },
+  {
+    name: "muggle-remote-action-script-delete",
+    idField: "actionScriptId",
+    expectedPath: `/v1/protected/actionScript/${VALID_UUID}`,
+  },
+  {
+    name: "muggle-remote-secret-delete",
+    idField: "secretId",
+    expectedPath: `/v1/protected/muggle-test/secrets/${VALID_UUID}`,
+  },
+] as const;
+
+describe("cloud E2E tool registry — delete by id", () => {
+  it.each(DELETE_TOOL_CONTRACTS)(
+    "$name issues DELETE to its entity path",
+    ({ name, idField, expectedPath }) => {
+      const tool = getQaToolByName(name);
+      expect(tool, `${name} must be advertised`).toBeDefined();
+
+      const upstream = tool!.mapToUpstream({ [idField]: VALID_UUID });
+      expect(upstream.method).toBe("DELETE");
+      expect(upstream.path).toBe(expectedPath);
+    },
+  );
+
+  it.each(DELETE_TOOL_CONTRACTS)("$name requires a well-formed id", ({ name, idField }) => {
+    const inputSchema = getQaToolByName(name)!.inputSchema;
+
+    expect(inputSchema.safeParse({}).success, `${name} must reject a missing id`).toBe(false);
+    expect(
+      inputSchema.safeParse({ [idField]: "not-a-uuid" }).success,
+      `${name} must reject a malformed id`,
+    ).toBe(false);
+    expect(inputSchema.safeParse({ [idField]: VALID_UUID }).success).toBe(true);
+  });
+
+  // The other delete routes soft-delete behind a ttl; this one calls ref.delete().
+  // If the wording ever drifts back to "soft delete", callers lose their only
+  // signal that the action script is unrecoverable.
+  it("warns that action-script delete is permanent", () => {
+    const description = getQaToolByName("muggle-remote-action-script-delete")!.description;
+
+    expect(description).toContain("Permanently delete");
+    expect(description).toContain("cannot be undone");
+    expect(description).not.toContain("soft delete");
+  });
+
+  // Deleting a use case takes its test cases and their scripts with it, which is
+  // the largest blast radius on the delete surface.
+  it("advertises the use-case delete cascade", () => {
+    const description = getQaToolByName("muggle-remote-use-case-delete")!.description;
+
+    expect(description).toContain("cascades");
+    expect(description).toContain("test scripts");
+  });
+});


### PR DESCRIPTION
Works exposed `get`/`list` for use cases, test cases, test scripts and action scripts but advertised no way to delete one, even though prompt-service has served `DELETE` for all four the whole time. An agent could create and read these entities and then had to leave them behind. This closes that gap.

## Tools added

| Tool | Upstream |
| ---- | -------- |
| `muggle-remote-use-case-delete` | `DELETE /v1/protected/muggle-test/use-cases/:useCaseId` |
| `muggle-remote-test-case-delete` | `DELETE /v1/protected/muggle-test/test-cases/:testCaseId` |
| `muggle-remote-test-script-delete` | `DELETE /v1/protected/muggle-test/test-scripts/:testScriptId` |
| `muggle-remote-action-script-delete` | `DELETE /v1/protected/actionScript/:actionScriptId` |

Each takes one required UUID validated by `IdSchema`, mirroring the shipped `muggle-remote-project-delete` / `muggle-remote-secret-delete` pattern. No confirmation flag — adding one to only the new tools would leave the delete surface inconsistent with the four already in production.

Backend work: none. Every endpoint already exists in `muggle-ai-prompt-service`.

## Two descriptions that are not boilerplate

The four routes look symmetric from the router, but they are not, and a tool description is the only API doc a calling agent gets:

- **Action-script delete is permanent.** `action_script_service.deleteActionScriptAsync` resolves to `action_script_dao.deleteActionScript`, which calls `ref.delete()`. The other three set `isDeleted`/`deletedAt`/`ttl` via `ISoftDeleteContext`. Its description says so, notes the orphaned `actionScriptId` left on referencing test scripts, and a test guards the wording against drifting back to "soft delete". (`action_script_dao` does have a soft-delete function, but it is reserved for orphan cleanup — the public route deliberately uses the hard path.)
- **Use-case delete cascades.** The controller calls `cascadeDeleteUseCaseById`, taking the use case's test cases and their test scripts with it. That is the largest blast radius on the delete surface, so it is stated in the description and pinned by a test.

## Scope

Bulk `DELETE /test-cases` is deliberately excluded — this change is one-entity-by-id only.

## Verification

- `npx vitest run` — exit 0, 110 files, 1551 tests green, 27 skipped
- New `tool-registry-delete.test.ts` — 14 assertions covering verb + full upstream path per tool, UUID validation (missing and malformed id both rejected), and the two description guards
- `tsc --noEmit` exit 0; ESLint on changed files exit 0
- `verify-compatibility-contracts`, `verify-plugin-marketplace`, `check-skill-deps` all exit 0
- `mcp-tool-surface` snapshot regenerated — purely additive, no existing tool reworded
- No browser E2E: this is an MCP tool registry change with no user-facing surface. Path correctness is asserted against the route registrations in `muggle_test_router.ts` and `protected.ts` rather than by a live round-trip, since exercising these tools for real would destroy real entities and action-script delete is unrecoverable.
