### PR TITLE
feat(browser-bench): score attempts with the judge instead of studio's own claim

### DIFF
--- a/internal/browser-bench/src/judge/claude-judge.test.ts
+++ b/internal/browser-bench/src/judge/claude-judge.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { buildJudgeContentBlocks, createClaudeJudgeInvoker } from "./claude-judge";
+
+const readAsBase64 = (screenshotPath: string): string => `bytes-of-${screenshotPath}`;
+
+describe("buildJudgeContentBlocks", () => {
+  it("puts the prompt first so the judge reads the task before the evidence", () => {
+    const blocks = buildJudgeContentBlocks({
+      prompt: "Did the agent find the recipe?",
+      screenshotPaths: ["a.png"],
+      readAsBase64: readAsBase64,
+    });
+
+    expect(blocks[0]).toEqual({ type: "text", text: "Did the agent find the recipe?" });
+  });
+
+  it("carries every screenshot in capture order", () => {
+    const blocks = buildJudgeContentBlocks({
+      prompt: "p",
+      screenshotPaths: ["first.png", "second.png"],
+      readAsBase64: readAsBase64,
+    });
+
+    expect(blocks.slice(1)).toEqual([
+      {
+        type: "image",
+        source: { type: "base64", media_type: "image/png", data: "bytes-of-first.png" },
+      },
+      {
+        type: "image",
+        source: { type: "base64", media_type: "image/png", data: "bytes-of-second.png" },
+      },
+    ]);
+  });
+
+  it("labels a jpeg by its own media type rather than assuming png", () => {
+    const blocks = buildJudgeContentBlocks({
+      prompt: "p",
+      screenshotPaths: ["shot.jpg"],
+      readAsBase64: readAsBase64,
+    });
+
+    expect(blocks[1]).toMatchObject({ source: { media_type: "image/jpeg" } });
+  });
+
+  it("judges on the answer alone when the attempt captured nothing", () => {
+    const blocks = buildJudgeContentBlocks({
+      prompt: "p",
+      screenshotPaths: [],
+      readAsBase64: readAsBase64,
+    });
+
+    expect(blocks).toHaveLength(1);
+  });
+});
+
+describe("createClaudeJudgeInvoker", () => {
+  it("returns the judge's text so the protocol can read its verdict line", async () => {
+    const createMessage = vi.fn().mockResolvedValue({
+      stop_reason: "end_turn",
+      content: [{ type: "text", text: "Looks right.\nStatus: SUCCESS" }],
+    });
+
+    const invokeJudgeAsync = createClaudeJudgeInvoker({
+      client: { messages: { create: createMessage } } as never,
+      readAsBase64: readAsBase64,
+    });
+
+    expect(await invokeJudgeAsync("Did it work?", [])).toBe("Looks right.\nStatus: SUCCESS");
+  });
+
+  it("joins every text block, so a verdict split across blocks still parses", async () => {
+    const createMessage = vi.fn().mockResolvedValue({
+      stop_reason: "end_turn",
+      content: [
+        { type: "thinking", thinking: "" },
+        { type: "text", text: "Reasoning." },
+        { type: "text", text: "Status: SUCCESS" },
+      ],
+    });
+
+    const invokeJudgeAsync = createClaudeJudgeInvoker({
+      client: { messages: { create: createMessage } } as never,
+      readAsBase64: readAsBase64,
+    });
+
+    expect(await invokeJudgeAsync("p", [])).toBe("Reasoning.\nStatus: SUCCESS");
+  });
+
+  it("throws when the judge refuses, rather than scoring the task a failure", async () => {
+    // A refusal returns HTTP 200 with empty content. Read as a verdict it would
+    // silently score the task "not success" and understate the agent's ability.
+    const createMessage = vi.fn().mockResolvedValue({
+      stop_reason: "refusal",
+      stop_details: { category: "cyber" },
+      content: [],
+    });
+
+    const invokeJudgeAsync = createClaudeJudgeInvoker({
+      client: { messages: { create: createMessage } } as never,
+      readAsBase64: readAsBase64,
+    });
+
+    await expect(invokeJudgeAsync("p", [])).rejects.toThrow(/refused/i);
+  });
+
+  it("throws when the judge is cut off mid-verdict", async () => {
+    const createMessage = vi.fn().mockResolvedValue({
+      stop_reason: "max_tokens",
+      content: [{ type: "text", text: "Partial reasoning" }],
+    });
+
+    const invokeJudgeAsync = createClaudeJudgeInvoker({
+      client: { messages: { create: createMessage } } as never,
+      readAsBase64: readAsBase64,
+    });
+
+    await expect(invokeJudgeAsync("p", [])).rejects.toThrow(/max_tokens/i);
+  });
+});

