### PR TITLE
fix(pr-watch): fail loudly when a slot is never seeded, instead of watching nothing

### DIFF
--- a/plugin/scripts/pr-watch-guards.sh
+++ b/plugin/scripts/pr-watch-guards.sh
@@ -30,6 +30,15 @@ MUGGLE_PR_WATCH_POLL_INTERVAL="${MUGGLE_PR_WATCH_POLL_INTERVAL:-60}"
 # revoked auth) exhausts it.
 MUGGLE_PR_WATCH_MAX_FETCH_FAILURES="${MUGGLE_PR_WATCH_MAX_FETCH_FAILURES:-60}"
 
+# Seconds a loop will wait for the arming session to write watch-watermark.env
+# before giving up. The loop cannot evaluate a single wake condition without it,
+# so an unseeded slot is a watcher that will never report anything — and one that
+# looks perfectly healthy while it does nothing, because it still holds its PID
+# lease and still touches its heartbeat. Arming writes the file in the same turn
+# it starts the loop, so anything past a couple of minutes means the arming
+# sequence was not followed and the watch is inert.
+MUGGLE_PR_WATCH_MAX_UNSEEDED="${MUGGLE_PR_WATCH_MAX_UNSEEDED:-180}"
+
 # Seconds to sleep after `fails` consecutive failed fetches: the poll interval,
 # then a linear back-off capped at 5 minutes so a sustained outage is retried
 # calmly rather than hammered every 60s.
@@ -57,6 +66,15 @@ watcher_lifetime_exceeded() {
     # wise make every loop exit on its first iteration.
     [ "$max" -eq 0 ] 2>/dev/null && return 1
     [ $((now - started)) -ge "$max" ]
+}
+
+# True when the slot has gone unseeded longer than the cap allows. 0 is
+# unbounded, matching `watcher_lifetime_exceeded`, for a caller that seeds the
+# watermark out of band.
+watcher_unseeded_too_long() {
+    local waited="$1" max="${2:-$MUGGLE_PR_WATCH_MAX_UNSEEDED}"
+    [ "$max" -eq 0 ] 2>/dev/null && return 1
+    [ "$waited" -ge "$max" ]
 }
 
 # True when pid names a running process. `kill -0` sends no signal; EPERM means

--- a/plugin/scripts/pr-watch-loop.sh
+++ b/plugin/scripts/pr-watch-loop.sh
@@ -54,6 +54,7 @@ state_projection="$(cat "${script_dir}/pr-watch-state.jq")"
 echo "$$" > "${slot}/watch.pid"
 started=$(date +%s)
 fails=0
+unseeded=0
 
 # In-memory floors, above the on-disk watermark. The watermark is advanced by
 # the session after it handles a wave; these stop the loop re-reporting an event
@@ -137,11 +138,24 @@ while :; do
     touch "${slot}/watch-heartbeat" 2>/dev/null
 
     # No watermark yet means the arming session has not finished seeding. Wait
-    # rather than treat every floor as zero, which would fire the whole backlog.
+    # rather than treat every floor as zero, which would fire the whole backlog —
+    # but not forever. Every wake condition below is evaluated against a floor
+    # read from this file, so a loop that never gets one polls nothing, reports
+    # nothing and never reaches the terminal check, while still holding its PID
+    # lease and touching its heartbeat. That combination is the worst kind of
+    # broken: reconcile reads the live lease and fresh beacon as healthy and
+    # declines to re-arm, so the PR is silently unwatched for as long as the
+    # session lives. Fail loudly instead.
     if [ ! -f "${slot}/watch-watermark.env" ]; then
+        unseeded=$((unseeded + MUGGLE_PR_WATCH_POLL_INTERVAL))
+        if watcher_unseeded_too_long "$unseeded"; then
+            echo "WATCH-FAIL pr=$pr_number no watch-watermark.env after ${unseeded}s — arming never seeded it, so this watch can detect nothing (arm-watcher.md steps 1-2)"
+            exit 1
+        fi
         sleep "$MUGGLE_PR_WATCH_POLL_INTERVAL"
         continue
     fi
+    unseeded=0
 
     watermark_review=$(read_watermark_value REV)
     watermark_comment=$(read_watermark_value COM)

--- a/src/test/scripts/pr-watch-guards.test.ts
+++ b/src/test/scripts/pr-watch-guards.test.ts
@@ -113,3 +113,31 @@ describe.skipIf(!hasBash)("pr-watch-guards.sh watcher_fetch_backoff", () => {
     expect(runGuard('[ "$(watcher_fetch_backoff 100)" = "300" ]')).toBe(0);
   });
 });
