### PR TITLE
feat(browser-bench): report each task's token cost beside its outcome

### DIFF
--- a/internal/browser-bench/src/studio/studio-result.test.ts
+++ b/internal/browser-bench/src/studio/studio-result.test.ts
@@ -86,3 +86,36 @@ describe("toTaskResult", () => {
     expect(toTaskResult(studioResult()).tokensUsed).toBe(0);
   });
 });
+
+describe("token totals", () => {
+  const withTokens = (extra: Record<string, unknown>) =>
+    JSON.stringify({
+      taskId: "Allrecipes--0",
+      finalAnswer: "answer",
+      studioStatus: "success",
+      stepCount: 3,
+      durationMs: 1000,
+      trajectoryDir: "C:/out/t",
+      ...extra,
+    });
+
+  it("carries the run's token spend onto the result", () => {
+    const parsed = parseStudioResult({
+      jsonContent: withTokens({ inputTokens: 900, outputTokens: 100, totalTokens: 1000 }),
+      expectedTaskId: "Allrecipes--0",
+    });
+
+    expect(toTaskResult(parsed).tokensUsed).toBe(1000);
+  });
+
+  it("reads zero for a studio build that predates token reporting", () => {
+    // Older studio builds write no token fields. Treating that as zero keeps a
+    // mixed-build batch parseable; the report's total simply understates.
+    const parsed = parseStudioResult({
+      jsonContent: withTokens({}),
+      expectedTaskId: "Allrecipes--0",
+    });
+
+    expect(toTaskResult(parsed).tokensUsed).toBe(0);
+  });
+});

--- a/internal/browser-bench/src/studio/studio-result.ts
+++ b/internal/browser-bench/src/studio/studio-result.ts
@@ -51,6 +51,10 @@ export const parseStudioResult = ({
     stepCount: requireNumber(record, "stepCount"),
     durationMs: requireNumber(record, "durationMs"),
     trajectoryDir: requireString(record, "trajectoryDir"),
+    // Optional, not required: a studio build older than token reporting writes no
+    // such field, and refusing to parse its result would turn a scoreable attempt
+    // into an infrastructure error over a missing cost figure.
+    totalTokens: typeof record.totalTokens === "number" ? record.totalTokens : undefined,
   };
 
   if (studioResult.taskId !== expectedTaskId) {
@@ -66,11 +70,12 @@ export const parseStudioResult = ({
  * Maps a studio result onto the harness's record of the attempt.
  *
  * The outcome here is studio's own claim; `judgeVerdict` stays unset until the
- * judging pass overrules it. `tokensUsed` is 0 because studio does not report
- * token spend yet — the field is real, the number is not measured.
+ * judging pass overrules it. `tokensUsed` reads 0 on studio builds older than
+ * token reporting, which understates a mixed-build batch's total rather than
+ * failing it.
  *
  * Output shape: `{ taskId: "Allrecipes--0", outcome: "pass", studioStatus: "success",
- * stepCount: 7, durationMs: 41230, tokensUsed: 0, trajectoryDir: "…" }`
+ * stepCount: 7, durationMs: 41230, tokensUsed: 48210, trajectoryDir: "…" }`
  */
 export const toTaskResult = (studioResult: StudioResultFile): TaskResult => ({
   taskId: studioResult.taskId,
@@ -82,6 +87,6 @@ export const toTaskResult = (studioResult: StudioResultFile): TaskResult => ({
   studioStatus: studioResult.studioStatus,
   stepCount: studioResult.stepCount,
   durationMs: studioResult.durationMs,
-  tokensUsed: 0,
+  tokensUsed: studioResult.totalTokens ?? 0,
   trajectoryDir: studioResult.trajectoryDir,
 });

--- a/internal/browser-bench/src/studio/types.ts
+++ b/internal/browser-bench/src/studio/types.ts
@@ -21,6 +21,8 @@ export interface StudioResultFile {
   stepCount: number;
   durationMs: number;
   trajectoryDir: string;
+  /** Absent on studio builds that predate token reporting; read as 0. */
+  totalTokens?: number;
 }
 
 /** Everything one studio process needs to attempt one task. */


### PR DESCRIPTION
The harness half of token accounting. `tokensUsed` was hardcoded to 0 because studio's
`result.json` carried no token count; teaching-service now writes one, so the report
can stop printing `Total tokens: 0` next to a pass rate.

`totalTokens` is parsed as optional rather than required. A studio build older than
token reporting writes no such field, and refusing to parse its result would turn a
perfectly scoreable attempt into an infrastructure error over a missing cost figure —
excluding it from the denominator and shrinking the evidence behind the score. A
mixed-build batch instead understates its total, which is visible and harmless.

Pairs with teaching-service#383, which accumulates the usage studio already computes
and discards.

Verified: `npx vitest run internal/browser-bench` — 80 tests across 13 files, all green. `npm run typecheck:browser-bench` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AzJ1mPrJ5YqZ4SEcqnZbT