### PR TITLE
fix(setup): stop a stale checksum pin from blocking a signed install

### DIFF
--- a/.claude/skills/muggle-works-npm-release/SKILL.md
+++ b/.claude/skills/muggle-works-npm-release/SKILL.md
@@ -88,13 +88,16 @@ The log is for reading; the **diff decides**. `NON_SHIPPING` drops paths that ca
 
 ### Electron bump decision
 
-If **`latestElectronVersion`** ≠ current **`electronAppVersion`**, ask: **bump** Electron + all four **`muggleConfig.checksums`** to **`latestElectronVersion`**, or **keep** current.
+If **`latestElectronVersion`** ≠ current **`electronAppVersion`**, ask: **bump** Electron + every **`muggleConfig.checksumsByStream`** entry to **`latestElectronVersion`**, or **keep** current.
 
-If bumping, checksums from:
+If bumping, take checksums from **both** release streams — that is **eight** values, four per stream, and a stream left behind is exactly how a stale pin ships:
 
-`https://github.com/multiplex-ai/muggle-ai-works/releases/download/electron-app-vVERSION/checksums.txt`
+- production → `https://github.com/multiplex-ai/muggle-ai-works/releases/download/electron-app-vVERSION/checksums.txt`
+- staging → `https://github.com/multiplex-ai/muggle-ai-works/releases/download/electron-app-staging-vVERSION/checksums.txt`
 
-Map zip artifacts → **`darwin-arm64`**, **`darwin-x64`**, **`win32-x64`**, **`linux-x64`** (same mapping rules as today).
+Map zip artifacts → **`darwin-arm64`**, **`darwin-x64`**, **`win32-x64`**, **`linux-x64`** under each stream (same mapping rules as today).
+
+`pnpm run verify:electron-release-checksums` fails on any pin that disagrees with its published release, so run it after editing rather than eyeballing the values.
 
 **Stop again:** user must **confirm** the full plan (**`nextNpmVersion`** + Electron choice). If they cancel, **do not** branch, merge, or dispatch CI.
 
@@ -111,7 +114,7 @@ npm version "<VERSION>" --no-git-tag-version
 
 Replace **`<VERSION>`** with **`nextNpmVersion`** (dots in the branch name are fine, e.g. `chore/release-4.8.0`).
 
-- If Electron bump agreed: set **`muggleConfig.electronAppVersion`** and all four **`muggleConfig.checksums`** in **`package.json`**.
+- If Electron bump agreed: set **`muggleConfig.electronAppVersion`** and every **`muggleConfig.checksumsByStream`** entry — all eight, both streams — in **`package.json`**.
 
 ### 2. Propagate versions (do not hand-edit manifests)
 

--- a/scripts/verify-electron-release-checksums.mjs
+++ b/scripts/verify-electron-release-checksums.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { existsSync, readFileSync } from "fs";
-import { dirname, join } from "path";
+import { dirname, join, resolve } from "path";
 import { fileURLToPath } from "url";
 
 const currentFilePath = fileURLToPath(import.meta.url);
@@ -10,14 +10,31 @@ const repositoryRootPath = join(scriptsDirectoryPath, "..");
 const packageJsonPath = join(repositoryRootPath, "package.json");
 const runtimeTargetsPath = join(repositoryRootPath, "config", "runtime-targets.json");
 
