### PR TITLE
ci: stop non-shipping paths from triggering CI and releases

### DIFF
--- a/.claude/skills/muggle-works-npm-release/SKILL.md
+++ b/.claude/skills/muggle-works-npm-release/SKILL.md
@@ -46,11 +46,17 @@ npm view @muggleai/works version 2>&1 | sed 's/^/npm latest: /'
 
 ```bash
 LAST_RELEASE_SHA=$(git log --grep='chore(release)' --format='%H' -1)
+NON_SHIPPING=(':(exclude)internal/' ':(exclude)docs/' ':(exclude)ops/' ':(exclude)test/' ':(exclude).github/' ':(exclude).claude/' ':(exclude).cursor/' ':(exclude)README.md' ':(exclude)eslint.config.js' ':(exclude)vitest.config.ts')
 git log --oneline "$LAST_RELEASE_SHA..HEAD"
+git diff --name-only "$LAST_RELEASE_SHA..HEAD" -- . "${NON_SHIPPING[@]}"
 ```
 
-- If the log is **empty**, tell the user there is **nothing to ship** and **stop** (no branch, no bump, no PR).
-- If non-empty, present commits as a short table (subject; PR number from title/body if present).
+The log is for reading; the **diff decides**. `NON_SHIPPING` drops paths that cannot reach the npm tarball — the shipping surface is `package.json` → `files`, plus the sources `dist/` is built from (`src/`, `packages/`, `tsup.config.ts`) and the lockfile pinning what gets bundled. The gate is a diff rather than a pathspec'd `git log` because path filtering makes `git log` simplify merge commits out of the range, which a tree-to-tree diff cannot do.
+
+`NON_SHIPPING` is a denylist on purpose: a new top-level path counts as shipping until someone proves it inert, so the gate errs toward releasing rather than silently swallowing a fix.
+
+- If the **diff** is **empty**, tell the user there is **nothing to ship** and **stop** (no branch, no bump, no PR) — name the non-shipping commits that were skipped, so the decision is visible.
+- If non-empty, present the commits as a short table (subject; PR number from title/body if present).
 
 ---
 

--- a/.cursor/skills/muggle-works-npm-release/SKILL.md
+++ b/.cursor/skills/muggle-works-npm-release/SKILL.md
@@ -46,11 +46,17 @@ npm view @muggleai/works version 2>&1 | sed 's/^/npm latest: /'
 
 ```bash
 LAST_RELEASE_SHA=$(git log --grep='chore(release)' --format='%H' -1)
+NON_SHIPPING=(':(exclude)internal/' ':(exclude)docs/' ':(exclude)ops/' ':(exclude)test/' ':(exclude).github/' ':(exclude).claude/' ':(exclude).cursor/' ':(exclude)README.md' ':(exclude)eslint.config.js' ':(exclude)vitest.config.ts')
 git log --oneline "$LAST_RELEASE_SHA..HEAD"
+git diff --name-only "$LAST_RELEASE_SHA..HEAD" -- . "${NON_SHIPPING[@]}"
 ```
 
-- If the log is **empty**, tell the user there is **nothing to ship** and **stop** (no branch, no bump, no PR).
-- If non-empty, present commits as a short table (subject; PR number from title/body if present).
+The log is for reading; the **diff decides**. `NON_SHIPPING` drops paths that cannot reach the npm tarball — the shipping surface is `package.json` → `files`, plus the sources `dist/` is built from (`src/`, `packages/`, `tsup.config.ts`) and the lockfile pinning what gets bundled. The gate is a diff rather than a pathspec'd `git log` because path filtering makes `git log` simplify merge commits out of the range, which a tree-to-tree diff cannot do.
+
+`NON_SHIPPING` is a denylist on purpose: a new top-level path counts as shipping until someone proves it inert, so the gate errs toward releasing rather than silently swallowing a fix.
+
+- If the **diff** is **empty**, tell the user there is **nothing to ship** and **stop** (no branch, no bump, no PR) — name the non-shipping commits that were skipped, so the decision is visible.
+- If non-empty, present the commits as a short table (subject; PR number from title/body if present).
 
 ---
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,22 @@ name: CI
 on:
   push:
     branches: [master]
