### PR TITLE
feat(mcp): let a caller queue a test-plan graph rebuild

### DIFF
--- a/packages/mcps/src/mcp/e2e/contracts/index.ts
+++ b/packages/mcps/src/mcp/e2e/contracts/index.ts
@@ -324,6 +324,10 @@ export const TestCaseAncestorsGetInputSchema = z.object({
   testCaseId: IdSchema.describe("Test case ID (UUID) to resolve the test-plan-graph ancestor chain for"),
 });
 
+export const TestPlanGraphRebuildInputSchema = z.object({
+  projectId: IdSchema.describe("Project ID (UUID) whose test-plan graph should be rebuilt"),
+});
+
 export const TestCaseListByUseCaseInputSchema = z.object({
   useCaseId: IdSchema.describe("Use case ID (UUID) to list test cases for"),
 });

--- a/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
+++ b/packages/mcps/src/mcp/tools/e2e/tool-registry.ts
@@ -325,6 +325,19 @@ const testCaseTools: IQaToolDefinition[] = [
     },
   },
   {
+    name: "muggle-remote-test-plan-graph-rebuild",
+    description:
+      "Queue a full rebuild of a project's test-plan dependency graph: every node is dropped and the dependency analysis runs again across the whole project. Needed because the incremental analysis only ever adds nodes for test cases that have none — a case already stored as a root stays a root even once a prerequisite for it exists, so a rebuild is the only way to re-derive those edges. Reach for this when muggle-remote-test-case-ancestors-get reports `orphan: true` across a project, which means nothing is ordering prerequisites and bulk replays are running cases that destroy each other's fixtures. Returns { projectId, workflowRuntimeId }: it resolves when the rebuild is QUEUED, not when it has finished, and it returns no graph — re-fetch the graph, or call muggle-remote-test-case-ancestors-get again, to observe the result.",
+    inputSchema: schemas.TestPlanGraphRebuildInputSchema,
+    mapToUpstream: (input) => {
+      const toolInput = input as z.infer<typeof schemas.TestPlanGraphRebuildInputSchema>;
+      return {
+        method: "POST",
+        path: `${MUGGLE_TEST_PREFIX}/projects/${toolInput.projectId}/test-plan-graph/rebuild`,
+      };
+    },
+  },
+  {
     name: "muggle-remote-test-case-list-by-use-case",
     description: "List test cases for a specific use case.",
     inputSchema: schemas.TestCaseListByUseCaseInputSchema,

--- a/packages/mcps/src/test/__snapshots__/mcp-tool-surface.test.ts.snap
+++ b/packages/mcps/src/test/__snapshots__/mcp-tool-surface.test.ts.snap
@@ -255,6 +255,10 @@ exports[`MCP tool surface (Lazy-core parity oracle) > advertises the exact name 
     "name": "muggle-remote-test-case-update",
   },
   {
+    "description": "Queue a full rebuild of a project's test-plan dependency graph: every node is dropped and the dependency analysis runs again across the whole project. Needed because the incremental analysis only ever adds nodes for test cases that have none — a case already stored as a root stays a root even once a prerequisite for it exists, so a rebuild is the only way to re-derive those edges. Reach for this when muggle-remote-test-case-ancestors-get reports \`orphan: true\` across a project, which means nothing is ordering prerequisites and bulk replays are running cases that destroy each other's fixtures. Returns { projectId, workflowRuntimeId }: it resolves when the rebuild is QUEUED, not when it has finished, and it returns no graph — re-fetch the graph, or call muggle-remote-test-case-ancestors-get again, to observe the result.",
+    "name": "muggle-remote-test-plan-graph-rebuild",
+  },
+  {
     "description": "Delete a test script by ID. This is a soft delete; the test case it belongs to is not affected.",
     "name": "muggle-remote-test-script-delete",
   },
@@ -490,6 +494,7 @@ exports[`MCP tool surface (Lazy-core parity oracle) > advertises the exact set o
   "muggle-remote-test-case-list",
   "muggle-remote-test-case-list-by-use-case",
   "muggle-remote-test-case-update",
+  "muggle-remote-test-plan-graph-rebuild",
   "muggle-remote-test-script-delete",
   "muggle-remote-test-script-get",
   "muggle-remote-test-script-list",

--- a/packages/mcps/src/test/test-plan-graph-rebuild.test.ts
+++ b/packages/mcps/src/test/test-plan-graph-rebuild.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for the muggle-remote-test-plan-graph-rebuild tool, which queues a full
+ * rebuild of a project's test-plan dependency graph so prerequisite edges the
+ * incremental analysis cannot add are re-derived.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../shared/config.js", () => ({
+  getConfig: () => ({
+    logLevel: "silent",
+    serverName: "test",
+    serverVersion: "0.0.0",
+    e2e: {
+      promptServiceBaseUrl: "http://test.invalid",
+      requestTimeoutMs: 1000,
+      workflowTimeoutMs: 5000,
+    },
+  }),
+}));
+
+vi.mock("../shared/logger.js", () => {
+  const noop = () => undefined;
+  const fakeLogger = {
+    info: noop,
+    warn: noop,
+    error: noop,
+    debug: noop,
+    verbose: noop,
+    silly: noop,
+    child: () => fakeLogger,
+  };
+  return {
+    getLogger: () => fakeLogger,
+    createChildLogger: () => fakeLogger,
+    resetLogger: noop,
+  };
+});
+
+vi.mock("../mcp/e2e/upstream-client.js", () => ({
+  getPromptServiceClient: () => ({ execute: vi.fn() }),
+}));
+
+vi.mock("../shared/auth.js", () => ({
+  getCallerCredentialsAsync: vi.fn(async () => ({ bearerToken: "test-token" })),
+}));
+
+import { TestPlanGraphRebuildInputSchema } from "../mcp/e2e/contracts/index.js";
+import { getQaToolByName } from "../mcp/tools/e2e/tool-registry.js";
+
+const PROJECT_ID = "44444444-4444-4444-8444-444444444444";
+
+describe("muggle-remote-test-plan-graph-rebuild", () => {
+  it("is registered and requires auth by default", () => {
+    const tool = getQaToolByName("muggle-remote-test-plan-graph-rebuild");
+    expect(tool).toBeDefined();
+    expect(tool!.requiresAuth).not.toBe(false);
+  });
+
+  it("maps to the project's test-plan-graph rebuild POST endpoint", () => {
+    const tool = getQaToolByName("muggle-remote-test-plan-graph-rebuild")!;
+    const call = tool.mapToUpstream({ projectId: PROJECT_ID });
+    expect(call.method).toBe("POST");
+    expect(call.path).toBe(
+      `/v1/protected/muggle-test/projects/${PROJECT_ID}/test-plan-graph/rebuild`,
+    );
+  });
+
+  // The rebuild is addressed entirely by its path, so a body would be the kind of
+  // detail an upstream schema later rejects.
+  it("sends no request body", () => {
+    const tool = getQaToolByName("muggle-remote-test-plan-graph-rebuild")!;
+    expect(tool.mapToUpstream({ projectId: PROJECT_ID }).body).toBeUndefined();
+  });
+
+  it("rejects a non-UUID projectId", () => {
+    expect(() => TestPlanGraphRebuildInputSchema.parse({ projectId: "not-a-uuid" })).toThrow();
+  });
+
+  it("requires a projectId", () => {
+    expect(() => TestPlanGraphRebuildInputSchema.parse({})).toThrow();
+  });
+
+  // Callers routinely mistake the acknowledgement for the finished graph, so the
+  // description has to say that it queues and returns a runtime id, not a graph.
+  it("tells the caller the rebuild is only queued", () => {
+    const tool = getQaToolByName("muggle-remote-test-plan-graph-rebuild")!;
+    expect(tool.description).toMatch(/QUEUED/);
+    expect(tool.description).toContain("workflowRuntimeId");
+  });
+});

