### PR TITLE
fix(skills): name the publish channel, so a release cannot ship to staging silently

### DIFF
--- a/.claude/skills/muggle-works-npm-release/SKILL.md
+++ b/.claude/skills/muggle-works-npm-release/SKILL.md
@@ -169,27 +169,45 @@ Prefer **explicit version** (not “auto bump”):
 
 ```bash
 gh workflow run publish-works-to-npm.yml --repo multiplex-ai/muggle-ai-works --ref master \
-  --field "version=<VERSION>" --field "bump=patch"
+  --field "version=<VERSION>" --field "channel=production"
 ```
 
-The `bump=patch` field is a harmless placeholder when `version` is set; the workflow prefers the explicit `version` input.
+**`channel=production` is required and easy to miss.** The input defaults to `staging`, deliberately — so a hand-run cannot move the `latest` dist-tag by accident. Omit it and the run publishes `<VERSION>-staging.<run-number>` under the `staging` tag, **every job reports success**, and `latest` never moves. The release looks shipped and is not.
 
-**Or** **`git tag "v<VERSION>"`** && **`git push origin "v<VERSION>"`** only if that tag **does not** already exist on the remote; if the tag exists, use **`workflow_dispatch`** with **`version`**.
+`bump` is read only when `version` is empty, so it is unnecessary alongside an explicit version.
+
+**Or** **`git tag "v<VERSION>"`** && **`git push origin "v<VERSION>"`** only if that tag **does not** already exist on the remote; if the tag exists, use **`workflow_dispatch`** with **`version`**. A tag push carries no inputs and still resolves to production — pushing a version tag is already an explicit release act.
 
 Watch the run and confirm jobs succeed:
 
 ```bash
-gh run list --repo multiplex-ai/muggle-ai-works --workflow=publish-works-to-npm.yml --limit 1
 gh run watch <RUN_ID> --repo multiplex-ai/muggle-ai-works --exit-status
+echo "exit=$?"
 ```
 
-Verify the registry:
+**Never pipe `gh run watch`.** `gh run watch … | tail` reports the *pipe’s* exit status, not the run’s, so a failed run reads as green. Redirect to a file when you need the output.
+
+### Verify against the registry
+
+A green run is not evidence the release shipped. Read the dist-tags, which expose a staging publish that `npm view <pkg> version` hides:
 
 ```bash
-npm view @muggleai/works version
+npm view @muggleai/works dist-tags --json
 ```
 
-Give the user the **Actions run URL**. If npm lags, wait ~60s and retry.
+`latest` must equal **`<VERSION>`**. If the run succeeded and `latest` did not move, the publish went to `staging` — re-dispatch with `channel=production`. Never read an unmoved `latest` as registry lag.
+
+Give the user the **Actions run URL**.
+
+### Staging guard is not a reason to re-cut
+
+Under `channel=staging` only, `package-audit` derives `<VERSION>-staging.<run-number>` and refuses a candidate not greater than the current `staging` tag:
+
+```
+Refusing to publish 5.12.1-staging.90: not greater than the current staging tag 5.13.0-staging.89.
+```
+
+Auto-staging publishes a pre-release on every green master build, deriving its base as `major.(minor+1).0` from `latest` — so the `staging` tag normally sits a minor **ahead** of the version being released. That refusal means the **channel** is wrong, not the version. Fix the channel; never bump the release version to climb over a staging tag.
 
 ---
 

--- a/.cursor/skills/muggle-works-npm-release/SKILL.md
+++ b/.cursor/skills/muggle-works-npm-release/SKILL.md
@@ -88,13 +88,16 @@ The log is for reading; the **diff decides**. `NON_SHIPPING` drops paths that ca
 
 ### Electron bump decision
 
-If **`latestElectronVersion`** ≠ current **`electronAppVersion`**, ask: **bump** Electron + all four **`muggleConfig.checksums`** to **`latestElectronVersion`**, or **keep** current.
+If **`latestElectronVersion`** ≠ current **`electronAppVersion`**, ask: **bump** Electron + every **`muggleConfig.checksumsByStream`** entry to **`latestElectronVersion`**, or **keep** current.
 
-If bumping, checksums from:
+If bumping, take checksums from **both** release streams — that is **eight** values, four per stream, and a stream left behind is exactly how a stale pin ships:
 
-`https://github.com/multiplex-ai/muggle-ai-works/releases/download/electron-app-vVERSION/checksums.txt`
+- production → `https://github.com/multiplex-ai/muggle-ai-works/releases/download/electron-app-vVERSION/checksums.txt`
+- staging → `https://github.com/multiplex-ai/muggle-ai-works/releases/download/electron-app-staging-vVERSION/checksums.txt`
 
-Map zip artifacts → **`darwin-arm64`**, **`darwin-x64`**, **`win32-x64`**, **`linux-x64`** (same mapping rules as today).
+Map zip artifacts → **`darwin-arm64`**, **`darwin-x64`**, **`win32-x64`**, **`linux-x64`** under each stream (same mapping rules as today).
+
+`pnpm run verify:electron-release-checksums` fails on any pin that disagrees with its published release, so run it after editing rather than eyeballing the values.
 
 **Stop again:** user must **confirm** the full plan (**`nextNpmVersion`** + Electron choice). If they cancel, **do not** branch, merge, or dispatch CI.
 
@@ -111,7 +114,7 @@ npm version "<VERSION>" --no-git-tag-version
 
 Replace **`<VERSION>`** with **`nextNpmVersion`** (dots in the branch name are fine, e.g. `chore/release-4.8.0`).
 
