### PR TITLE
fix(pr-section): link the walkthrough at the ring the run happened on

### DIFF
--- a/config/runtime-targets.json
+++ b/config/runtime-targets.json
@@ -10,6 +10,7 @@
   "targets": {
     "production": {
       "promptServiceBaseUrl": "https://promptservice.muggle-ai.com",
+      "uiBaseUrl": "https://www.muggle-ai.com/muggleTestV0",
       "auth0Domain": "login.muggle-ai.com",
       "auth0ClientId": "UgG5UjoyLksxMciWWKqVpwfWrJ4rFvtT",
       "auth0Audience": "https://muggleai.us.auth0.com/api/v2/",
@@ -17,6 +18,7 @@
     },
     "staging": {
       "promptServiceBaseUrl": "https://staging.promptservice.muggle-ai.com",
+      "uiBaseUrl": "https://staging.muggle-ai.com/muggleTestV0",
       "auth0Domain": "login.staging.muggle-ai.com",
       "auth0ClientId": "C6rmJN3FeX3EuGZdY8qbHpbJVRadxsly",
       "auth0Audience": "https://staging-muggleai.us.auth0.com/api/v2/",
@@ -24,6 +26,7 @@
     },
     "dev": {
       "promptServiceBaseUrl": "http://localhost:5050",
+      "uiBaseUrl": "http://localhost:3999/muggleTestV0",
       "auth0Domain": "dev-po4mxmz0rd8a0w8w.us.auth0.com",
       "auth0ClientId": "GBvkMdTbCI80XJXnJ90MmbEvXwcWGUtw",
       "auth0Audience": "https://dev-po4mxmz0rd8a0w8w.us.auth0.com/api/v2/",

--- a/packages/mcps/src/shared/runtime-target-types.ts
+++ b/packages/mcps/src/shared/runtime-target-types.ts
@@ -31,6 +31,8 @@ export interface IElectronAppReleaseStreamProfile {
 export interface IRuntimeTargetProfile {
   /** Base URL of the prompt service backend for this target. */
   promptServiceBaseUrl: string;
+  /** Base URL of the dashboard web app for this target, without a trailing slash. */
+  uiBaseUrl: string;
   /** Auth0 domain used for the device code login flow. */
   auth0Domain: string;
   /** Auth0 client ID for the device code grant. Empty when the target has no provisioned client. */

--- a/src/cli/build-pr-section.ts
+++ b/src/cli/build-pr-section.ts
@@ -9,6 +9,7 @@
 import { ZodError } from "zod";
 
 import { buildPrSection, E2eReportSchema } from "./pr-section/index.js";
+import { DASHBOARD_URL_BASE } from "./pr-section/render.js";
 import { resolveGsScreenshotUrls } from "./pr-section/resolve-urls.js";
 
 /** Default UTF-8 byte budget for the PR description. */
@@ -25,6 +26,28 @@ export const REPORT_SECTION_SENTINEL = "<!-- muggle-pr-section:v1 -->";
 
 const withSentinel = <T extends string | null>(s: T): T =>
   (s ? (`${REPORT_SECTION_SENTINEL}\n${s}` as T) : s);
+
+/**
+ * Dashboard projects base for the ring this CLI is pointed at.
+ *
+ * A staging run's evidence must link into the staging dashboard; emitting the
+ * production host sends reviewers to a different environment than the one the
+ * run happened in. Falls back to the renderer's production default when the
+ * target cannot be resolved, so rendering never fails over a link.
+ * @param stderrWrite - Sink for the fallback warning.
+ * @returns Base URL ending in `/dashboard/projects`, without a trailing slash.
+ */
+async function resolveDashboardBaseUrl (stderrWrite: (s: string) => void): Promise<string> {
+  try {
+    const mcps = await import("../../packages/mcps/src/index.js");
+    return `${mcps.resolveActiveProfile().uiBaseUrl}/dashboard/projects`;
+  } catch (err) {
+    stderrWrite(
+      `build-pr-section: could not resolve the runtime target, linking to production: ${errMsg(err)}\n`,
+    );
+    return DASHBOARD_URL_BASE;
+  }
+}
 
 interface IRunOptions {
   stdin: NodeJS.ReadableStream;
@@ -83,6 +106,7 @@ export async function runBuildPrSection (opts: IRunOptions): Promise<number> {
   const sentinelCost = Buffer.byteLength(`${REPORT_SECTION_SENTINEL}\n`, "utf-8");
   const renderedSection = buildPrSection(resolvedReport, {
     maxBodyBytes: opts.maxBodyBytes - sentinelCost,
+    dashboardBaseUrl: await resolveDashboardBaseUrl(opts.stderrWrite),
   });
   opts.stdoutWrite(
     JSON.stringify({

--- a/src/cli/pr-section/overflow.ts
+++ b/src/cli/pr-section/overflow.ts
@@ -16,6 +16,11 @@ import type { E2eReport } from "./types.js";
 export interface ISplitOptions {
   /** Maximum UTF-8 byte length of the rendered body. */
   maxBodyBytes: number;
+  /**
+   * Dashboard projects base for the ring this run happened on. Omitted falls
+   * back to production, so a caller that never resolved a target is unchanged.
+   */
+  dashboardBaseUrl?: string;
 }
 
 export interface ISplitResult {
@@ -38,7 +43,7 @@ export function splitWithOverflow (
   report: E2eReport,
   opts: ISplitOptions,
 ): ISplitResult {
-  const inlineBody = renderBody(report, { inlineDetails: true });
+  const inlineBody = renderBody(report, { inlineDetails: true, dashboardBaseUrl: opts.dashboardBaseUrl });
   const inlineBytes = Buffer.byteLength(inlineBody, "utf-8");
   if (inlineBytes <= opts.maxBodyBytes) {
     return { body: inlineBody, comment: null };
@@ -47,8 +52,8 @@ export function splitWithOverflow (
     // Nothing to spill. Return as-is; the caller decides how to handle the budget.
     return { body: inlineBody, comment: null };
   }
-  const spilledBody = renderBody(report, { inlineDetails: false });
-  const comment = renderComment(report);
+  const spilledBody = renderBody(report, { inlineDetails: false, dashboardBaseUrl: opts.dashboardBaseUrl });
+  const comment = renderComment(report, { dashboardBaseUrl: opts.dashboardBaseUrl });
   return {
     body: spilledBody,
     comment: comment.length > 0 ? comment : null,

--- a/src/cli/pr-section/render.ts
+++ b/src/cli/pr-section/render.ts
@@ -11,6 +11,13 @@
 
 import type { E2eReport, Step, TestResult } from "./types.js";
 
+/**
+ * Dashboard projects base used when the caller supplies none.
+ *
+ * Production, because a report rendered without a resolved runtime target is
+ * overwhelmingly a production run. A caller on another ring passes its own base
+ * so the link lands on the environment the run actually happened in.
+ */
 export const DASHBOARD_URL_BASE =
   "https://www.muggle-ai.com/muggleTestV0/dashboard/projects";
 
@@ -218,10 +225,15 @@ export function renderOverview (report: E2eReport): string {
  * `testNumber` is the 1-based index used to prefix the collapsible summary line
  * so it lines up with the numbered list in the overview section.
  */
-export function renderTestDetails (test: TestResult, projectId: string, testNumber: number): string {
+export function renderTestDetails (
+  test: TestResult,
+  projectId: string,
+  testNumber: number,
+  dashboardBaseUrl: string = DASHBOARD_URL_BASE,
+): string {
   const summary = renderSummaryLine(test, testNumber);
   const frameBlock = renderEndingFrame(test);
-  const resultLines = renderResultSummary(test, projectId);
+  const resultLines = renderResultSummary(test, projectId, dashboardBaseUrl);
   const body: string[] = ["", "<br>", ""];
   if (frameBlock) {
     body.push(...frameBlock, "");
@@ -257,8 +269,8 @@ function renderEndingFrame (test: TestResult): string[] | null {
   ];
 }
 
-function renderResultSummary (test: TestResult, projectId: string): string[] {
-  const dashboardUrl = `${DASHBOARD_URL_BASE}/${projectId}/scripts?modal=script-details&testCaseId=${encodeURIComponent(test.testCaseId)}`;
+function renderResultSummary (test: TestResult, projectId: string, dashboardBaseUrl: string): string[] {
+  const dashboardUrl = `${dashboardBaseUrl}/${projectId}/scripts?modal=script-details&testCaseId=${encodeURIComponent(test.testCaseId)}`;
   const lines: string[] = [];
   if (test.status === "passed") {
     lines.push(`**Result:** ✅ PASSED`);
@@ -274,8 +286,20 @@ function renderResultSummary (test: TestResult, projectId: string): string[] {
   return lines;
 }
 
+/** Options shared by both render entry points. */
+export interface IDashboardLinkOptions {
+  /**
+   * Dashboard projects base for the ring this run happened on, without a
+   * trailing slash. Omitted falls back to production.
+   */
+  dashboardBaseUrl?: string;
+}
+
+/** Options for renderComment. */
+export type IRenderCommentOptions = IDashboardLinkOptions;
+
 /** Options for renderBody. */
-export interface IRenderBodyOptions {
+export interface IRenderBodyOptions extends IDashboardLinkOptions {
   /**
    * When true, the per-test `<details>` blocks are included inline in the body.
    * When false, a single pointer line is written instead and the details are expected
@@ -299,7 +323,8 @@ export function renderBody (report: E2eReport, opts: IRenderBodyOptions): string
       "_Full per-test details in the comment below — the PR description was too large to inline them._",
     ].join("\n");
   }
-  const detailBlocks = report.tests.map((t, i) => renderTestDetails(t, report.projectId, i + 1));
+  const detailBlocks = report.tests.map((t, i) =>
+    renderTestDetails(t, report.projectId, i + 1, opts.dashboardBaseUrl ?? DASHBOARD_URL_BASE));
   return [
     overview,
     "",
@@ -310,11 +335,12 @@ export function renderBody (report: E2eReport, opts: IRenderBodyOptions): string
 }
 
 /** Render the overflow comment body. Returns empty string if there are no tests. */
-export function renderComment (report: E2eReport): string {
+export function renderComment (report: E2eReport, opts: IRenderCommentOptions = {}): string {
   if (report.tests.length === 0) {
     return "";
   }
-  const detailBlocks = report.tests.map((t, i) => renderTestDetails(t, report.projectId, i + 1));
+  const detailBlocks = report.tests.map((t, i) =>
+    renderTestDetails(t, report.projectId, i + 1, opts.dashboardBaseUrl ?? DASHBOARD_URL_BASE));
   return [
     "## E2E acceptance evidence (overflow)",
     "",

--- a/src/test/cli/pr-section/render.test.ts
+++ b/src/test/cli/pr-section/render.test.ts
@@ -274,8 +274,29 @@ describe("renderTestDetails", () => {
     expect(md).toContain('<img src="https://cdn/1-2.png" width="720"');
     expect(md).toContain("**Result:** ✅ PASSED");
     expect(md).toContain("**Steps:** 3");
-    expect(md).toContain(`${DASHBOARD_URL_BASE}/p1/scripts?modal=script-details&testCaseId=tc-1`);
+    expect(md).toContain(
+      "https://www.muggle-ai.com/muggleTestV0/dashboard/projects/p1/scripts?modal=script-details&testCaseId=tc-1",
+    );
     expect(md).toContain("</details>");
+  });
+
+  it("links into the ring the run happened on when a base is supplied", () => {
+    const md = renderTestDetails(
+      passedWithDesc,
+      PROJECT_ID,
+      1,
+      "https://staging.muggle-ai.com/muggleTestV0/dashboard/projects",
+    );
+    expect(md).toContain(
+      "https://staging.muggle-ai.com/muggleTestV0/dashboard/projects/p1/scripts?modal=script-details&testCaseId=tc-1",
+    );
+    // A staging run must not send reviewers to production.
+    expect(md).not.toContain("https://www.muggle-ai.com");
+  });
+
+  it("falls back to production when no base is supplied", () => {
+    const md = renderTestDetails(passedWithDesc, PROJECT_ID, 1);
+    expect(md).toContain(DASHBOARD_URL_BASE);
   });
 
   it("renders a passed test without description (no em-dash, no description text)", () => {
@@ -338,7 +359,9 @@ describe("renderTestDetails", () => {
     // No ending-screen block when there are zero steps.
     expect(md).not.toContain("**📸 Ending screen");
     // Dashboard link still works — that's what makes per-TC navigation possible.
-    expect(md).toContain(`${DASHBOARD_URL_BASE}/p1/scripts?modal=script-details&testCaseId=tc-6`);
+    expect(md).toContain(
+      "https://www.muggle-ai.com/muggleTestV0/dashboard/projects/p1/scripts?modal=script-details&testCaseId=tc-6",
+    );
   });
 
   it("renders an inconclusive test with steps using a 'cut short' caption", () => {


### PR DESCRIPTION
Every "View steps on Muggle AI →" link in a rendered PR walkthrough points at production, whatever ring the run actually happened on.

## The bug

`render.ts` built the link from a hardcoded constant:

```ts
export const DASHBOARD_URL_BASE =
  "https://www.muggle-ai.com/muggleTestV0/dashboard/projects";
```

So a walkthrough for a **staging** run sends reviewers to the **production** dashboard. It appears to work only because production and staging share one Firestore, so the project and test-case ids resolve on both hosts — the reviewer just silently lands in the wrong environment.

Found while posting a walkthrough for a staging-only project.

## Why the tests didn't catch it

They interpolated the very constant under test:

```ts
expect(md).toContain(`${DASHBOARD_URL_BASE}/p1/scripts?...`);
```

That assertion holds for *any* value of `DASHBOARD_URL_BASE`, including a wrong one. Both link assertions now pin literal hosts instead.

## A red herring worth recording

`E2eReportSchema` already requires a `viewUrl` on every test variant, and **nothing has ever read it** — it is parsed, validated, carried through URL resolution, and discarded. It looks like the obvious fix, but it isn't: the fixtures show it is a *run* link (`/dashboard/runs/run-1`) while the rendered link is a *script-details* link (`/projects/<id>/scripts?modal=script-details&testCaseId=…`). Substituting it would change where the link goes, not just which host. Left alone here.

## The fix

The base is supplied by the caller and resolved from the **active runtime target** — the thing that already knows which ring the CLI points at. `config/runtime-targets.json` gains a `uiBaseUrl` per target (production / staging / dev), alongside the `promptServiceBaseUrl` that was already there.

`render.ts` keeps its documented "no I/O" contract: it takes the base as an option and defaults to production, so any caller that never resolved a target renders exactly as before. Only `build-pr-section.ts` — which already does I/O — resolves the target, and it falls back to the production default with a warning rather than failing a render over a link.

## Verification

- `tsc --noEmit` exit 0; ESLint clean.
- Full suite scoped to the top-level paths: **1455 passed**, 0 failed.
- New coverage: a staging base renders a staging link *and* asserts the production host is absent; a caller supplying no base still gets production.

Note for anyone running the suite locally: a bare `vitest run` from the repo root also collects copies of these tests from stale `.claude/worktrees/*` checkouts and reports phantom failures. Scope the run to `src/test test/`.

## Not addressed

`config/runtime-targets.json` now carries a UI host, but the skill markdown under `plugin/skills/**` still hardcodes `www.muggle-ai.com/muggleTestV0/dashboard` in prose — including the report-assembly guidance that produces the unused `viewUrl`. Those are docs, not code paths, so they are left for a separate pass.
