### PR TITLE
fix(auth): validate stored session issuer and derive dashboard links per ring

### DIFF
--- a/config/runtime-targets.json
+++ b/config/runtime-targets.json
@@ -11,6 +11,7 @@
     "production": {
       "promptServiceBaseUrl": "https://promptservice.muggle-ai.com",
       "uiBaseUrl": "https://www.muggle-ai.com/muggleTestV0",
+      "dashboardBaseUrl": "https://www.muggle-ai.com/muggleTestV0/dashboard/projects",
       "auth0Domain": "login.muggle-ai.com",
       "auth0ClientId": "UgG5UjoyLksxMciWWKqVpwfWrJ4rFvtT",
       "auth0Audience": "https://muggleai.us.auth0.com/api/v2/",
@@ -19,6 +20,7 @@
     "staging": {
       "promptServiceBaseUrl": "https://staging.promptservice.muggle-ai.com",
       "uiBaseUrl": "https://staging.muggle-ai.com/muggleTestV0",
+      "dashboardBaseUrl": "https://staging.muggle-ai.com/muggleTestV0/dashboard/projects",
       "auth0Domain": "login.staging.muggle-ai.com",
       "auth0ClientId": "C6rmJN3FeX3EuGZdY8qbHpbJVRadxsly",
       "auth0Audience": "https://staging-muggleai.us.auth0.com/api/v2/",
@@ -27,6 +29,7 @@
     "dev": {
       "promptServiceBaseUrl": "http://localhost:5050",
       "uiBaseUrl": "http://localhost:3999/muggleTestV0",
+      "dashboardBaseUrl": "http://localhost:3999/muggleTestV0/dashboard/projects",
       "auth0Domain": "dev-po4mxmz0rd8a0w8w.us.auth0.com",
       "auth0ClientId": "GBvkMdTbCI80XJXnJ90MmbEvXwcWGUtw",
       "auth0Audience": "https://dev-po4mxmz0rd8a0w8w.us.auth0.com/api/v2/",

--- a/packages/mcps/src/mcp/local/services/auth-service.ts
+++ b/packages/mcps/src/mcp/local/services/auth-service.ts
@@ -17,7 +17,7 @@ import type {
   ITokenResponse,
 } from "../types/index.js";
 import { DeviceCodePollStatus } from "../types/index.js";
-import { isStoredAuthForRuntimeTarget } from "./stored-auth-target.js";
+import { isStoredAuthForRuntimeTarget, extractJwtIssuer } from "./stored-auth-target.js";
 
 /** Default timeout for waiting on browser login completion. */
 const DEFAULT_LOGIN_WAIT_TIMEOUT_MS = 120000;
@@ -110,7 +110,7 @@ export class AuthService {
       throw new Error(`Failed to start device code flow: ${response.status} ${errorText}`);
     }
 
-    const data = (await response.json()) as {
+    const deviceCodeResponse = (await response.json()) as {
       device_code: string;
       user_code: string;
       verification_uri: string;
@@ -120,18 +120,18 @@ export class AuthService {
     };
 
     logger.info("Device code flow started", {
-      userCode: data.user_code,
-      verificationUri: data.verification_uri,
-      expiresIn: data.expires_in,
+      userCode: deviceCodeResponse.user_code,
+      verificationUri: deviceCodeResponse.verification_uri,
+      expiresIn: deviceCodeResponse.expires_in,
     });
 
     this.storePendingDeviceCode({
-      deviceCode: data.device_code,
-      userCode: data.user_code,
-      expiresAt: new Date(Date.now() + data.expires_in * 1000).toISOString(),
+      deviceCode: deviceCodeResponse.device_code,
+      userCode: deviceCodeResponse.user_code,
+      expiresAt: new Date(Date.now() + deviceCodeResponse.expires_in * 1000).toISOString(),
     });
 
-    let browserUrl = data.verification_uri_complete;
+    let browserUrl = deviceCodeResponse.verification_uri_complete;
 
     if (options?.forceNewSession) {
       // A stale local token would otherwise mask the account switch; pollDeviceCode()
@@ -145,7 +145,7 @@ export class AuthService {
       // caller must finish login in a fresh/incognito browser instead.
       const logoutUrl = new URL(`https://${domain}/v2/logout`);
       logoutUrl.searchParams.set("client_id", clientId);
-      logoutUrl.searchParams.set("returnTo", data.verification_uri_complete);
+      logoutUrl.searchParams.set("returnTo", deviceCodeResponse.verification_uri_complete);
       browserUrl = logoutUrl.toString();
       logger.info("Force new session: cleared local token, opening logout-redirect URL", {
         logoutUrl: browserUrl,
@@ -166,12 +166,12 @@ export class AuthService {
     }
 
     return {
-      deviceCode: data.device_code,
-      userCode: data.user_code,
-      verificationUri: data.verification_uri,
-      verificationUriComplete: data.verification_uri_complete,
-      expiresIn: data.expires_in,
-      interval: data.interval,
+      deviceCode: deviceCodeResponse.device_code,
+      userCode: deviceCodeResponse.user_code,
+      verificationUri: deviceCodeResponse.verification_uri,
+      verificationUriComplete: deviceCodeResponse.verification_uri_complete,
+      expiresIn: deviceCodeResponse.expires_in,
+      interval: deviceCodeResponse.interval,
       browserOpened: browserOpenResult.opened,
       browserOpenError: browserOpenResult.error,
     };
@@ -213,14 +213,14 @@ export class AuthService {
 
     try {
       const content = fs.readFileSync(this.pendingDeviceCodePath, "utf-8");
-      const data = JSON.parse(content) as {
+      const pendingDeviceCodeData = JSON.parse(content) as {
         deviceCode: string;
         userCode: string;
         expiresAt: string;
       };
 
       const now = new Date();
-      const expiresAt = new Date(data.expiresAt);
+      const expiresAt = new Date(pendingDeviceCodeData.expiresAt);
 
       if (now >= expiresAt) {
         logger.debug("Pending device code expired");
@@ -228,7 +228,7 @@ export class AuthService {
         return null;
       }
 
-      return data.deviceCode;
+      return pendingDeviceCodeData.deviceCode;
     } catch (error) {
       logger.warn("Failed to read pending device code", {
         error: error instanceof Error ? error.message : String(error),
@@ -386,10 +386,10 @@ export class AuthService {
     });
 
     while (Date.now() - startedAt < timeoutMs) {
-      const result = await this.pollDeviceCode(params.deviceCode);
+      const pollResult = await this.pollDeviceCode(params.deviceCode);
 
-      if (result.status !== DeviceCodePollStatus.Pending) {
-        return result;
+      if (pollResult.status !== DeviceCodePollStatus.Pending) {
+        return pollResult;
       }
 
       const remainingMs = timeoutMs - (Date.now() - startedAt);
@@ -430,8 +430,8 @@ export class AuthService {
         return {};
       }
 
-      const data = (await response.json()) as { email?: string; sub?: string };
-      return data;
+      const userInfoData = (await response.json()) as { email?: string; sub?: string };
+      return userInfoData;
     } catch (error) {
       logger.warn("User info request failed", {
         error: error instanceof Error ? error.message : String(error),
@@ -490,16 +490,23 @@ export class AuthService {
       const content = fs.readFileSync(this.oauthSessionFilePath, "utf-8");
       const storedAuth = JSON.parse(content) as IStoredAuth;
       const activeRuntimeTarget = getActiveRuntimeTarget();
+      const config = getConfig();
+      const expectedAuth0Domain = config.localQa.auth0.domain;
+      const tokenIssuer = extractJwtIssuer(storedAuth.accessToken);
 
       if (
         !isStoredAuthForRuntimeTarget({
           storedRuntimeTarget: storedAuth.runtimeTarget,
           activeRuntimeTarget: activeRuntimeTarget,
+          tokenIssuer: tokenIssuer,
+          expectedAuth0Domain: expectedAuth0Domain,
         })
       ) {
         logger.warn("Ignoring stored auth issued for a different runtime target", {
           storedRuntimeTarget: storedAuth.runtimeTarget ?? "unrecorded",
           activeRuntimeTarget: activeRuntimeTarget,
+          tokenIssuer: tokenIssuer ?? "undecodable",
+          expectedAuth0Domain: expectedAuth0Domain,
         });
         return null;
       }

--- a/packages/mcps/src/mcp/local/services/stored-auth-target.ts
+++ b/packages/mcps/src/mcp/local/services/stored-auth-target.ts
@@ -5,21 +5,87 @@
 import { RuntimeTarget } from "../../../shared/runtime-target-types.js";
 
 /**
+ * Decode a JWT's payload without verifying the signature.
+ *
+ * Used to extract claims for local consistency checks, not authentication decisions.
+ * @param token - The JWT token string.
+ * @returns The decoded payload, or null if the token cannot be decoded.
+ */
+export function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  try {
+    const parts = token.split(".");
+    if (parts.length !== 3) {
+      return null;
+    }
+    const payload = parts[1];
+    const decoded = Buffer.from(payload, "base64url").toString("utf-8");
+    return JSON.parse(decoded) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract the issuer from a JWT token's payload.
+ *
+ * @param token - The JWT token string.
+ * @returns The issuer claim value, or null if it cannot be extracted.
+ */
+export function extractJwtIssuer(token: string): string | null {
+  const payload = decodeJwtPayload(token);
+  if (!payload || typeof payload.iss !== "string") {
+    return null;
+  }
+  return payload.iss;
+}
+
+/**
+ * Normalize an issuer URL for comparison by removing https:// prefix and trailing slash.
+ *
+ * @param issuer - The issuer URL from a JWT or Auth0 domain.
+ * @returns Normalized issuer host (domain only).
+ */
+function normalizeIssuerHost(issuer: string): string {
+  return issuer.replace(/^https:\/\//, "").replace(/\/$/, "");
+}
+
+/**
  * Decide whether a stored session may be used for the active runtime target.
  *
  * A session carrying no target predates targets being recorded, and can only be
  * a production one: every build able to write it pointed at production.
+ *
+ * Additionally, validates that the stored session's token issuer matches the expected
+ * Auth0 domain for the active target. This prevents using tokens minted by a different
+ * Auth0 tenant.
+ *
  * @param params - Session ownership parameters.
  * @param params.storedRuntimeTarget - Target recorded on the session, if any.
  * @param params.activeRuntimeTarget - Target the harness is running as.
- * @returns True when the session belongs to the active target.
+ * @param params.tokenIssuer - Issuer claim extracted from the access token, if available.
+ * @param params.expectedAuth0Domain - The Auth0 domain configured for the active target.
+ * @returns True when the session belongs to the active target and was issued by the correct tenant.
  */
 export function isStoredAuthForRuntimeTarget(params: {
   storedRuntimeTarget?: RuntimeTarget;
   activeRuntimeTarget: RuntimeTarget;
+  tokenIssuer?: string | null;
+  expectedAuth0Domain?: string;
 }): boolean {
+  // Checked before the target comparison because it is independent of it: a session
+  // whose target is absent or mis-stamped is exactly the case a foreign-tenant token
+  // produces, so deferring this until after the target matches would skip it there.
+  if (params.tokenIssuer && params.expectedAuth0Domain) {
+    const issuerHost = normalizeIssuerHost(params.tokenIssuer);
+    const expectedHost = normalizeIssuerHost(params.expectedAuth0Domain);
+    if (issuerHost !== expectedHost) {
+      return false;
+    }
+  }
+
   if (!params.storedRuntimeTarget) {
     return params.activeRuntimeTarget === RuntimeTarget.Production;
   }
+
   return params.storedRuntimeTarget === params.activeRuntimeTarget;
 }

--- a/packages/mcps/src/shared/runtime-target-types.ts
+++ b/packages/mcps/src/shared/runtime-target-types.ts
@@ -33,6 +33,8 @@ export interface IRuntimeTargetProfile {
   promptServiceBaseUrl: string;
   /** Base URL of the dashboard web app for this target, without a trailing slash. */
   uiBaseUrl: string;
+  /** Base URL for PR dashboard links (e.g., dashboard projects list), without a trailing slash. */
+  dashboardBaseUrl: string;
   /** Auth0 domain used for the device code login flow. */
   auth0Domain: string;
   /** Auth0 client ID for the device code grant. Empty when the target has no provisioned client. */

--- a/packages/mcps/src/test/stored-auth-target.test.ts
+++ b/packages/mcps/src/test/stored-auth-target.test.ts
@@ -1,54 +1,234 @@
 import { describe, expect, it } from "vitest";
 
-import { isStoredAuthForRuntimeTarget } from "../mcp/local/services/stored-auth-target.js";
 import { RuntimeTarget } from "../shared/runtime-target-types.js";
+import {
+  decodeJwtPayload,
+  extractJwtIssuer,
+  isStoredAuthForRuntimeTarget,
+} from "../mcp/local/services/stored-auth-target.js";
+
+/**
+ * Create a mock JWT token with the given issuer claim.
+ * @param iss - The issuer value to encode.
+ * @returns A JWT-shaped token string (no signature validation).
+ */
+function createMockJwt(iss: string): string {
+  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
+  const payload = Buffer.from(JSON.stringify({ iss, sub: "user123", aud: "test" })).toString("base64url");
+  const signature = "mock_signature";
+  return `${header}.${payload}.${signature}`;
+}
+
+describe("JWT decoding utilities", () => {
+  describe("decodeJwtPayload", () => {
+    it("decodes a valid JWT payload", () => {
+      const token = createMockJwt("https://login.muggle-ai.com/");
+      const payload = decodeJwtPayload(token);
+      expect(payload).not.toBeNull();
+      expect(payload?.iss).toBe("https://login.muggle-ai.com/");
+    });
+
+    it("returns null for an invalid token (wrong part count)", () => {
+      const invalidToken = "invalid.token";
+      const payload = decodeJwtPayload(invalidToken);
+      expect(payload).toBeNull();
+    });
+
+    it("returns null for malformed base64url payload", () => {
+      const invalidToken = "header.!!!invalid!!!.signature";
+      const payload = decodeJwtPayload(invalidToken);
+      expect(payload).toBeNull();
+    });
+
+    it("returns null for invalid JSON in payload", () => {
+      const header = "header";
+      const invalidPayload = Buffer.from("not valid json").toString("base64url");
+      const invalidToken = `${header}.${invalidPayload}.signature`;
+      const payload = decodeJwtPayload(invalidToken);
+      expect(payload).toBeNull();
+    });
+  });
+
+  describe("extractJwtIssuer", () => {
+    it("extracts the issuer from a valid JWT", () => {
+      const token = createMockJwt("https://login.muggle-ai.com/");
+      const issuer = extractJwtIssuer(token);
+      expect(issuer).toBe("https://login.muggle-ai.com/");
+    });
+
+    it("returns null when the token is invalid", () => {
+      const issuer = extractJwtIssuer("invalid.token");
+      expect(issuer).toBeNull();
+    });
+
+    it("returns null when the issuer claim is missing", () => {
+      const header = Buffer.from(JSON.stringify({ alg: "RS256" })).toString("base64url");
+      const payload = Buffer.from(JSON.stringify({ sub: "user123" })).toString("base64url");
+      const token = `${header}.${payload}.signature`;
+      const issuer = extractJwtIssuer(token);
+      expect(issuer).toBeNull();
+    });
+
+    it("returns null when the issuer claim is not a string", () => {
+      const header = Buffer.from(JSON.stringify({ alg: "RS256" })).toString("base64url");
+      const payload = Buffer.from(JSON.stringify({ iss: 12345 })).toString("base64url");
+      const token = `${header}.${payload}.signature`;
+      const issuer = extractJwtIssuer(token);
+      expect(issuer).toBeNull();
+    });
+  });
+});
 
 describe("isStoredAuthForRuntimeTarget", () => {
-  it("accepts a session recorded for the active target", () => {
-    expect(
-      isStoredAuthForRuntimeTarget({
-        storedRuntimeTarget: RuntimeTarget.Staging,
-        activeRuntimeTarget: RuntimeTarget.Staging,
-      }),
-    ).toBe(true);
+  const productionDomain = "login.muggle-ai.com";
+  const stagingDomain = "login.staging.muggle-ai.com";
+
+  it("accepts a session with no recorded target on production", () => {
+    const result = isStoredAuthForRuntimeTarget({
+      storedRuntimeTarget: undefined,
+      activeRuntimeTarget: RuntimeTarget.Production,
+    });
+    expect(result).toBe(true);
   });
 
-  // The production tenant's token is rejected by the staging backend with a
-  // 401, so reporting it as an authenticated staging session describes a state
-  // that cannot make a single successful call.
-  it("rejects a production session while running as staging", () => {
-    expect(
-      isStoredAuthForRuntimeTarget({
-        storedRuntimeTarget: RuntimeTarget.Production,
-        activeRuntimeTarget: RuntimeTarget.Staging,
-      }),
-    ).toBe(false);
+  it("rejects a session with no recorded target on staging", () => {
+    const result = isStoredAuthForRuntimeTarget({
+      storedRuntimeTarget: undefined,
+      activeRuntimeTarget: RuntimeTarget.Staging,
+    });
+    expect(result).toBe(false);
   });
 
-  it("rejects a staging session while running as production", () => {
-    expect(
-      isStoredAuthForRuntimeTarget({
-        storedRuntimeTarget: RuntimeTarget.Staging,
-        activeRuntimeTarget: RuntimeTarget.Production,
-      }),
-    ).toBe(false);
+  it("accepts a matching target without issuer validation", () => {
+    const result = isStoredAuthForRuntimeTarget({
+      storedRuntimeTarget: RuntimeTarget.Production,
+      activeRuntimeTarget: RuntimeTarget.Production,
+    });
+    expect(result).toBe(true);
   });
 
-  it("accepts an unrecorded session as production, the only ring that could have written it", () => {
-    expect(
-      isStoredAuthForRuntimeTarget({
-        storedRuntimeTarget: undefined,
-        activeRuntimeTarget: RuntimeTarget.Production,
-      }),
-    ).toBe(true);
+  it("rejects a mismatched target regardless of issuer", () => {
+    const token = createMockJwt("https://login.muggle-ai.com/");
+    const issuer = extractJwtIssuer(token);
+    const result = isStoredAuthForRuntimeTarget({
+      storedRuntimeTarget: RuntimeTarget.Production,
+      activeRuntimeTarget: RuntimeTarget.Staging,
+      tokenIssuer: issuer,
+      expectedAuth0Domain: stagingDomain,
+    });
+    expect(result).toBe(false);
   });
 
-  it("rejects an unrecorded session on every other ring", () => {
-    expect(
-      isStoredAuthForRuntimeTarget({
-        storedRuntimeTarget: undefined,
-        activeRuntimeTarget: RuntimeTarget.Staging,
-      }),
-    ).toBe(false);
+  it("accepts a matching target with matching issuer", () => {
+    const token = createMockJwt("https://login.muggle-ai.com/");
+    const issuer = extractJwtIssuer(token);
+    const result = isStoredAuthForRuntimeTarget({
+      storedRuntimeTarget: RuntimeTarget.Production,
+      activeRuntimeTarget: RuntimeTarget.Production,
+      tokenIssuer: issuer,
+      expectedAuth0Domain: productionDomain,
+    });
+    expect(result).toBe(true);
+  });
+
+  it("rejects a matching target with mismatched issuer", () => {
+    const token = createMockJwt("https://login.staging.muggle-ai.com/");
+    const issuer = extractJwtIssuer(token);
+    const result = isStoredAuthForRuntimeTarget({
+      storedRuntimeTarget: RuntimeTarget.Production,
+      activeRuntimeTarget: RuntimeTarget.Production,
+      tokenIssuer: issuer,
+      expectedAuth0Domain: productionDomain,
+    });
+    expect(result).toBe(false);
+  });
+
+  it("normalizes issuer URL by removing https:// and trailing slash", () => {
+    const token = createMockJwt("https://login.muggle-ai.com/");
+    const issuer = extractJwtIssuer(token);
+    const result = isStoredAuthForRuntimeTarget({
+      storedRuntimeTarget: RuntimeTarget.Production,
+      activeRuntimeTarget: RuntimeTarget.Production,
+      tokenIssuer: issuer,
+      expectedAuth0Domain: "login.muggle-ai.com",
+    });
+    expect(result).toBe(true);
+  });
+
+  it("accepts matching target when token issuer is absent (no rejection on missing info)", () => {
+    const result = isStoredAuthForRuntimeTarget({
+      storedRuntimeTarget: RuntimeTarget.Production,
+      activeRuntimeTarget: RuntimeTarget.Production,
+      tokenIssuer: null,
+      expectedAuth0Domain: productionDomain,
+    });
+    expect(result).toBe(true);
+  });
+
+  it("accepts matching target when expected domain is absent (no rejection on missing info)", () => {
+    const token = createMockJwt("https://login.muggle-ai.com/");
+    const issuer = extractJwtIssuer(token);
+    const result = isStoredAuthForRuntimeTarget({
+      storedRuntimeTarget: RuntimeTarget.Production,
+      activeRuntimeTarget: RuntimeTarget.Production,
+      tokenIssuer: issuer,
+      expectedAuth0Domain: undefined,
+    });
+    expect(result).toBe(true);
+  });
+
+  it("detects issuer mismatch for staging token on production", () => {
+    const token = createMockJwt("https://login.staging.muggle-ai.com/");
+    const issuer = extractJwtIssuer(token);
+    const result = isStoredAuthForRuntimeTarget({
+      storedRuntimeTarget: RuntimeTarget.Production,
+      activeRuntimeTarget: RuntimeTarget.Production,
+      tokenIssuer: issuer,
+      expectedAuth0Domain: productionDomain,
+    });
+    expect(result).toBe(false);
+  });
+
+  it("handles issuer without https:// prefix", () => {
+    const token = createMockJwt("login.muggle-ai.com/");
+    const issuer = extractJwtIssuer(token);
+    const result = isStoredAuthForRuntimeTarget({
+      storedRuntimeTarget: RuntimeTarget.Production,
+      activeRuntimeTarget: RuntimeTarget.Production,
+      tokenIssuer: issuer,
+      expectedAuth0Domain: "https://login.muggle-ai.com",
+    });
+    expect(result).toBe(true);
+  });
+  it("rejects an untargeted session whose token came from another tenant", () => {
+    const token = createMockJwt("https://login.staging.muggle-ai.com/");
+    const result = isStoredAuthForRuntimeTarget({
+      storedRuntimeTarget: undefined,
+      activeRuntimeTarget: RuntimeTarget.Production,
+      tokenIssuer: extractJwtIssuer(token),
+      expectedAuth0Domain: "https://login.muggle-ai.com/",
+    });
+    expect(result).toBe(false);
+  });
+
+  it("still accepts an untargeted session when its issuer matches", () => {
+    const token = createMockJwt("https://login.muggle-ai.com/");
+    const result = isStoredAuthForRuntimeTarget({
+      storedRuntimeTarget: undefined,
+      activeRuntimeTarget: RuntimeTarget.Production,
+      tokenIssuer: extractJwtIssuer(token),
+      expectedAuth0Domain: "https://login.muggle-ai.com/",
+    });
+    expect(result).toBe(true);
+  });
+
+  it("still accepts an untargeted session when no issuer can be read", () => {
+    const result = isStoredAuthForRuntimeTarget({
+      storedRuntimeTarget: undefined,
+      activeRuntimeTarget: RuntimeTarget.Production,
+      tokenIssuer: null,
+      expectedAuth0Domain: "https://login.muggle-ai.com/",
+    });
+    expect(result).toBe(true);
   });
 });

--- a/src/cli/build-pr-section.ts
+++ b/src/cli/build-pr-section.ts
@@ -40,7 +40,7 @@ const withSentinel = <T extends string | null>(s: T): T =>
 async function resolveDashboardBaseUrl (stderrWrite: (s: string) => void): Promise<string> {
   try {
     const mcps = await import("../../packages/mcps/src/index.js");
-    return `${mcps.resolveActiveProfile().uiBaseUrl}/dashboard/projects`;
+    return mcps.resolveActiveProfile().dashboardBaseUrl;
   } catch (err) {
     stderrWrite(
       `build-pr-section: could not resolve the runtime target, linking to production: ${errMsg(err)}\n`,


### PR DESCRIPTION
## What

Two fixes to how the client resolves its runtime target.

## The guard could not detect a foreign tenant

`isStoredAuthForRuntimeTarget` compared the session's recorded `runtimeTarget` against the active
one. Both derive from the same value that selected which session file to read, so the comparison was
circular — it could never detect a session minted by a different Auth0 tenant.

That matters because `AUTH0_DOMAIN` / `AUTH0_CLIENT_ID` / `AUTH0_AUDIENCE` move the identity tenant
**without** moving which session file gets written. A login performed against one tenant is therefore
stamped with the other target and passes the guard from then on. The two tenants are genuinely
distinct — `login.muggle-ai.com` and `login.staging.muggle-ai.com` issue different `sub` values for
the same account.

The guard now also compares the access token's `iss` against the Auth0 domain configured for the
active target, matched host-to-host so a `https://` prefix or trailing slash does not matter. The
JWT payload is decoded without signature verification: this is a local consistency check, not an
authentication decision, and it adds no dependency.

**It fails open on missing information.** An unreadable token, an absent `iss`, or an unconfigured
domain all keep the previous behaviour, so no existing session is invalidated on upgrade. Only a
genuine mismatch rejects.

The issuer check runs *before* the target comparison, because it is independent of it — a session
whose target is absent or mis-stamped is exactly what a foreign-tenant token produces, so checking it
only after the targets already agree would skip the case the fix exists for.

## Dashboard links were pinned to production

`DASHBOARD_URL_BASE` hardcoded the production host, so a walkthrough rendered on another ring emitted
links into an environment the run never touched. The base now comes from the active runtime target
via a new `dashboardBaseUrl` per target, with the production constant kept as the fallback for a
caller that resolves no profile. `render.ts` stays pure as its header documents — the resolved base is
passed in rather than read from config.

## Verification

- `pnpm lint:workspace`: exit 0
- `pnpm test:workspace`: exit 0 — 267 across the mcp package, 4 in workflows, including 22 covering
  the guard (issuer match, mismatch, unreadable token, URL normalisation, and the untargeted-session
  paths).
- `pnpm typecheck:workspace`: exits 2, and **does so identically on a clean `master`** — 12 `TS6305`
  errors from an unbuilt `packages/mcps/dist/index.d.ts` under TypeScript project references. This is
  pre-existing build-state, unrelated to this change, and none of the errors are in touched files. It
  is called out here so a reviewer does not read it as a regression.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sBg9bQZ6oPY3E2jc4idnc