--- a/internal/browser-bench/src/judge/claude-judge.ts
+++ b/internal/browser-bench/src/judge/claude-judge.ts
@@ -1,0 +1,111 @@
+import type Anthropic from "@anthropic-ai/sdk";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import {
+  JUDGE_IMAGE_MEDIA_TYPES,
+  JUDGE_MAX_TOKENS,
+  JUDGE_MODEL,
+} from "./constants";
+
+type JudgeContentBlock =
+  | { type: "text"; text: string }
+  | {
+      type: "image";
+      source: { type: "base64"; media_type: string; data: string };
+    };
+
+const resolveMediaType = (screenshotPath: string): string =>
+  JUDGE_IMAGE_MEDIA_TYPES[path.extname(screenshotPath).toLowerCase()] ??
+  JUDGE_IMAGE_MEDIA_TYPES[".png"];
+
+/**
+ * Builds the judge's message content: the scoring prompt, then every screenshot
+ * in capture order.
+ *
+ * The whole trajectory is sent rather than a trailing slice — WebVoyager's judge
+ * sees the run, and truncating it would score a different protocol than the one
+ * the number is reported against. Task step count is capped, so the image count
+ * is bounded by that cap rather than by the run's length.
+ *
+ * Output shape: `[{ type: "text", text: "…" }, { type: "image", source: {…} }]`
+ *
+ * @param params.readAsBase64 - Injected so the block shape is testable without disk.
+ */
+export const buildJudgeContentBlocks = ({
+  prompt,
+  screenshotPaths,
+  readAsBase64,
+}: {
+  prompt: string;
+  screenshotPaths: string[];
+  readAsBase64: (screenshotPath: string) => string;
+}): JudgeContentBlock[] => [
+  { type: "text", text: prompt },
+  ...screenshotPaths.map(
+    (screenshotPath): JudgeContentBlock => ({
+      type: "image",
+      source: {
+        type: "base64",
+        media_type: resolveMediaType(screenshotPath),
+        data: readAsBase64(screenshotPath),
+      },
+    }),
+  ),
+];
+
+/**
+ * Builds the judge seam `judgeTaskAsync` calls, backed by a real vision model.
+ *
+ * A refusal or a truncated reply throws rather than returning text. Both come
+ * back as an HTTP 200 that the WebVoyager protocol would read as "no SUCCESS
+ * line" — scoring the attempt a capability failure when the judge simply never
+ * rendered a verdict. Raising sends it to the orchestrator's infrastructure
+ * bucket, which is excluded from the pass-rate rather than counted against the
+ * agent.
+ *
+ * Output shape: `"The agent reached the recipe page…\nStatus: SUCCESS"`
+ *
+ * @param params.client - An authenticated Anthropic client.
+ */
+export const createClaudeJudgeInvoker = ({
+  client,
+  readAsBase64 = (screenshotPath: string): string =>
+    fs.readFileSync(screenshotPath).toString("base64"),
+}: {
+  client: Anthropic;
+  readAsBase64?: (screenshotPath: string) => string;
+}): ((prompt: string, screenshotPaths: string[]) => Promise<string>) => {
+  return async (prompt, screenshotPaths) => {
+    const response = await client.messages.create({
+      model: JUDGE_MODEL,
+      max_tokens: JUDGE_MAX_TOKENS,
+      messages: [
+        {
+          role: "user",
+          content: buildJudgeContentBlocks({
+            prompt: prompt,
+            screenshotPaths: screenshotPaths,
+            readAsBase64: readAsBase64,
+          }) as Anthropic.MessageParam["content"],
+        },
+      ],
+    });
+
+    if (response.stop_reason === "refusal") {
+      throw new Error(
+        `Judge refused to score the attempt (category ${response.stop_details?.category ?? "unknown"}).`,
+      );
+    }
+    if (response.stop_reason === "max_tokens") {
+      throw new Error(
+        `Judge hit max_tokens before rendering a verdict; raise JUDGE_MAX_TOKENS (currently ${JUDGE_MAX_TOKENS}).`,
+      );
+    }
+
+    return response.content
+      .filter((block): block is Anthropic.TextBlock => block.type === "text")
+      .map((block) => block.text)
+      .join("\n");
+  };
+};

