### PR TITLE
feat(browser-bench): run the batch under a named benchmark identity

### DIFF
--- a/internal/browser-bench/src/run.ts
+++ b/internal/browser-bench/src/run.ts
@@ -1,6 +1,5 @@
 import Anthropic from "@anthropic-ai/sdk";
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -29,7 +28,6 @@ import { judgeTaskAsync } from "./judge/judge";
 import { applyJudgeVerdict, resolveTrajectoryScreenshotPaths } from "./judge/judged-result";
 import {
   DEFAULT_STUDIO_BIN,
-  MUGGLE_SESSION_PATH_SEGMENTS,
   STUDIO_BIN_ENV_VAR,
 } from "./studio/constants";
 import {
@@ -37,6 +35,7 @@ import {
   writeStudioAuthFile,
 } from "./studio/studio-auth";
 import { nodeTaskFileSystem } from "./studio/node-file-system";
+import { resolveBenchmarkSessionPath } from "./studio/benchmark-session";
 import { spawnStudioProcess } from "./studio/node-studio-spawn";
 import { runStudioTaskAsync } from "./studio/studio-runner";
 import { loadWebVoyagerTasks } from "./task-source/webvoyager-source";
@@ -100,9 +99,7 @@ const mainAsync = async (): Promise<void> => {
   // One profile for the whole batch. Studio authenticates with its own client
   // credentials and reads this only for identity, so there is nothing per-task
   // about it — and one short-lived file beats one per task.
-  const authFilePath = writeStudioAuthFile(
-    path.join(os.homedir(), ...MUGGLE_SESSION_PATH_SEGMENTS),
-  );
+  const authFilePath = writeStudioAuthFile(resolveBenchmarkSessionPath(process.env));
 
   process.stdout.write(
     `browser-bench: ${pendingTasks.length} task(s) to run, ${resumedResults.length} resumed, ` +

--- a/internal/browser-bench/src/studio/benchmark-session.test.ts
+++ b/internal/browser-bench/src/studio/benchmark-session.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { BENCHMARK_SESSION_ENV_VAR } from "./constants";
+import { resolveBenchmarkSessionPath } from "./benchmark-session";
+
+describe("resolveBenchmarkSessionPath", () => {
+  it("uses the benchmark identity the environment names", () => {
+    expect(
+      resolveBenchmarkSessionPath({ [BENCHMARK_SESSION_ENV_VAR]: "C:/creds/bench.json" }),
+    ).toBe("C:/creds/bench.json");
+  });
+
+  it("refuses to fall back to whoever happens to be logged in", () => {
+    // With no projectId and no organizationId, metering bills the executing
+    // user's personal wallet — so an unset benchmark identity silently charges
+    // a real person for the batch.
+    expect(() => resolveBenchmarkSessionPath({})).toThrow(/MUGGLE_BENCHMARK_SESSION/);
+  });
+
+  it("explains why it refuses, not just that it did", () => {
+    expect(() => resolveBenchmarkSessionPath({})).toThrow(/wallet/i);
+  });
+
+  it("treats an empty value as unset", () => {
+    expect(() => resolveBenchmarkSessionPath({ [BENCHMARK_SESSION_ENV_VAR]: "" })).toThrow(
+      /MUGGLE_BENCHMARK_SESSION/,
+    );
+  });
+});

--- a/internal/browser-bench/src/studio/benchmark-session.ts
+++ b/internal/browser-bench/src/studio/benchmark-session.ts
@@ -1,0 +1,26 @@
+import { BENCHMARK_SESSION_ENV_VAR } from "./constants";
+
+/**
+ * Resolves the muggle session the batch runs under.
+ *
+ * Required rather than defaulted. A benchmark task carries no `projectId` and no
+ * `organizationId`, and with both unset the studio's metering bills the executing
+ * user's personal wallet — so falling back to whoever last ran `muggle login`
+ * charges a real person for the batch, silently and at benchmark scale. Naming
+ * the identity is the one thing that keeps that deliberate.
+ *
+ * Output shape: an absolute path to a muggle session file.
+ *
+ * @throws When the variable is unset or empty.
+ */
+export const resolveBenchmarkSessionPath = (env: NodeJS.ProcessEnv): string => {
+  const sessionPath = env[BENCHMARK_SESSION_ENV_VAR];
+  if (!sessionPath) {
+    throw new Error(
+      `${BENCHMARK_SESSION_ENV_VAR} is unset. Point it at the benchmark account's ` +
+        `muggle session file — a batch bills the wallet of whichever identity it runs ` +
+        `under, so it must not inherit a personal login.`,
+    );
+  }
+  return sessionPath;
+};

--- a/internal/browser-bench/src/studio/constants.ts
+++ b/internal/browser-bench/src/studio/constants.ts
@@ -32,7 +32,7 @@ export const STUDIO_RUN_MODE = "explore";
 export const STUDIO_AUTH_FILENAME = "studio-auth.json";
 
 /**
- * The muggle session `muggle login` writes, and the source of the identity the
- * benchmark hands studio.
+ * Names the muggle session file the batch runs under. Required: a batch bills the
+ * wallet of whichever identity it runs as, so it must never inherit a personal login.
  */
-export const MUGGLE_SESSION_PATH_SEGMENTS = [".muggle-ai", "oauth-session.json"];
+export const BENCHMARK_SESSION_ENV_VAR = "MUGGLE_BENCHMARK_SESSION";


### PR DESCRIPTION
The batch ran under whichever identity last ran `muggle login` — in practice, mine.

That is not a neutral default. A benchmark task carries no `projectId` and no
`organizationId`, and with both unset the studio's metering bills the executing
user's personal wallet. So the harness silently charged a real person for every
task it ran, at benchmark scale.

The session file is now named explicitly by `MUGGLE_BENCHMARK_SESSION` and the batch
refuses to start without it. Required rather than defaulted: a fallback here is the
whole defect, since the failure is invisible — the run works fine and someone else
pays for it.

Checked before the first task, alongside the judge credential, so a missing identity
costs nothing rather than surfacing partway through a batch.

Follow-up to teaching-service#367, which proposed making benchmark runs non-billable
instead. Retired in review in favour of a dedicated internal account with auto-topup,
which keeps the real cost visible and adds no bypass to billing code.

Verified: `npx vitest run internal/browser-bench` — 78 tests across 13 files, all green. `npm run typecheck:browser-bench` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AzJ1mPrJ5YqZ4SEcqnZbT