### PR TITLE
fix(browser-bench): keep the judge retrying, and make the step budget disclose itself

### DIFF
--- a/internal/browser-bench/src/cli/args.test.ts
+++ b/internal/browser-bench/src/cli/args.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { DEFAULT_CONCURRENCY } from "../domain/constants";
+import { DEFAULT_CONCURRENCY, MAX_STEPS_PER_TASK } from "../domain/constants";
 import { parseCliArgs } from "./args";
 
 const parse = (argv: string[]) =>
@@ -16,6 +16,7 @@ describe("parseCliArgs", () => {
       concurrency: DEFAULT_CONCURRENCY,
       outDir: "/defaults/reports",
       resume: false,
+      maxSteps: MAX_STEPS_PER_TASK,
     });
   });
 
@@ -28,6 +29,7 @@ describe("parseCliArgs", () => {
       concurrency: 4,
       outDir: "/tmp/run",
       resume: false,
+      maxSteps: MAX_STEPS_PER_TASK,
     });
   });
 
@@ -61,5 +63,29 @@ describe("parseCliArgs", () => {
 
   it("rejects a zero count", () => {
     expect(() => parse(["--concurrency", "0"])).toThrow(/positive whole number/);
+  });
+});
+
+describe("step budget flag", () => {
+  it("defaults to WebVoyager's own cap so results stay comparable", () => {
+    expect(
+      parseCliArgs({ argv: [], defaultTasksPath: "t.jsonl", defaultOutDir: "out" }).maxSteps,
+    ).toBe(MAX_STEPS_PER_TASK);
+  });
+
+  it("accepts a raised budget, which the report then has to disclose", () => {
+    expect(
+      parseCliArgs({
+        argv: ["--max-steps", "30"],
+        defaultTasksPath: "t.jsonl",
+        defaultOutDir: "out",
+      }).maxSteps,
+    ).toBe(30);
+  });
+
+  it("rejects a budget that is not a positive whole number", () => {
+    expect(() =>
+      parseCliArgs({ argv: ["--max-steps", "0"], defaultTasksPath: "t.jsonl", defaultOutDir: "out" }),
+    ).toThrow(/max-steps/i);
   });
 });