--- a/internal/browser-bench/src/judge/constants.ts
+++ b/internal/browser-bench/src/judge/constants.ts
@@ -1,0 +1,24 @@
+/** The judge model. Vision-capable, and the strongest available — a weak judge caps the benchmark's own accuracy. */
+export const JUDGE_MODEL = "claude-opus-5";
+
+/**
+ * Output budget for one verdict. Thinking is on by default on this model and
+ * shares the budget with the reply, so a tight cap truncates the verdict line
+ * rather than the reasoning.
+ */
+export const JUDGE_MAX_TOKENS = 16_000;
+
+/** Maps a screenshot's extension to the media type the image block declares. */
+export const JUDGE_IMAGE_MEDIA_TYPES: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".webp": "image/webp",
+  ".gif": "image/gif",
+};
+
+/** Names the credential the judge needs; the batch refuses to start without it. */
+export const JUDGE_API_KEY_ENV_VAR = "ANTHROPIC_API_KEY";
+
+/** Studio writes the judge's input manifest here, inside each task's trajectory directory. */
+export const TRAJECTORY_MANIFEST_FILENAME = "trajectory.json";

--- a/internal/browser-bench/src/judge/judge.ts
+++ b/internal/browser-bench/src/judge/judge.ts
@@ -7,7 +7,11 @@ const SUCCESS_PATTERN = /Status:\s*SUCCESS\b/i;
  * Scores one task attempt by WebVoyager's judge protocol: the judge model reads
  * the instruction, the agent's answer, and the trailing screenshots, and returns
  * a binary verdict. Model invocation is injected so the protocol stays testable
- * without a network call; call the judge at temperature 0 so verdicts reproduce.
+ * without a network call.
+ *
+ * Verdicts are not bit-reproducible: the judge model rejects `temperature`
+ * outright, so a re-judged batch can move by a task or two. Re-judging is
+ * therefore a new measurement, not a replay of the old one.
  *
  * A response the judge protocol cannot parse counts as a failure, never an
  * error — infrastructure classification belongs to the orchestrator, and

