### PR TITLE
feat(browser-bench): draw the benchmark slice from a seed

### DIFF
--- a/internal/browser-bench/README.md
+++ b/internal/browser-bench/README.md
@@ -2,9 +2,10 @@
 
 Internal harness that measures the browser agent against
 [WebVoyager](https://github.com/MinorJerry/WebVoyager) — 643 open-web tasks over
-15 live sites. It runs one studio process per task, records what studio reports,
-and renders a batch report. Judging is a separate later pass, so `judgeVerdict`
-stays unset here and the reported outcome is studio's own claim.
+15 live sites. It runs one studio process per task, judges the trajectory, and
+renders a batch report. Studio's own `studioStatus` is recorded for diagnosis but
+never scores the run — the outcome comes from the judge reading the final answer
+against the screenshots.
 
 ## Running
 
@@ -19,6 +20,13 @@ tsx internal/browser-bench/src/run.ts [flags]
 | `--concurrency <n>` | `2` | Parallel studio processes |
 | `--out <dir>` | `reports/` | Where trajectories, profiles, and the report land |
 | `--resume` | off | Skip tasks already recorded in `<out>/partial.jsonl` |
+| `--max-steps <n>` | `15` | Steps an agent may take per task |
+| `--sample-size <n>` | whole file | Draw a site-stratified sample of `n` tasks |
+| `--sample-seed <n>` | — | Seed for that draw; required with `--sample-size` |
+
+Raising `--max-steps` above WebVoyager's cap of 15 makes the score
+incomparable to published WebVoyager results, so the report says so in its
+header whenever it is raised.
 
 Concurrency is memory-bound: every task is a full Electron instance, so raising
 it past what the machine's RAM allows makes tasks fail for reasons the benchmark
@@ -81,7 +89,9 @@ any other status a fail. A non-zero exit, a missing or unreadable result file,
 or outliving `TASK_TIMEOUT_MS` (10 minutes) kills the process and records an
 infrastructure error instead, which is excluded from the pass-rate denominator.
 
-`tokensUsed` is recorded as `0`: studio does not report token spend yet.
+`tokensUsed` carries studio's reported spend for the attempt, so a score is
+always reportable next to what it cost. A build that predates token reporting
+omits the field and records `0` rather than failing the parse.
 
 ### Environment
 
@@ -115,6 +125,20 @@ curl -L -o /tmp/WebVoyager_data.jsonl \
 tsx internal/browser-bench/src/run.ts --tasks /tmp/WebVoyager_data.jsonl --out /tmp/wv-full
 ```
 
+### Reproducible slices
+
+The full 643 tasks take a long time and a lot of tokens, so a measurement
+usually runs a sample. Draw it by seed rather than by hand:
+
+```
+tsx internal/browser-bench/src/run.ts   --tasks /tmp/WebVoyager_data.jsonl --sample-size 100 --sample-seed 20260906
+```
+
+Each site keeps its share of the sample, so the slice exercises the same breadth
+of page structures as the full set. The draw depends on the seed alone, so
+quoting the seed is enough for anyone to rebuild the exact task list a score was
+measured on — no slice file to pass around, and nothing to drift.
+
 WebVoyager tasks run against the live web, so some are unanswerable on any given
 day — a site redesign, a paywall, or a deleted page. Published WebVoyager scores
 carry the same caveat.
@@ -131,7 +155,7 @@ internal/browser-bench/
     partial-log/    partial.jsonl round-trip, resume filter, result ordering
     report/         Markdown report
     studio/         the spawn contract: task/result files, runner, node adapters
-    task-source/    WebVoyager JSONL loader
-    judge/          WebVoyager judge protocol (not yet wired into a run)
+    task-source/    WebVoyager JSONL loader and the stratified sampler
+    judge/          WebVoyager judge protocol, run as each task lands
     run.ts          CLI entrypoint
 ```

--- a/internal/browser-bench/src/cli/args.test.ts
+++ b/internal/browser-bench/src/cli/args.test.ts
@@ -89,3 +89,32 @@ describe("step budget flag", () => {
     ).toThrow(/max-steps/i);
   });
 });