-verifyElectronReleaseChecksums().catch((error) => {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    console.error(`Electron release checksum verification failed: ${errorMessage}`);
-    process.exit(1);
-});
+/**
+ * Release asset file name to the `checksumsByStream` platform key it is pinned under.
+ * The pin map is keyed by platform, the release by asset name; this is the only bridge.
+ */
+const PLATFORM_KEY_BY_ASSET_FILE_NAME = {
+    "MuggleAI-darwin-arm64.zip": "darwin-arm64",
+    "MuggleAI-darwin-x64.zip": "darwin-x64",
+    "MuggleAI-linux-x64.zip": "linux-x64",
+    "MuggleAI-win32-x64.zip": "win32-x64",
+};
+
+const isDirectInvocation =
+    Boolean(process.argv[1]) && resolve(process.argv[1]) === resolve(currentFilePath);
+
+if (isDirectInvocation) {
+    verifyElectronReleaseChecksums().catch((error) => {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        console.error(`Electron release checksum verification failed: ${errorMessage}`);
+        process.exit(1);
+    });
+}
 
 /**
- * Verify checksums.txt exists and includes all required platform artifacts.
+ * Verify checksums.txt exists, includes all required platform artifacts, and agrees
+ * with the checksums pinned in package.json.
  * @returns {Promise<void>}
  */
 async function verifyElectronReleaseChecksums() {
@@ -34,12 +51,7 @@ async function verifyElectronReleaseChecksums() {
         message: "package.json muggleConfig.downloadBaseUrl must be defined.",
     });
 
-    const requiredAssetFileNames = [
-        "MuggleAI-darwin-arm64.zip",
-        "MuggleAI-darwin-x64.zip",
-        "MuggleAI-linux-x64.zip",
-        "MuggleAI-win32-x64.zip",
-    ];
+    const requiredAssetFileNames = Object.keys(PLATFORM_KEY_BY_ASSET_FILE_NAME);
 
     const { streams } = readJsonFile(runtimeTargetsPath);
     const checksumsByStream = packageJson?.muggleConfig?.checksumsByStream ?? {};
@@ -73,16 +85,58 @@ async function verifyElectronReleaseChecksums() {
             });
         }
 
+        assertPinnedChecksumsMatchPublished({
+            pinnedChecksums: checksumsByStream[releaseStream],
+            checksumsContent: checksumsContent,
+            releaseStream: releaseStream,
+            releaseTag: releaseTag,
+        });
+
         console.log(`checksums.txt verified for ${releaseTag}.`);
     }
 }
 
 /**
- * Check whether checksums content has a valid sha256 line for an asset.
- * @param {{ checksumsContent: string, assetFileName: string }} params
- * @returns {boolean}
+ * Assert every pinned checksum equals the one the release actually published.
+ *
+ * Well-formedness alone cannot catch a pin left behind by an earlier electron-app
+ * version: the pin map is keyed by stream and platform with no version dimension, so a
+ * stale value stays syntactically valid and ships green. Comparing against the release
+ * is what turns that into a build failure.
+ *
+ * @param {{ pinnedChecksums: Record<string, string>, checksumsContent: string, releaseStream: string, releaseTag: string }} params
+ * @returns {void}
+ * @throws {Error} When a pinned checksum differs from the published one, or is absent.
  */