--- a/internal/browser-bench/src/judge/judged-result.test.ts
+++ b/internal/browser-bench/src/judge/judged-result.test.ts
@@ -1,0 +1,96 @@
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { BenchmarkOutcome, type TaskResult } from "../domain/types";
+import { applyJudgeVerdict, resolveTrajectoryScreenshotPaths } from "./judged-result";
+
+const studioClaimedPass: TaskResult = {
+  taskId: "Allrecipes--0",
+  outcome: BenchmarkOutcome.Pass,
+  finalAnswer: "Found a lasagna recipe.",
+  studioStatus: "success",
+  stepCount: 7,
+  durationMs: 41_230,
+  tokensUsed: 0,
+  trajectoryDir: "C:/out/trajectories/Allrecipes--0",
+};
+
+describe("applyJudgeVerdict", () => {
+  it("overrules studio's own claim of success", () => {
+    // Studio reporting "success" means it stopped without erroring, not that the
+    // task was achieved. Only the judge decides the score.
+    const judged = applyJudgeVerdict({
+      taskResult: studioClaimedPass,
+      verdict: { outcome: BenchmarkOutcome.Fail, reasoning: "Wrong recipe." },
+    });
+
+    expect(judged.outcome).toBe(BenchmarkOutcome.Fail);
+  });
+
+  it("records the verdict and its reasoning alongside studio's claim", () => {
+    const judged = applyJudgeVerdict({
+      taskResult: studioClaimedPass,
+      verdict: { outcome: BenchmarkOutcome.Fail, reasoning: "Wrong recipe." },
+    });
+
+    expect(judged.judgeVerdict).toBe(BenchmarkOutcome.Fail);
+    expect(judged.judgeReasoning).toBe("Wrong recipe.");
+    expect(judged.studioStatus).toBe("success");
+  });
+
+  it("leaves every other field untouched", () => {
+    const judged = applyJudgeVerdict({
+      taskResult: studioClaimedPass,
+      verdict: { outcome: BenchmarkOutcome.Pass, reasoning: "Correct." },
+    });
+
+    expect(judged).toMatchObject({
+      taskId: "Allrecipes--0",
+      stepCount: 7,
+      durationMs: 41_230,
+      trajectoryDir: "C:/out/trajectories/Allrecipes--0",
+    });
+  });
+});
+
+describe("resolveTrajectoryScreenshotPaths", () => {
+  it("resolves each basename against the trajectory directory", () => {
+    const paths = resolveTrajectoryScreenshotPaths({
+      trajectoryDir: "C:/out/trajectories/Allrecipes--0",
+      manifestContent: JSON.stringify({ screenshots: ["step001.png", "step002.png"] }),
+    });
+
+    // Joined with the platform's own separator — these paths are handed to the
+    // filesystem, not compared as strings.
+    expect(paths).toEqual([
+      path.join("C:/out/trajectories/Allrecipes--0", "step001.png"),
+      path.join("C:/out/trajectories/Allrecipes--0", "step002.png"),
+    ]);
+  });
+
+  it("returns nothing when the attempt captured no screenshots", () => {
+    expect(
+      resolveTrajectoryScreenshotPaths({
+        trajectoryDir: "C:/out/t",
+        manifestContent: JSON.stringify({ screenshots: [] }),
+      }),
+    ).toEqual([]);
+  });
+
+  it("throws on a manifest whose screenshots field is not a list of names", () => {
+    // Silently treating a malformed manifest as "no screenshots" would judge the
+    // attempt blind and report the result as if it had been seen.
+    expect(() =>
+      resolveTrajectoryScreenshotPaths({
+        trajectoryDir: "C:/out/t",
+        manifestContent: JSON.stringify({ screenshots: "step001.png" }),
+      }),
+    ).toThrow(/screenshots/i);
+  });
+
+  it("throws on a manifest that is not JSON", () => {
+    expect(() =>
+      resolveTrajectoryScreenshotPaths({ trajectoryDir: "C:/out/t", manifestContent: "not json" }),
+    ).toThrow(/JSON/i);
+  });
+});

--- a/internal/browser-bench/src/judge/judged-result.ts
+++ b/internal/browser-bench/src/judge/judged-result.ts
@@ -1,0 +1,64 @@
+import * as path from "node:path";
+
+import { type BenchmarkOutcome, type TaskResult } from "../domain/types";
+
+/**
+ * Replaces studio's self-reported outcome with the judge's verdict.
+ *
+ * Studio reporting `success` means its own run loop finished without erroring,
+ * which is a liveness signal rather than a capability one. Scoring on it grades
+ * the agent's homework with the agent's own marking, so the judged outcome is
+ * what the report counts and studio's claim is kept beside it for triage.
+ *
+ * Output shape: `{ …, outcome: "fail", judgeVerdict: "fail", judgeReasoning: "Wrong recipe.", studioStatus: "success" }`
+ */
+export const applyJudgeVerdict = ({
+  taskResult,
+  verdict,
+}: {
+  taskResult: TaskResult;
+  verdict: { outcome: BenchmarkOutcome; reasoning: string };
+}): TaskResult => ({
+  ...taskResult,
+  outcome: verdict.outcome,
+  judgeVerdict: verdict.outcome,
+  judgeReasoning: verdict.reasoning,
+});
+
+/**
+ * Resolves the screenshots one attempt captured, from its trajectory manifest.
+ *
+ * The manifest stores basenames so the folder stays portable; the judge needs
+ * absolute paths, and this is the one place that mapping happens.
+ *
+ * A manifest that cannot be read is an error rather than an empty list: judging
+ * an attempt with no screenshots is a legitimate case, but doing it because the
+ * manifest was malformed reports a blind verdict as a sighted one.
+ *
+ * Output shape: `["C:/out/trajectories/Allrecipes--0/step001.png"]`
+ *
+ * @throws When the manifest is not JSON, or its `screenshots` field is not an array of names.
+ */
+export const resolveTrajectoryScreenshotPaths = ({
+  trajectoryDir,
+  manifestContent,
+}: {
+  trajectoryDir: string;
+  manifestContent: string;
+}): string[] => {
+  let manifest: { screenshots?: unknown };
+  try {
+    manifest = JSON.parse(manifestContent) as { screenshots?: unknown };
+  } catch {
+    throw new Error(`Trajectory manifest in ${trajectoryDir} is not valid JSON.`);
+  }
+
+  const { screenshots } = manifest;
+  if (!Array.isArray(screenshots) || screenshots.some((name) => typeof name !== "string")) {
+    throw new Error(
+      `Trajectory manifest in ${trajectoryDir} must list "screenshots" as an array of filenames.`,
+    );
+  }
+
+  return screenshots.map((name) => path.join(trajectoryDir, name as string));
+};

