### PR TITLE
fix(guardrails): continue gate conditions with a real newline

### DIFF
--- a/plugin/scripts/guardrail-debug-path-gate.sh
+++ b/plugin/scripts/guardrail-debug-path-gate.sh
@@ -32,7 +32,8 @@ state_file="$home/.muggle-ai/guardrails/$sid.json"
 if [ ! -f "$state_file" ] \
   || ! grep -q '"failedRuns"' "$state_file" \
   || grep -q '"failedRuns": \[\]' "$state_file" \
-  || grep -q '"debugReleased": true' "$state_file" \n  || grep -q '"debugSkipped": true' "$state_file"; then
+  || grep -q '"debugReleased": true' "$state_file" \
+  || grep -q '"debugSkipped": true' "$state_file"; then
   printf '{}'
   exit 0
 fi

--- a/plugin/scripts/guardrail-e2e-gate.sh
+++ b/plugin/scripts/guardrail-e2e-gate.sh
@@ -29,7 +29,8 @@ fi
 state_file="$home/.muggle-ai/guardrails/$sid.json"
 if [ ! -f "$state_file" ] \
   || ! grep -q '"unitTestsGreen": true' "$state_file" \
-  || grep -q '"e2eReleased": true' "$state_file" \n  || grep -q '"e2eRun": true' "$state_file"; then
+  || grep -q '"e2eReleased": true' "$state_file" \
+  || grep -q '"e2eRun": true' "$state_file"; then
   printf '{}'
   exit 0
 fi

--- a/plugin/scripts/guardrail-stage-gate.sh
+++ b/plugin/scripts/guardrail-stage-gate.sh
@@ -34,7 +34,8 @@ state_file="$home/.muggle-ai/guardrails/$sid.json"
 if [ ! -f "$state_file" ] \
   || ! grep -q '"mandatoryStages"' "$state_file" \
   || grep -q '"mandatoryStages": \[\]' "$state_file" \
-  || grep -q '"stageReleased": true' "$state_file" \n  || grep -q '"stageSkipped": true' "$state_file"; then
+  || grep -q '"stageReleased": true' "$state_file" \
+  || grep -q '"stageSkipped": true' "$state_file"; then
   printf '{}'
   exit 0
 fi

--- a/plugin/scripts/guardrail-walkthrough-gate.sh
+++ b/plugin/scripts/guardrail-walkthrough-gate.sh
@@ -32,7 +32,8 @@ state_file="$home/.muggle-ai/guardrails/$sid.json"
 if [ ! -f "$state_file" ] \
   || ! grep -q '"e2eRun": true' "$state_file" \
   || grep -q '"walkthroughPosted": true' "$state_file" \
-  || grep -q '"walkthroughReleased": true' "$state_file" \n  || grep -q '"walkthroughSkipped": true' "$state_file"; then
+  || grep -q '"walkthroughReleased": true' "$state_file" \
+  || grep -q '"walkthroughSkipped": true' "$state_file"; then
   printf '{}'
   exit 0
 fi

--- a/plugin/scripts/guardrail-watch-gate.sh
+++ b/plugin/scripts/guardrail-watch-gate.sh
@@ -31,7 +31,8 @@ state_file="$home/.muggle-ai/guardrails/$sid.json"
 if [ ! -f "$state_file" ] \
   || ! grep -q '"prsHandled"' "$state_file" \
   || grep -q '"prsHandled": \[\]' "$state_file" \
-  || grep -q '"watchReleased": true' "$state_file" \n  || grep -q '"watchSkipped": true' "$state_file"; then
+  || grep -q '"watchReleased": true' "$state_file" \
+  || grep -q '"watchSkipped": true' "$state_file"; then
   printf '{}'
   exit 0
 fi

--- a/src/test/guardrails/hook-prefilter.test.ts
+++ b/src/test/guardrails/hook-prefilter.test.ts
@@ -330,4 +330,19 @@ describe("state-file pre-filters match the state guardrails.mjs writes", () => {
       ).toBe(true);
     }
   });
+
+  // A continuation backslash has to end its line. Written as an escaped "n" it
+  // still parses, so bash -n and CI stay green while the trailing `n` becomes an
+  // extra operand on the preceding grep: the gate then searches a file named `n`
+  // in the working directory alongside the state file, and any match there
+  // satisfies the pre-filter and silences the gate.
+  const BOTCHED_CONTINUATION = /\\n\s*(?:\|\||&&)/;
+
+  it.each(wrapperScriptNames)("%s continues its conditions with a real newline", (wrapperScriptName) => {
+    const wrapperBody = readFileSync(join(SCRIPTS, wrapperScriptName), "utf-8");
+    const offending = wrapperBody
+      .split("\n")
+      .filter((line) => BOTCHED_CONTINUATION.test(line));
+    expect(offending, `${wrapperScriptName} escapes a line continuation as \\n`).toEqual([]);
+  });
 });


### PR DESCRIPTION
Five Stop-gate pre-filters wrote the last line continuation of their condition as an escaped `"n"` rather than ending the line with the backslash:

```sh
  || grep -q '"e2eReleased": true' "$state_file" \n  || grep -q '"e2eRun": true' "$state_file"; then
```

The construct still parses, so `bash -n` and CI stayed green. But the trailing `n` reaches grep as an extra file operand — confirmed by dumping argv:

```
grep|-q|"e2eReleased": true|/tmp/…/state.json|n|
```

grep then searches a file named `n` in the working directory alongside the state file, and a match in *either* satisfies the pre-filter.

## Impact

Normally `n` is absent, so grep writes `grep: n: No such file or directory` to stderr and the condition still falls through to the next clause — the gate behaves correctly, just noisily. The real hazard is the other branch: a stray file named `n` whose contents match silences the gate outright. Reproduced:

| working directory | verdict |
| :-- | :-- |
| no `n` present | gate fires (correct) |
| `n` containing `"e2eReleased": true` | gate inert (wrong) |

Affected gates: `debug-path`, `e2e`, `stage`, `walkthrough`, `watch`.

## Fix

Each becomes a real line continuation. No behavior change on the normal path — the same repro yields the same verdict before and after when `n` is absent.

## Test

`hook-prefilter.test.ts` gains an assertion that no wrapper escapes a continuation this way. It is source-level rather than execution-level, so it also runs on Windows, where the bash-only wrapper cases are skipped.

Verified the assertion is not vacuous: re-introducing the defect into one gate makes it fail and name the offending line; restoring the fix returns it to green.

Full suite: 115 files, 1603 green, 27 skipped, none red. `tsc --noEmit`, `eslint`, `verify-plugin-marketplace`, and `verify-compatibility-contracts` all clean.