+
+describe.skipIf(!hasBash)("pr-watch-guards.sh watcher_unseeded_too_long", () => {
+  // A slot with no watch-watermark.env cannot evaluate a single wake condition,
+  // so the loop reports nothing and never reaches its terminal check — while
+  // still holding the PID lease and touching the heartbeat that reconcile reads
+  // as proof of health. The cap is what turns that silent no-op into a failure.
+  it("is false while the arming session still has time to seed", () => {
+    expect(runGuard("watcher_unseeded_too_long 60")).toBe(1);
+  });
+
+  it("is true once the wait passes the cap", () => {
+    expect(runGuard("watcher_unseeded_too_long 180")).toBe(0);
+  });
+
+  it("takes an explicit cap over the default", () => {
+    expect(runGuard("watcher_unseeded_too_long 30 20")).toBe(0);
+  });
+
+  // 0 is unbounded, matching watcher_lifetime_exceeded, rather than "already
+  // expired" — which would kill every loop on its first pass.
+  it("treats a cap of 0 as unbounded", () => {
+    expect(runGuard("watcher_unseeded_too_long 99999 0")).toBe(1);
+  });
+
+  it("defaults to 180 seconds", () => {
+    expect(runGuard('[ "$MUGGLE_PR_WATCH_MAX_UNSEEDED" = "180" ]')).toBe(0);
+  });
+});


### PR DESCRIPTION
## What happens today

Every wake condition in `pr-watch-loop.sh` is evaluated against a floor read from `watch-watermark.env`. Without that file the loop cannot evaluate any of them, so it waits:

```sh
if [ ! -f "${slot}/watch-watermark.env" ]; then
    sleep "$MUGGLE_PR_WATCH_POLL_INTERVAL"
    continue
fi
```

That wait is unbounded. A slot the arming sequence never seeded loops here forever: **it never fetches, never reports an event, and never reaches the `MERGED`/`CLOSED` check**, so it does not even exit when its PR is merged.

## Why it is worse than an obvious hang

The `continue` is *above* the watermark gate, so the loop still touches `watch-heartbeat` every pass, and it still holds `watch.pid`. Those are exactly the two signals `reconcile` uses to decide a watcher is healthy — and `reconcile` explicitly declines to re-arm a slot whose PID lease is live.

So an unseeded watcher presents as a **perfectly healthy watch that is watching nothing**, and the recovery path is disabled by the very evidence that should have triggered it. Nothing in the system can notice.

## Observed

Eleven watchers were armed in one session without the watermark being seeded — `arm-watcher.md` steps 1 (drain) and 2 (seed the watermark) were skipped, and the loop was started straight after writing `prs.json` / `last_seen.json` / `cron.json` / `state.md`.

All eleven ran for hours with live PIDs and advancing heartbeats. Between them they missed **nine merges and a red CI run**, and reported nothing. The slots that *were* seeded, by other sessions on the same machine, worked normally throughout — which is what isolates this to seeding rather than to the host or the script's polling.

## The change

- `MUGGLE_PR_WATCH_MAX_UNSEEDED` (default **180s**, `0` = unbounded, matching `watcher_lifetime_exceeded`) — arming writes the file in the same turn it starts the loop, so minutes without it means the sequence was not followed.
- `watcher_unseeded_too_long` guard alongside the other predicates.
- The loop counts the wait and exits **1** with a line naming the cause and pointing at the arming steps.

A watcher that cannot work now says so within three minutes instead of impersonating a working one indefinitely.

## Verified

Guard predicates, run directly against the library — 5/5:

```
ok   false while still within the cap
ok   true once the wait passes the cap
ok   explicit cap beats the default
ok   cap of 0 is unbounded
ok   defaults to 180
```

End to end, against a slot with no `watch-watermark.env`:

| | Result |
|---|---|
| shipped `5.11.0` | `exit=124` — killed at 8s **still looping**, no output |
| this branch | `exit=1` at 3s — `WATCH-FAIL pr=999999 no watch-watermark.env after 3s — arming never seeded it, so this watch can detect nothing (arm-watcher.md steps 1-2)` |

`bash -n` clean on both scripts; both stay LF.

Five cases added to `src/test/scripts/pr-watch-guards.test.ts` in the existing style. I could not execute the vitest file locally — the worktree has no `node_modules`, and running it from the main checkout is a no-op because `vitest.config` excludes `**/.claude/worktrees/**` (it reports `No test files found, exiting with code 0`, which reads as a pass). The shell behaviour is proven by the two runs above; CI runs the vitest file.

## Not fixed here

This does not stop a caller skipping the arming steps — it only stops the result being invisible. The arming sequence in `arm-watcher.md` is already explicit that the drain and the watermark seed come before the monitor; the gap was that nothing enforced it.