--- a/internal/browser-bench/src/run.ts
+++ b/internal/browser-bench/src/run.ts
@@ -1,3 +1,4 @@
+import Anthropic from "@anthropic-ai/sdk";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -19,6 +20,13 @@ import {
   serializePartialLogEntry,
 } from "./partial-log/partial-log";
 import { renderReport } from "./report/report";
+import {
+  JUDGE_API_KEY_ENV_VAR,
+  TRAJECTORY_MANIFEST_FILENAME,
+} from "./judge/constants";
+import { createClaudeJudgeInvoker } from "./judge/claude-judge";
+import { judgeTaskAsync } from "./judge/judge";
+import { applyJudgeVerdict, resolveTrajectoryScreenshotPaths } from "./judge/judged-result";
 import {
   DEFAULT_STUDIO_BIN,
   MUGGLE_SESSION_PATH_SEGMENTS,
@@ -78,6 +86,17 @@ const mainAsync = async (): Promise<void> => {
   });
   const studioBinPath = process.env[STUDIO_BIN_ENV_VAR] ?? DEFAULT_STUDIO_BIN;
 
+  // Checked before the first task rather than at the first verdict: a batch that
+  // runs every task and only then finds it cannot score them has spent the whole
+  // run to produce nothing.
+  if (!process.env[JUDGE_API_KEY_ENV_VAR]) {
+    throw new Error(
+      `${JUDGE_API_KEY_ENV_VAR} is unset, so no attempt could be scored. ` +
+        `Export it before running the benchmark.`,
+    );
+  }
+  const invokeJudgeAsync = createClaudeJudgeInvoker({ client: new Anthropic() });
+
   // One profile for the whole batch. Studio authenticates with its own client
   // credentials and reads this only for identity, so there is nothing per-task
   // about it — and one short-lived file beats one per task.
