### PR TITLE
test(pr-watch): read the watch scripts with node, not a Git-Bash cat

### DIFF
--- a/src/test/scripts/pr-watch-state.test.ts
+++ b/src/test/scripts/pr-watch-state.test.ts
@@ -10,6 +10,7 @@
 
 import { describe, it, expect } from "vitest";
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 const toBash = (p: string) => p.replace(/\\/g, "/");
@@ -227,13 +228,13 @@ describe.skipIf(!hasJq)("pr-watch-state projection", () => {
   // PR through one projection. A watermark seeded through a different shape than
   // the one it is later compared against is worse than no watermark at all.
   it("is the filter the shared fetch actually loads", () => {
-    const fetchBody = execFileSync("cat", [toBash(fetchPath)], { encoding: "utf8" });
+    const fetchBody = readFileSync(fetchPath, "utf8");
     expect(fetchBody).toContain('--jq "$state_projection"');
   });
 
   it("is loaded by both readers through that one library", () => {
-    const loopBody = execFileSync("cat", [toBash(loopPath)], { encoding: "utf8" });
-    const armBody = execFileSync("cat", [toBash(armPath)], { encoding: "utf8" });
+    const loopBody = readFileSync(loopPath, "utf8");
+    const armBody = readFileSync(armPath, "utf8");
 
     [loopBody, armBody].forEach((body) => {
       expect(body).toContain("pr-watch-state.jq");


### PR DESCRIPTION
Two tests in `src/test/scripts/pr-watch-state.test.ts` are red on `master` for anyone running the suite outside a Git Bash shell:

- `pr-watch-state projection > is the filter the shared fetch actually loads`
- `pr-watch-state projection > is loaded by both readers through that one library`

Both error with `spawnSync cat ENOENT`.

## Why

Each reads a script via `execFileSync("cat", …)`. `execFileSync` spawns without a shell, so `cat` has to resolve on the **Windows** `PATH` — and it doesn't; it's a Git-Bash binary. The call throws before either `expect()` ever runs.

The suite's `hasJq` guard doesn't cover it: `jq` is a winget-installed `.exe` that *does* resolve, so `describe.skipIf(!hasJq)` happily runs the block and only the two `cat`-based reads die. The other nine tests in the file are unaffected.

## The invariants are correct — the shell scripts are fine

Worth stating plainly, because "delete the red test" would be the wrong move here. Both assertions hold against the shipped scripts:

- `pr-watch-fetch.sh` passes the caller's projection straight to `gh` as `--jq "$state_projection"`, so the `.jq` file the other tests exercise with fixtures really is the filter that runs in production.
- Both readers — `pr-watch-loop.sh` and `pr-watch-arm.sh` — source `pr-watch-fetch.sh`, load `pr-watch-state.jq`, and call `watch_fetch_state`. Neither hand-rolls its own `gh api graphql` call.

That second invariant is load-bearing: a watermark seeded through a different shape than the one it is later compared against is worse than no watermark at all. These checks are worth keeping, and worth having actually execute.

## The change

Use `readFileSync` from `node:fs`, matching every sibling test in `src/test/scripts/` — `pr-watch-arm.test.ts` already does exactly this. It also drops the now-pointless bash-path conversion on those three reads, and removes the second undeclared external dependency outright rather than adding another probe for it.

Three lines, one import.

## Verification

Reverting just this test file to master's version reproduces both `spawnSync cat ENOENT` errors; with the change the file is fully green at 11/11. The whole suite, scoped to the top-level `src/test test/` paths, is green with no regressions.

Note for local runs: a bare `vitest run` from the repo root also collects copies of these tests out of stale `.claude/worktrees/*` checkouts and reports phantom breakage. Scope the run.
