### PR TITLE
fix(mcp): scripts summary is per test case, and is slimmed (re-land of #431)

### DIFF
--- a/packages/mcps/src/mcp/e2e/contracts/index.ts
+++ b/packages/mcps/src/mcp/e2e/contracts/index.ts
@@ -483,6 +483,22 @@ export const ProjectTestResultsSummaryInputSchema = z.object({
 
 export const ProjectTestScriptsSummaryInputSchema = z.object({
   projectId: IdSchema.describe("Project ID (UUID) to get test scripts summary for"),
+  page: z.number().int().positive().default(1).describe("Page number, 1-based. Defaults to 1."),
+  pageSize: z
+    .number()
+    .int()
+    .positive()
+    .max(100)
+    .default(20)
+    .describe("Number of rows per page. Defaults to 20, max 100."),
+  sortBy: z
+    .enum(["createdAt", "updatedAt"])
+    .default("createdAt")
+    .describe("Sort field for the page. Defaults to createdAt (stable under concurrent writes)."),
+  sortOrder: z
+    .enum(["asc", "desc"])
+    .default("desc")
+    .describe("Sort direction. Defaults to desc (newest first)."),
 });
 
 export const ProjectTestRunsSummaryInputSchema = z.object({

--- a/packages/mcps/src/mcp/tools/e2e/test-scripts-summary-transform.ts
+++ b/packages/mcps/src/mcp/tools/e2e/test-scripts-summary-transform.ts
@@ -1,0 +1,96 @@
+/**
+ * Slim the per-row payload returned by the test-scripts/summary endpoint.
+ *
+ * The rows are one per TEST CASE, not one per script: a case that has never
+ * produced a script still gets a row, carrying its lifecycle status and no
+ * script id. Surfacing those is the point of the endpoint, so the transform
+ * keeps them and simply omits `testScriptId` — it must never drop such a row
+ * or invent an id, either of which would hide a case that needs generating.
+ *
+ * Each raw row carries the full use case, the test case state view, the script
+ * definition, the latest workflow run and its studio result; an agent reasons
+ * over almost none of that, so the wire payload is cut to the identifying and
+ * status fields.
+ *
+ * No input type lives here: the request shape is owned and validated by
+ * `ProjectTestScriptsSummaryInputSchema` in `mcp/e2e/contracts`, and the tool
+ * handler derives its parameter type from that schema via `z.infer`.
+ *
+ * No per-page aggregate is emitted, for the same reason the runs transform
+ * omits one: a histogram over a single page describes only that page and
+ * misleads about project-wide health.
+ */
+
+import type { IUpstreamResponse } from "../../e2e/types.js";
+
+interface IRawScriptsSummaryEntry {
+    useCase?: { id?: string; title?: string };
+    testCase?: { id?: string; title?: string };
+    testScript?: { id?: string };
+    status?: string;
+    lastRunAt?: number;
+    error?: string;
+}
+
+interface IRawScriptsEnvelope {
+    data?: IRawScriptsSummaryEntry[];
+    page?: number;
+    pageSize?: number;
+    totalCount?: number;
+    totalPages?: number;
+    hasMore?: boolean;
+}
+
+interface ISlimScriptsSummaryEntry {
+    status: string;
+    testCaseId?: string;
+    testCaseTitle?: string;
+    useCaseId?: string;
+    useCaseTitle?: string;
+    testScriptId?: string;
+    lastRunAt?: number;
+    error?: string;
+}
+
+export interface ITestScriptsSummaryOutput {
+    page: number;
+    pageSize: number;
+    totalCount: number;
+    totalPages: number;
+    hasMore: boolean;
+    scripts: ISlimScriptsSummaryEntry[];
+}
+
+const UNKNOWN_STATUS = "UNKNOWN";
+
+/** Keeps only the fields an agent reasons about, omitting absent ones rather than nulling them. */
+function slimScriptsEntry(raw: IRawScriptsSummaryEntry): ISlimScriptsSummaryEntry {
+    return {
+        status: raw.status || UNKNOWN_STATUS,
+        ...(raw.testCase?.id && { testCaseId: raw.testCase.id }),
+        ...(raw.testCase?.title && { testCaseTitle: raw.testCase.title }),
+        ...(raw.useCase?.id && { useCaseId: raw.useCase.id }),
+        ...(raw.useCase?.title && { useCaseTitle: raw.useCase.title }),
+        ...(raw.testScript?.id && { testScriptId: raw.testScript.id }),
+        ...(raw.lastRunAt && { lastRunAt: raw.lastRunAt }),
+        ...(raw.error && { error: raw.error }),
+    };
+}
+
+/**
+ * Maps the upstream scripts-summary envelope to the slimmed tool response.
+ *
+ * Output shape: `{ page, pageSize, totalCount, totalPages, hasMore, scripts: [...] }`
+ */
+export function mapTestScriptsSummary(response: IUpstreamResponse): ITestScriptsSummaryOutput {
+    const envelope = (response.data ?? {}) as IRawScriptsEnvelope;
+    const scripts = Array.isArray(envelope.data) ? envelope.data.map(slimScriptsEntry) : [];
+    return {
+        page: envelope.page ?? 1,
+        pageSize: envelope.pageSize ?? scripts.length,
+        totalCount: envelope.totalCount ?? scripts.length,
+        totalPages: envelope.totalPages ?? (scripts.length === 0 ? 0 : 1),
+        hasMore: envelope.hasMore ?? false,
+        scripts: scripts,
+    };
+}

--- a/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
+++ b/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
@@ -16,6 +16,7 @@ import { getPromptServiceClient } from "../../e2e/upstream-client.js";
 import { getAuthService } from "../../local/services/index.js";
 import { DeviceCodePollStatus } from "../../local/types/index.js";
 import { mapTestRunsSummary } from "./test-runs-summary-transform.js";
+import { mapTestScriptsSummary } from "./test-scripts-summary-transform.js";
 
 /** Muggle Test API prefix. */
 const MUGGLE_TEST_PREFIX = "/v1/protected/muggle-test";
@@ -879,15 +880,23 @@ const reportTools: IQaToolDefinition[] = [
   },
   {
     name: "muggle-remote-project-test-scripts-summary-get",
-    description: "Get a summary of test scripts for a project.",
+    description:
+      "Get a paginated, slimmed script-generation summary for a project. One row per TEST CASE, not per script: a test case with no script yet still gets a row, with `testScriptId` absent and a status such as TEST_CASE_DRAFTED. Row count is therefore a test-case count — do not read it as a number of scripts, and do not infer from a row's presence that a script exists. Response shape: { page, pageSize, totalCount, totalPages, hasMore, scripts: [{ status, testCaseId, testCaseTitle, useCaseId, useCaseTitle, testScriptId, lastRunAt, error }] }. Returns 20 rows per page by default (max 100). Check `hasMore` to decide whether to fetch additional pages. Use muggle-remote-test-script-get for full per-script detail.",
     inputSchema: schemas.ProjectTestScriptsSummaryInputSchema,
     mapToUpstream: (input) => {
       const toolInput = input as z.infer<typeof schemas.ProjectTestScriptsSummaryInputSchema>;
       return {
         method: "GET",
         path: `${MUGGLE_TEST_PREFIX}/projects/${toolInput.projectId}/test-scripts/summary`,
+        queryParams: {
+          page: toolInput.page,
+          pageSize: toolInput.pageSize,
+          sortBy: toolInput.sortBy,
+          sortOrder: toolInput.sortOrder,
+        },
       };
     },
+    mapFromUpstream: mapTestScriptsSummary,
   },
   {
     name: "muggle-remote-project-test-runs-summary-get",

--- a/packages/mcps/src/test/__snapshots__/mcp-tool-surface.test.ts.snap
+++ b/packages/mcps/src/test/__snapshots__/mcp-tool-surface.test.ts.snap
@@ -167,7 +167,7 @@ exports[`MCP tool surface (Lazy-core parity oracle) > advertises the exact name 
     "name": "muggle-remote-project-test-runs-summary-get",
   },
   {
-    "description": "Get a summary of test scripts for a project.",
+    "description": "Get a paginated, slimmed script-generation summary for a project. One row per TEST CASE, not per script: a test case with no script yet still gets a row, with \`testScriptId\` absent and a status such as TEST_CASE_DRAFTED. Row count is therefore a test-case count — do not read it as a number of scripts, and do not infer from a row's presence that a script exists. Response shape: { page, pageSize, totalCount, totalPages, hasMore, scripts: [{ status, testCaseId, testCaseTitle, useCaseId, useCaseTitle, testScriptId, lastRunAt, error }] }. Returns 20 rows per page by default (max 100). Check \`hasMore\` to decide whether to fetch additional pages. Use muggle-remote-test-script-get for full per-script detail.",
     "name": "muggle-remote-project-test-scripts-summary-get",
   },
   {

--- a/packages/mcps/src/test/test-scripts-summary-transform.test.ts
+++ b/packages/mcps/src/test/test-scripts-summary-transform.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+
+import type { IUpstreamResponse } from "../mcp/e2e/types.js";
+import {
+  mapTestScriptsSummary,
+  type ITestScriptsSummaryOutput,
+} from "../mcp/tools/e2e/test-scripts-summary-transform.js";
+
+function makeEntry(overrides: Record<string, unknown> = {}) {
+  return {
+    useCase: { id: "uc-1", title: "Use case 1" },
+    testCase: { id: "tc-1", title: "Test case 1" },
+    testScript: { id: "ts-1" },
+    status: "TEST_SCRIPT_ACTIVE",
+    lastRunAt: 1000,
+    ...overrides,
+  };
+}
+
+function makeEnvelopeResponse(envelope: Record<string, unknown>): IUpstreamResponse {
+  return { statusCode: 200, data: envelope, headers: {} };
+}
+
+describe("mapTestScriptsSummary", () => {
+  it("slims each row to the fields an agent reasons about", () => {
+    const out = mapTestScriptsSummary(
+      makeEnvelopeResponse({ data: [makeEntry()], page: 1, pageSize: 20, totalCount: 1 })
+    );
+
+    expect(out.scripts).toEqual([
+      {
+        status: "TEST_SCRIPT_ACTIVE",
+        testCaseId: "tc-1",
+        testCaseTitle: "Test case 1",
+        useCaseId: "uc-1",
+        useCaseTitle: "Use case 1",
+        testScriptId: "ts-1",
+        lastRunAt: 1000,
+      },
+    ]);
+  });
+
+  it("keeps a row that has no script, omitting testScriptId rather than dropping it", () => {
+    const out = mapTestScriptsSummary(
+      makeEnvelopeResponse({
+        data: [makeEntry({ testScript: undefined, status: "TEST_CASE_DRAFTED", lastRunAt: undefined })],
+        totalCount: 1,
+      })
+    );
+
+    // A hand-written case with no script is exactly what this endpoint exists to surface.
+    expect(out.scripts).toHaveLength(1);
+    expect(out.scripts[0].status).toBe("TEST_CASE_DRAFTED");
+    expect(out.scripts[0].testCaseId).toBe("tc-1");
+    expect(out.scripts[0]).not.toHaveProperty("testScriptId");
+  });
+
+  it("omits absent optional fields rather than nulling them", () => {
+    const out = mapTestScriptsSummary(
+      makeEnvelopeResponse({ data: [{ status: "TEST_SCRIPT_ACTIVE" }], totalCount: 1 })
+    );
+
+    expect(out.scripts[0]).toEqual({ status: "TEST_SCRIPT_ACTIVE" });
+  });
+
+  it("buckets a missing status as UNKNOWN", () => {
+    const out = mapTestScriptsSummary(makeEnvelopeResponse({ data: [makeEntry({ status: undefined })] }));
+
+    expect(out.scripts[0].status).toBe("UNKNOWN");
+  });
+
+  it("passes the envelope's pagination through untouched", () => {
+    const out = mapTestScriptsSummary(
+      makeEnvelopeResponse({
+        data: [makeEntry()],
+        page: 3,
+        pageSize: 20,
+        totalCount: 116,
+        totalPages: 6,
+        hasMore: true,
+      })
+    );
+
+    expect(out.page).toBe(3);
+    expect(out.pageSize).toBe(20);
+    expect(out.totalCount).toBe(116);
+    expect(out.totalPages).toBe(6);
+    expect(out.hasMore).toBe(true);
+  });
+
+  it("returns an empty page rather than throwing when the envelope carries no rows", () => {
+    const out = mapTestScriptsSummary(makeEnvelopeResponse({ data: [], page: 1, pageSize: 20, totalCount: 0 }));
+
+    expect(out.scripts).toEqual([]);
+    expect(out.totalPages).toBe(0);
+  });
+
+  it("falls back sensibly when envelope fields are missing", () => {
+    const out = mapTestScriptsSummary(makeEnvelopeResponse({ data: [makeEntry()] }));
+
+    expect(out.page).toBe(1);
+    expect(out.pageSize).toBe(1);
+    expect(out.totalCount).toBe(1);
+    expect(out.totalPages).toBe(1);
+    expect(out.hasMore).toBe(false);
+  });
+
+  it("handles a heavy page payload from upstream — backend slices, MCP slims", () => {
+    const heavyUseCase = {
+      id: "uc-heavy",
+      title: "Heavy use case",
+      description: "x".repeat(800),
+      useCaseBreakdown: Array.from({ length: 6 }, () => ({
+        requirement: "x".repeat(200),
+        acceptanceCriteria: "x".repeat(400),
+      })),
+    };
+    const heavyEntries = Array.from({ length: 20 }, () =>
+      makeEntry({
+        useCase: heavyUseCase,
+        testScript: { id: "ts-1", actionScriptId: "as-1", steps: Array.from({ length: 30 }, () => ({ instruction: "x".repeat(120) })) },
+        latestWorkflowRun: { id: "wf-1", studioReturnedResult: { structuredSummary: { detail: "x".repeat(600) } } },
+      })
+    );
+
+    const rawSize = JSON.stringify(heavyEntries).length;
+    const out = mapTestScriptsSummary(
+      makeEnvelopeResponse({
+        data: heavyEntries,
+        page: 1,
+        pageSize: 20,
+        totalCount: 116,
+        totalPages: 6,
+        hasMore: true,
+      })
+    ) as ITestScriptsSummaryOutput;
+    const slimSize = JSON.stringify(out).length;
+
+    expect(slimSize).toBeLessThan(rawSize * 0.1);
+    expect(out.scripts).toHaveLength(20);
+    expect(out.totalCount).toBe(116);
+  });
+});


### PR DESCRIPTION
**Re-lands #431, which GitHub marked merged but which never reached `master`.**

#431 was stacked on #430. When #430 merged first, #431's base branch (`users/stan4/mcp-name-tool-inputs`) had already been absorbed into master — so merging #431 put its commit on that dead branch instead of on master. GitHub shows it as MERGED, and master got the renames from #430 and none of this.

Verified on `master` before opening this:

```
test-scripts-summary-transform.ts   404 (absent)
mapTestScriptsSummary               0 occurrences
const toolInput = input as          78   <- #430 did land
"Get a summary of test scripts…"    1    <- stale description still there
git merge-base --is-ancestor f20578d origin/master  ->  NO
```

Same content as #431, rebased onto master. No new work, no behaviour differences.

## What it does

The scripts-summary tool described its rows as *"a summary of test scripts"*. Since muggle-ai-prompt-service#739 the rows are one per **test case** — a hand-written case with no script yet gets a row too. An agent reading the old description counts rows as scripts and overcounts, or sees a row and concludes a script exists. The description now states the grain, that `testScriptId` may be absent, and the response shape.

The tool also sent no pagination, so it took the legacy path and returned the whole project as a bare array of full `ITestSummary` rows — and that array just grew from "rows = scripts" to "rows = all test cases". It now sends `page`/`pageSize`/`sortBy`/`sortOrder` and slims each row through a `mapFromUpstream` transform, mirroring the runs tool.

**Pagination was not the optional half.** The transform reads an envelope; without those params the endpoint answers with a bare array and slimming would have produced an empty page. All four params carry zod defaults, so a caller passing only `projectId` still validates.

The transform is a sibling of `mapTestRunsSummary`, not a reuse — the row shape differs (script id rather than workflow run id, `scripts` rather than `runs`), so a shared generic would have fit neither. It keeps a script-less row with `testScriptId` omitted rather than dropping it or inventing an id, which is the point of the endpoint, and has a test guarding that.

## Verification

23 suites / 250 tests pass on this branch, rebased onto current master. `tsc --noEmit` clean, eslint clean. The tool-surface snapshot is included. CI should actually run this time — #431 never had a check-run against it, because `ci.yml` only triggers on `pull_request: branches: [master]` and its base was a feature branch.

## Cleanup

`users/stan4/mcp-scripts-summary-per-test-case` and `users/stan4/mcp-name-tool-inputs` can both be deleted once this lands.
