### PR TITLE
chore(release): @muggleai/works 5.13.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "5.12.1"
+      "version": "5.13.0"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "5.12.1"
+      "version": "5.13.0"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@muggleai/works",
   "mcpName": "io.github.multiplex-ai/muggle",
-  "version": "5.12.1",
+  "version": "5.13.0",
   "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
   "type": "module",
   "main": "dist/index.js",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "5.12.1",
+  "version": "5.13.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "5.12.1",
+  "version": "5.13.0",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "5.12.1",
+  "version": "5.13.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "5.12.1",
+      "version": "5.13.0",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
Re-cuts the 5.12.1 release as **5.13.0**. Content is identical; only the version fields move.

## Why 5.12.1 could not publish

`publish-works-to-npm.yml`'s `package-audit` job derives a staging pre-release from the release version (`<version>-staging.<run>`) and refuses one that is not greater than the current `staging` dist-tag:

```
Refusing to publish 5.12.1-staging.90: not greater than the current staging tag 5.13.0-staging.89.
```

Auto-staging (`da6e9af`, staging pre-release on every green master build) computes its base as `major.(minor+1).0` from npm `latest`, so with `latest` at 5.12.0 it had already published **5.13.0-staging.89**. That claims the 5.13.0 line, making every explicit version below it unpublishable. 5.13.0 is the lowest the guard accepts.

5.12.1 merged as `6bcc40f` but was never published — npm `latest` stayed at 5.12.0.

## Already shipped in 6bcc40f (this PR only re-versions it)

- `fix(pr-section)`: number the overview by position, not testCaseId (#436)
- `fix(mcp)`: scripts summary is per test case, and is slimmed
- `fix(guardrails)`: continue gate conditions with a real newline (#433)
- Electron `1.9.0` → `1.10.3` on both streams, crossing `electronAppSignedFromVersion: 1.10.0`

## Test plan

- [x] `pnpm run lint:check`
- [x] `pnpm run typecheck`
- [x] `pnpm test` — 116 files, 1620 passed, 27 skipped
- [x] `pnpm run build`
- [x] `pnpm run verify:plugin`
- [x] `pnpm run verify:contracts`
- [x] `pnpm run verify:electron-release-checksums` — both streams resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKSZLCDd6tQfZLPvZsUT42