### PR TITLE
fix(upgrade): keep the installed release lane instead of forcing stable

### DIFF
--- a/plugin/skills/muggle-upgrade/SKILL.md
+++ b/plugin/skills/muggle-upgrade/SKILL.md
@@ -1,31 +1,50 @@
 ---
 name: muggle-upgrade
 model: haiku
-description: Update Muggle AI to latest version. Use when user types muggle upgrade or asks to update Muggle Test tools.
+description: Update Muggle AI to the newest version on its current release lane. Use when user types muggle upgrade or asks to update Muggle Test tools.
 ---
 
 # Muggle Test Upgrade
 
 > Telemetry first step: see [`_shared/telemetry-emit.md`](../_shared/telemetry-emit.md). Use `skillName: "muggle-upgrade"`.
 
-Update all Muggle AI components to the latest published version. This means **both** the `@muggleai/works` CLI on npm **and** the Electron runner the CLI manages.
+Update all Muggle AI components to the newest version **on the release lane the machine is already on**. This means **both** the `@muggleai/works` CLI on npm **and** the Electron runner the CLI manages.
+
+## Release lanes
+
+Two lanes ship on npm, each with its own dist-tag:
+
+| Lane | dist-tag | Version shape |
+| :--- | :------- | :------------ |
+| stable | `latest` | `5.15.0` |
+| staging | `staging` | `5.16.0-staging.109` |
+
+**The lane is read off the installed build, never chosen by this skill.** A version carrying a prerelease identifier is on staging; a plain release is on stable. Stable is the default, and a machine that has never installed a prerelease stays there.
+
+**Upgrade within the lane, and compare against that lane's tag.** Semver orders `5.15.0-staging.106` *below* `5.15.0`, so a staging build measured against `latest` looks out of date — that comparison silently moves a staging user onto stable and takes away the lane they were testing on. It is the specific bug this section exists to prevent.
+
+**Switch lanes only when the user asks in this invocation** — "switch to stable", "go back to prod", "put me on staging", or naming an explicit version to install. A bare invocation always keeps the lane it found. When the user does name a version, install exactly that and say which lane it lands on.
 
 ## Steps
 
 1. Run `/muggle:muggle-status` checks to capture current versions.
 
-2. Capture CLI versions:
+2. Capture the installed CLI and resolve its lane:
    - Installed CLI: `muggle --version`
-   - Latest on npm: `npm view @muggleai/works version`
+   - Published heads of both lanes: `npm view @muggleai/works dist-tags --json`
    - Detect install location: `npm ls -g @muggleai/works --depth=0` (falls back to `pnpm ls -g @muggleai/works` if not found)
 
-3. **If installed CLI < latest on npm**, upgrade the CLI itself before touching Electron:
-   - npm global install: `npm install -g @muggleai/works@latest`
-   - pnpm global install: `pnpm add -g @muggleai/works@latest`
-   - If neither is detected, report the situation and ask the user how the CLI was installed before proceeding.
+   Read the lane off the installed version per the table above, then take that lane's tag as the upgrade target. Do not compare across lanes.
 
-4. Run `muggle upgrade` to pull the Electron runner version that the (now-latest) CLI expects.
+3. **If the installed CLI is behind its own lane's tag**, upgrade the CLI before touching Electron. Install the **tag**, not a version string, so the lane keeps resolving on later runs:
+   - stable, npm: `npm install -g @muggleai/works@latest` — pnpm: `pnpm add -g @muggleai/works@latest`
+   - staging, npm: `npm install -g @muggleai/works@staging` — pnpm: `pnpm add -g @muggleai/works@staging`
+   - Already at the lane's tag → report "already current" and continue to step 4.
+   - If neither package manager is detected, report the situation and ask the user how the CLI was installed before proceeding.
+
+4. Run `muggle upgrade` to pull the Electron runner version the (now-current) CLI expects.
    - Note: `muggle upgrade` only manages the Electron runner — it does NOT upgrade the CLI npm package. That is why step 3 must run first.
+   - The runner tracks published Studio releases only. When it reports "already on the latest version", that is the newest *released* runner — code merged to the Studio repo since that release is not in it, and no upgrade command can reach it until a new runner is published. Say so rather than implying the merge shipped.
 
 5. **Reload plugins** — the npm install (step 3) triggers a postinstall script that updates the plugin cache at `~/.claude/plugins/cache/`, but Claude Code only picks up new skills/agents/hooks after a reload. Tell the user:
 
@@ -37,7 +56,7 @@ Update all Muggle AI components to the latest published version. This means **bo
 
 ## Output
 
-Show a before/after table for **CLI**, **Electron runner**, **MCP server**, and **Auth**. Call out any version that did not change so the user understands what shipped vs what was already current.
+Show a before/after table for **CLI**, **Electron runner**, **MCP server**, and **Auth**, and name the lane beside the CLI version so it is visible that it did not move. Call out any version that did not change so the user understands what shipped vs what was already current.
 
 If any component upgraded, always end with the `/reload-plugins` reminder — even if the user doesn't need new features right away, stale cached skills can cause confusing behavior.
 