--- a/internal/browser-bench/src/cli/args.ts
+++ b/internal/browser-bench/src/cli/args.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_CONCURRENCY } from "../domain/constants";
+import { DEFAULT_CONCURRENCY, MAX_STEPS_PER_TASK } from "../domain/constants";
 import { CliFlag, type BenchmarkCliOptions } from "./types";
 
 const readFlagValue = (argv: string[], flagIndex: number): string => {
@@ -44,6 +44,7 @@ export const parseCliArgs = ({
     concurrency: DEFAULT_CONCURRENCY,
     outDir: defaultOutDir,
     resume: false,
+    maxSteps: MAX_STEPS_PER_TASK,
   };
 
   let index = 0;
@@ -68,6 +69,9 @@ export const parseCliArgs = ({
         break;
       case CliFlag.Concurrency:
         options.concurrency = readPositiveInteger(argv, index);
+        break;
+      case CliFlag.MaxSteps:
+        options.maxSteps = readPositiveInteger(argv, index);
         break;
       default:
         throw new Error(`Unknown flag ${flag}. Accepted: ${Object.values(CliFlag).join(", ")}.`);

--- a/internal/browser-bench/src/cli/types.ts
+++ b/internal/browser-bench/src/cli/types.ts
@@ -5,6 +5,7 @@ export enum CliFlag {
   Concurrency = "--concurrency",
   Out = "--out",
   Resume = "--resume",
+  MaxSteps = "--max-steps",
 }
 
 /** One benchmark run's configuration, with every default already resolved. */
@@ -15,4 +16,6 @@ export interface BenchmarkCliOptions {
   concurrency: number;
   outDir: string;
   resume: boolean;
+  /** Steps an agent may take per task. Defaults to WebVoyager's own cap. */
+  maxSteps: number;
 }

--- a/internal/browser-bench/src/judge/constants.ts
+++ b/internal/browser-bench/src/judge/constants.ts
@@ -22,3 +22,10 @@ export const JUDGE_API_KEY_ENV_VAR = "ANTHROPIC_API_KEY";
 
 /** Studio writes the judge's input manifest here, inside each task's trajectory directory. */
 export const TRAJECTORY_MANIFEST_FILENAME = "trajectory.json";
+
+/**
+ * Judge retries before an attempt is abandoned. Well above the SDK default of 2:
+ * a 529 that outlasts the retries costs the task its verdict and removes it from
+ * the pass-rate denominator, which is a worse outcome than waiting.
+ */
+export const JUDGE_MAX_RETRIES = 8;

--- a/internal/browser-bench/src/report/report.test.ts
+++ b/internal/browser-bench/src/report/report.test.ts
@@ -42,3 +42,29 @@ describe("renderReport", () => {
     expect(markdown).toContain("**Total tokens:** 1000");
   });
 });
+
+describe("step budget disclosure", () => {
+  const result = {
+    taskId: "T--0",
+    outcome: BenchmarkOutcome.Pass,
+    finalAnswer: "a",
+    studioStatus: "success",
+    stepCount: 3,
+    durationMs: 10,
+    tokensUsed: 5,
+    trajectoryDir: "d",
+  };
+
+  it("states the step budget the run used", () => {
+    // A pass rate is only comparable to a published one at the same budget, so
+    // the number and the budget that produced it travel together.
+    expect(renderReport([result], { maxSteps: 15 })).toMatch(/step budget.*15/i);
+  });
+
+  it("marks a raised budget as a deviation rather than leaving it to a footnote", () => {
+    const rendered = renderReport([result], { maxSteps: 30 });
+
+    expect(rendered).toMatch(/30/);
+    expect(rendered).toMatch(/not comparable|deviat/i);
+  });
+});

--- a/internal/browser-bench/src/report/report.ts
+++ b/internal/browser-bench/src/report/report.ts
@@ -1,3 +1,4 @@
+import { MAX_STEPS_PER_TASK } from "../domain/constants";
 import { BenchmarkOutcome, type TaskResult } from "../domain/types";
 
 /**
@@ -8,10 +9,21 @@ import { BenchmarkOutcome, type TaskResult } from "../domain/types";
  * capability regression. This differs from how most published browser-agent
  * scores are computed, so any published number must say so.
  *
+ * The step budget is printed beside the pass rate, and a budget above
+ * WebVoyager's own cap is labelled a deviation in the same line as the score.
+ * A raised budget makes the number incomparable to every published result, and
+ * a caveat that lives only in the surrounding prose is a caveat that gets
+ * dropped the first time someone quotes the figure.
+ *
  * Output shape: a Markdown document opening with
  * `**Pass rate:** 50.0% (scored 2, infrastructure errors 1)`.
+ *
+ * @param params.maxSteps - Steps each task was allowed.
  */
-export const renderReport = (results: TaskResult[]): string => {
+export const renderReport = (
+  results: TaskResult[],
+  { maxSteps }: { maxSteps: number } = { maxSteps: MAX_STEPS_PER_TASK },
+): string => {
   const passes = results.filter((result) => result.outcome === BenchmarkOutcome.Pass).length;
   const fails = results.filter((result) => result.outcome === BenchmarkOutcome.Fail).length;
   const errors = results.filter((result) => result.outcome === BenchmarkOutcome.Error).length;
@@ -23,6 +35,11 @@ export const renderReport = (results: TaskResult[]): string => {
     `# Browser-capability benchmark`,
     ``,
     `**Pass rate:** ${passRate.toFixed(1)}% (scored ${scored}, infrastructure errors ${errors})`,
+    `**Step budget:** ${maxSteps}${
+      maxSteps > MAX_STEPS_PER_TASK
+        ? ` — raised above WebVoyager's cap of ${MAX_STEPS_PER_TASK}; this score is NOT comparable to published WebVoyager results`
+        : ""
+    }`,
     `**Total tokens:** ${totalTokens}`,
     ``,
     `| Task | Outcome | Steps | Duration (ms) | Tokens |`,

--- a/internal/browser-bench/src/run.ts
+++ b/internal/browser-bench/src/run.ts
@@ -5,7 +5,6 @@ import { fileURLToPath } from "node:url";
 
 import { parseCliArgs } from "./cli/args";
 import {
-  MAX_STEPS_PER_TASK,
   PARTIAL_LOG_FILENAME,
   REPORT_FILENAME,
   TASK_TIMEOUT_MS,
@@ -21,6 +20,7 @@ import {
 import { renderReport } from "./report/report";
 import {
   JUDGE_API_KEY_ENV_VAR,
+  JUDGE_MAX_RETRIES,
   TRAJECTORY_MANIFEST_FILENAME,
 } from "./judge/constants";
 import { createClaudeJudgeInvoker } from "./judge/claude-judge";
@@ -94,7 +94,13 @@ const mainAsync = async (): Promise<void> => {
         `Export it before running the benchmark.`,
     );
   }
-  const invokeJudgeAsync = createClaudeJudgeInvoker({ client: new Anthropic() });
+  // The SDK's default of two retries was not enough: a busy hour returned 529
+  // Overloaded past it and cost two tasks their verdict, which excludes them
+  // from the denominator. A judge that gives up shrinks the evidence behind the
+  // score, so it retries well past the point of politeness.
+  const invokeJudgeAsync = createClaudeJudgeInvoker({
+    client: new Anthropic({ maxRetries: JUDGE_MAX_RETRIES }),
+  });
 
   // One profile for the whole batch. Studio authenticates with its own client
   // credentials and reads this only for identity, so there is nothing per-task
@@ -117,7 +123,7 @@ const mainAsync = async (): Promise<void> => {
           outDir: options.outDir,
           studioBinPath: studioBinPath,
           authFilePath: authFilePath,
-          maxSteps: MAX_STEPS_PER_TASK,
+          maxSteps: options.maxSteps,
           taskTimeoutMs: TASK_TIMEOUT_MS,
           spawnStudio: spawnStudioProcess,
           fileSystem: nodeTaskFileSystem,
@@ -158,7 +164,7 @@ const mainAsync = async (): Promise<void> => {
     tasks: tasks,
     results: [...resumedResults, ...freshResults],
   });
-  fs.writeFileSync(reportPath, `${renderReport(orderedResults)}\n`, "utf8");
+  fs.writeFileSync(reportPath, `${renderReport(orderedResults, { maxSteps: options.maxSteps })}\n`, "utf8");
 
   process.stdout.write(`Report: ${reportPath}\n`);
 };


### PR DESCRIPTION
Two fixes from the first 100-task run.

**The judge gave up too early.** Two tasks lost their verdict to HTTP 529 Overloaded,
which exhausted the SDK's default of two retries. A judge that gives up does not score
a task as failed — it removes it from the pass-rate denominator entirely, shrinking the
evidence behind the number while the percentage carries on looking healthy. Retries are
now 8, well past the point of politeness, because waiting is strictly better than
discarding a task that ran fine.

**The step budget is now a flag, and the report discloses it.** `--max-steps` defaults
to WebVoyager's own cap of 15, and the report prints the budget beside the pass rate.
Above 15 it prints, on that same line, that the score is not comparable to published
WebVoyager results.

The disclosure is deliberately in the output rather than in surrounding prose. A raised
budget makes the number incomparable to every published result, and a caveat that lives
in a commit message or a chat thread is one that gets dropped the first time someone
quotes the figure. Putting it in the artifact means the number cannot travel without it.

Context: 22 of 94 scored tasks in the first run exhausted the 15-step budget and only 4
of those passed, so the budget is a live variable rather than a formality.

Verified: `npx vitest run internal/browser-bench` — 85 tests across 13 files, all green. `npm run typecheck:browser-bench` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AzJ1mPrJ5YqZ4SEcqnZbT