-- If Electron bump agreed: set **`muggleConfig.electronAppVersion`** and all four **`muggleConfig.checksums`** in **`package.json`**.
+- If Electron bump agreed: set **`muggleConfig.electronAppVersion`** and every **`muggleConfig.checksumsByStream`** entry — all eight, both streams — in **`package.json`**.
 
 ### 2. Propagate versions (do not hand-edit manifests)
 
@@ -166,27 +169,45 @@ Prefer **explicit version** (not “auto bump”):
 
 ```bash
 gh workflow run publish-works-to-npm.yml --repo multiplex-ai/muggle-ai-works --ref master \
-  --field "version=<VERSION>" --field "bump=patch"
+  --field "version=<VERSION>" --field "channel=production"
 ```
 
-The `bump=patch` field is a harmless placeholder when `version` is set; the workflow prefers the explicit `version` input.
+**`channel=production` is required and easy to miss.** The input defaults to `staging`, deliberately — so a hand-run cannot move the `latest` dist-tag by accident. Omit it and the run publishes `<VERSION>-staging.<run-number>` under the `staging` tag, **every job reports success**, and `latest` never moves. The release looks shipped and is not.
 
-**Or** **`git tag "v<VERSION>"`** && **`git push origin "v<VERSION>"`** only if that tag **does not** already exist on the remote; if the tag exists, use **`workflow_dispatch`** with **`version`**.
+`bump` is read only when `version` is empty, so it is unnecessary alongside an explicit version.
+
+**Or** **`git tag "v<VERSION>"`** && **`git push origin "v<VERSION>"`** only if that tag **does not** already exist on the remote; if the tag exists, use **`workflow_dispatch`** with **`version`**. A tag push carries no inputs and still resolves to production — pushing a version tag is already an explicit release act.
 
 Watch the run and confirm jobs succeed:
 
 ```bash
-gh run list --repo multiplex-ai/muggle-ai-works --workflow=publish-works-to-npm.yml --limit 1
 gh run watch <RUN_ID> --repo multiplex-ai/muggle-ai-works --exit-status
+echo "exit=$?"
 ```
 
-Verify the registry:
+**Never pipe `gh run watch`.** `gh run watch … | tail` reports the *pipe’s* exit status, not the run’s, so a failed run reads as green. Redirect to a file when you need the output.
+
+### Verify against the registry
+
+A green run is not evidence the release shipped. Read the dist-tags, which expose a staging publish that `npm view <pkg> version` hides:
 
 ```bash
-npm view @muggleai/works version
+npm view @muggleai/works dist-tags --json
 ```
 
-Give the user the **Actions run URL**. If npm lags, wait ~60s and retry.
+`latest` must equal **`<VERSION>`**. If the run succeeded and `latest` did not move, the publish went to `staging` — re-dispatch with `channel=production`. Never read an unmoved `latest` as registry lag.
+
+Give the user the **Actions run URL**.
+
+### Staging guard is not a reason to re-cut
+
+Under `channel=staging` only, `package-audit` derives `<VERSION>-staging.<run-number>` and refuses a candidate not greater than the current `staging` tag:
+
+```
+Refusing to publish 5.12.1-staging.90: not greater than the current staging tag 5.13.0-staging.89.
+```
+
+Auto-staging publishes a pre-release on every green master build, deriving its base as `major.(minor+1).0` from `latest` — so the `staging` tag normally sits a minor **ahead** of the version being released. That refusal means the **channel** is wrong, not the version. Fix the channel; never bump the release version to climb over a staging tag.
 
 ---
 


### PR DESCRIPTION
## The gap

Phase 5 of the release playbook dispatched `publish-works-to-npm.yml` without the `channel` input:

```bash
--field "version=<VERSION>" --field "bump=patch"
```

`channel` defaults to `staging` — deliberately, so a hand-run cannot move `latest` by accident. Following the playbook verbatim therefore publishes `<version>-staging.<run>` under the `staging` dist-tag, **every job reports success**, and `latest` never moves. The release reads as shipped and is not.

Hit twice in one session: 5.12.1 and 5.13.0 both needed a re-dispatch with `channel=production` before `latest` moved.

## What changed

`bump` is dropped from the recipe — it is read only when `version` is empty.

Three follow-on traps from the same episode, each of which independently hid the failure:

| Trap | Was | Now |
| :-- | :-- | :-- |
| Registry check | `npm view <pkg> version` — shows `latest`, so a staging publish just looks stale | `npm view <pkg> dist-tags --json`, where a staging publish is visible |
| "If npm lags, wait ~60s and retry" | explained away the exact failure it should have caught | removed; an unmoved `latest` after a green run means wrong channel |
| `gh run watch --exit-status \| tail` | reports the *pipe's* status — a failed run reads green | called out, with the redirect alternative |

Plus a new subsection: under `channel=staging` only, `package-audit` refuses a staging candidate not greater than the current `staging` tag. Auto-staging keeps that tag a minor **ahead** of the version being released (it derives `major.(minor+1).0` from `latest`), so that refusal means the **channel** is wrong — not the version. Re-cutting a higher release version to climb over it is the wrong repair, and is what happened here.

## Mirror re-sync

`.cursor/skills/…/SKILL.md` was left behind by `c66bde2` (#439) and still documented the pre-`checksumsByStream` shape — four checksums, production-only. It is now byte-identical to the `.claude` copy again, which is why its diff is larger.

## Verification

- Command in the doc is the one that actually worked: [run 33928270306](https://github.com/multiplex-ai/muggle-ai-works/actions/runs/33928270306) used `--field version=5.13.0 --field channel=production` and moved `latest` to 5.13.0.
- Code fences balanced (24), frontmatter intact, both mirrors byte-identical.
- Docs-only, under `.claude/` and `.cursor/` — both on the release `NON_SHIPPING` list, so this cannot reach the npm tarball or trigger a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKSZLCDd6tQfZLPvZsUT42