@@ -96,7 +115,7 @@ const mainAsync = async (): Promise<void> => {
       tasks: pendingTasks,
       concurrency: options.concurrency,
       runTaskAsync: async (task) => {
-        const taskResult = await runStudioTaskAsync({
+        const studioTaskResult = await runStudioTaskAsync({
           task: task,
           outDir: options.outDir,
           studioBinPath: studioBinPath,
@@ -106,6 +125,23 @@ const mainAsync = async (): Promise<void> => {
           spawnStudio: spawnStudioProcess,
           fileSystem: nodeTaskFileSystem,
         });
+
+        const taskResult = applyJudgeVerdict({
+          taskResult: studioTaskResult,
+          verdict: await judgeTaskAsync({
+            instruction: task.instruction,
+            finalAnswer: studioTaskResult.finalAnswer,
+            screenshotPaths: resolveTrajectoryScreenshotPaths({
+              trajectoryDir: studioTaskResult.trajectoryDir,
+              manifestContent: fs.readFileSync(
+                path.join(studioTaskResult.trajectoryDir, TRAJECTORY_MANIFEST_FILENAME),
+                "utf8",
+              ),
+            }),
+            invokeJudgeAsync: invokeJudgeAsync,
+          }),
+        });
+
         appendPartialLogEntry(taskResult);
         return taskResult;
       },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "test:watch": "vitest",
     "test:gates:behavioral": "tsx internal/skill-gate-eval/src/run.ts",
     "test:agents:behavioral": "tsx internal/agent-gate-eval/src/run.ts",
-    "eval:studio-gen": "tsx internal/studio-gen-eval/src/run.ts"
+    "eval:studio-gen": "tsx internal/studio-gen-eval/src/run.ts",
+    "typecheck:browser-bench": "tsc --noEmit -p internal/browser-bench/tsconfig.json"
   },
   "muggleConfig": {
     "electronAppVersion": "1.9.0",
@@ -85,6 +86,7 @@
   },
   "devDependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.133",
+    "@anthropic-ai/sdk": "^0.121.0",
     "@eslint/js": "^10.0.1",
     "@muggleai/mcp": "file:packages/mcps",
     "@muggleai/telemetry": "0.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.2.133
         version: 0.2.138(zod@4.4.3)
+      '@anthropic-ai/sdk':
+        specifier: ^0.121.0
+        version: 0.121.0(zod@4.4.3)
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.3.0)
@@ -164,6 +167,15 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^4.0.0
+
+  '@anthropic-ai/sdk@0.121.0':
+    resolution: {integrity: sha512-WFzwcH8l49CZHv0vQ9QQT51VJ1/DLDQfNSs9awpGlnKBdaSnqtdZa+tw/3cxxosTPIgK8uw1GqsJ2dSbCBD1Lg==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@anthropic-ai/sdk@0.81.0':
     resolution: {integrity: sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==}
@@ -1094,6 +1106,9 @@ packages:
   '@so-ric/colorspace@1.1.6':
     resolution: {integrity: sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1671,6 +1686,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
@@ -2525,6 +2543,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -2889,6 +2910,13 @@ snapshots:
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - supports-color
+
+  '@anthropic-ai/sdk@0.121.0(zod@4.4.3)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      zod: 4.4.3
 
   '@anthropic-ai/sdk@0.81.0(zod@4.4.3)':
     dependencies:
@@ -3853,6 +3881,8 @@ snapshots:
       color: 5.0.3
       text-hex: 1.0.0
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@tufjs/canonical-json@2.0.0': {}
@@ -4535,6 +4565,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-sha256@1.3.0: {}
 
   fast-uri@3.1.0: {}
 
@@ -5423,6 +5455,11 @@ snapshots:
   stack-trace@0.0.10: {}
 
   stackback@0.0.2: {}
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
 
   statuses@2.0.2: {}
 


### PR DESCRIPTION
`judge.ts` has existed and been tested since the harness was built, and `run.ts`
never called it. Every outcome came from `studioStatus === "success"` -- studio's
report that its own run loop finished without erroring. That is a liveness signal,
not a capability one, so the pass rate was the agent grading its own homework and
would have stayed that way through a completely clean run.

The judging pass the code already anticipated is now wired in: each attempt is
scored by a vision model against the task instruction, the agent's answer, and the
screenshots from its trajectory. Studio's claim is kept beside the verdict for
triage, and the verdict is what the report counts.

A refusal or a truncated reply raises instead of returning text. Both arrive as an
HTTP 200 the WebVoyager protocol reads as "no SUCCESS line", which would score the
attempt a capability failure because the judge never rendered a verdict. Raising
routes it to the infrastructure bucket, which is excluded from the pass rate rather
than counted against the agent.

The credential is checked before the first task rather than at the first verdict --
a batch that runs everything and only then finds it cannot score anything has spent
the whole run for nothing.

Two things found on the way:

- The doc-comment instructed calling the judge at temperature 0 for reproducible
  verdicts. The judge model rejects `temperature` outright, so that was
  unimplementable as written; the comment now states plainly that re-judging is a
  new measurement rather than a replay.
- `internal/browser-bench/` has a correct, strict tsconfig that nothing ever runs --
  it is in no script and no workflow, and the root `tsconfig.json` covers only
  `src/**/*`. This tool has therefore never been typechecked; `tsx` strips types
  without checking them. Added `typecheck:browser-bench` so the check is at least
  invocable by name. **It is still not wired into CI** -- that wants its own change.

The SDK is a devDependency: `files` in package.json excludes `internal/`, so none of
this ships to users.

Verified: `npx vitest run internal/browser-bench` — 74 tests across 12 files, all green. `npm run typecheck:browser-bench` clean (33 files in the program).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AzJ1mPrJ5YqZ4SEcqnZbT