### PR TITLE
fix(pr-section): number the overview by position, not testCaseId

### DIFF
--- a/src/cli/pr-section/render.ts
+++ b/src/cli/pr-section/render.ts
@@ -137,14 +137,16 @@ function safeInlineCode (s: string): string {
 }
 
 /**
- * Build a `Map<testCaseId, testNumber>` so both the overview and the per-test
- * details use the same 1-based numbering regardless of grouping. Tests without
- * a testCaseId (shouldn't happen — schema requires it) are silently skipped.
+ * Assign each entry its 1-based position in `report.tests`, keyed by the test
+ * object rather than its testCaseId. A report legitimately repeats an id when a
+ * failed run is followed by its rerun, and keying by id would collapse that pair
+ * onto one number, leaving the overview out of step with the details blocks —
+ * which number by array index. Object identity is unique within a render pass.
  */
-function buildTestNumbering (report: E2eReport): Map<string, number> {
-  const map = new Map<string, number>();
+function buildTestNumbering (report: E2eReport): Map<TestResult, number> {
+  const map = new Map<TestResult, number>();
   report.tests.forEach((t, i) => {
-    map.set(t.testCaseId, i + 1);
+    map.set(t, i + 1);
   });
   return map;
 }
@@ -172,7 +174,7 @@ export function renderOverview (report: E2eReport): string {
   const anyGrouped = report.tests.some((t) => Boolean(t.useCaseName));
   if (!anyGrouped) {
     for (const t of report.tests) {
-      lines.push(`- **${numbering.get(t.testCaseId)}.** ${statusEmoji(t)} ${t.name}`);
+      lines.push(`- **${numbering.get(t)}.** ${statusEmoji(t)} ${t.name}`);
     }
     return lines.join("\n");
   }
@@ -199,11 +201,11 @@ export function renderOverview (report: E2eReport): string {
   }
   for (const entry of flat) {
     if (entry.type === "test") {
-      lines.push(`- **${numbering.get(entry.test.testCaseId)}.** ${statusEmoji(entry.test)} ${entry.test.name}`);
+      lines.push(`- **${numbering.get(entry.test)}.** ${statusEmoji(entry.test)} ${entry.test.name}`);
     } else {
       lines.push(`- **${entry.key}**`);
       for (const t of groups.get(entry.key)!) {
-        lines.push(`  - **${numbering.get(t.testCaseId)}.** ${statusEmoji(t)} ${t.name}`);
+        lines.push(`  - **${numbering.get(t)}.** ${statusEmoji(t)} ${t.name}`);
       }
     }
   }

--- a/src/test/cli/pr-section/render.test.ts
+++ b/src/test/cli/pr-section/render.test.ts
@@ -11,6 +11,14 @@ import {
 import type { E2eReport, FailedTest, InconclusiveTest, PassedTest } from "../../../cli/pr-section/types.js";
 
 const PROJECT_ID = "p1";
+const CHECKOUT_USE_CASE = "Checkout";
+const OVERVIEW_ORDINAL = /\*\*\d+\.\*\*/g;
+const DETAILS_ORDINAL = /<b>\d+\. <\/b>/g;
+
+/** Pull the rendered test ordinals out of a markdown chunk, in document order. */
+function ordinalsFrom (markdown: string, pattern: RegExp): number[] {
+  return (markdown.match(pattern) ?? []).map((token) => Number(token.replace(/[^0-9]/g, "")));
+}
 
 const passedWithDesc: PassedTest = {
   name: "User creates a new project with valid URL",
@@ -107,6 +115,51 @@ const inconclusiveWithSteps: InconclusiveTest = {
   steps: [
     { stepIndex: 0, action: "Open cart", screenshotUrl: "https://cdn/7-0.png" },
     { stepIndex: 1, action: "Hit cookie banner", screenshotUrl: "https://cdn/7-1.png" },
+  ],
+};
+
+// A failed run and its rerun carry the same testCaseId: the ordinary shape of a
+// report assembled after a retry.
+const rerunFirstAttempt: FailedTest = {
+  name: "Checkout completes with a saved card",
+  testCaseId: "tc-8",
+  runId: "run-8a",
+  viewUrl: "https://www.muggle-ai.com/x/run-8a",
+  status: "failed",
+  failureStepIndex: 2,
+  error: "Timed out waiting for the confirmation banner",
+  steps: [
+    { stepIndex: 0, action: "Open cart", screenshotUrl: "https://cdn/8a-0.png" },
+    { stepIndex: 1, action: "Pay", screenshotUrl: "https://cdn/8a-1.png" },
+    { stepIndex: 2, action: "Await confirmation", screenshotUrl: "https://cdn/8a-2.png" },
+  ],
+};
+
+const rerunSecondAttempt: PassedTest = {
+  name: "Checkout completes with a saved card (rerun)",
+  testCaseId: "tc-8",
+  runId: "run-8b",
+  viewUrl: "https://www.muggle-ai.com/x/run-8b",
+  status: "passed",
+  steps: [
+    { stepIndex: 0, action: "Open cart", screenshotUrl: "https://cdn/8b-0.png" },
+    { stepIndex: 1, action: "Pay", screenshotUrl: "https://cdn/8b-1.png" },
+    { stepIndex: 2, action: "Await confirmation", screenshotUrl: "https://cdn/8b-2.png" },
+  ],
+};
+
+const flatRerunReport: E2eReport = {
+  projectId: PROJECT_ID,
+  tests: [passedNoMeta, rerunFirstAttempt, rerunSecondAttempt, failedNoMeta],
+};
+
+const groupedRerunReport: E2eReport = {
+  projectId: PROJECT_ID,
+  tests: [
+    passedWithDesc,
+    { ...rerunFirstAttempt, useCaseName: CHECKOUT_USE_CASE },
+    { ...rerunSecondAttempt, useCaseName: CHECKOUT_USE_CASE },
+    passedAuthGroup,
   ],
 };
 
@@ -354,5 +407,26 @@ describe("renderComment", () => {
     expect(comment).toContain("## E2E acceptance evidence (overflow)");
     const detailsCount = (comment.match(/<details>/g) ?? []).length;
     expect(detailsCount).toBe(2);
+  });
+});
+
+describe("numbering when one testCaseId appears twice", () => {
+  it("numbers a failed run and its rerun consecutively in a flat list", () => {
+    const md = renderOverview(flatRerunReport);
+    expect(ordinalsFrom(md, OVERVIEW_ORDINAL)).toEqual([1, 2, 3, 4]);
+    const lines = md.split("\n");
+    expect(lines.find((l) => l.endsWith("Checkout completes with a saved card"))!).toContain("**2.**");
+    expect(lines.find((l) => l.endsWith("(rerun)"))!).toContain("**3.**");
+  });
+
+  it("numbers a failed run and its rerun consecutively inside a use-case group", () => {
+    const md = renderOverview(groupedRerunReport);
+    expect(ordinalsFrom(md, OVERVIEW_ORDINAL)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("gives the overview the same ordinals as the details blocks", () => {
+    const [overview, details] = renderBody(flatRerunReport, { inlineDetails: true }).split("\n---\n");
+    expect(ordinalsFrom(details, DETAILS_ORDINAL)).toEqual([1, 2, 3, 4]);
+    expect(ordinalsFrom(overview, OVERVIEW_ORDINAL)).toEqual(ordinalsFrom(details, DETAILS_ORDINAL));
   });
 });


### PR DESCRIPTION
## Defect

`buildTestNumbering` in `src/cli/pr-section/render.ts` keyed the overview's numbering map by `testCaseId`:

```ts
report.tests.forEach((t, i) => { map.set(t.testCaseId, i + 1); });
```

A report legitimately contains two entries with the same `testCaseId` — a run and its rerun. The second `set` overwrote the first, so both entries looked up the same ordinal.

## How it manifests

The overview list duplicates one number and skips another: a four-entry report whose middle two entries share an id renders `1. / 3. / 3. / 4.` instead of `1. / 2. / 3. / 4.`.

The per-test `<details>` blocks are unaffected — `renderBody` and `renderComment` number them from the array index (`report.tests.map((t, i) => renderTestDetails(t, ..., i + 1))`) — so the two sections disagree, which is exactly what the function's own doc comment promised would not happen. Seen on a real report of a run plus its rerun.

## Fix

Key the map by the `TestResult` object (`Map<TestResult, number>`) and pass the test object at the three overview call sites. Object identity is unique within a render pass, so the overview and the details blocks now number by the same positional rule by construction. The doc comment now states what the map keys on and why.

## Regression test

`src/test/cli/pr-section/render.test.ts` gains a `numbering when one testCaseId appears twice` block: a four-entry report whose middle two entries share `tc-8`, exercised flat and inside a use-case group, plus an assertion that the overview ordinals equal the details-block ordinals.

The three new cases were first run against the unfixed `buildTestNumbering`. All three errored with `expected [ 1, 3, 3, 4 ] to deeply equal [ 1, 2, 3, 4 ]` — the collision signature. With the fix in place the file is green at 28 cases, up from 25 on `master`.

## Verification

Run from a clean worktree branched at `bc0e4ca` (Windows, pnpm 10, Node 22), after `pnpm install --frozen-lockfile`:

| Command | Exit | Result |
|---|---|---|
| `pnpm run typecheck` (`tsc --noEmit`) | 0 | clean |
| `pnpm run lint:check` (`eslint .`) | 0 | 17 warnings, all pre-existing unused `eslint-disable` directives in `internal/agent-gate-eval/src/run.ts` and `internal/skill-gate-eval/src/run.ts`; neither file is touched here |
| `pnpm test` (`vitest run`) | 0 | 116 test files, 1620 passed, 27 skipped |

One environmental note, not a code issue: `src/test/scripts/pr-watch-state.test.ts` shells out to `cat` via `execFileSync`, so it errors with `spawnSync cat ENOENT` under a bare PowerShell PATH. With Git's `usr/bin` on PATH — as on CI — it is green, and the numbers above are from that run.