### PR TITLE
chore(release): @muggleai/works 5.13.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "5.13.0"
+      "version": "5.13.1"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "muggleai",
       "source": "./plugin",
       "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-      "version": "5.13.0"
+      "version": "5.13.1"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@muggleai/works",
   "mcpName": "io.github.multiplex-ai/muggle",
-  "version": "5.13.0",
+  "version": "5.13.1",
   "description": "Ship quality products with AI-powered E2E acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
   "type": "module",
   "main": "dist/index.js",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "muggle",
   "description": "Run real-browser end-to-end (E2E) acceptance tests on your web app from any AI coding agent. Generate test scripts from plain English, replay them on localhost, capture screenshots, and validate user flows like signup, checkout, and dashboards. Works across Claude Code, Cursor, Codex, and Windsurf.",
-  "version": "5.13.0",
+  "version": "5.13.1",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "muggle",
   "displayName": "Muggle AI",
   "description": "Ship quality products with AI-powered end-to-end (E2E) acceptance testing that validates your web app like a real user — from Claude Code and Cursor to PR.",
-  "version": "5.13.0",
+  "version": "5.13.1",
   "author": {
     "name": "Muggle AI",
     "email": "support@muggle-ai.com"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/multiplex-ai/muggle-ai-works",
     "source": "github"
   },
-  "version": "5.13.0",
+  "version": "5.13.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@muggleai/works",
-      "version": "5.13.0",
+      "version": "5.13.1",
       "runtime": "node",
       "runtimeArgs": [
         ">=22.0.0"


### PR DESCRIPTION
Ships the guardrail and watcher fixes that landed since 5.13.0. Baseline is 5.13.0 (npm latest and master agree); every shipping commit is a `fix`, so patch.

| Commit | Change |
| :-- | :-- |
| `cad6181` | `fix(guardrails)`: block a turn that took a build request and shipped no PR (#441) |
| `9fb0a1b` | `fix(pr-watch)`: stop a dead session's orphan holding a slot against a live one (#442) |
| `c66bde2` | `fix(setup)`: stop a stale checksum pin from blocking a signed install (#439) |

#440 is excluded from the shipping surface — it changes `.claude/` and `.cursor/` only, both on the `NON_SHIPPING` list.

## Electron

Unchanged at **1.10.3**, already the newest release on both the production and staging streams. No checksum work needed.

## Test plan

- [x] `pnpm run lint:check`
- [x] `pnpm run typecheck`
- [x] `pnpm test` — 118 files green, 1649 specs passing, 27 skipped
- [x] `pnpm run build`
- [x] `pnpm run verify:plugin`
- [x] `pnpm run verify:contracts`
- [x] `pnpm run verify:electron-release-checksums` — both streams resolve

Publish will be dispatched with `channel=production` per the corrected Phase 5 in #440.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKSZLCDd6tQfZLPvZsUT42