### PR TITLE
chore(release): @muggleai/works 5.12.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "5.11.0"
+      "version": "5.12.1"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "5.11.0"
+      "version": "5.12.1"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@muggleai/works",
   "mcpName": "io.github.multiplex-ai/muggle",
-  "version": "5.11.0",
+  "version": "5.12.1",
   "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
   "type": "module",
   "main": "dist/index.js",
@@ -52,21 +52,21 @@
     "typecheck:browser-bench": "tsc --noEmit -p internal/browser-bench/tsconfig.json"
   },
   "muggleConfig": {
-    "electronAppVersion": "1.9.0",
+    "electronAppVersion": "1.10.3",
     "downloadBaseUrl": "https://github.com/multiplex-ai/muggle-ai-works/releases/download",
     "runtimeTargetDefault": "dev",
     "checksumsByStream": {
       "production": {
-        "darwin-arm64": "1baa38bde71b74984705bcac3e5a42a7a158a7b0574dab496f3e240846c0ac65",
-        "darwin-x64": "098cc2db6f32c7857bd933512320524d213804b378dc8bf0ade791396f058041",
-        "linux-x64": "d434a88a087c7410785a443cfe03102322fa7a295b77600f5ed92e2113e271c2",
-        "win32-x64": "0aecbc01010ab0a268137ed31bcaaa05fe9215daa9f4c0e4871b07554d28c0c8"
+        "win32-x64": "58e2238b1609ceff65b836b4b724b1c4c341d737a15debaa8a71af21b70bc436",
+        "linux-x64": "731c2ab093ef77202191d0fec8e98f19ef895019d3e7817bacef197c7197a358",
+        "darwin-arm64": "a3f8229678d4c6cd7514726b480fa97dc9dffed7ac45c2ff76e6abf220e1709f",
+        "darwin-x64": "b193c2fc02174636bee3fbb3b1041b301639315f2af55fb0352f09e7454a5694"
       },
       "staging": {
-        "darwin-x64": "754bbdaa9ccb0f10bfd92c0f5efd7877c4635708b8a7dde8bbf76bc6c74598b1",
-        "darwin-arm64": "8f8854788769971af4ad5c83531d595951f3c0306d3ddcc9b6b8cb5a5ccd375d",
-        "linux-x64": "929396f628a05f001782d48524cd9f76fdbb59216658982a5a3909dfe413cbea",
-        "win32-x64": "a8b5b46b97ed788030be84982a3e8d463abbfa7f3e8bc795692ccbffc82bfa92"
+        "darwin-arm64": "0769b8b146b393fbf582b995a1bf7d2e1b9a8ee8fbc08a2108ad9be283291d37",
+        "linux-x64": "5bdf0e98f3eb95c6cd9461cbddefa19e5361354f3faefaba7bead9ea4feabca7",
+        "win32-x64": "d029700622445ab2dab931b2cd206922cf20cf16137ccc7f164ef5c195b45ac5",
+        "darwin-x64": "db29f8fbddd4e1f1f3098aca33e3ecf6ea1a0647de6d17a0ac809a09524e7464"
       }
     },
     "electronAppSignedFromVersion": "1.10.0",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "5.11.0",
+  "version": "5.12.1",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "5.11.0",
+  "version": "5.12.1",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "5.11.0",
+  "version": "5.12.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "5.11.0",
+      "version": "5.12.1",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
Cuts 5.12.1 from master and moves the bundled studio onto the signed 1.10.3 desktop build.

## Version

`5.11.0` -> **`5.12.1`**. Baseline is **5.12.0** (npm latest), not master's `5.11.0` — the publish workflow bumps in CI and does not commit the version back, so the repo field lags the registry.

## Shipping

| Commit | Change |
| :-- | :-- |
| `837b6c1` | `fix(pr-section)`: number the overview by position, not testCaseId (#436) |
| `936a62e` | `fix(mcp)`: scripts summary is per test case, and is slimmed |
| `b11b570` | `fix(guardrails)`: continue gate conditions with a real newline (#433) |

All shipping commits are `fix`/`chore`, hence patch. The two `feat(browser-bench)` commits in the range touch only `package.json` and the lockfile within the shipping surface.

## Electron 1.9.0 -> 1.10.3

`electronAppVersion` is a single field that drives **both** streams, and `verify-electron-release-checksums.mjs` resolves `<streamTagPrefix><version>/checksums.txt` for every stream with recorded checksums. Production `electron-app-v1.10.3` already existed, but staging's newest was `1.9.0`, so the bump would have failed verify on a 404 for `electron-app-staging-v1.10.3`.

The matching staging build was cut first ([teaching-service run 33925493511](https://github.com/multiplex-ai/muggle-ai-teaching-service/actions/runs/33925493511), success). All eight checksums are read from the published `checksums.txt` of their own stream's release rather than transcribed.

This also crosses `electronAppSignedFromVersion: 1.10.0`, so both streams now ship signed artifacts.

**Parity note:** the staging 1.10.3 build comes from teaching-service master, which carries one commit production 1.10.3 does not (`c80dded`, #374 canonical Auth0 issuer). `workflow_dispatch` accepts only a branch/tag ref, so rebuilding from production 1.10.3's exact commit was not dispatchable. Staging is a prerelease stream and #374 is backend-auth work that belongs there, but the two 1.10.3 builds are not byte-identical.

## Manifests

`pnpm run sync:versions` owns these; none were hand-edited: `.claude-plugin/marketplace.json`, `.cursor-plugin/marketplace.json`, `plugin/.claude-plugin/plugin.json`, `plugin/.cursor-plugin/plugin.json`, `server.json`.

## Test plan

- [x] `pnpm run lint:check`
- [x] `pnpm run typecheck`
- [x] `pnpm test` — 116 files, 1620 passed, 27 skipped
- [x] `pnpm run build`
- [x] `pnpm run verify:plugin`
- [x] `pnpm run verify:contracts`
- [x] `pnpm run verify:electron-release-checksums` — both streams resolve and verify

E2E acceptance was skipped deliberately: this is a CLI/MCP/plugin package with no web surface to drive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKSZLCDd6tQfZLPvZsUT42