--- a/plugin/skills/_shared/test-case-chain-readiness.md
+++ b/plugin/skills/_shared/test-case-chain-readiness.md
@@ -12,6 +12,7 @@ Run once the target `testCaseId` is chosen and the local URL + services are conf
 
 1. **Resolve the chain.** `muggle-remote-test-case-ancestors-get` with the target `testCaseId`. Response: `{ testCaseId, ancestors, orphan }`.
    - `orphan: true` **or** empty `ancestors` → no prerequisites. Skip the rest; continue to Step 5.
+     One orphan is ordinary. **Every** case in a project reading `orphan: true` is not — it means the graph was never built, so nothing orders prerequisites and a bulk replay runs cases that destroy each other's fixtures (one empties a household another needs). Queue `muggle-remote-test-plan-graph-rebuild` for the project, then re-read the chain. It only queues the work, so the graph is not ready the moment it returns.
    - Otherwise `ancestors` is ordered **immediate-parent → root**. Reverse it to **root-first** so prerequisites are satisfied bottom-up.
 
 2. **For each ancestor, root-first:**


### PR DESCRIPTION
A project's test-plan graph can be empty or stale, and until now nothing could rebuild it except a human clicking the dashboard button that muggle-ai-ui #553 shipped.

That gap has a cost. On the Ride to Rebuild project, every test case sampled answers `muggle-remote-test-case-ancestors-get` with `orphan: true` — no prerequisite edges at all. Nothing orders anything, so a bulk replay runs "remove a member from the household" alongside "rename an existing member" and they destroy each other's fixtures. The pass rate sits near 55% and the failures read as product defects. They are not.

An agent can already *diagnose* that in one call. It could not act on the diagnosis.

## The tool

`muggle-remote-test-plan-graph-rebuild` — `projectId` in, `POST {prefix}/projects/{id}/test-plan-graph/rebuild`, no body, `{ projectId, workflowRuntimeId }` out. Schema, registration and tests mirror the `test-case-ancestors-get` sibling; the upstream client keeps owning auth and error surfacing.

The description carries the two things that otherwise cost the caller a wasted cycle: it **queues** rather than finishes, returning a runtime id and not a graph; and a rebuild is the only way to re-derive edges the incremental analysis cannot add, because a case stored as a root stays a root even once a prerequisite for it exists.

## Also here

`test-case-chain-readiness.md` told the reader that `orphan: true` means "no prerequisites — skip the rest". True of one case, badly wrong across a whole project, and it is exactly what sent me looking for product defects that did not exist. It now separates the two and points at the rebuild.

## Verification

- 24 files / 256 tests, exit 0. Typecheck exit 0. pnpm throughout.
- The new file run alone and verbose: 6/6 executed by name, so they are running rather than silently skipping.
- `mcp-tool-surface.test.ts` snapshots every tool's name and description, and it **caught this change** — my impact analysis had grepped for length assertions and missed `toMatchSnapshot`. Snapshot updated, then the diff read rather than trusted: 5 lines added, **0 removed**.
- Diff is additive: 114 insertions, no deletions.

Nothing is published or deployed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W9C2SLuhSfWvgSVhgjwReG
