### PR TITLE
fix(guardrails): block a turn that took a build request and shipped no PR

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -192,6 +192,12 @@
           },
           {
             "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/guardrail-build-followthrough-gate.sh\"",
+            "async": false,
+            "timeout": 10
+          },
+          {
+            "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/guardrail-walkthrough-gate.sh\"",
             "async": false,
             "timeout": 15

--- a/plugin/scripts/guardrail-build-followthrough-gate.sh
+++ b/plugin/scripts/guardrail-build-followthrough-gate.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# build-followthrough gate (Stop). When the front-door router took a
+# build/implement/fix prompt this session but no PR was ever opened, block the
+# turn end and point at /muggle-do (or the MUGGLE_BUILD_SKIP escape hatch). The
+# router's offer is advisory and a session that finds the root cause can still
+# end without shipping it — the fix then lives only in a transcript that dies
+# with the session, and no other gate catches it: the watcher gate only fires on
+# a PR that already exists.
+#
+# Mirrors guardrail-watch-gate.sh: synchronous (only a sync Stop hook can block
+# the turn end), fires on EVERY turn end, and pre-filters in shell so Node spawns
+# only when a build request was routed and no PR was handled. On the
+# overwhelming majority of turns no build intent was detected, so the state file
+# is absent or the flag is unset and we return {} in-shell, never paying Node
+# cold-start. Degrades to {}.
+payload="$(cat)"
+
+raw_sid="$(printf '%s' "$payload" | grep -oE '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed -E 's/.*:[[:space:]]*"([^"]*)".*/\1/')"
+[ -n "$raw_sid" ] || raw_sid="unknown"
+sid="$(printf '%s' "$raw_sid" | sed 's/[^A-Za-z0-9_-]/_/g')"
+
+# Resolve the same home dir Node's os.homedir() uses. HOME is correct on
+# macOS/Linux and on most Git Bash setups; fall back to converting USERPROFILE
+# when HOME doesn't hold the state dir (some Windows shells point HOME elsewhere).
+home="${HOME:-}"
+if [ ! -d "$home/.muggle-ai" ] && command -v cygpath >/dev/null 2>&1 && [ -n "${USERPROFILE:-}" ]; then
+  home="$(cygpath -u "$USERPROFILE" 2>/dev/null || printf '%s' "$home")"
+fi
+
+# A non-empty prsHandled array spans lines, so the empty match reliably says no
+# PR was opened. Skip Node unless a build request was routed and nothing shipped.
+state_file="$home/.muggle-ai/guardrails/$sid.json"
+if [ ! -f "$state_file" ] \
+  || ! grep -q '"buildIntentRouted": true' "$state_file" \
+  || ! grep -q '"prsHandled": \[\]' "$state_file" \
+  || grep -q '"buildSkipped": true' "$state_file"; then
+  printf '{}'
+  exit 0
+fi
+
+root="${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-}}"
+printf '%s' "$payload" | node "${root}/scripts/guardrails.mjs" build-followthrough-gate 2>/dev/null || printf '{}'

--- a/plugin/scripts/guardrails.mjs
+++ b/plugin/scripts/guardrails.mjs
@@ -13,6 +13,7 @@ var GH_PR_REOPENED_LINE = /\bReopened pull request [\w./-]*#(\d+)/;
 var PR_MONITOR_TERMINAL_LINE = /\bTERMINAL pr=(\d+): (MERGED|CLOSED)\b/;
 var MAX_PR_TERMINAL_BLOCKS = 3;
 var MAX_WATCH_BLOCKS = 3;
+var MAX_BUILD_BLOCKS = 3;
 var MAX_WALKTHROUGH_BLOCKS = 3;
 var GH_LOOKUP_TIMEOUT_MS = 1e4;
 var MUGGLE_SKILL_EMIT_TOOL = /muggle-local-telemetry-skill-emit/i;
@@ -583,6 +584,25 @@ function watchGateDecision(state, untrackedPrUrls, maxBlocks = MAX_WATCH_BLOCKS)
     untracked: untrackedPrUrls
   };
 }
+
+// src/guardrails/buildFollowthrough.ts
+var BUILD_SKIP_MARKER = /^\s*echo\s+["']?MUGGLE_BUILD_SKIP\b/;
+function isBuildSkipMarker(cmd) {
+  return BUILD_SKIP_MARKER.test(cmd);
+}
+function applyBuildSkip(state, skipped) {
+  if (!skipped || state.buildSkipped === true) return state;
+  return { ...state, buildSkipped: true };
+}
+function buildFollowthroughDecision(state, maxBlocks = MAX_BUILD_BLOCKS) {
+  const blockCount = state.buildBlockCount ?? 0;
+  const owed = state.buildIntentRouted === true && state.buildSkipped !== true && state.prsHandled.length === 0;
+  if (!owed) return { action: "none" /* None */, blockCount };
+  if (blockCount >= maxBlocks) {
+    return { action: "release" /* Release */, blockCount };
+  }
+  return { action: "block" /* Block */, blockCount: blockCount + 1 };
+}
 var REPORT_SENTINEL = "muggle-pr-section";
 var PR_PROSE_CMD = /\bgh\s+pr\s+(comment|create|edit)\b/;
 var GH_API_CMD = /\bgh\s+api\b/;
@@ -1080,7 +1100,8 @@ function recordTests() {
     e2eSkipped: isE2ESkipMarker(cmd)
   });
   const withWatchSkip = applyWatchSkip(recorded, isWatchSkipMarker(cmd));
-  const withWalkthroughPost = applyWalkthroughPosted(withWatchSkip, detectWalkthroughPost(input));
+  const withBuildSkip = applyBuildSkip(withWatchSkip, isBuildSkipMarker(cmd));
+  const withWalkthroughPost = applyWalkthroughPosted(withBuildSkip, detectWalkthroughPost(input));
   const withWalkthroughSkip = applyWalkthroughSkip(withWalkthroughPost, isWalkthroughSkipMarker(cmd));
   const failedRunId = detectFailedRunId(input);
   const next = failedRunId ? applyFailedRun(withWalkthroughSkip, failedRunId) : withWalkthroughSkip;
@@ -1177,6 +1198,16 @@ function watchGate() {
   writeState(state);
   const prList = decision.untracked.join(", ");
   const reason = decision.blockCount === 1 ? `Do not end the turn yet. A PR was opened this session but no muggle-do session slot tracks it: ${prList}. Seed the slot and hand off per muggle-do Stage 8 \u2014 /muggle:muggle-pr-followup ${decision.untracked[0]} does both. Seeding is what matters: once a slot exists, reconcile arms it at the next session start and finalizes it when the PR goes terminal, so an unarmed slot is fine but no slot means nothing ever picks this PR up. If it genuinely should not be tracked (autoWatchPR=never, handed off elsewhere), tell the user why and run \`echo "MUGGLE_WATCH_SKIP: <reason>"\` \u2014 that records the skip and keeps this gate quiet for the rest of the session.` : `PR hand-off still owed for ${prList} (reminder ${decision.blockCount}/${MAX_WATCH_BLOCKS}): seed a slot via /muggle:muggle-pr-followup, or record a legitimate skip via \`echo "MUGGLE_WATCH_SKIP: <reason>"\`.`;
+  return blockStop(reason, host);
+}
+function buildFollowthroughGate() {
+  const state = readState(sessionId);
+  const decision = buildFollowthroughDecision(state);
+  if (decision.action === "release" /* Release */) return releaseGate("buildSkipped");
+  if (decision.action === "none" /* None */) return "{}";
+  state.buildBlockCount = decision.blockCount;
+  writeState(state);
+  const reason = decision.blockCount === 1 ? `Do not end the turn yet. This session took a build/implement/fix request but no PR was opened. A root cause written into the transcript ships nothing \u2014 once the session ends it is gone, and the watcher gate never fires because it only looks at PRs that exist. Carry the work to a PR via /muggle-do, which runs requirements \u2192 build \u2192 impact \u2192 unit tests \u2192 E2E \u2192 PR \u2192 watcher. If no PR is owed here (the user changed their mind, the fix landed in another repo, the answer was advice rather than a change), tell the user why and run \`echo "MUGGLE_BUILD_SKIP: <reason>"\` \u2014 that records the skip and keeps this gate quiet for the rest of the session.` : `Build request still unanswered \u2014 no PR opened (reminder ${decision.blockCount}/${MAX_BUILD_BLOCKS}): carry it to a PR via /muggle-do, or record a legitimate skip via \`echo "MUGGLE_BUILD_SKIP: <reason>"\`.`;
   return blockStop(reason, host);
 }
 function walkthroughGate() {
@@ -1302,6 +1333,7 @@ var handlers = {
   "e2e-gate": e2eGate,
   "terminal-gate": terminalGate,
   "watch-gate": watchGate,
+  "build-followthrough-gate": buildFollowthroughGate,
   "walkthrough-gate": walkthroughGate,
   "record-comment-replies": recordCommentReplies,
   "comment-reply-gate": commentReplyGate,

--- a/src/guardrails/buildFollowthrough.ts
+++ b/src/guardrails/buildFollowthrough.ts
@@ -1,0 +1,62 @@
+import { MAX_BUILD_BLOCKS } from "./constants.js";
+import {
+  BuildFollowthroughAction,
+  type BuildFollowthroughDecision,
+  type GuardrailState,
+} from "./types.js";
+
+// A deliberate "no PR owed for this build request" declaration: the model runs
+// `echo "MUGGLE_BUILD_SKIP: <reason>"` and the gate stays quiet for the session
+// (the user changed their mind, the work landed in another repo's PR, the answer
+// turned out to be advice rather than a change). Anchored to a leading echo for
+// the same reason the watcher and E2E skip markers are — a grep, commit, or
+// skill edit that merely mentions the token must not disarm the gate.
+const BUILD_SKIP_MARKER = /^\s*echo\s+["']?MUGGLE_BUILD_SKIP\b/;
+
+/** Whether a Bash command is the explicit build-followthrough skip declaration. */
+export function isBuildSkipMarker(cmd: string): boolean {
+  return BUILD_SKIP_MARKER.test(cmd);
+}
+
+/** Record a build-followthrough skip into the gate state, returning the same reference when nothing changed so the caller can skip a redundant write. */
+export function applyBuildSkip(state: GuardrailState, skipped: boolean): GuardrailState {
+  if (!skipped || state.buildSkipped === true) return state;
+  return { ...state, buildSkipped: true };
+}
+
+/**
+ * Decide what the Stop hook does about an unanswered build request.
+ *
+ * `buildIntentRouted` is set by the front-door router the moment it offers
+ * `/muggle-do` on a build/implement/fix prompt, so it marks a session the user
+ * asked to change something in. `prsHandled` is the only durable evidence the
+ * change was actually delivered — a diagnosis narrated into the transcript
+ * leaves nothing behind once the session ends.
+ *
+ * The router's advisory was purely informational, and a session that found the
+ * root cause could still end without shipping anything: observed 2026-09-04,
+ * where a session root-caused a dashboard defect, wrote the fix into its final
+ * message, and stopped. Nothing else catches that — the watcher gate only fires
+ * once a PR exists, so a session that opens none clears every gate.
+ *
+ * Pure: the caller reads the state.
+ * - `None`    — nothing owed (no build intent, a PR was handled, or a skip recorded).
+ * - `Block`   — a build request went unanswered; force the turn on.
+ * - `Release` — blocked `maxBlocks` times already; stop nagging so a request that
+ *               legitimately resolves without a PR can't trap the session.
+ */
+export function buildFollowthroughDecision(
+  state: GuardrailState,
+  maxBlocks: number = MAX_BUILD_BLOCKS,
+): BuildFollowthroughDecision {
+  const blockCount = state.buildBlockCount ?? 0;
+  const owed =
+    state.buildIntentRouted === true &&
+    state.buildSkipped !== true &&
+    state.prsHandled.length === 0;
+  if (!owed) return { action: BuildFollowthroughAction.None, blockCount: blockCount };
+  if (blockCount >= maxBlocks) {
+    return { action: BuildFollowthroughAction.Release, blockCount: blockCount };
+  }
+  return { action: BuildFollowthroughAction.Block, blockCount: blockCount + 1 };
+}

--- a/src/guardrails/cli.ts
+++ b/src/guardrails/cli.ts
@@ -17,6 +17,7 @@ import {
   MAX_STAGE_BLOCKS,
   MAX_WALKTHROUGH_BLOCKS,
   MAX_WATCH_BLOCKS,
+  MAX_BUILD_BLOCKS,
 } from "./constants.js";
 import { detectFalseCapabilityClaim, lastAssistantText } from "./capabilityClaim.js";
 import {
@@ -56,6 +57,11 @@ import {
   applyWatchSkip,
 } from "./watchArmed.js";
 import {
+  buildFollowthroughDecision,
+  isBuildSkipMarker,
+  applyBuildSkip,
+} from "./buildFollowthrough.js";
+import {
   detectWalkthroughPost,
   isWalkthroughSkipMarker,
   applyWalkthroughPosted,
@@ -87,6 +93,7 @@ import {
   StageGateAction,
   WalkthroughGateAction,
   WatchGateAction,
+  BuildFollowthroughAction,
   type HookInput,
 } from "./types.js";
 
@@ -195,7 +202,8 @@ function recordTests(): string {
     e2eSkipped: isE2ESkipMarker(cmd),
   });
   const withWatchSkip = applyWatchSkip(recorded, isWatchSkipMarker(cmd));
-  const withWalkthroughPost = applyWalkthroughPosted(withWatchSkip, detectWalkthroughPost(input));
+  const withBuildSkip = applyBuildSkip(withWatchSkip, isBuildSkipMarker(cmd));
+  const withWalkthroughPost = applyWalkthroughPosted(withBuildSkip, detectWalkthroughPost(input));
   const withWalkthroughSkip = applyWalkthroughSkip(withWalkthroughPost, isWalkthroughSkipMarker(cmd));
   const failedRunId = detectFailedRunId(input);
   const next = failedRunId ? applyFailedRun(withWalkthroughSkip, failedRunId) : withWalkthroughSkip;
@@ -361,6 +369,28 @@ function watchGate(): string {
         `this gate quiet for the rest of the session.`
       : `PR hand-off still owed for ${prList} (reminder ${decision.blockCount}/${MAX_WATCH_BLOCKS}): ` +
         `seed a slot via /muggle:muggle-pr-followup, or record a legitimate skip via \`echo "MUGGLE_WATCH_SKIP: <reason>"\`.`;
+  return blockStop(reason, host);
+}
+
+function buildFollowthroughGate(): string {
+  const state = readState(sessionId);
+  const decision = buildFollowthroughDecision(state);
+  if (decision.action === BuildFollowthroughAction.Release) return releaseGate("buildSkipped");
+  if (decision.action === BuildFollowthroughAction.None) return "{}";
+  state.buildBlockCount = decision.blockCount;
+  writeState(state);
+  // Full instruction once; repeats are one line — same rationale as e2eGate.
+  const reason =
+    decision.blockCount === 1
+      ? `Do not end the turn yet. This session took a build/implement/fix request but no PR was opened. ` +
+        `A root cause written into the transcript ships nothing — once the session ends it is gone, and the ` +
+        `watcher gate never fires because it only looks at PRs that exist. Carry the work to a PR via ` +
+        `/muggle-do, which runs requirements → build → impact → unit tests → E2E → PR → watcher. ` +
+        `If no PR is owed here (the user changed their mind, the fix landed in another repo, the answer was ` +
+        `advice rather than a change), tell the user why and run \`echo "MUGGLE_BUILD_SKIP: <reason>"\` — ` +
+        `that records the skip and keeps this gate quiet for the rest of the session.`
+      : `Build request still unanswered — no PR opened (reminder ${decision.blockCount}/${MAX_BUILD_BLOCKS}): ` +
+        `carry it to a PR via /muggle-do, or record a legitimate skip via \`echo "MUGGLE_BUILD_SKIP: <reason>"\`.`;
   return blockStop(reason, host);
 }
 
@@ -546,6 +576,7 @@ const handlers: Record<string, () => string> = {
   "e2e-gate": e2eGate,
   "terminal-gate": terminalGate,
   "watch-gate": watchGate,
+  "build-followthrough-gate": buildFollowthroughGate,
   "walkthrough-gate": walkthroughGate,
   "record-comment-replies": recordCommentReplies,
   "comment-reply-gate": commentReplyGate,

--- a/src/guardrails/constants.ts
+++ b/src/guardrails/constants.ts
@@ -28,6 +28,9 @@ export const MAX_PR_TERMINAL_BLOCKS = 3;
 /** How many times the watcher-arm Stop gate blocks a turn end before releasing, so a genuinely un-watchable PR can't trap the session. */
 export const MAX_WATCH_BLOCKS = 3;
 
+/** Stop-hook reminders about an unanswered build request before the gate releases the session. */
+export const MAX_BUILD_BLOCKS = 3;
+
 /** How many times the walkthrough Stop gate blocks a turn end before releasing, so a result that genuinely can't be posted can't trap the session. */
 export const MAX_WALKTHROUGH_BLOCKS = 3;
 

--- a/src/guardrails/types.ts
+++ b/src/guardrails/types.ts
@@ -12,6 +12,8 @@ export interface GuardrailState {
   terminalBlockCount?: number;
   watchSkipped?: boolean;
   watchBlockCount?: number;
+  buildSkipped?: boolean;
+  buildBlockCount?: number;
   walkthroughPosted?: boolean;
   walkthroughSkipped?: boolean;
   walkthroughBlockCount?: number;
@@ -91,6 +93,17 @@ export enum WatchGateAction {
   Block = "block",
   Release = "release",
   None = "none",
+}
+
+export enum BuildFollowthroughAction {
+  Block = "block",
+  Release = "release",
+  None = "none",
+}
+
+export interface BuildFollowthroughDecision {
+  action: BuildFollowthroughAction;
+  blockCount: number;
 }
 
 /** A watcher-arm gate decision: the action, the running block count, and the opened-but-untracked PR urls that drove it. */

--- a/src/test/guardrails/buildFollowthrough.test.ts
+++ b/src/test/guardrails/buildFollowthrough.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import {
+  isBuildSkipMarker,
+  applyBuildSkip,
+  buildFollowthroughDecision,
+} from "../../guardrails/buildFollowthrough.js";
+import { BuildFollowthroughAction, type GuardrailState } from "../../guardrails/types.js";
+
+const base = (over: Partial<GuardrailState> = {}): GuardrailState => ({
+  sessionId: "s",
+  prsHandled: [],
+  ...over,
+});
+
+describe("isBuildSkipMarker", () => {
+  it("matches a leading MUGGLE_BUILD_SKIP echo", () => {
+    expect(isBuildSkipMarker('echo "MUGGLE_BUILD_SKIP: user withdrew the request"')).toBe(true);
+  });
+  it("ignores the token when it is merely mentioned mid-command", () => {
+    expect(isBuildSkipMarker('grep -r MUGGLE_BUILD_SKIP plugin/')).toBe(false);
+    expect(isBuildSkipMarker('git commit -m "document MUGGLE_BUILD_SKIP"')).toBe(false);
+  });
+});
+
+describe("applyBuildSkip", () => {
+  it("returns the same reference when nothing changed, so the caller can skip the write", () => {
+    const state = base();
+    expect(applyBuildSkip(state, false)).toBe(state);
+    const already = base({ buildSkipped: true });
+    expect(applyBuildSkip(already, true)).toBe(already);
+  });
+  it("stamps the skip", () => {
+    expect(applyBuildSkip(base(), true).buildSkipped).toBe(true);
+  });
+});
+
+describe("buildFollowthroughDecision", () => {
+  it("None when no build request was routed this session", () => {
+    expect(buildFollowthroughDecision(base()).action).toBe(BuildFollowthroughAction.None);
+  });
+  it("None when a PR was opened, which is the evidence the request was answered", () => {
+    const state = base({ buildIntentRouted: true, prsHandled: ["https://x/pull/1"] });
+    expect(buildFollowthroughDecision(state).action).toBe(BuildFollowthroughAction.None);
+  });
+  it("None when a skip was recorded", () => {
+    const state = base({ buildIntentRouted: true, buildSkipped: true });
+    expect(buildFollowthroughDecision(state).action).toBe(BuildFollowthroughAction.None);
+  });
+  it("Block and increments the count when a build request shipped nothing", () => {
+    const decision = buildFollowthroughDecision(base({ buildIntentRouted: true }));
+    expect(decision.action).toBe(BuildFollowthroughAction.Block);
+    expect(decision.blockCount).toBe(1);
+  });
+  it("Release after the block budget is spent, so a request that needs no PR can't trap the session", () => {
+    const state = base({ buildIntentRouted: true, buildBlockCount: 3 });
+    expect(buildFollowthroughDecision(state).action).toBe(BuildFollowthroughAction.Release);
+  });
+});

--- a/src/test/guardrails/hook-prefilter.test.ts
+++ b/src/test/guardrails/hook-prefilter.test.ts
@@ -243,6 +243,8 @@ describe("state-file pre-filters match the state guardrails.mjs writes", () => {
     terminalBlockCount: 1,
     watchSkipped: true,
     watchBlockCount: 1,
+    buildSkipped: true,
+    buildBlockCount: 1,
     walkthroughPosted: true,
     walkthroughSkipped: true,
     walkthroughBlockCount: 1,


### PR DESCRIPTION
## The hole

`guardrail-build-router.sh` fires on a build/implement/fix prompt, offers `/muggle-do`, and sets `state.buildIntentRouted`. That offer is **advisory text the model can ignore**, and nothing downstream checks whether the request was ever answered.

The watcher gate only fires once a PR exists (`prsHandled` non-empty), so a session that opens **no** PR clears every Stop gate. A root cause written into the final message ships nothing and dies with the session.

Observed 2026-09-04: a session root-caused a dashboard screenshot defect end-to-end — frozen `useState` URL vs. live resolution — and ended with no PR, despite `autoRouteBuildToMuggleDo=always` and the router advisory firing. The fix was rediscovered from scratch later.

## The gate

`buildFollowthroughDecision` owes a PR when **`buildIntentRouted`** is set, **`prsHandled`** is empty, and no skip is recorded.

| State | Action |
| :-- | :-- |
| No build intent routed | `None` |
| A PR was handled | `None` — a PR is the durable evidence the request was answered |
| Skip recorded | `None` |
| Routed, nothing shipped | `Block` |
| Blocked `MAX_BUILD_BLOCKS` (3) times | `Release` — a request that needs no PR can't trap the session |

Escape hatch mirrors the watcher and E2E ones: `echo "MUGGLE_BUILD_SKIP: <reason>"`, anchored to a leading `echo` so a grep, commit, or skill edit that merely mentions the token cannot disarm the gate.

The shell wrapper pre-filters in-shell (`buildIntentRouted` true, `prsHandled` empty, no skip) so Node only spawns when something is actually owed — on the overwhelming majority of turns no build intent was routed and it returns `{}` without paying cold-start.

## Verification

Unit tests are not enough for a gate — a dead escape hatch or a pre-filter typo passes them and silently never fires. Exercised the real hook against a synthetic state file:

| Scenario | Result |
| :-- | :-- |
| Routed, no PR | **blocks** with the full instruction |
| PR handled | `{}` |
| Skip recorded | `{}` |
| No build intent | `{}` |
| `MUGGLE_BUILD_SKIP` through `record-tests` | stamps `buildSkipped: true`, gate goes quiet |

Plus the repo's own `hook-prefilter` suite, which asserts every pre-filter greps only shapes the state file can hold and only fields a guardrail actually writes — it caught the missing fixture fields on the first run.

- `pnpm run lint:check` / `typecheck` / `build` / `verify:plugin` / `verify:contracts` — all clean
- `pnpm test` — **118 files, 1643 passed, 27 skipped**
- `plugin/scripts/guardrails.mjs` regenerated by `pnpm run build`, not hand-edited

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKSZLCDd6tQfZLPvZsUT42