### PR TITLE
feat(browser-bench): score a bot-defence block as its own outcome

### DIFF
--- a/internal/browser-bench/README.md
+++ b/internal/browser-bench/README.md
@@ -32,6 +32,26 @@ Concurrency is memory-bound: every task is a full Electron instance, so raising
 it past what the machine's RAM allows makes tasks fail for reasons the benchmark
 should not be measuring.
 
+### Outcomes
+
+| Outcome | Means | In the pass rate |
+| :--- | :--- | :--- |
+| `pass` | The judge read the final answer against the screenshots and accepted it | yes |
+| `fail` | The judge rejected it | yes |
+| `blocked` | The site served an automated-access check — a security or bot verification interstitial, a "checking your browser" hold, an access denial — so the agent never reached the content | no |
+| `error` | The harness or studio failed: non-zero exit, missing or unreadable result file, or a task outliving `TASK_TIMEOUT_MS` | no |
+
+`blocked` and `error` are counted and reported on their own report lines but
+kept out of the denominator: neither measures what the agent can do, and
+scoring them understates it.
+
+The judge returns `blocked` as its own verdict, chosen from the same status line
+that carries `SUCCESS` and `NOT SUCCESS`. It is the only party that has already
+read the screenshots, and asking it to pick a token beats matching English in
+its reasoning — interstitial copy varies by vendor and locale. The harness
+classifies a block, never defeats one: fingerprint evasion and stealth browser
+flags are out of scope, and would put runs the wrong side of site terms.
+
 ### Output tree
 
 ```
@@ -84,10 +104,11 @@ Studio writes `result.json`:
 }
 ```
 
-Exit 0 means the attempt completed — `studioStatus: "success"` scores a pass,
-any other status a fail. A non-zero exit, a missing or unreadable result file,
-or outliving `TASK_TIMEOUT_MS` (10 minutes) kills the process and records an
-infrastructure error instead, which is excluded from the pass-rate denominator.
+Exit 0 means the attempt completed and the judge scores it; `studioStatus` is
+kept beside the verdict for triage and never decides it. A non-zero exit, a
+missing or unreadable result file, or outliving `TASK_TIMEOUT_MS` (10 minutes)
+kills the process and records an infrastructure error instead, which is excluded
+from the pass-rate denominator.
 
 `tokensUsed` carries studio's reported spend for the attempt, so a score is
 always reportable next to what it cost. A build that predates token reporting

--- a/internal/browser-bench/src/domain/types.ts
+++ b/internal/browser-bench/src/domain/types.ts
@@ -6,11 +6,19 @@ export interface BenchmarkTask {
   startUrl: string;
 }
 
-/** How a single task attempt is counted toward (or excluded from) the score. */
+/**
+ * How a single task attempt is counted toward (or excluded from) the score.
+ *
+ * `Pass` and `Fail` are the whole scored denominator. `Error` (the harness or
+ * studio failed) and `Blocked` (the site refused the agent with a bot-defence
+ * interstitial, so its capability was never exercised) are both counted and
+ * reported, never scored — neither measures what the agent can do.
+ */
 export enum BenchmarkOutcome {
   Pass = "pass",
   Fail = "fail",
   Error = "error",
+  Blocked = "blocked",
 }
 
 /** One task attempt's recorded result. */

--- a/internal/browser-bench/src/judge/constants.ts
+++ b/internal/browser-bench/src/judge/constants.ts
@@ -17,6 +17,9 @@ export const JUDGE_IMAGE_MEDIA_TYPES: Record<string, string> = {
   ".gif": "image/gif",
 };
 
+/** Opens the judge's verdict line. The prompt asks for it and the parser reads it, so both build from here. */
+export const JUDGE_VERDICT_LINE_PREFIX = "Status:";
+
 /** Names the credential the judge needs; the batch refuses to start without it. */
 export const JUDGE_API_KEY_ENV_VAR = "ANTHROPIC_API_KEY";
 