-function hasValidChecksumEntry({ checksumsContent, assetFileName }) {
+function assertPinnedChecksumsMatchPublished({ pinnedChecksums, checksumsContent, releaseStream, releaseTag }) {
+    for (const [assetFileName, platformKey] of Object.entries(PLATFORM_KEY_BY_ASSET_FILE_NAME)) {
+        const pinnedChecksum = pinnedChecksums?.[platformKey];
+        if (!pinnedChecksum) {
+            continue;
+        }
+
+        const publishedChecksum = findPublishedChecksum({
+            checksumsContent: checksumsContent,
+            assetFileName: assetFileName,
+        });
+
+        assertValue({
+            condition: pinnedChecksum.toLowerCase() === publishedChecksum?.toLowerCase(),
+            message:
+                `Pinned checksum is stale for ${releaseStream}/${platformKey} in ${releaseTag}.\n` +
+                `  pinned (package.json muggleConfig.checksumsByStream.${releaseStream}.${platformKey}): ${pinnedChecksum}\n` +
+                `  published (${assetFileName} in checksums.txt): ${publishedChecksum ?? "absent"}\n` +
+                `Update the pin to the published value before publishing.`,
+        });
+    }
+}
+
+/**
+ * Read the published SHA256 for one asset out of checksums.txt content.
+ * @param {{ checksumsContent: string, assetFileName: string }} params
+ * @returns {string | null} The checksum, or null when the asset has no valid entry.
+ */
+function findPublishedChecksum({ checksumsContent, assetFileName }) {
     const outputLines = checksumsContent.split("\n");
     const checksumPattern = /^[a-fA-F0-9]{64}$/;
 
@@ -101,11 +155,23 @@ function hasValidChecksumEntry({ checksumsContent, assetFileName }) {
         const fileNameValue = parts.slice(1).join(" ").replace(/^\*?/, "");
 
         if (fileNameValue === assetFileName && checksumPattern.test(checksumValue)) {
-            return true;
+            return checksumValue;
         }
     }
 
-    return false;
+    return null;
+}
+
+/**
+ * Check whether checksums content has a valid sha256 line for an asset.
+ * @param {{ checksumsContent: string, assetFileName: string }} params
+ * @returns {boolean}
+ */
+function hasValidChecksumEntry({ checksumsContent, assetFileName }) {
+    return findPublishedChecksum({
+        checksumsContent: checksumsContent,
+        assetFileName: assetFileName,
+    }) !== null;
 }
 
 /**
@@ -131,3 +197,10 @@ function assertValue({ condition, message }) {
         throw new Error(message);
     }
 }
+
+export {
+    PLATFORM_KEY_BY_ASSET_FILE_NAME,
+    assertPinnedChecksumsMatchPublished,
+    findPublishedChecksum,
+    hasValidChecksumEntry,
+};

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -390,16 +390,29 @@ export async function setupCommand(options: ISetupOptions): Promise<void> {
     const checksumResult = await verifyFileChecksum(tempFile, expectedChecksum);
 
     if (!checksumResult.valid && expectedChecksum) {
-      cleanupFailedInstall(versionDir);
-      throw new Error(
-        `Checksum verification failed!\n` +
-        `Expected: ${checksumResult.expected}\n` +
-        `Actual:   ${checksumResult.actual}\n` +
-        `The downloaded file may be corrupted or tampered with.`,
-      );
+      // A verified signature is the stronger control, and the policy already declares
+      // the checksum non-required once it applies. Failing here anyway would let a pin
+      // left behind by an earlier electron-app version block an artifact whose
+      // provenance was just proven — while accusing it of being tampered with.
+      if (!integrityPolicy.requiresChecksum) {
+        console.warn(
+          `Pinned checksum does not match this download, but its signature verified.\n` +
+          `Expected: ${checksumResult.expected}\n` +
+          `Actual:   ${checksumResult.actual}\n` +
+          `The pin in package.json muggleConfig.checksumsByStream is stale for this release; continuing on the signature.`,
+        );
+      } else {
+        cleanupFailedInstall(versionDir);
+        throw new Error(
+          `Checksum verification failed!\n` +
+          `Expected: ${checksumResult.expected}\n` +
+          `Actual:   ${checksumResult.actual}\n` +
+          `The downloaded file may be corrupted or tampered with.`,
+        );
+      }
     }
 
-    if (expectedChecksum) {
+    if (expectedChecksum && checksumResult.valid) {
       console.log("Checksum verified successfully.");
     }
 

--- a/src/test/cli/setup.test.ts
+++ b/src/test/cli/setup.test.ts
@@ -31,6 +31,20 @@ const mcpsMocks = vi.hoisted(() => ({
   getLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
 }));
 
+// Only the signature check is stubbed; resolveIntegrityPolicy stays real because the
+// checksum's advisory-vs-required behaviour is exactly what these tests exercise.
+const releaseIntegrityMocks = vi.hoisted(() => ({
+  verifyReleaseSignature: vi.fn(async () => ({ valid: false, reason: "no signature bundle" })),
+}));
+
+vi.mock("../../../scripts/release-integrity/index.mjs", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    verifyReleaseSignature: releaseIntegrityMocks.verifyReleaseSignature,
+  };
+});
+
 const childProcessMock = vi.hoisted(() => ({
   execFile: vi.fn((_cmd: string, _args: string[], cb: (e: Error | null) => void) => cb(null)),
 }));
@@ -94,6 +108,7 @@ function fetchOk(): void {
 describe("setupCommand", () => {
   let logSpy: ReturnType<typeof vi.spyOn>;
   let errSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
   let exitSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
@@ -114,8 +129,13 @@ describe("setupCommand", () => {
     mcpsMocks.getChecksumForPlatform.mockReturnValue("expected-archive-sum");
     mcpsMocks.getElectronAppVersion.mockReturnValue("1.0.5");
     childProcessMock.execFile.mockImplementation((_c, _a, cb) => cb(null));
+    releaseIntegrityMocks.verifyReleaseSignature.mockResolvedValue({
+      valid: false,
+      reason: "no signature bundle",
+    });
     logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
     errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     exitSpy = vi.spyOn(process, "exit").mockImplementation(((): never => undefined as never));
     fetchOk();
   });
@@ -123,6 +143,7 @@ describe("setupCommand", () => {
   afterEach(() => {
     logSpy.mockRestore();
     errSpy.mockRestore();
+    warnSpy.mockRestore();
     exitSpy.mockRestore();
     vi.unstubAllGlobals();
   });
@@ -190,6 +211,33 @@ describe("setupCommand", () => {
     await setupCommand({ force: true });
     expect(exitSpy).toHaveBeenCalledWith(1);
     expect(errSpy.mock.calls.map((c) => String(c[0])).join("\n")).toContain("Failed to download");
+  });
+
+  it("installs a signature-verified release even when its pinned checksum is stale", async () => {
+    // At/above the signed-from version the signature is the required control, so a pin
+    // left behind by an earlier electron-app version must not block the install.
+    const signedVersion = "1.10.3";
+    mcpsMocks.getElectronAppVersion.mockReturnValue(signedVersion);
+    releaseIntegrityMocks.verifyReleaseSignature.mockResolvedValue({ valid: true, reason: "" });
+    mcpsMocks.verifyFileChecksum.mockResolvedValue({
+      valid: false,
+      expected: "stale-pin-from-an-older-release",
+      actual: "hash-of-what-was-actually-published",
+    });
+    fsState.existing.add(join(`/data/electron-app/${signedVersion}`, "MuggleAI.exe"));
+
+    await setupCommand({ force: true });
+
+    expect(exitSpy).not.toHaveBeenCalledWith(1);
+    expect(childProcessMock.execFile).toHaveBeenCalled();
+
+    const warned = warnSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(warned).toContain("stale");
+    expect(warned).toContain("stale-pin-from-an-older-release");
+    expect(warned).toContain("hash-of-what-was-actually-published");
+    // The scary wording belongs only to a genuinely unverifiable download.
+    expect(warned).not.toContain("tampered with");
+    expect(logSpy.mock.calls.map((c) => String(c[0])).join("\n")).not.toContain("Checksum verified");
   });
 
   it("exits 1 when the extracted executable is missing", async () => {

--- a/test/scripts/verify-electron-release-checksums.test.mjs
+++ b/test/scripts/verify-electron-release-checksums.test.mjs
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+
+const {
+    PLATFORM_KEY_BY_ASSET_FILE_NAME,
+    assertPinnedChecksumsMatchPublished,
+    findPublishedChecksum,
+    hasValidChecksumEntry,
+} = await import("../../scripts/verify-electron-release-checksums.mjs");
+
+const WIN32_PUBLISHED = "d029700622445ab2dab931b2cd206922cf20cf16137ccc7f164ef5c195b45ac5";
+const WIN32_STALE = "a8b5b46b97ed788030be84982a3e8d463abbfa7f3e8bc795692ccbffc82bfa92";
+const DARWIN_ARM64_PUBLISHED = "0769b8b146b393fbf582b995a1bf7d2e1b9a8ee8fbc08a2108ad9be283291d37";
+const DARWIN_X64_PUBLISHED = "db29f8fbddd4e1f1f3098aca33e3ecf6ea1a0647de6d17a0ac809a09524e7464";
+const LINUX_PUBLISHED = "5bdf0e98f3eb95c6cd9461cbddefa19e5361354f3faefaba7bead9ea4feabca7";
+
+const publishedChecksumsContent = [
+    `${DARWIN_ARM64_PUBLISHED}  MuggleAI-darwin-arm64.zip`,
+    `${LINUX_PUBLISHED}  MuggleAI-linux-x64.zip`,
+    `${WIN32_PUBLISHED}  MuggleAI-win32-x64.zip`,
+    `${DARWIN_X64_PUBLISHED}  MuggleAI-darwin-x64.zip`,
+].join("\n");
+
+const freshPins = {
+    "darwin-arm64": DARWIN_ARM64_PUBLISHED,
+    "darwin-x64": DARWIN_X64_PUBLISHED,
+    "linux-x64": LINUX_PUBLISHED,
+    "win32-x64": WIN32_PUBLISHED,
+};
+
+const assertPins = (pinnedChecksums) =>
+    assertPinnedChecksumsMatchPublished({
+        pinnedChecksums: pinnedChecksums,
+        checksumsContent: publishedChecksumsContent,
+        releaseStream: "staging",
+        releaseTag: "electron-app-staging-v1.10.3",
+    });
+
+describe("findPublishedChecksum", () => {
+    it("reads the checksum for an asset", () => {
+        expect(
+            findPublishedChecksum({
+                checksumsContent: publishedChecksumsContent,
+                assetFileName: "MuggleAI-win32-x64.zip",
+            }),
+        ).toBe(WIN32_PUBLISHED);
+    });
+
+    it("returns null for an absent asset", () => {
+        expect(
+            findPublishedChecksum({
+                checksumsContent: publishedChecksumsContent,
+                assetFileName: "MuggleAI-solaris-sparc.zip",
+            }),
+        ).toBeNull();
+    });
+
+    it("ignores an entry whose checksum is not a sha256", () => {
+        expect(
+            findPublishedChecksum({
+                checksumsContent: "notahash  MuggleAI-win32-x64.zip",
+                assetFileName: "MuggleAI-win32-x64.zip",
+            }),
+        ).toBeNull();
+    });
+});
+
+describe("hasValidChecksumEntry", () => {
+    it("still reports presence for every required asset", () => {
+        for (const assetFileName of Object.keys(PLATFORM_KEY_BY_ASSET_FILE_NAME)) {
+            expect(
+                hasValidChecksumEntry({
+                    checksumsContent: publishedChecksumsContent,
+                    assetFileName: assetFileName,
+                }),
+            ).toBe(true);
+        }
+    });
+});
+
+describe("assertPinnedChecksumsMatchPublished", () => {
+    it("accepts pins that match the published release", () => {
+        expect(() => assertPins(freshPins)).not.toThrow();
+    });
+
+    it("rejects a pin left behind by an earlier electron-app version", () => {
+        // The exact regression: a 1.9.0-era staging pin against a 1.10.3 artifact. It is
+        // well-formed hex, so presence checks alone let it ship.
+        expect(() => assertPins({ ...freshPins, "win32-x64": WIN32_STALE })).toThrow(
+            /Pinned checksum is stale for staging\/win32-x64/,
+        );
+    });
+
+    it("names both hashes and the release tag so the fix is obvious", () => {
+        let thrownMessage = "";
+        try {
+            assertPins({ ...freshPins, "win32-x64": WIN32_STALE });
+        } catch (error) {
+            thrownMessage = error.message;
+        }
+
+        expect(thrownMessage).toContain(WIN32_STALE);
+        expect(thrownMessage).toContain(WIN32_PUBLISHED);
+        expect(thrownMessage).toContain("electron-app-staging-v1.10.3");
+        expect(thrownMessage).toContain("checksumsByStream.staging.win32-x64");
+    });
+
+    it("rejects a pin for an asset the release never published", () => {
+        expect(() =>
+            assertPinnedChecksumsMatchPublished({
+                pinnedChecksums: freshPins,
+                checksumsContent: `${WIN32_PUBLISHED}  MuggleAI-win32-x64.zip`,
+                releaseStream: "production",
+                releaseTag: "electron-app-v1.10.3",
+            }),
+        ).toThrow(/absent/);
+    });
+
+    it("compares case-insensitively", () => {
+        expect(() => assertPins({ ...freshPins, "win32-x64": WIN32_PUBLISHED.toUpperCase() })).not.toThrow();
+    });
+
+    it("skips a platform the stream does not pin", () => {
+        const { "win32-x64": _omitted, ...withoutWin32 } = freshPins;
+        expect(() => assertPins(withoutWin32)).not.toThrow();
+    });
+});


### PR DESCRIPTION
A stale pinned checksum could block an install whose signature had already verified, and CI could not detect the staleness that caused it.

## What happened

`muggle setup` against the staging stream refused to install electron-app v1.10.3:

```
Checksum verification failed!
Expected: a8b5b46b97ed788030be84982a3e8d463abbfa7f3e8bc795692ccbffc82bfa92
Actual:   d029700622445ab2dab931b2cd206922cf20cf16137ccc7f164ef5c195b45ac5
The downloaded file may be corrupted or tampered with.
```

The artifact was fine. `d0297006…` is exactly what that release publishes in its own `checksums.txt`, and its Sigstore signature had verified moments earlier. `a8b5b46b…` is the **staging win32 pin from electron-app v1.9.0** — a pin left behind by an earlier version.

The pin map is keyed by `stream → platform` with **no version dimension**, so a value left behind by an older electron-app stays syntactically valid and nothing notices.

## Two defects

**`setup.ts` ignored the policy it had just computed.** `resolveIntegrityPolicy` returns `requiresChecksum: !requiresSignature` — at or above `electronAppSignedFromVersion`, the signature is the required control and the checksum explicitly is not. `setup.ts` computed that policy, used it to decide whether to check the signature, then enforced the checksum unconditionally anyway, gated only on the pin being non-empty. A signed, verified, intact download was refused — and told it might have been tampered with.

It now honours the policy. Behind a verified signature a mismatch is a loud stale-pin warning naming both hashes and pointing at `muggleConfig.checksumsByStream`, and the install proceeds on the signature. Where the checksum *is* the control — releases predating signing — the hard failure is unchanged, as is the refusal to install a download with no integrity evidence at all.

**The release gate could not see it.** `verify:electron-release-checksums` read the pin map only to decide whether to skip a stream, then asserted that `checksums.txt` contained a well-formed entry per asset. It never compared the pinned value to the published one, so a stale pin passed green — which is how this shipped.

It now compares them per stream and per platform and fails naming the stream, platform, release tag, and both hashes. Making that testable meant guarding the script's top-level run behind a direct-invocation check so the comparison can be imported; it had no test coverage at all before.

Also fixed the drift that produced the stale pin: the release skill said "all four checksums" when there are **eight** across two streams, and never mentioned the `electron-app-staging-v` tag.

## Note on the trigger

The pin **values** are already correct on `master` — I verified all eight against the live releases today. This PR does not touch a single checksum. It fixes the mechanism so the next one cannot go stale silently.

## Verification

- `tsc --noEmit` exit 0; ESLint clean on all changed files.
- Full suite: 1563 passed. Two failures in `src/test/scripts/pr-watch-state.test.ts` are **pre-existing** — confirmed by running that file on an untouched checkout with a 0-line diff against `origin/master`, which reproduces the identical two.
- **Red-before-green:** reverting `setup.ts` and the verify script to `origin/master` and re-running produced 11 failures — all ten new gate tests plus "installs a signature-verified release even when its pinned checksum is stale". Restored, all 26 pass.

No E2E: this is a CLI install path and a Node release script, with no web surface to drive.

## Worth a reviewer's judgement

Downgrading the checksum to advisory behind a verified signature is a deliberate loosening. My reasoning is that the policy already declared it non-required there and the signature is the stronger control — but it is the security-relevant call in this diff, so it deserves a second opinion. The narrower alternative would be to keep the hard failure and simply fix the pins each release, at the cost of this recurring.

Separately: `setup` and `upgrade` still disagree about where truth lives — `upgrade` fetches `checksums.txt` at runtime and can never go stale, while `setup` trusts the pin. Unifying them would make this class of bug impossible, but it is a larger change than this fix.