--- a/src/test/skills/upgrade-release-lane.test.ts
+++ b/src/test/skills/upgrade-release-lane.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Static wiring lint for the upgrade skill's release lane. Semver orders a staging
+ * prerelease below the stable release of the same version, so comparing an installed
+ * staging build against the `latest` tag reads as "out of date" and silently moves the
+ * machine onto stable — losing the lane it was testing on. This test locks the rule that
+ * the lane is read off the installed build and each lane upgrades against its own tag.
+ * It reads the file; it runs no package manager.
+ */
+
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "../../..");
+const UPGRADE_SKILL = path.join(
+  REPO_ROOT,
+  "plugin",
+  "skills",
+  "muggle-upgrade",
+  "SKILL.md",
+);
+
+const skill = fs.readFileSync(UPGRADE_SKILL, "utf8");
+
+describe("muggle-upgrade release lane", () => {
+  it("documents both lanes and their dist-tags", () => {
+    expect(skill).toMatch(/## Release lanes/);
+    expect(skill).toMatch(/`latest`/);
+    expect(skill).toMatch(/`staging`/);
+  });
+
+  it("reads the lane off the installed build rather than choosing one", () => {
+    expect(skill).toMatch(/lane is read off the installed build, never chosen/i);
+    expect(skill).toMatch(/prerelease identifier/i);
+  });
+
+  it("names stable as the default for a machine that never installed a prerelease", () => {
+    expect(skill).toMatch(/[Ss]table is the default/);
+  });
+
+  it("spells out the cross-lane comparison trap that caused the silent switch", () => {
+    expect(skill).toMatch(/staging\.106/);
+    expect(skill).toMatch(/below/);
+    expect(skill).toMatch(/silently moves? a staging user onto stable/i);
+  });
+
+  it("requires an explicit user request before switching lanes", () => {
+    expect(skill).toMatch(/Switch lanes only when the user asks/i);
+    expect(skill).toMatch(/bare invocation always keeps the lane it found/i);
+  });
+
+  it("installs each lane by its tag, never by a bare version string", () => {
+    expect(skill).toMatch(/@muggleai\/works@latest/);
+    expect(skill).toMatch(/@muggleai\/works@staging/);
+    expect(skill).toMatch(/Install the \*\*tag\*\*, not a version string/i);
+  });
+
+  it("no longer resolves the target through the unqualified latest-version lookup", () => {
+    expect(
+      skill,
+      "`npm view @muggleai/works version` returns the stable head regardless of lane — resolve dist-tags instead",
+    ).not.toMatch(/npm view @muggleai\/works version/);
+    expect(skill).toMatch(/npm view @muggleai\/works dist-tags --json/);
+  });
+
+  it("does not gate the upgrade on a comparison against latest", () => {
+    expect(
+      skill,
+      "comparing the installed build against `latest` is the cross-lane bug",
+    ).not.toMatch(/installed CLI < latest on npm/);
+    expect(skill).toMatch(/behind its own lane's tag/i);
+  });
+
+  it("keeps the runner's published-release limit honest", () => {
+    expect(skill).toMatch(/tracks published Studio releases only/i);
+    expect(skill).toMatch(/already on the latest version/);
+  });
+
+  it("surfaces the lane in the before/after table", () => {
+    expect(skill).toMatch(/name the lane beside the CLI version/i);
+  });
+
+  it("keeps the routing triggers the description is matched on", () => {
+    expect(skill).toMatch(/Use when user types muggle upgrade/);
+    expect(skill).toMatch(/update Muggle Test tools/);
+  });
+});


### PR DESCRIPTION
A bare `/mupgrade` silently moved a machine off the staging lane onto stable. Reproduced live today: installed `5.15.0-staging.106`, ran the skill, ended up on `5.15.0`.

## Why it happened

The skill resolved its target with `npm view @muggleai/works version`, which returns the **stable** head regardless of which lane is installed, then gated the upgrade on *"installed CLI < latest on npm"*. Semver orders a prerelease below the release of the same version — `5.15.0-staging.106` **<** `5.15.0` — so a staging build always reads as out of date, and step 3 installed `@latest`. Nothing in the output named the lane, so the switch was invisible until the user caught it.

Because the install pinned a resolved version rather than a tag, the machine also stopped tracking staging on subsequent runs.

## What changed

The lane is now **read off the installed build**, never chosen by the skill: a version carrying a prerelease identifier is on staging, a plain release is on stable. Stable remains the default for any machine that has never installed a prerelease — general users are unaffected.

Each lane resolves and compares against **its own dist-tag** (`latest` / `staging`) via `npm view @muggleai/works dist-tags --json`, and installs the **tag** rather than a version string so the lane keeps resolving on later runs. Lanes change only when the user asks in the same invocation ("switch to stable", "put me on staging") or names an explicit version; a bare invocation always keeps the lane it found.

## Also corrected

`muggle upgrade` tracks *published* Studio releases only. Its "already on the latest version" line was being read as "you have everything merged", which is wrong — code merged to the Studio repo after the last release is not in the runner, and no upgrade command can reach it until a new runner ships. The skill now says so instead of letting a merge look delivered. This bit us today: three merged Studio agent fixes are not in runner 1.10.3, and the upgrade reported itself current.

## Verification

New static lint `src/test/skills/upgrade-release-lane.test.ts`, in the shape of `signed-commits-recipe.test.ts` — it reads the skill text and runs no package manager. It pins the lane rule, both tags, the explicit-switch requirement, and the runner caveat, and asserts the two constructs that caused the switch are **gone**: the unqualified `npm view … version` lookup and the `installed CLI < latest on npm` gate.

Layer-1 skills suite green at 419 checks across 16 files; full suite green at 1,633 with 99 skipped. ESLint clean. `dist/` is gitignored here, so there is no bundled copy to regenerate.