+
+describe("sampling flags", () => {
+  const parse = (argv: string[]) =>
+    parseCliArgs({ argv: argv, defaultTasksPath: "t.jsonl", defaultOutDir: "out" });
+
+  it("leaves sampling off by default, so the task file runs as given", () => {
+    expect(parse([]).sampleSize).toBeUndefined();
+    expect(parse([]).sampleSeed).toBeUndefined();
+  });
+
+  it("accepts a size and seed together", () => {
+    const options = parse(["--sample-size", "100", "--sample-seed", "20260906"]);
+
+    expect(options.sampleSize).toBe(100);
+    expect(options.sampleSeed).toBe(20260906);
+  });
+
+  it("refuses a sample size with no seed, which would be irreproducible", () => {
+    expect(() => parse(["--sample-size", "100"])).toThrow(/must be given together/);
+  });
+
+  it("refuses a seed with no sample size", () => {
+    expect(() => parse(["--sample-seed", "7"])).toThrow(/must be given together/);
+  });
+
+  it("rejects a sample size that is not a positive whole number", () => {
+    expect(() => parse(["--sample-size", "0", "--sample-seed", "7"])).toThrow(/sample-size/i);
+  });
+});

--- a/internal/browser-bench/src/cli/args.ts
+++ b/internal/browser-bench/src/cli/args.ts
@@ -9,6 +9,15 @@ const readFlagValue = (argv: string[], flagIndex: number): string => {
   return value;
 };
 