--- a/internal/browser-bench/src/judge/judge.test.ts
+++ b/internal/browser-bench/src/judge/judge.test.ts
@@ -25,6 +25,46 @@ describe("judgeTaskAsync", () => {
     expect(verdict.outcome).toBe(BenchmarkOutcome.Fail);
   });
 
+  it("maps BLOCKED to Blocked, so a bot-defence interstitial is not scored as a capability failure", async () => {
+    const verdict = await judgeTaskAsync({
+      instruction: "Look up the word 'ephemeral'.",
+      finalAnswer: "The site showed a security verification page.",
+      screenshotPaths: [],
+      invokeJudgeAsync: async () =>
+        "Thoughts: every screenshot shows Cloudflare's verification hold.\nStatus: BLOCKED",
+    });
+
+    expect(verdict.outcome).toBe(BenchmarkOutcome.Blocked);
+  });
+
+  it("scores a completed task Pass even when the reply also names an interstitial", async () => {
+    const verdict = await judgeTaskAsync({
+      instruction: "Look up the word 'ephemeral'.",
+      finalAnswer: "ephemeral: lasting a very short time.",
+      screenshotPaths: [],
+      invokeJudgeAsync: async () =>
+        "Thoughts: an interstitial appeared but cleared, and the definition is correct.\nStatus: SUCCESS",
+    });
+
+    expect(verdict.outcome).toBe(BenchmarkOutcome.Pass);
+  });
+
+  it("tells the judge how to report a site that refused the agent", async () => {
+    let seenPrompt = "";
+
+    await judgeTaskAsync({
+      instruction: "q",
+      finalAnswer: "a",
+      screenshotPaths: [],
+      invokeJudgeAsync: async (prompt) => {
+        seenPrompt = prompt;
+        return "Status: SUCCESS";
+      },
+    });
+
+    expect(seenPrompt).toContain("Status: BLOCKED");
+  });
+
   it("treats an unparseable judge response as Fail, never Error", async () => {
     const verdict = await judgeTaskAsync({
       instruction: "q",

--- a/internal/browser-bench/src/judge/judge.ts
+++ b/internal/browser-bench/src/judge/judge.ts
@@ -1,13 +1,45 @@
 import { BenchmarkOutcome } from "../domain/types";
+import { JUDGE_VERDICT_LINE_PREFIX } from "./constants";
+import { JudgeVerdictToken } from "./types";
 
-/** WebVoyager's judge answers with a trailing `Status: SUCCESS` line; anything else is a failure. */
-const SUCCESS_PATTERN = /Status:\s*SUCCESS\b/i;
+const carriesVerdict = (judgeReply: string, token: JudgeVerdictToken): boolean =>
+  new RegExp(`${JUDGE_VERDICT_LINE_PREFIX}\\s*${token}\\b`, "i").test(judgeReply);
+
+const buildJudgePrompt = ({
+  instruction,
+  finalAnswer,
+}: {
+  instruction: string;
+  finalAnswer: string;
+}): string =>
+  `You are evaluating whether a web agent completed its task.\n\n` +
+  `Task: ${instruction}\n\n` +
+  `Agent's final answer: ${finalAnswer}\n\n` +
+  `The screenshots show the agent's last actions. Decide whether the task was ` +
+  `completed. Reply with your reasoning, then a final line reading exactly one of:\n` +
+  `"${JUDGE_VERDICT_LINE_PREFIX} ${JudgeVerdictToken.Success}" — the agent completed the task.\n` +
+  `"${JUDGE_VERDICT_LINE_PREFIX} ${JudgeVerdictToken.NotSuccess}" — the agent did not complete it.\n` +
+  `"${JUDGE_VERDICT_LINE_PREFIX} ${JudgeVerdictToken.Blocked}" — the site never let the agent ` +
+  `reach its content, because it served an automated-access check: a security or bot ` +
+  `verification interstitial, a "checking your browser" hold, or an outright access ` +
+  `denial. Choose this only when the screenshots show that barrier standing between the ` +
+  `agent and the content it needed. An agent that reached the content and then got the ` +
+  `task wrong is ${JudgeVerdictToken.NotSuccess}.`;
 
 /**
  * Scores one task attempt by WebVoyager's judge protocol: the judge model reads
  * the instruction, the agent's answer, and the trailing screenshots, and returns
- * a binary verdict. Model invocation is injected so the protocol stays testable
- * without a network call.
+ * one of three verdicts. Model invocation is injected so the protocol stays
+ * testable without a network call.
+ *
+ * The blocked verdict is asked of the judge rather than inferred here. The judge
+ * is the only party that has already read the screenshots, and asking it to pick
+ * a token beats matching English in its reasoning — interstitial copy varies by
+ * vendor and locale, and prose patterns would both miss real blocks and fire on
+ * a verdict that merely mentions one.
+ *
+ * Success is checked before blocked: an agent that finished the task did reach
+ * the content, whatever else the reasoning mentions on the way there.
  *
  * Verdicts are not bit-reproducible: the judge model rejects `temperature`
  * outright, so a re-judged batch can move by a task or two. Re-judging is
@@ -30,18 +62,19 @@ export const judgeTaskAsync = async ({
   screenshotPaths: string[];
   invokeJudgeAsync: (prompt: string, screenshotPaths: string[]) => Promise<string>;
 }): Promise<{ outcome: BenchmarkOutcome; reasoning: string }> => {
-  const prompt =
-    `You are evaluating whether a web agent completed its task.\n\n` +
-    `Task: ${instruction}\n\n` +
-    `Agent's final answer: ${finalAnswer}\n\n` +
-    `The screenshots show the agent's last actions. Decide whether the task was ` +
-    `completed. Reply with your reasoning, then a final line reading exactly ` +
-    `"Status: SUCCESS" or "Status: NOT SUCCESS".`;
+  const reasoning = await invokeJudgeAsync(
+    buildJudgePrompt({ instruction: instruction, finalAnswer: finalAnswer }),
+    screenshotPaths,
+  );
 
-  const reasoning = await invokeJudgeAsync(prompt, screenshotPaths);
+  const resolveOutcome = (): BenchmarkOutcome => {
+    if (carriesVerdict(reasoning, JudgeVerdictToken.Success)) return BenchmarkOutcome.Pass;
+    if (carriesVerdict(reasoning, JudgeVerdictToken.Blocked)) return BenchmarkOutcome.Blocked;
+    return BenchmarkOutcome.Fail;
+  };
 
   return {
-    outcome: SUCCESS_PATTERN.test(reasoning) ? BenchmarkOutcome.Pass : BenchmarkOutcome.Fail,
+    outcome: resolveOutcome(),
     reasoning: reasoning,
   };
 };

--- a/internal/browser-bench/src/judge/types.ts
+++ b/internal/browser-bench/src/judge/types.ts
@@ -1,0 +1,12 @@
+/**
+ * The verdicts the judge may return, as the exact token its status line carries.
+ *
+ * The prompt and the parser are both built from these, so the wording the judge
+ * is asked for and the wording the harness reads can never drift apart. A
+ * verdict is a token the judge chooses from, not English the harness matches.
+ */
+export enum JudgeVerdictToken {
+  Success = "SUCCESS",
+  NotSuccess = "NOT SUCCESS",
+  Blocked = "BLOCKED",
+}

--- a/internal/browser-bench/src/report/report.test.ts
+++ b/internal/browser-bench/src/report/report.test.ts
@@ -26,6 +26,25 @@ describe("renderReport", () => {
     expect(markdown).toContain("infrastructure errors 1");
   });
 
+  it("keeps bot-defence blocks out of the denominator and gives them their own line", () => {
+    const markdown = renderReport([
+      result("a", BenchmarkOutcome.Pass),
+      result("b", BenchmarkOutcome.Fail),
+      result("c", BenchmarkOutcome.Blocked),
+      result("d", BenchmarkOutcome.Blocked),
+    ]);
+
+    expect(markdown).toContain("50.0%");
+    expect(markdown).toContain("scored 2");
+    expect(markdown).toContain("**Blocked by bot defence:** 2");
+  });
+
+  it("still prints the blocked line at zero, so a clean run says so rather than staying silent", () => {
+    expect(renderReport([result("a", BenchmarkOutcome.Pass)])).toContain(
+      "**Blocked by bot defence:** 0",
+    );
+  });
+
   it("reports 0.0% rather than dividing by zero when every task errored", () => {
     const markdown = renderReport([result("a", BenchmarkOutcome.Error)]);
 

--- a/internal/browser-bench/src/report/report.ts
+++ b/internal/browser-bench/src/report/report.ts
@@ -4,10 +4,16 @@ import { BenchmarkOutcome, type TaskResult } from "../domain/types";
 /**
  * Renders the batch report.
  *
- * The pass-rate denominator is passes + fails only — infrastructure errors are
- * counted and reported separately so a lockout or a crash can never read as a
- * capability regression. This differs from how most published browser-agent
- * scores are computed, so any published number must say so.
+ * The pass-rate denominator is passes + fails only — infrastructure errors and
+ * bot-defence blocks are counted and reported separately so a lockout, a crash,
+ * or a site that refuses automated access can never read as a capability
+ * regression. This differs from how most published browser-agent scores are
+ * computed, so any published number must say so.
+ *
+ * Blocked attempts get their own line and keep their rows in the table, printed
+ * even at zero. A benchmark that reports what it could not reach is more honest
+ * than one that hides it, and a line that appears only when non-zero is a line
+ * nobody learns to look for.
  *
  * The step budget is printed beside the pass rate, and a budget above
  * WebVoyager's own cap is labelled a deviation in the same line as the score.
@@ -27,6 +33,7 @@ export const renderReport = (
   const passes = results.filter((result) => result.outcome === BenchmarkOutcome.Pass).length;
   const fails = results.filter((result) => result.outcome === BenchmarkOutcome.Fail).length;
   const errors = results.filter((result) => result.outcome === BenchmarkOutcome.Error).length;
+  const blocked = results.filter((result) => result.outcome === BenchmarkOutcome.Blocked).length;
   const scored = passes + fails;
   const passRate = scored === 0 ? 0 : (passes / scored) * 100;
   const totalTokens = results.reduce((sum, result) => sum + result.tokensUsed, 0);
@@ -35,6 +42,7 @@ export const renderReport = (
     `# Browser-capability benchmark`,
     ``,
     `**Pass rate:** ${passRate.toFixed(1)}% (scored ${scored}, infrastructure errors ${errors})`,
+    `**Blocked by bot defence:** ${blocked} — the site refused automated access, so the agent's capability was never exercised; excluded from the pass rate`,
     `**Step budget:** ${maxSteps}${
       maxSteps > MAX_STEPS_PER_TASK
         ? ` — raised above WebVoyager's cap of ${MAX_STEPS_PER_TASK}; this score is NOT comparable to published WebVoyager results`


### PR DESCRIPTION
## Problem

Cambridge Dictionary scored 0/7 on the last 100-task slice. Every one of those
tasks shows a Cloudflare "Performing security verification" interstitial in its
screenshots — the agent never reached the dictionary. There is no CAPTCHA
widget, so the CAPTCHA solver does not apply.

Scoring those seven as capability failures understates the agent and pollutes
the pass rate, by the same metric-integrity principle the harness already
applies to infrastructure errors: a bucket that does not measure what the agent
can do must not sit in the denominator.

## Change

A bot-defence block is now its own outcome — recorded, reported on its own line,
and excluded from the capability denominator exactly as infrastructure errors
already are. The harness classifies a block; it never tries to defeat one. No
fingerprint evasion, no stealth flags.

```
**Pass rate:** 50.0% (scored 2, infrastructure errors 1)
**Blocked by bot defence:** 1 — the site refused automated access, so the agent's capability was never exercised; excluded from the pass rate
**Step budget:** 15
**Total tokens:** 2000

| Task | Outcome | Steps | Duration (ms) | Tokens |
| :--- | :------ | ----: | ------------: | -----: |
| Allrecipes--0 | pass | 3 | 1000 | 500 |
| Amazon--0 | fail | 3 | 1000 | 500 |
| Cambridge Dictionary--0 | blocked | 3 | 1000 | 500 |
| Coursera--0 | error | 3 | 1000 | 500 |
```

The line prints even at zero. A line that appears only when non-zero is a line
nobody learns to look for, and the point of the outcome is that the benchmark
says what it could not reach.

## Design decisions

**Detection is a judge verdict, not a downstream inference.** The judge already
reads every screenshot and already ends its reply with a `Status:` line. It now
picks from three tokens instead of two: `SUCCESS`, `NOT SUCCESS`, `BLOCKED`. No
English is substring-matched anywhere — not the judge's reasoning, not studio's
final answer. Interstitial copy varies by vendor and by locale, so prose
patterns would both miss real blocks and fire on a verdict that merely mentions
one in passing.

The prompt and the parser are both built from a single `JudgeVerdictToken` enum
(`src/judge/types.ts`) and one `JUDGE_VERDICT_LINE_PREFIX` constant, so the
wording the judge is asked for and the wording the harness reads cannot drift
apart. The prompt defines the verdict narrowly: choose it only when the
screenshots show the barrier standing between the agent and the content it
needed, and an agent that reached the content and then got the task wrong is
`NOT SUCCESS`.

`SUCCESS` is checked before `BLOCKED`, because an agent that finished the task
did reach the content, whatever else its reasoning mentions on the way there.

**A fourth value on `BenchmarkOutcome`, not a parallel field.** The four states
are mutually exclusive — a run cannot be both a pass and a block. A separate
boolean would make `outcome: pass, blocked: true` representable, force every
consumer to read two fields to learn one thing, and change the `partial.jsonl`
shape for resumed batches. As an enum value it rides through
`applyJudgeVerdict`, the partial log, the merge, and the report with no
per-hop handling.

**Judge-only detection is sufficient.** A blocked run is not a crashed run:
studio finishes, writes its result, and the judge is reached. Nothing about a
block routes around the verdict path.

## Red/green proof

Baseline on `origin/master`: 98 tests across 14 files, all green.

Five tests added, four of them red before the change:

| Test | Before |
| :--- | :--- |
| `maps BLOCKED to Blocked, so a bot-defence interstitial is not scored as a capability failure` | red — `expected 'fail' to be undefined` |
| `tells the judge how to report a site that refused the agent` | red — prompt does not contain `Status: BLOCKED` |
| `keeps bot-defence blocks out of the denominator and gives them their own line` | red — report has no `**Blocked by bot defence:** 2` |
| `still prints the blocked line at zero, so a clean run says so rather than staying silent` | red — report has no `**Blocked by bot defence:** 0` |
| `scores a completed task Pass even when the reply also names an interstitial` | green both ways — guards the SUCCESS-before-BLOCKED precedence |

- Before the change: 4 of 103 tests red, in 2 of the 14 files.
- After the change: all 103 green, all 14 files green.

`npx tsc -p internal/browser-bench/tsconfig.json --noEmit` reports **4 errors
before and 4 errors after**, the same pre-existing `@anthropic-ai/sdk` module
resolution errors in `claude-judge.ts` (3) and `run.ts` (1) — that package is
not installed in this worktree. Identical on clean master; confirmed before
touching anything.

The benchmark itself was not run: it costs hours and millions of tokens, and
nothing here changes how a task is executed.

## Out of scope

Fingerprint evasion, stealth-mode browser flags, or any attempt to get past the
bot defence. Deliberately so — it would be fragile and would put runs the wrong
side of site terms. Classify, do not defeat.