+    # docs/ and ops/ are unreachable from every job below: nothing in src/,
+    # test/, or scripts/ references them, eslint lints only ts/mts/js/mjs/cjs,
+    # and neither ships in package.json `files`. internal/ and scripts/ look
+    # equally inert but are not — internal/**/*.test.ts matches the vitest
+    # include and src/test/scripts/ covers scripts/. Actions has no YAML
+    # anchors, so pull_request repeats the list.
+    paths-ignore:
+      - "docs/**"
+      - "ops/**"
+      - "README.md"
   pull_request:
     branches: [master]
+    paths-ignore:
+      - "docs/**"
+      - "ops/**"
+      - "README.md"
 
 concurrency:
   # Superseded PR pushes are dead work. Master runs are per-commit history, so


### PR DESCRIPTION
Stops changes that cannot affect anything shippable from triggering CI or an npm release.

## CI (`ci.yml`)

`paths-ignore` for `docs/**`, `ops/**`, `README.md` on both `push` and `pull_request`. These are unreachable from every one of the 9 jobs: nothing under `src/`, `test/`, or `scripts/` references them, eslint lints only `ts/mts/js/mjs/cjs` (so `ops/`'s `.ps1`/`.vbs` are invisible to it), and neither ships in `package.json` `files`. Today a two-line docs edit spins up the full matrix — typecheck ×3, node-compat ×2, and platform-compat on Linux + Windows + macOS.

`master` branch protection has **zero required status check contexts**, so a workflow that never starts cannot leave a PR permanently pending.

**`internal/` and `scripts/` are deliberately not excluded.** They look inert but are not: `internal/**/*.test.ts` matches the vitest `include` glob, and `src/test/scripts/*.test.ts` covers `scripts/`. Excluding them would silently drop real coverage.

`skill-eval.yml` is left alone on purpose — each of its jobs already scopes itself with a `Determine scope` step, and a workflow-level filter would break the documented `run-full-eval` label escape hatch on a docs-only PR.

## Release gate (`muggle-works-npm-release` skill)

The gate treated *any* commit since the last `chore(release)` as shippable, so a docs-only commit could cut a version whose tarball is byte-identical to the previous one. It now gates on a diff restricted to the shipping surface: `package.json` `files`, plus the sources `dist/` is built from (`src/`, `packages/` — `@muggleai/mcp` is bundled via `noExternal` — and `tsup.config.ts`) and the lockfile pinning what gets bundled.

Measured on the current range: **53 commits since the last release, 28 touch shipping paths.** The other 25 cannot change what npm installs.

Two design points worth flagging for review:

- **Diff, not a pathspec'd `git log`.** Adding paths to `git log` makes it simplify merge commits out of the range; a tree-to-tree diff cannot do that, so it is the honest test for "did anything shippable change".
- **`NON_SHIPPING` is a denylist, not an allowlist.** A new top-level path counts as shipping until someone proves it inert. An allowlist rots into missed releases, which is the dangerous failure; a denylist rots into a redundant release, which is harmless. Flip this if you would rather have the tighter list.

The `.cursor/` mirror of the skill is kept byte-identical, as it was before.

## Verification

- `ci.yml` parsed with PyYAML; both triggers carry the filter and all 9 jobs survive.
- The gate snippet was run verbatim in Windows git bash — the `:(exclude)` pathspecs survive MSYS argument mangling.
- Negative control: the most recent docs-touching commit range yields an empty shipping diff, so the gate correctly reports nothing to ship. That control is also what surfaced the `.cursor/` path, which was missing from the first draft of the list.
- No test asserts on the three changed files; `scripts/link-maintainer-skills.mjs` only requires `SKILL.md` to exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUgfNK6fEnJ2GMF5be4Wu3