+const readInteger = (argv: string[], flagIndex: number): number => {
+  const rawValue = readFlagValue(argv, flagIndex);
+  const parsedValue = Number(rawValue);
+  if (!Number.isInteger(parsedValue)) {
+    throw new Error(`${argv[flagIndex]} needs a whole number, got "${rawValue}".`);
+  }
+  return parsedValue;
+};
+
 const readPositiveInteger = (argv: string[], flagIndex: number): number => {
   const rawValue = readFlagValue(argv, flagIndex);
   const parsedValue = Number(rawValue);
@@ -73,11 +82,26 @@ export const parseCliArgs = ({
       case CliFlag.MaxSteps:
         options.maxSteps = readPositiveInteger(argv, index);
         break;
+      case CliFlag.SampleSize:
+        options.sampleSize = readPositiveInteger(argv, index);
+        break;
+      case CliFlag.SampleSeed:
+        options.sampleSeed = readInteger(argv, index);
+        break;
       default:
         throw new Error(`Unknown flag ${flag}. Accepted: ${Object.values(CliFlag).join(", ")}.`);
     }
 
     index += 2;
+  }
+
+  // A sample without a seed cannot be regenerated, which makes the score it
+  // produces impossible to check. Refuse rather than invent a seed.
+  if ((options.sampleSize === undefined) !== (options.sampleSeed === undefined)) {
+    throw new Error(
+      `${CliFlag.SampleSize} and ${CliFlag.SampleSeed} must be given together — ` +
+        `a sample drawn without a recorded seed cannot be reproduced.`,
+    );
   }
 
   return options;

--- a/internal/browser-bench/src/cli/types.ts
+++ b/internal/browser-bench/src/cli/types.ts
@@ -6,6 +6,8 @@ export enum CliFlag {
   Out = "--out",
   Resume = "--resume",
   MaxSteps = "--max-steps",
+  SampleSize = "--sample-size",
+  SampleSeed = "--sample-seed",
 }
 
 /** One benchmark run's configuration, with every default already resolved. */
@@ -18,4 +20,8 @@ export interface BenchmarkCliOptions {
   resume: boolean;
   /** Steps an agent may take per task. Defaults to WebVoyager's own cap. */
   maxSteps: number;
+  /** Absent means run the task file as given, with no sampling. */
+  sampleSize?: number;
+  /** Selects the draw. Required whenever `sampleSize` is set, so a slice is always reproducible. */
+  sampleSeed?: number;
 }

--- a/internal/browser-bench/src/run.ts
+++ b/internal/browser-bench/src/run.ts
@@ -39,6 +39,7 @@ import { resolveBenchmarkSessionPath } from "./studio/benchmark-session";
 import { spawnStudioProcess } from "./studio/node-studio-spawn";
 import { runStudioTaskAsync } from "./studio/studio-runner";
 import { loadWebVoyagerTasks } from "./task-source/webvoyager-source";
+import { selectStratifiedSample } from "./task-source/stratified-sample";
 
 const TOOL_DIR = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -61,10 +62,19 @@ const mainAsync = async (): Promise<void> => {
   const allTasks = loadWebVoyagerTasks(
     fs.readFileSync(options.tasksPath, "utf8"),
   );
+  // Sampling picks which tasks; --limit then truncates whatever that produced.
+  const selectedTasks =
+    options.sampleSize === undefined
+      ? allTasks
+      : selectStratifiedSample({
+          tasks: allTasks,
+          sampleSize: options.sampleSize,
+          seed: options.sampleSeed!,
+        });
   const tasks =
     options.taskLimit === undefined
-      ? allTasks
-      : allTasks.slice(0, options.taskLimit);
+      ? selectedTasks
+      : selectedTasks.slice(0, options.taskLimit);
 
   fs.mkdirSync(options.outDir, { recursive: true });
   const partialLogPath = path.join(options.outDir, PARTIAL_LOG_FILENAME);

--- a/internal/browser-bench/src/task-source/stratified-sample.test.ts
+++ b/internal/browser-bench/src/task-source/stratified-sample.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import { type BenchmarkTask } from "../domain/types";
+import { selectStratifiedSample } from "./stratified-sample";
+
+const buildTasks = (siteSizes: Record<string, number>): BenchmarkTask[] =>
+  Object.entries(siteSizes).flatMap(([siteName, size]) =>
+    Array.from({ length: size }, (_unused, index) => ({
+      taskId: `${siteName}--${index}`,
+      siteName: siteName,
+      instruction: `do thing ${index}`,
+      startUrl: `https://${siteName.toLowerCase()}.example`,
+    })),
+  );
+
+const countBySite = (tasks: BenchmarkTask[]): Record<string, number> =>
+  tasks.reduce<Record<string, number>>((counts, task) => {
+    counts[task.siteName] = (counts[task.siteName] ?? 0) + 1;
+    return counts;
+  }, {});
+
+const taskIds = (tasks: BenchmarkTask[]): string[] => tasks.map((task) => task.taskId);
+
+describe("selectStratifiedSample", () => {
+  it("returns the same tasks for the same seed", () => {
+    const tasks = buildTasks({ Alpha: 40, Beta: 30, Gamma: 30 });
+
+    const first = selectStratifiedSample({ tasks: tasks, sampleSize: 20, seed: 7 });
+    const second = selectStratifiedSample({ tasks: tasks, sampleSize: 20, seed: 7 });
+
+    expect(taskIds(first)).toEqual(taskIds(second));
+  });
+
+  it("returns different tasks for a different seed", () => {
+    const tasks = buildTasks({ Alpha: 40, Beta: 30, Gamma: 30 });
+
+    const seven = selectStratifiedSample({ tasks: tasks, sampleSize: 20, seed: 7 });
+    const eight = selectStratifiedSample({ tasks: tasks, sampleSize: 20, seed: 8 });
+
+    expect(taskIds(seven)).not.toEqual(taskIds(eight));
+  });
+
+  it("keeps each site's share of the sample", () => {
+    const tasks = buildTasks({ Alpha: 50, Beta: 30, Gamma: 20 });
+
+    const sample = selectStratifiedSample({ tasks: tasks, sampleSize: 10, seed: 1 });
+
+    expect(countBySite(sample)).toEqual({ Alpha: 5, Beta: 3, Gamma: 2 });
+  });
+
+  it("fills exactly the requested count when shares do not divide evenly", () => {
+    const tasks = buildTasks({ Alpha: 7, Beta: 7, Gamma: 7 });
+
+    const sample = selectStratifiedSample({ tasks: tasks, sampleSize: 10, seed: 3 });
+
+    expect(sample).toHaveLength(10);
+  });
+
+  it("never draws more from a site than it has", () => {
+    const tasks = buildTasks({ Alpha: 90, Beta: 1 });
+
+    const sample = selectStratifiedSample({ tasks: tasks, sampleSize: 80, seed: 5 });
+
+    expect(countBySite(sample).Beta ?? 0).toBeLessThanOrEqual(1);
+    expect(sample).toHaveLength(80);
+  });
+
+  it("returns every task when the sample is not smaller than the set", () => {
+    const tasks = buildTasks({ Alpha: 3, Beta: 2 });
+
+    expect(selectStratifiedSample({ tasks: tasks, sampleSize: 5, seed: 1 })).toHaveLength(5);
+    expect(selectStratifiedSample({ tasks: tasks, sampleSize: 99, seed: 1 })).toHaveLength(5);
+  });
+
+  it("orders the sample by task id so a run's order never depends on the draw", () => {
+    const tasks = buildTasks({ Alpha: 20, Beta: 20 });
+
+    const sample = selectStratifiedSample({ tasks: tasks, sampleSize: 8, seed: 11 });
+
+    expect(taskIds(sample)).toEqual([...taskIds(sample)].sort());
+  });
+
+  it("rejects a sample size that is not a positive whole number", () => {
+    const tasks = buildTasks({ Alpha: 5 });
+
+    expect(() => selectStratifiedSample({ tasks: tasks, sampleSize: 0, seed: 1 })).toThrow(
+      /positive whole number/,
+    );
+    expect(() => selectStratifiedSample({ tasks: tasks, sampleSize: 2.5, seed: 1 })).toThrow(
+      /positive whole number/,
+    );
+  });
+});

--- a/internal/browser-bench/src/task-source/stratified-sample.ts
+++ b/internal/browser-bench/src/task-source/stratified-sample.ts
@@ -1,0 +1,122 @@
+import { type BenchmarkTask } from "../domain/types";
+
+/**
+ * Mulberry32: a small deterministic PRNG.
+ *
+ * Selection has to depend on the seed and nothing else — a slice nobody can
+ * regenerate is a score nobody can check — so `Math.random` is not an option.
+ * @param seed - Any integer; the same seed always yields the same sequence.
+ */
+const createSeededRandom = (seed: number): (() => number) => {
+  let state = seed;
+  return () => {
+    state |= 0;
+    state = (state + 0x6d2b79f5) | 0;
+    let mixed = Math.imul(state ^ (state >>> 15), 1 | state);
+    mixed = (mixed + Math.imul(mixed ^ (mixed >>> 7), 61 | mixed)) ^ mixed;
+    return ((mixed ^ (mixed >>> 14)) >>> 0) / 4294967296;
+  };
+};
+
+const shuffleInPlace = <T>(items: T[], nextRandom: () => number): void => {
+  for (let index = items.length - 1; index > 0; index--) {
+    const swapIndex = Math.floor(nextRandom() * (index + 1));
+    [items[index], items[swapIndex]] = [items[swapIndex], items[index]];
+  }
+};
+
+/**
+ * Allocates `sampleSize` places across sites in proportion to how many tasks
+ * each contributes, using largest-remainder so the parts total exactly the
+ * whole instead of drifting with rounding.
+ */
+const allocatePlacesPerSite = ({
+  siteNames,
+  taskCountBySite,
+  totalTaskCount,
+  sampleSize,
+}: {
+  siteNames: string[];
+  taskCountBySite: Map<string, number>;
+  totalTaskCount: number;
+  sampleSize: number;
+}): Map<string, number> => {
+  const allocations = siteNames.map((siteName) => {
+    const exactShare = (taskCountBySite.get(siteName)! / totalTaskCount) * sampleSize;
+    return {
+      siteName: siteName,
+      places: Math.floor(exactShare),
+      remainder: exactShare - Math.floor(exactShare),
+    };
+  });
+
+  let allocatedPlaces = allocations.reduce((total, entry) => total + entry.places, 0);
+  allocations
+    .slice()
+    .sort((left, right) => right.remainder - left.remainder)
+    .forEach((entry) => {
+      if (allocatedPlaces < sampleSize && entry.places < taskCountBySite.get(entry.siteName)!) {
+        entry.places += 1;
+        allocatedPlaces += 1;
+      }
+    });
+
+  return new Map(allocations.map((entry) => [entry.siteName, entry.places]));
+};
+
+/**
+ * Draws a site-stratified sample of tasks, reproducible from `seed` alone.
+ *
+ * Every site keeps its share of the sample, so a slice exercises the same
+ * breadth of page structures as the full set rather than over-weighting
+ * whichever sites happen to contribute the most tasks.
+ *
+ * Output shape: `[{ taskId: "Allrecipes--3", siteName: "Allrecipes", … }]`,
+ * ordered by `taskId`.
+ *
+ * @param tasks - The full task set to draw from.
+ * @param sampleSize - Places to fill; the whole set is returned when it is not smaller.
+ * @param seed - Selects the draw; the same seed and inputs always return the same tasks.
+ * @throws When `sampleSize` is not a positive whole number.
+ */
+export const selectStratifiedSample = ({
+  tasks,
+  sampleSize,
+  seed,
+}: {
+  tasks: BenchmarkTask[];
+  sampleSize: number;
+  seed: number;
+}): BenchmarkTask[] => {
+  if (!Number.isInteger(sampleSize) || sampleSize < 1) {
+    throw new Error(`Sample size must be a positive whole number, got "${sampleSize}".`);
+  }
+  if (sampleSize >= tasks.length) return [...tasks];
+
+  const tasksBySite = new Map<string, BenchmarkTask[]>();
+  tasks.forEach((task) => {
+    const siteTasks = tasksBySite.get(task.siteName) ?? [];
+    siteTasks.push(task);
+    tasksBySite.set(task.siteName, siteTasks);
+  });
+
+  const siteNames = [...tasksBySite.keys()].sort();
+  const placesBySite = allocatePlacesPerSite({
+    siteNames: siteNames,
+    taskCountBySite: new Map(siteNames.map((site) => [site, tasksBySite.get(site)!.length])),
+    totalTaskCount: tasks.length,
+    sampleSize: sampleSize,
+  });
+
+  // One generator drawn in a fixed site order: the sequence each site consumes
+  // is part of what the seed reproduces.
+  const nextRandom = createSeededRandom(seed);
+  const sampled: BenchmarkTask[] = [];
+  siteNames.forEach((siteName) => {
+    const sitePool = [...tasksBySite.get(siteName)!];
+    shuffleInPlace(sitePool, nextRandom);
+    sampled.push(...sitePool.slice(0, placesBySite.get(siteName)!));
+  });
+
+  return sampled.sort((left, right) => left.taskId.localeCompare(right.taskId));
+};


### PR DESCRIPTION
The 100-task slice behind the current benchmark score lived in a scratch directory. Nobody else could rebuild that task list, and nothing stopped it drifting between runs — which makes the score unverifiable, whatever the number says.

## Change

`selectStratifiedSample` draws the slice from a seed. Each site keeps its share of the sample, so a slice exercises the same breadth of page structures as the full 643 rather than over-weighting whichever sites contribute the most tasks.

```
tsx internal/browser-bench/src/run.ts \
  --tasks /tmp/WebVoyager_data.jsonl --sample-size 100 --sample-seed 20260906
```

`--sample-size` and `--sample-seed` must be given together. A sample drawn without a recorded seed cannot be regenerated, so the parser refuses rather than inventing a seed and producing a slice that looks reproducible but is not.

## Verification

Seed `20260906` over the 643-task set reproduces **all 100 task ids** of the existing slice — so the run already in flight and any future run are the same tasks, and the before/after comparison holds.

Largest-remainder allocation makes the per-site parts total exactly the sample size instead of drifting with rounding, and a site can never be drawn beyond its own task count.

## README

Brought back in line with what the harness actually does:

- `--max-steps` was undocumented
- judging runs per task now, not as "a separate later pass"
- `tokensUsed` carries real spend; the README still said it was always `0`

## Notes

Typecheck in this worktree reports 4 pre-existing `@anthropic-ai/sdk` resolution errors, identical on clean `master` (the package is not installed here). No new errors. 98 tests pass.
